### PR TITLE
opentel: make tracing filter dynamic

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -96,8 +96,7 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let tracing_target_callbacks =
-        mz_ore::tracing::configure("computed", &args.tracing).await?;
+    let tracing_target_callbacks = mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -130,7 +129,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_modify_filter_target(tracing_target_callbacks.tracing, payload).await
+                            mz_http_util::handle_modify_filter_target(
+                                tracing_target_callbacks.tracing,
+                                payload,
+                            )
+                            .await
                         }),
                     )
                     .route(

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -96,7 +96,7 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let (otel_enable_callback, stderr_filter_callback) =
+    let tracing_target_callbacks =
         mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     let mut _pid_file = None;
@@ -130,14 +130,14 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
+                            mz_http_util::handle_modify_filter_target(tracing_target_callbacks.tracing, payload).await
                         }),
                     )
                     .route(
                         "/api/stderr/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_modify_stderr_filter(
-                                stderr_filter_callback,
+                            mz_http_util::handle_modify_filter_target(
+                                tracing_target_callbacks.stderr,
                                 payload,
                             )
                             .await

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -574,10 +574,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         &metrics_registry,
     );
     let persist_clients = Arc::new(Mutex::new(persist_clients));
-    let orchestrator = Arc::new(TracingOrchestrator::new(
-        orchestrator,
-        args.tracing.clone(),
-    ));
+    let orchestrator = Arc::new(TracingOrchestrator::new(orchestrator, args.tracing.clone()));
     let controller = ControllerConfig {
         build_info: &mz_environmentd::BUILD_INFO,
         orchestrator,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -432,7 +432,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     } else {
         None
     };
-    let (otel_enable_callback, stderr_filter_callback) =
+    let tracing_target_callbacks =
         runtime.block_on(mz_ore::tracing::configure("environmentd", &args.tracing))?;
 
     // Initialize fail crate for failpoint support
@@ -577,7 +577,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     let orchestrator = Arc::new(TracingOrchestrator::new(
         orchestrator,
         args.tracing.clone(),
-        otel_enable_callback.clone(),
     ));
     let controller = ControllerConfig {
         build_info: &mz_environmentd::BUILD_INFO,
@@ -703,8 +702,7 @@ max log level: {max_log_level}",
             args.aws_external_id_prefix,
             secrets_reader,
         ),
-        otel_enable_callback,
-        stderr_filter_callback,
+        tracing_target_callbacks,
         storage_usage_collection_interval: args.storage_usage_collection_interval_sec,
     }))?;
 

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -734,14 +734,21 @@ impl InternalServer {
             .route(
                 "/api/opentelemetry/config",
                 routing::put(move |payload| async move {
-                    mz_http_util::handle_modify_filter_target(self.tracing_target_callbacks.tracing, payload).await
+                    mz_http_util::handle_modify_filter_target(
+                        self.tracing_target_callbacks.tracing,
+                        payload,
+                    )
+                    .await
                 }),
             )
             .route(
                 "/api/stderr/config",
                 routing::put(move |payload| async move {
-                    mz_http_util::handle_modify_filter_target(self.tracing_target_callbacks.stderr, payload)
-                        .await
+                    mz_http_util::handle_modify_filter_target(
+                        self.tracing_target_callbacks.stderr,
+                        payload,
+                    )
+                    .await
                 }),
             );
         axum::Server::bind(&addr).serve(router.into_make_service())

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -57,7 +57,7 @@ use mz_adapter::{
 };
 use mz_frontegg_auth::{FronteggAuthentication, FronteggError};
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::tracing::{OpenTelemetryEnableCallback, StderrFilterCallback};
+use mz_ore::tracing::TracingTargetCallbacks;
 use mz_repr::{Datum, RowArena};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Raw, Statement};
@@ -704,20 +704,17 @@ async fn auth<B>(
 #[derive(Clone)]
 pub struct InternalServer {
     metrics_registry: MetricsRegistry,
-    otel_enable_callback: OpenTelemetryEnableCallback,
-    stderr_filter_callback: StderrFilterCallback,
+    tracing_target_callbacks: TracingTargetCallbacks,
 }
 
 impl InternalServer {
     pub fn new(
         metrics_registry: MetricsRegistry,
-        otel_enable_callback: OpenTelemetryEnableCallback,
-        stderr_filter_callback: StderrFilterCallback,
+        tracing_target_callbacks: TracingTargetCallbacks,
     ) -> Self {
         Self {
             metrics_registry,
-            otel_enable_callback,
-            stderr_filter_callback,
+            tracing_target_callbacks,
         }
     }
 
@@ -737,13 +734,13 @@ impl InternalServer {
             .route(
                 "/api/opentelemetry/config",
                 routing::put(move |payload| async move {
-                    mz_http_util::handle_enable_otel(self.otel_enable_callback, payload).await
+                    mz_http_util::handle_modify_filter_target(self.tracing_target_callbacks.tracing, payload).await
                 }),
             )
             .route(
                 "/api/stderr/config",
                 routing::put(move |payload| async move {
-                    mz_http_util::handle_modify_stderr_filter(self.stderr_filter_callback, payload)
+                    mz_http_util::handle_modify_filter_target(self.tracing_target_callbacks.stderr, payload)
                         .await
                 }),
             );

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -37,7 +37,7 @@ use mz_frontegg_auth::FronteggAuthentication;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::task;
-use mz_ore::tracing::{OpenTelemetryEnableCallback, StderrFilterCallback};
+use mz_ore::tracing::TracingTargetCallbacks;
 use mz_persist_client::usage::StorageUsageClient;
 use mz_secrets::SecretsController;
 use mz_storage::types::connections::ConnectionContext;
@@ -111,10 +111,8 @@ pub struct Config {
     // === Tracing options. ===
     /// The metrics registry to use.
     pub metrics_registry: MetricsRegistry,
-    /// A callback to enable or disable the OpenTelemetry tracing collector.
-    pub otel_enable_callback: OpenTelemetryEnableCallback,
-    /// A callback to modify the stderr log filter
-    pub stderr_filter_callback: StderrFilterCallback,
+    /// Callbacks used to modify tracing/logging filters
+    pub tracing_target_callbacks: TracingTargetCallbacks,
 
     // === Testing options. ===
     /// A now generation function for mocking time.
@@ -212,8 +210,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         let metrics_registry = config.metrics_registry.clone();
         let server = http::InternalServer::new(
             metrics_registry,
-            config.otel_enable_callback,
-            config.stderr_filter_callback,
+            config.tracing_target_callbacks,
         );
         let bound_server = server.bind(config.internal_http_listen_addr);
         let internal_http_local_addr = bound_server.local_addr();

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -208,10 +208,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Listen on the internal HTTP API port.
     let internal_http_local_addr = {
         let metrics_registry = config.metrics_registry.clone();
-        let server = http::InternalServer::new(
-            metrics_registry,
-            config.tracing_target_callbacks,
-        );
+        let server = http::InternalServer::new(metrics_registry, config.tracing_target_callbacks);
         let bound_server = server.bind(config.internal_http_listen_addr);
         let internal_http_local_addr = bound_server.local_addr();
         task::spawn(|| "internal_http_server", {

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -214,8 +214,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         connection_context: ConnectionContext::for_tests(
             (Arc::clone(&orchestrator) as Arc<dyn SecretsController>).reader(),
         ),
-        otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
-        stderr_filter_callback: mz_ore::tracing::StderrFilterCallback::none(),
+        tracing_target_callbacks: mz_ore::tracing::TracingTargetCallbacks::default(),
         storage_usage_collection_interval: config.storage_usage_collection_interval,
     }))?;
     let server = Server {

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -110,38 +110,15 @@ pub async fn handle_prometheus(registry: &MetricsRegistry) -> impl IntoResponse 
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct DynamicOtelConfig {
-    enabled: bool,
-}
-
-/// Allows dynamic control of the OpenTelemetry `tracing` subscriber.
-#[allow(clippy::unused_async)]
-pub async fn handle_enable_otel(
-    callback: mz_ore::tracing::OpenTelemetryEnableCallback,
-    Json(cfg): Json<DynamicOtelConfig>,
-) -> impl IntoResponse {
-    match callback.call(cfg.enabled) {
-        Ok(()) => (
-            StatusCode::OK,
-            format!(
-                "Otel collector successfully {}",
-                if cfg.enabled { "enabled" } else { "disabled" }
-            ),
-        ),
-        Err(e) => (StatusCode::BAD_REQUEST, e.to_string()),
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct DynamicStderrConfig {
+pub struct DynamicFilterTarget {
     targets: String,
 }
 
 /// Allows dynamic control of the stderr log filter
 #[allow(clippy::unused_async)]
-pub async fn handle_modify_stderr_filter(
-    callback: mz_ore::tracing::StderrFilterCallback,
-    Json(cfg): Json<DynamicStderrConfig>,
+pub async fn handle_modify_filter_target(
+    callback: mz_ore::tracing::DynamicTargetsCallback,
+    Json(cfg): Json<DynamicFilterTarget>,
 ) -> impl IntoResponse {
     match cfg.targets.parse::<Targets>() {
         Ok(targets) => match callback.call(targets) {

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -285,7 +285,7 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 opentelemetry_header,
                 opentelemetry_filter,
                 opentelemetry_resource,
-                opentelemetry_enabled: _,
+                opentelemetry_enabled,
                 #[cfg(feature = "tokio-console")]
                     tokio_console_listen_addr: _,
                 #[cfg(feature = "tokio-console")]
@@ -312,6 +312,10 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 for kv in opentelemetry_resource {
                     args.push(format!("--opentelemetry-resource={}={}", kv.key, kv.value));
                 }
+                args.push(format!(
+                    "--opentelemetry-enabled={}",
+                    opentelemetry_enabled
+                ));
             }
             #[cfg(feature = "tokio-console")]
             if let Some(port) = tokio_console_port {

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -34,9 +34,7 @@ use mz_orchestrator::{
 use mz_ore::cli::{DefaultTrue, KeyValueArg};
 #[cfg(feature = "tokio-console")]
 use mz_ore::tracing::TokioConsoleConfig;
-use mz_ore::tracing::{
-    OpenTelemetryConfig, StderrLogConfig, TracingConfig,
-};
+use mz_ore::tracing::{OpenTelemetryConfig, StderrLogConfig, TracingConfig};
 
 /// Command line arguments for application tracing.
 ///
@@ -239,10 +237,7 @@ impl TracingOrchestrator {
     ///
     /// All services created by the orchestrator **must** embed the
     /// [`TracingCliArgs`] in their command-line argument parser.
-    pub fn new(
-        inner: Arc<dyn Orchestrator>,
-        tracing_args: TracingCliArgs,
-    ) -> TracingOrchestrator {
+    pub fn new(inner: Arc<dyn Orchestrator>, tracing_args: TracingCliArgs) -> TracingOrchestrator {
         TracingOrchestrator {
             inner,
             tracing_args,
@@ -312,10 +307,7 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 for kv in opentelemetry_resource {
                     args.push(format!("--opentelemetry-resource={}={}", kv.key, kv.value));
                 }
-                args.push(format!(
-                    "--opentelemetry-enabled={}",
-                    opentelemetry_enabled
-                ));
+                args.push(format!("--opentelemetry-enabled={}", opentelemetry_enabled));
             }
             #[cfg(feature = "tokio-console")]
             if let Some(port) = tokio_console_port {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -689,8 +689,7 @@ impl Runner {
             connection_context: ConnectionContext::for_tests(
                 (Arc::clone(&orchestrator) as Arc<dyn SecretsController>).reader(),
             ),
-            otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
-            stderr_filter_callback: mz_ore::tracing::StderrFilterCallback::none(),
+            tracing_target_callbacks: mz_ore::tracing::TracingTargetCallbacks::default(),
             storage_usage_collection_interval: Duration::from_secs(3600),
         };
         // We need to run the server on its own Tokio runtime, which in turn

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -127,8 +127,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let tracing_target_callbacks =
-        mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let tracing_target_callbacks = mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -166,7 +165,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_modify_filter_target(tracing_target_callbacks.tracing, payload).await
+                            mz_http_util::handle_modify_filter_target(
+                                tracing_target_callbacks.tracing,
+                                payload,
+                            )
+                            .await
                         }),
                     )
                     .route(

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -127,7 +127,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let (otel_enable_callback, stderr_filter_callback) =
+    let tracing_target_callbacks =
         mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
@@ -166,14 +166,14 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
+                            mz_http_util::handle_modify_filter_target(tracing_target_callbacks.tracing, payload).await
                         }),
                     )
                     .route(
                         "/api/stderr/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_modify_stderr_filter(
-                                stderr_filter_callback,
+                            mz_http_util::handle_modify_filter_target(
+                                tracing_target_callbacks.stderr,
                                 payload,
                             )
                             .await


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Follow on to https://github.com/MaterializeInc/materialize/pull/14818, this PR updates our tracing filter to be dynamically configurable in the same way as `stderr` logging now is, and incorporates @guswynn's feedback from before.

Perhaps semi-controversially, this PR also removes the dynamic propagation of `opentelemetry-enabled` down to `computed` and `storaged` pods. I think the current model is a bit of a footgun ([more details](https://github.com/MaterializeInc/materialize/pull/14818#discussion_r973365811)), and instead the propagated flag is always based on the CLI flag passed into `environmentd`. For now, this still leaves us the ability to toggle telemetry for an environment (update `environmentd` and bounce it), and direct updates to the filters (hit each pod's http api).


### Motivation

  * This PR adds a feature that has not yet been specified.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
