### PR TITLE
doc/user: make integration guide titles consistent

### DIFF
--- a/doc/user/content/integrations/aws-aurora.md
+++ b/doc/user/content/integrations/aws-aurora.md
@@ -1,5 +1,5 @@
 ---
-title: "How to connect AWS Aurora to Materialize"
+title: "AWS Aurora (PostgreSQL)"
 description: "How to connect AWS Aurora PostgreSQL as a source to Materialize."
 menu:
   main:

--- a/doc/user/content/integrations/aws-msk.md
+++ b/doc/user/content/integrations/aws-msk.md
@@ -1,5 +1,5 @@
 ---
-title: "How to connect AWS MSK to Materialize"
+title: "AWS Managed Streaming for Kafka (MSK)"
 description: "How to securely connect an AWS Managed Streaming for Kafka (MSK) cluster as a source to Materialize."
 menu:
   main:

--- a/doc/user/content/integrations/aws-rds.md
+++ b/doc/user/content/integrations/aws-rds.md
@@ -1,5 +1,5 @@
 ---
-title: "How to connect AWS RDS to Materialize"
+title: "AWS RDS (PostgreSQL)"
 description: "How to connect Amazon RDS managed PostgreSQL as a source to Materialize"
 menu:
   main:

--- a/doc/user/content/integrations/azure-postgres.md
+++ b/doc/user/content/integrations/azure-postgres.md
@@ -1,5 +1,5 @@
 ---
-title: "How to connect Azure Database for PostgreSQL to Materialize"
+title: "Azure Database for PostgreSQL"
 description: "How to connect Azure Database for PostgreSQL as a source to Materialize."
 menu:
   main:

--- a/doc/user/content/integrations/digitalocean-postgres.md
+++ b/doc/user/content/integrations/digitalocean-postgres.md
@@ -1,10 +1,6 @@
 ---
-title: "How to connect DigitalOcean Managed PostgreSQL to Materialize"
+title: "DigitalOcean Managed PostgreSQL"
 description: "How to connect DigitalOcean Managed PostgreSQL as a source to Materialize."
-menu:
-  main:
-    parent: "integration-guides"
-    name: "DigitalOcean PostgreSQL"
 ---
 
 Materialize can read data from DigitalOcean Managed PostgreSQL via the direct [Postgres Source](/sql/create-source/postgres/).

--- a/doc/user/content/integrations/gcp-cloud-sql.md
+++ b/doc/user/content/integrations/gcp-cloud-sql.md
@@ -1,5 +1,5 @@
 ---
-title: "How to connect GCP Cloud SQL to Materialize"
+title: "GCP Cloud SQL (PostgreSQL)"
 description: "How to connect GCP Cloud SQL as a source to Materialize."
 menu:
   main:

--- a/doc/user/content/integrations/redpanda-cloud.md
+++ b/doc/user/content/integrations/redpanda-cloud.md
@@ -1,5 +1,5 @@
 ---
-title: "How to connect Redpanda Cloud to Materialize"
+title: "Redpanda Cloud"
 description: "How to securely connect a Redpanda Cloud cluster as a source to Materialize."
 menu:
   main:

--- a/doc/user/content/integrations/redpanda.md
+++ b/doc/user/content/integrations/redpanda.md
@@ -1,5 +1,5 @@
 ---
-title: "How to use Redpanda with Materialize"
+title: "Redpanda"
 description: "Get details about using Materialize with Redpanda"
 aliases:
   /third-party/redpanda/


### PR DESCRIPTION
Ensure that all integrations guides are consistently titled using the name of the tool. We could probably get rid of the Redpanda guide; need to double-check whether the configuration parameters that had to be enabled explicitly for previous versions are still valid (IIRC, these are now enabled by default in Redpanda too).