### PR TITLE
`inline_literal_constraints` should also kick in for complex expressions

### DIFF
--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -494,7 +494,8 @@ query T multiline
 EXPLAIN SELECT a FROM t1
 WHERE (
     (a = 1 AND b like 'nope') OR
-    (a = 2)
+    (a = 2) OR
+    (a = 1 AND a = 2)
 ) AND
 (b like 'l%' OR b like 'aaa')
 ----
@@ -547,6 +548,23 @@ WHERE a IN (1,2) AND a IN (2,3,4)
 | ReadExistingIndex materialize.public.idx_t1_a
 | | Lookup value (2)
 | Project (#0)
+
+EOF
+
+# Inlining complex expressions in `inline_literal_constraints`.
+# The important thing in this query is the `(a = 2 AND a = 3)` appearing twice. The other stuff is just to make it
+# impossible for `undistribute_and_or` to factor out the `(a = 2 AND a = 3)`, so that MFP CSE can kick in, and then we
+# can test that `inline_literal_constraints` inlines it back.
+
+query T multiline
+EXPLAIN SELECT a FROM t1
+WHERE
+(b = 'bbb' OR b = 'y') AND
+((a = 2 AND a = 3) OR b = 'x' OR b = 'y') AND
+((a = 2 AND a = 3) OR b = 'z')
+----
+%0 =
+| Constant
 
 EOF
 


### PR DESCRIPTION
@philip-stoev's super thorough testing found an issue in the literal constraints detection while testing the predicate duplication PR:
https://github.com/MaterializeInc/materialize/pull/14725#issuecomment-1253679742
What is happening there is that before the commit in that PR, an impossible predicate was getting turned into `false`, after which constant folding removed the union with the empty branch. (This would have been almost impossible to figure out without @aalexandrov's [tracing](https://github.com/MaterializeInc/materialize/pull/14913).)
However, after that commit, the impossible expression is not getting removed because the predicate duplication causes that expression `((#1 = 3) AND (#1 = 4))` to appear twice in the predicate, after which MFP CSE lifts it out into a `map`, and then `detect_literal_constraints` cannot eliminate this impossible expression, because it is hidden by the MFP CSE.

This PR makes `inline_literal_constraints` smarter to detect literal constraints inside complex expressions, i.e., it now does a traversal instead of just directly matching. So now it realizes that `((#1 = 3) AND (#1 = 4))` involves literal constraints, so it inlines it. The inlining enables `detect_literal_constraints` to see into the expression, detect the impossibility, and simplify to `false`.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/pull/14725#issuecomment-1253679742

### Tips for reviewer

The second commit is just a trivial fix in an earlier test to make it consistent.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No significant change.
