### PR TITLE
[sinks] More error handling in the Kafka sink

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1155,14 +1155,10 @@ where
                             .expect("init_transactions");
                     }
 
-                    let latest_ts = match s.determine_latest_progress_record().await {
-                        Ok(ts) => ts,
-                        Err(e) => {
-                            s.shutdown_flag.store(true, Ordering::SeqCst);
-                            info!("shutting down kafka sink while initializing: {}", e);
-                            return true;
-                        }
-                    };
+                    let latest_ts = s
+                        .determine_latest_progress_record()
+                        .await
+                        .expect("determining latest progress record");
                     info!(
                         "{}: initial as_of: {:?}, latest progress record: {:?}",
                         s.name, as_of.frontier, latest_ts

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1147,27 +1147,12 @@ where
             // Panic if there's not exactly once element in the frontier like we expect.
             let frontier = frontiers.clone().into_element();
 
-            // Can't use `?` when the return type is a `bool` so use a custom try operator
-            macro_rules! bail_err {
-                ($expr:expr, $msg:tt) => {
-                    match $expr {
-                        Ok(val) => val,
-                        Err(e) => {
-                            warn!("Kafka sink error {:?}: {:?}", e, $msg);
-                            s.activator.activate();
-                            return true;
-                        }
-                    }
-                };
-            }
-
             if is_active_worker {
                 if let KafkaSinkStateEnum::Init(ref init) = s.sink_state {
                     if s.transactional {
-                        bail_err!(
-                            s.retry_on_txn_error(|p| p.init_transactions()).await,
-                            "init_transactions"
-                        );
+                        s.retry_on_txn_error(|p| p.init_transactions())
+                            .await
+                            .expect("init_transactions");
                     }
 
                     let latest_ts = match s.determine_latest_progress_record().await {
@@ -1262,10 +1247,9 @@ where
                         ts,
                         rows.len()
                     );
-                    bail_err!(
-                        s.retry_on_txn_error(|p| p.begin_transaction()).await,
-                        "begin transaction"
-                    );
+                    s.retry_on_txn_error(|p| p.begin_transaction())
+                        .await
+                        .expect("begin transaction");
                 }
 
                 let mut repeat_counter = 0;
@@ -1287,7 +1271,7 @@ where
                     }));
 
                     // Only fatal errors are returned from send
-                    bail_err!(s.send(record).await, "send record");
+                    s.send(record).await.expect("send record");
 
                     // advance to the next repetition of this row, or the next row if all
                     // repetitions are exhausted
@@ -1300,24 +1284,22 @@ where
 
                 // Flush to make sure that errored messages have been properly retried before
                 // sending progress records and commit transactions.
-                bail_err!(s.flush().await, "post-records flush");
+                s.flush().await.expect("post-records flush");
 
                 if let Some(ref progress_state) = s.sink_state.unwrap_running() {
-                    bail_err!(
-                        s.send_progress_record(*ts, progress_state).await,
-                        "send progress record"
-                    );
+                    s.send_progress_record(*ts, progress_state)
+                        .await
+                        .expect("send progress record");
                 }
 
                 if s.transactional {
                     info!("Committing transaction for {:?}", ts,);
-                    bail_err!(
-                        s.retry_on_txn_error(|p| p.commit_transaction()).await,
-                        "commit transaction"
-                    );
+                    s.retry_on_txn_error(|p| p.commit_transaction())
+                        .await
+                        .expect("commit transaction");
                 };
 
-                bail_err!(s.flush().await, "post-commit flush");
+                s.flush().await.expect("post-commit flush");
 
                 // sanity check for the continuous updating
                 // of the write frontier below
@@ -1347,7 +1329,7 @@ where
                         if progress_emitted {
                             // Don't flush if we know there were no records emitted.
                             // It has a noticeable negative performance impact.
-                            bail_err!(s.flush().await, "progress emitted flush");
+                            s.flush().await.expect("progress emitted flush");
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
Right now the Kafka sink handles errors fairly quietly. This means any persistent errors don't always percolate up, and if the Kafka client gets into a bad state it may never get unstuck.

The goal of this PR is to switch to being noisy about errors, including possibly panicing to force a restart of the `storaged` instance. The idea is that being crashy is better than getting into a "zombie" state where we're up but not making progress, and we can follow up in the future to improve reporting.

### Motivation

We have a number of related bugs under #11503, including stuff like #14098.

### Tips for reviewer
I've erred on the aggressive side as far as percolating errors up; I think I like it but let me know if it seems like too much!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
