### PR TITLE
doc/user: add documentation for source sizes

### DIFF
--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -1,0 +1,23 @@
+---
+title: "ALTER SOURCE"
+description: "`ALTER SOURCE` changes the provisioned size of a source."
+menu:
+  main:
+    parent: 'commands'
+---
+
+`ALTER SOURCE` changes the provisioned [size](/sql/create-source/#sizing-a-source) of a source.
+
+## Syntax
+
+{{< diagram "alter-source.svg" >}}
+
+Field   | Use
+--------|-----
+_name_  | The identifier of the source you want to alter.
+_value_ | The new value for the source size. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+
+## See also
+
+- [`CREATE SOURCE`](/sql/create-source/)
+- [`SHOW SOURCES`](/sql/show-sources)

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -220,6 +220,32 @@ The envelope exposes the `before` and `after` value fields from change events. I
 
 Debezium may produce duplicate records if the connector is interrupted. Materialize makes a best-effort attempt to detect and filter out duplicates.
 
+## Sizes
+
+The `SIZE` option controls the amount of CPU and memory available to the source.
+
+Valid sizes are:
+
+- `3xsmall`
+- `2xsmall`
+- `xsmall`
+- `small`
+- `medium`
+- `large`
+
+The default source size is `3xsmall`.
+
+Consider increasing the size of your source when:
+
+  * You want to increase throughput. Larger sources will typically ingest data
+    faster, as they have more CPU available to read and decode data from your
+    external system.
+
+  * You are using the [upsert envelope](#upsert-envelope) and your source
+    contains many unique keys. The upsert envelope must keep in-memory state
+    proportional to the number of unique keys in your upstream source. Larger
+    sizes can store more unique keys.
+
 ## Related pages
 
 - [Key Concepts](../../overview/key-concepts/)

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -220,31 +220,22 @@ The envelope exposes the `before` and `after` value fields from change events. I
 
 Debezium may produce duplicate records if the connector is interrupted. Materialize makes a best-effort attempt to detect and filter out duplicates.
 
-## Sizes
+## Best practices
 
-The `SIZE` option controls the amount of CPU and memory available to the source.
+### Sizing a source
 
-Valid sizes are:
+Some sources are low traffic and require relatively few resources to handle data ingestion, while others are high traffic and require hefty resource allocations. You can provision a specific amount of CPU and memory to a source using the `SIZE` option, and adjust the provisioned size after source creation using the [`ALTER SOURCE`](/sql/alter-source) command.
 
-- `3xsmall`
-- `2xsmall`
-- `xsmall`
-- `small`
-- `medium`
-- `large`
+By default, Materialize provisions sources using the smallest size (`3xsmall`). It's a good idea to increase the size of a source when:
 
-The default source size is `3xsmall`.
+  * You want to **increase throughput**. Larger sources will typically ingest data
+    faster, as there is more CPU available to read and decode data from the
+    upstream external system.
 
-Consider increasing the size of your source when:
-
-  * You want to increase throughput. Larger sources will typically ingest data
-    faster, as they have more CPU available to read and decode data from your
-    external system.
-
-  * You are using the [upsert envelope](#upsert-envelope) and your source
-    contains many unique keys. The upsert envelope must keep in-memory state
-    proportional to the number of unique keys in your upstream source. Larger
-    sizes can store more unique keys.
+  * You are using the [upsert envelope](#upsert-envelope), and your source
+    contains **many unique keys**. This envelope must keep in-memory state
+    proportional to the number of unique keys in the upstream external system.
+    Larger sizes can store more unique keys.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -53,7 +53,7 @@ The same syntax, supported formats and features can be used to connect to a [Red
 
 {{% create-source/syntax-connector-details connector="kafka" envelopes="debezium upsert append-only" %}}
 
-### `WITH` options
+### Kafka connection options
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
@@ -64,6 +64,12 @@ Field                                | Value     | Description
 `topic_metadata_refresh_interval_ms` | `int`     | Default: `300000`. Sets the frequency in `ms` at which the system checks for new partitions. Accepts values [0,3600000].
 `enable_auto_commit`                 | `boolean` | Default: `false`. Controls whether or not Materialize commits read offsets back into Kafka. This is purely for consumer progress monitoring and does not cause Materialize to resume reading from where it left off across restarts.
 `fetch_message_max_bytes` | `int` | Default: `134217728`. Controls the initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched. Accepts values [1, 1000000000].
+
+### `WITH` options
+
+Field                                | Value     | Description
+-------------------------------------|-----------|-------------------------------------
+`SIZE`                               | `text`    | The size for the source. For valid sizes, see [source sizes](/sql/create-source#sizes).
 
 ## Supported formats
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -53,7 +53,7 @@ The same syntax, supported formats and features can be used to connect to a [Red
 
 {{% create-source/syntax-connector-details connector="kafka" envelopes="debezium upsert append-only" %}}
 
-### Kafka connection options
+### `CONNECTION` options
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
@@ -69,7 +69,7 @@ Field                                | Value     | Description
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | The size for the source. For valid sizes, see [source sizes](/sql/create-source#sizes).
+`SIZE`                               | `text`    | Default: `3xsmall`. The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Supported formats
 
@@ -280,7 +280,7 @@ A strategy of `LATEST` (the default) will choose the latest writer schema from t
 
 A connection describes how to connect and authenticate to an external system you want Materialize to read data from.
 
-Once created, a connection is **reusable** across multiple `CREATE SOURCE` statements. For more details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#kafka) documentation page.
+Once created, a connection is **reusable** across multiple `CREATE SOURCE` statements. For more details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection) documentation page.
 
 #### Broker
 
@@ -395,9 +395,29 @@ CREATE SOURCE csv_source (col_foo, col_bar, col_baz)
 {{< /tab >}}
 {{< /tabs >}}
 
+### Sizing a source
+
+To provision a specific amount of CPU and memory to a source on creation, use the `SIZE` option:
+
+```sql
+CREATE SOURCE avro_source
+  FROM KAFKA
+    CONNECTION kafka_connection (TOPIC 'test_topic')
+    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
+    WITH (SIZE = 'xsmall');
+```
+
+To resize the source after creation:
+
+```sql
+ALTER SOURCE avro_source SET (SIZE = 'large');
+```
+
+By default, sources are provisioned using the smallest size (`3xsmall`). For more details on sizing sources, check the [`CREATE SOURCE`](../) documentation page.
+
 ## Related pages
 
-- `CREATE SECRET`
+- [`CREATE SECRET`](/sql/create-secret)
 - [`CREATE CONNECTION`](/sql/create-connection)
 - [`CREATE SOURCE`](../)
 - [Using Debezium](/integrations/debezium/)

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -7,7 +7,7 @@ menu:
     parent: 'create-source'
     identifier: load-generator
     name: Load generator
-    weight: 20
+    weight: 40
 ---
 
 {{% create-source/intro %}}
@@ -35,7 +35,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | The size for the source. For valid sizes, see [source sizes](/sql/create-source#sizes).
+`SIZE`                               | `text`    | Default: `3xsmall`. The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Description
 
@@ -167,8 +167,26 @@ SELECT * from bids;
 (3 rows)
 ```
 
+### Sizing a source
+
+To provision a specific amount of CPU and memory to a source on creation, use the `SIZE` option:
+
+```sql
+CREATE SOURCE auction_load FROM LOAD GENERATOR AUCTION
+WITH (SIZE = 'xsmall');
+```
+
+To resize the source after creation:
+
+```sql
+ALTER SOURCE auction_load SET (SIZE = 'large');
+```
+
+By default, sources are provisioned using the smallest size (`3xsmall`). For more details on sizing sources, check the [`CREATE SOURCE`](../) documentation page.
+
 ## Related pages
 
+- [`CREATE SOURCE`](../)
 - [`CREATE VIEWS`](/sql/create-views/)
 
 [`bigint`]: /sql/types/bigint

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -31,6 +31,12 @@ _src_name_  | The name for the source.
 **IF NOT EXISTS**  | Do nothing (except issuing a notice) if a source with the same name already exists.
 **TICK INTERVAL**  | The interval at which the next datum should be emitted. Defaults to one second.
 
+### `WITH` options
+
+Field                                | Value     | Description
+-------------------------------------|-----------|-------------------------------------
+`SIZE`                               | `text`    | The size for the source. For valid sizes, see [source sizes](/sql/create-source#sizes).
+
 ## Description
 
 Materialize has several built-in load generators, which provide a quick way to

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -33,7 +33,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | The size for the source. For valid sizes, see [source sizes](/sql/create-source#sizes).
+`SIZE`                               | `text`    | Default: `3xsmall`. The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Features
 
@@ -174,6 +174,26 @@ FROM POSTGRES
   CONNECTION pg_connection
   PUBLICATION 'mz_source';
 ```
+
+### Sizing a source
+
+To provision a specific amount of CPU and memory to a source on creation, use the `SIZE` option:
+
+```sql
+CREATE SOURCE mz_source
+FROM POSTGRES
+  CONNECTION pg_connection
+  PUBLICATION 'mz_source'
+  WITH (SIZE = 'xsmall');
+```
+
+To resize the source after creation:
+
+```sql
+ALTER SOURCE mz_source SET (SIZE = 'large');
+```
+
+By default, sources are provisioned using the smallest size (`3xsmall`). For more details on sizing sources, check the [`CREATE SOURCE`](../) documentation page.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -29,6 +29,12 @@ _src_name_  | The name for the source.
 **CONNECTION** _connection_name_ | The name of the Postgres connection to use in the source. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#postgres) documentation page.
 **PUBLICATION** _publication_name_ | Postgres [publication](https://www.postgresql.org/docs/current/logical-replication-publication.html) (the replication data set containing the tables to be streamed to Materialize).
 
+### `WITH` options
+
+Field                                | Value     | Description
+-------------------------------------|-----------|-------------------------------------
+`SIZE`                               | `text`    | The size for the source. For valid sizes, see [source sizes](/sql/create-source#sizes).
+
 ## Features
 
 ### Change data capture

--- a/doc/user/layouts/partials/sql-grammar/alter-source.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-source.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="551" height="135">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">ALTER</text>
+   <rect x="117" y="3" width="78" height="32" rx="10"/>
+   <rect x="115"
+         y="1"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="125" y="21">SOURCE</text>
+   <rect x="235" y="35" width="86" height="32" rx="10"/>
+   <rect x="233"
+         y="33"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="53">IF EXISTS</text>
+   <rect x="361" y="3" width="56" height="32"/>
+   <rect x="359" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="369" y="21">name</text>
+   <rect x="437" y="3" width="46" height="32" rx="10"/>
+   <rect x="435"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="445" y="21">SET</text>
+   <rect x="503" y="3" width="26" height="32" rx="10"/>
+   <rect x="501"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="511" y="21">(</text>
+   <rect x="353" y="101" width="50" height="32" rx="10"/>
+   <rect x="351"
+         y="99"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="361" y="119">SIZE</text>
+   <rect x="423" y="101" width="54" height="32"/>
+   <rect x="421" y="99" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="431" y="119">value</text>
+   <rect x="497" y="101" width="26" height="32" rx="10"/>
+   <rect x="495"
+         y="99"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="119">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-220 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m50 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
+   <polygon points="541 115 549 111 549 119"/>
+   <polygon points="541 115 533 111 533 119"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="981">
+<svg xmlns="http://www.w3.org/2000/svg" width="601" height="1103">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -188,48 +188,94 @@
    <rect x="438" y="565" width="56" height="32"/>
    <rect x="436" y="563" width="56" height="32" class="nonterminal"/>
    <text class="nonterminal" x="446" y="583">name</text>
-   <rect x="171" y="827" width="94" height="32" rx="10"/>
-   <rect x="169"
-         y="825"
+   <rect x="111" y="823" width="94" height="32" rx="10"/>
+   <rect x="109"
+         y="821"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="845">ENVELOPE</text>
-   <rect x="305" y="827" width="60" height="32" rx="10"/>
-   <rect x="303"
-         y="825"
+   <text class="terminal" x="119" y="841">ENVELOPE</text>
+   <rect x="245" y="823" width="60" height="32" rx="10"/>
+   <rect x="243"
+         y="821"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="313" y="845">NONE</text>
-   <rect x="305" y="871" width="92" height="32" rx="10"/>
-   <rect x="303"
-         y="869"
+   <text class="terminal" x="253" y="841">NONE</text>
+   <rect x="245" y="867" width="92" height="32" rx="10"/>
+   <rect x="243"
+         y="865"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="313" y="889">DEBEZIUM</text>
-   <rect x="437" y="903" width="76" height="32" rx="10"/>
-   <rect x="435"
-         y="901"
+   <text class="terminal" x="253" y="885">DEBEZIUM</text>
+   <rect x="377" y="899" width="76" height="32" rx="10"/>
+   <rect x="375"
+         y="897"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="445" y="921">UPSERT</text>
-   <rect x="305" y="947" width="76" height="32" rx="10"/>
-   <rect x="303"
-         y="945"
+   <text class="terminal" x="385" y="917">UPSERT</text>
+   <rect x="245" y="943" width="76" height="32" rx="10"/>
+   <rect x="243"
+         y="941"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="313" y="965">UPSERT</text>
+   <text class="terminal" x="253" y="961">UPSERT</text>
+   <rect x="189" y="1053" width="58" height="32" rx="10"/>
+   <rect x="187"
+         y="1051"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="197" y="1071">WITH</text>
+   <rect x="267" y="1053" width="26" height="32" rx="10"/>
+   <rect x="265"
+         y="1051"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="275" y="1071">(</text>
+   <rect x="333" y="1053" width="48" height="32"/>
+   <rect x="331" y="1051" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="341" y="1071">field</text>
+   <rect x="401" y="1053" width="28" height="32" rx="10"/>
+   <rect x="399"
+         y="1051"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="409" y="1071">=</text>
+   <rect x="449" y="1053" width="38" height="32"/>
+   <rect x="447" y="1051" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="457" y="1071">val</text>
+   <rect x="333" y="1009" width="24" height="32" rx="10"/>
+   <rect x="331"
+         y="1007"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="1027">,</text>
+   <rect x="527" y="1053" width="26" height="32" rx="10"/>
+   <rect x="525"
+         y="1051"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="535" y="1071">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-579 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-390 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-467 262 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h392 m-422 0 h20 m402 0 h20 m-442 0 q10 0 10 10 m422 0 q0 -10 10 -10 m-432 10 v12 m422 0 v-12 m-422 12 q0 10 10 10 m402 0 q10 0 10 -10 m-412 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h168 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v24 m268 0 v-24 m-268 24 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m92 0 h10 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m-238 -42 v20 m268 0 v-20 m-268 20 v56 m268 0 v-56 m-268 56 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m76 0 h10 m0 0 h152 m43 -152 h-3"/>
-   <polygon points="591 809 599 805 599 813"/>
-   <polygon points="591 809 583 805 583 813"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-579 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-390 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-527 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h392 m-422 0 h20 m402 0 h20 m-442 0 q10 0 10 10 m422 0 q0 -10 10 -10 m-432 10 v12 m422 0 v-12 m-422 12 q0 10 10 10 m402 0 q10 0 10 -10 m-412 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h168 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v24 m268 0 v-24 m-268 24 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m92 0 h10 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m-238 -42 v20 m268 0 v-20 m-268 20 v56 m268 0 v-56 m-268 56 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m76 0 h10 m0 0 h152 m42 -152 l2 0 m2 0 l2 0 m2 0 l2 0 m-388 262 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="591 1067 599 1063 599 1071"/>
+   <polygon points="591 1067 583 1063 583 1071"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,52 +1,52 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="539" height="349">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="140" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="533" height="475">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="140" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="140"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">CREATE SOURCE</text>
-   <rect x="213" y="35" width="120" height="32" rx="10"/>
-   <rect x="211"
+   <text class="terminal" x="39" y="21">CREATE SOURCE</text>
+   <rect x="211" y="35" width="120" height="32" rx="10"/>
+   <rect x="209"
          y="33"
          width="120"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="221" y="53">IF NOT EXISTS</text>
-   <rect x="373" y="3" width="82" height="32"/>
-   <rect x="371" y="1" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="381" y="21">src_name</text>
-   <rect x="80" y="145" width="26" height="32" rx="10"/>
-   <rect x="78"
+   <text class="terminal" x="219" y="53">IF NOT EXISTS</text>
+   <rect x="371" y="3" width="82" height="32"/>
+   <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="379" y="21">src_name</text>
+   <rect x="76" y="145" width="26" height="32" rx="10"/>
+   <rect x="74"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="88" y="163">(</text>
-   <rect x="146" y="145" width="82" height="32"/>
-   <rect x="144" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="154" y="163">col_name</text>
-   <rect x="146" y="101" width="24" height="32" rx="10"/>
-   <rect x="144"
+   <text class="terminal" x="84" y="163">(</text>
+   <rect x="142" y="145" width="82" height="32"/>
+   <rect x="140" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="150" y="163">col_name</text>
+   <rect x="142" y="101" width="24" height="32" rx="10"/>
+   <rect x="140"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="154" y="119">,</text>
-   <rect x="288" y="145" width="196" height="32" rx="10"/>
-   <rect x="286"
+   <text class="terminal" x="150" y="119">,</text>
+   <rect x="284" y="145" width="196" height="32" rx="10"/>
+   <rect x="282"
          y="143"
          width="196"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="296" y="163">FROM LOAD GENERATOR</text>
+   <text class="terminal" x="292" y="163">FROM LOAD GENERATOR</text>
    <rect x="45" y="271" width="86" height="32" rx="10"/>
    <rect x="43"
          y="269"
@@ -90,8 +90,54 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="473" y="289">)</text>
+   <rect x="121" y="425" width="58" height="32" rx="10"/>
+   <rect x="119"
+         y="423"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="129" y="443">WITH</text>
+   <rect x="199" y="425" width="26" height="32" rx="10"/>
+   <rect x="197"
+         y="423"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="207" y="443">(</text>
+   <rect x="265" y="425" width="48" height="32"/>
+   <rect x="263" y="423" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="443">field</text>
+   <rect x="333" y="425" width="28" height="32" rx="10"/>
+   <rect x="331"
+         y="423"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="341" y="443">=</text>
+   <rect x="381" y="425" width="38" height="32"/>
+   <rect x="379" y="423" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="389" y="443">val</text>
+   <rect x="265" y="381" width="24" height="32" rx="10"/>
+   <rect x="263"
+         y="379"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="273" y="399">,</text>
+   <rect x="459" y="425" width="26" height="32" rx="10"/>
+   <rect x="457"
+         y="423"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="467" y="443">)</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-439 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m-188 44 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v14 m208 0 v-14 m-208 14 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m0 0 h178 m20 -34 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-503 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m23 -34 h-3"/>
-   <polygon points="529 285 537 281 537 289"/>
-   <polygon points="529 285 521 281 521 289"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-441 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m-188 44 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v14 m208 0 v-14 m-208 14 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m0 0 h178 m20 -34 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-499 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="523 439 531 435 531 443"/>
+   <polygon points="523 439 515 435 515 443"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="571" height="201">
+<svg xmlns="http://www.w3.org/2000/svg" width="571" height="327">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -55,11 +55,57 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="441" y="119">PUBLICATION</text>
-   <rect x="409" y="167" width="134" height="32"/>
-   <rect x="407" y="165" width="134" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="417" y="185">publication_name</text>
+   <rect x="220" y="167" width="134" height="32"/>
+   <rect x="218" y="165" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="228" y="185">publication_name</text>
+   <rect x="159" y="277" width="58" height="32" rx="10"/>
+   <rect x="157"
+         y="275"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="295">WITH</text>
+   <rect x="237" y="277" width="26" height="32" rx="10"/>
+   <rect x="235"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="245" y="295">(</text>
+   <rect x="303" y="277" width="48" height="32"/>
+   <rect x="301" y="275" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="311" y="295">field</text>
+   <rect x="371" y="277" width="28" height="32" rx="10"/>
+   <rect x="369"
+         y="275"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="379" y="295">=</text>
+   <rect x="419" y="277" width="38" height="32"/>
+   <rect x="417" y="275" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="427" y="295">val</text>
+   <rect x="303" y="233" width="24" height="32" rx="10"/>
+   <rect x="301"
+         y="231"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="311" y="251">,</text>
+   <rect x="497" y="277" width="26" height="32" rx="10"/>
+   <rect x="495"
+         y="275"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="505" y="295">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-552 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m116 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-184 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m134 0 h10 m3 0 h-3"/>
-   <polygon points="561 181 569 177 569 185"/>
-   <polygon points="561 181 553 177 553 185"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-552 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m116 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m134 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-259 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="561 291 569 287 569 295"/>
+   <polygon points="561 291 553 287 553 295"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/with-options.svg
+++ b/doc/user/layouts/partials/sql-grammar/with-options.svg
@@ -1,54 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="423" height="81">
+<svg xmlns="http://www.w3.org/2000/svg" width="463" height="97">
    <polygon points="9 61 1 57 1 65"/>
    <polygon points="17 61 9 57 9 65"/>
-   <rect x="31" y="47" width="58" height="32" rx="10"/>
-   <rect x="29"
+   <rect x="51" y="47" width="58" height="32" rx="10"/>
+   <rect x="49"
          y="45"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="65">WITH</text>
-   <rect x="109" y="47" width="26" height="32" rx="10"/>
-   <rect x="107"
+   <text class="terminal" x="59" y="65">WITH</text>
+   <rect x="129" y="47" width="26" height="32" rx="10"/>
+   <rect x="127"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="117" y="65">(</text>
-   <rect x="175" y="47" width="48" height="32"/>
-   <rect x="173" y="45" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="183" y="65">field</text>
-   <rect x="243" y="47" width="28" height="32" rx="10"/>
-   <rect x="241"
+   <text class="terminal" x="137" y="65">(</text>
+   <rect x="195" y="47" width="48" height="32"/>
+   <rect x="193" y="45" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="203" y="65">field</text>
+   <rect x="263" y="47" width="28" height="32" rx="10"/>
+   <rect x="261"
          y="45"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="251" y="65">=</text>
-   <rect x="291" y="47" width="38" height="32"/>
-   <rect x="289" y="45" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="299" y="65">val</text>
-   <rect x="175" y="3" width="24" height="32" rx="10"/>
-   <rect x="173"
+   <text class="terminal" x="271" y="65">=</text>
+   <rect x="311" y="47" width="38" height="32"/>
+   <rect x="309" y="45" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="319" y="65">val</text>
+   <rect x="195" y="3" width="24" height="32" rx="10"/>
+   <rect x="193"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="183" y="21">,</text>
-   <rect x="369" y="47" width="26" height="32" rx="10"/>
-   <rect x="367"
+   <text class="terminal" x="203" y="21">,</text>
+   <rect x="389" y="47" width="26" height="32" rx="10"/>
+   <rect x="387"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="377" y="65">)</text>
+   <text class="terminal" x="397" y="65">)</text>
    <path class="line"
-         d="m17 61 h2 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m3 0 h-3"/>
-   <polygon points="413 61 421 57 421 65"/>
-   <polygon points="413 61 405 57 405 65"/>
+         d="m17 61 h2 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="453 61 461 57 461 65"/>
+   <polygon points="453 61 445 57 445 65"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -81,6 +81,7 @@ create_source_kafka ::=
     ( ('KEY' | 'PARTITION' | 'OFFSET' | 'TIMESTAMP' | 'HEADERS' ) ('AS' name)? )*
   )?
   ('ENVELOPE' ('NONE' | 'DEBEZIUM' ('UPSERT')? | 'UPSERT'))?
+  ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_source_kinesis ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
@@ -92,12 +93,14 @@ create_source_load_generator ::=
   ('(' (col_name) ( ( ',' col_name ) )*)?
   'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER')
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
+  ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 load_generator_option ::=
     'TICK INTERVAL' interval
 create_source_postgres ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   'FROM' 'POSTGRES' 'CONNECTION' connection_name
   'PUBLICATION' publication_name
+  ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_source_s3 ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
@@ -396,7 +399,7 @@ update_stmt ::=
   'UPDATE' table_name ('AS'? alias)?
   'SET' ( column_name '=' expr ) ( ( ',' column_name '=' expr ) )*
   'WHERE' condition
-with_options ::= 'WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')'
+with_options ::= ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 with_options_aws ::= 'WITH' '('
     (
       static_credentials

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -5,6 +5,8 @@ alter_index ::=
   'ALTER' 'INDEX' name 'SET' 'ENABLED'
 alter_secret ::=
   'ALTER' 'SECRET' 'IF EXISTS'? name AS value
+alter_source ::=
+  'ALTER' 'SOURCE' 'IF EXISTS'? name 'SET' '(' 'SIZE' value ')'
 array_agg ::=
   'array_agg' '(' values  ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 as_of ::=


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds missing documentation for a feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
