### PR TITLE
coord: Refactor determine_timestamp

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -97,7 +97,11 @@ impl<S: Append + 'static> Coordinator<S> {
         if since.less_equal(&candidate) {
             Ok(candidate)
         } else {
-            coord_bail!(self.generate_error_msg(id_bundle, compute_instance, candidate));
+            coord_bail!(self.generate_timestamp_not_valid_error_msg(
+                id_bundle,
+                compute_instance,
+                candidate
+            ));
         }
     }
 
@@ -215,7 +219,7 @@ impl<S: Append + 'static> Coordinator<S> {
         })
     }
 
-    fn generate_error_msg(
+    fn generate_timestamp_not_valid_error_msg(
         &self,
         id_bundle: &CollectionIdBundle,
         compute_instance: ComputeInstanceId,


### PR DESCRIPTION
This commit refactors the `determine_timestamp` method to extract some logic out to helper methods. The rationale is that only logic relevant to understanding how timestamps are selected should be left in `determine_timestamp`. Everything else should be extracted out into helper methods, so they don't distract the reader.

### Motivation
This PR refactors existing code.

### Tips for reviewer
This entire PR is pure code movement, without any changes to actual logic.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
