### PR TITLE
[sinks] Remove the manual retry logic from our Kafka sink

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -442,6 +442,16 @@ impl KafkaSinkState {
         // all bets are off and full exactly once support is required.
         config.set("enable.idempotence", "true");
 
+        // We rely on the Kafka client's built-in retries for produced messages, instead of
+        // explicitly retrying ourselves. Aside from convenience, this also plays better with
+        // transactional producing: any failed send will fail a transaction, even if we manually
+        // re-produce it later.
+        //
+        // At time of writing, we're fine with the default values... but let's set them here to be
+        // explicit.
+        config.set("message.send.max.retries", "2147483647");
+        config.set("message.timeout.ms", "300000");
+
         // Increase limits for the Kafka producer's internal buffering of messages
         // Currently we don't have a great backpressure mechanism to tell indexes or
         // views to slow down, so the only thing we can do with a message that we


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

rdkafka should already retry messages on retriable errors. (For details, search [the rdkafka docs](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) for `message.send.max.retries`.) Not only does this make our own retry logic redundant, it also will never allow us to make progress: a transaction will fail if any send consistently fails, and rdkafka has no way to tell that the retries are "the same message" as before and not a totally distinct message, so even if our retries are successful we'll still fail the transaction.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
