### PR TITLE
doc/user: adapt language cheatsheets to nu Materialize

### DIFF
--- a/doc/user/content/integrations/golang.md
+++ b/doc/user/content/integrations/golang.md
@@ -13,7 +13,7 @@ Materialize is **wire-compatible** with PostgreSQL, which means that Go applicat
 
 ## Connect
 
-To [connect](https://pkg.go.dev/github.com/jackc/pgx#ConnConfig) to a local Materialize instance using `pgx`, you can use either a URI or DSN [connection string](https://pkg.go.dev/github.com/jackc/pgx#ParseConnectionString):
+To [connect](https://pkg.go.dev/github.com/jackc/pgx#ConnConfig) to Materialize using `pgx`, you can use either a URI or DSN [connection string](https://pkg.go.dev/github.com/jackc/pgx#ParseConnectionString):
 
 ```go
 package main
@@ -27,7 +27,7 @@ import (
 func main() {
 
 	ctx := context.Background()
-	connStr := "postgres://materialize@localhost:6875/materialize?sslmode=disable"
+	connStr := "postgres://MATERIALIZE_USERNAME:APP_SPECIFIC_PASSWORD@MATERIALIZE_HOST:6875/materialize"
 
 	conn, err := pgx.Connect(ctx, connStr)
 	if err != nil {
@@ -98,7 +98,7 @@ An `MzDiff` value of `-1` indicates that Materialize is deleting one row with th
 
 Querying Materialize is identical to querying a PostgreSQL database: Go executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
-Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+Because Materialize maintains results incrementally updated, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
 To query a view `my_view` using a `SELECT` statement:
 

--- a/doc/user/content/integrations/java-jdbc.md
+++ b/doc/user/content/integrations/java-jdbc.md
@@ -13,7 +13,7 @@ Materialize is **wire-compatible** with PostgreSQL, which means that Java applic
 
 ## Connect
 
-To [connect](https://jdbc.postgresql.org/documentation/head/connect.html) to a local Materialize instance using the PostgreSQL JDBC Driver:
+To [connect](https://jdbc.postgresql.org/documentation/head/connect.html) to Materialize using the PostgreSQL JDBC Driver:
 
 ```java
 import java.sql.Connection;
@@ -23,9 +23,9 @@ import java.util.Properties;
 
 public class App {
 
-    private final String url = "jdbc:postgresql://localhost:6875/materialize";
-    private final String user = "materialize";
-    private final String password = "materialize";
+    private final String url = "jdbc:postgresql://MATERIALIZE_HOST:6875/materialize";
+    private final String user = "MATERIALIZE_USERNAME";
+    private final String password = "MATERIALIZE_PASSWORD";
 
     /**
      * Connect to Materialize
@@ -36,7 +36,7 @@ public class App {
         Properties props = new Properties();
         props.setProperty("user", user);
         props.setProperty("password", password);
-        props.setProperty("ssl","false");
+        props.setProperty("ssl","true");
         Connection conn = null;
         try {
             conn = DriverManager.getConnection(url, props);
@@ -73,9 +73,9 @@ import java.sql.Statement;
 
 public class App {
 
-    private final String url = "jdbc:postgresql://localhost:6875/materialize";
-    private final String user = "materialize";
-    private final String password = "materialize";
+    private final String url = "jdbc:postgresql://MATERIALIZE_HOST:6875/materialize";
+    private final String user = "MATERIALIZE_USERNAME";
+    private final String password = "MATERIALIZE_PASSWORD";
 
     /**
      * Connect to Materialize
@@ -86,7 +86,7 @@ public class App {
         Properties props = new Properties();
         props.setProperty("user", user);
         props.setProperty("password", password);
-        props.setProperty("ssl","false");
+        props.setProperty("ssl","true");
 
         return DriverManager.getConnection(url, props);
 
@@ -132,7 +132,7 @@ A `mz_diff` value of `-1` indicates that Materialize is deleting one row with th
 
 Querying Materialize is identical to querying a PostgreSQL database: Java executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
-Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+Because Materialize keeps results incrementally updated, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
 To query a view `my_view` using a `SELECT` statement:
 
@@ -146,9 +146,9 @@ import java.sql.Statement;
 
 public class App {
 
-    private final String url = "jdbc:postgresql://localhost:6875/materialize";
-    private final String user = "materialize";
-    private final String password = "materialize";
+    private final String url = "jdbc:postgresql://MATERIALIZE_HOST:6875/materialize";
+    private final String user = "MATERIALIZE_USERNAME";
+    private final String password = "MATERIALIZE_PASSWORD";
 
     /**
      * Connect to Materialize
@@ -159,7 +159,7 @@ public class App {
         Properties props = new Properties();
         props.setProperty("user", user);
         props.setProperty("password", password);
-        props.setProperty("ssl","false");
+        props.setProperty("ssl","true");
 
         return DriverManager.getConnection(url, props);
 
@@ -206,9 +206,9 @@ import java.sql.PreparedStatement;
 
 public class App {
 
-    private final String url = "jdbc:postgresql://localhost:6875/materialize";
-    private final String user = "materialize";
-    private final String password = "materialize";
+    private final String url = "jdbc:postgresql://MATERIALIZE_HOST:6875/materialize";
+    private final String user = "MATERIALIZE_USERNAME";
+    private final String password = "MATERIALIZE_PASSWORD";
 
     /**
      * Connect to Materialize
@@ -219,7 +219,7 @@ public class App {
         Properties props = new Properties();
         props.setProperty("user", user);
         props.setProperty("password", password);
-        props.setProperty("ssl","false");
+        props.setProperty("ssl","true");
 
         return DriverManager.getConnection(url, props);
 
@@ -265,9 +265,9 @@ import java.sql.PreparedStatement;
 
 public class App {
 
-    private final String url = "jdbc:postgresql://localhost:6875/materialize";
-    private final String user = "materialize";
-    private final String password = "materialize";
+    private final String url = "jdbc:postgresql://MATERIALIZE_HOST:6875/materialize";
+    private final String user = "MATERIALIZE_USERNAME";
+    private final String password = "MATERIALIZE_PASSWORD";
 
     /**
      * Connect to Materialize
@@ -278,7 +278,7 @@ public class App {
         Properties props = new Properties();
         props.setProperty("user", user);
         props.setProperty("password", password);
-        props.setProperty("ssl","false");
+        props.setProperty("ssl","true");
 
         return DriverManager.getConnection(url, props);
 

--- a/doc/user/content/integrations/node-js.md
+++ b/doc/user/content/integrations/node-js.md
@@ -13,11 +13,18 @@ Materialize is **wire-compatible** with PostgreSQL, which means that Node.js app
 
 ## Connect
 
-To [connect](https://node-postgres.com/features/connecting) to a local Materialize instance using `node-postgres`, you can use the connection URI shorthand (`postgres://<USER>@<HOST>:<PORT>/<SCHEMA>`):
+To [connect](https://node-postgres.com/features/connecting) to Materialize using `node-postgres`, you can use the connection URI shorthand (`postgres://<USER>@<HOST>:<PORT>/<SCHEMA>`):
 
 ```js
 const { Client } = require('pg');
-const client = new Client('postgres://materialize@localhost:6875/materialize');
+const client = new Client({
+    user: MATERIALIZE_USERNAME,
+    password: MATERIALIZE_PASSWORD,
+    host: MATERIALIZE_HOST,
+    port: 6875,
+    database: 'materialize',
+    ssl: true
+});
 
 async function main() {
     await client.connect();
@@ -37,7 +44,14 @@ To read a stream of updates from an existing materialized view, open a long-live
 const { Client } = require('pg');
 
 async function main() {
-  const client = new Client('postgres://materialize@localhost:6875/materialize');
+  const client = new Client({
+    user: MATERIALIZE_USERNAME,
+    password: MATERIALIZE_PASSWORD,
+    host: MATERIALIZE_HOST,
+    port: 6875,
+    database: "materialize",
+    ssl: true,
+  });
   await client.connect();
 
   await client.query('BEGIN');
@@ -98,13 +112,21 @@ client.connect((err, client) => {
 
 Querying Materialize is identical to querying a PostgreSQL database: Node.js executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
-Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+Because Materialize keeps results incrementally updated, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
 To query a view `my_view` using a `SELECT` statement:
 
 ```js
 const { Client } = require('pg');
-const client = new Client('postgres://materialize@localhost:6875/materialize');
+
+const client = new Client({
+  user: MATERIALIZE_USERNAME,
+  password: MATERIALIZE_PASSWORD,
+  host: MATERIALIZE_HOST,
+  port: 6875,
+  database: 'materialize',
+  ssl: true
+});
 
 async function main() {
   await client.connect();
@@ -119,14 +141,14 @@ For more details, see the  [`node-postgres` query](https://node-postgres.com/fea
 
 ## Push data to a source
 
-Materialize processes live streams of data and maintains views in memory, relying on external systems (like PostgreSQL, or Kafka) to serve as "systems of record" for the data. Instead of updating Materialize directly, **Node.js should send data to an intermediary system**. Materialize connects to the intermediary system as a [source](/sql/create-source/) and reads streaming updates from it.
+Materialize processes live streams of data and maintains query results up-to-date as new data arrives, relying on external systems (like PostgreSQL, or Kafka) to serve as "systems of record" for the data. Instead of updating Materialize directly, **Node.js should send data to an intermediary system**. Materialize connects to the intermediary system as a [source](/sql/create-source/) and reads streaming updates from it.
 
 The table below lists the intermediary systems a Node.js application can use to feed data into Materialize:
 
 Intermediary System | Notes
 -------------|-------------
 **Kafka** | Produce messages from [Node.js to Kafka](https://kafka.js.org/docs/getting-started), and create a [Kafka source](/sql/create-source/json-kafka/) to consume them. This is recommended for scenarios where low-latency and high-throughput are important.
-**PostgreSQL** | Send data from Node.js to PostgreSQL, and create a [PostgreSQL source](/sql/create-source/postgres/) that consumes a replication stream from the database based on its write-ahead log. This is recommended for Node.js apps that already use PostgreSQL and fast-changing transactional data.to the stream.
+**PostgreSQL** | Send data from Node.js to PostgreSQL, and create a [PostgreSQL source](/sql/create-source/postgres/) that consumes a replication stream from the database based on its write-ahead log. This is recommended for Node.js apps that already use PostgreSQL and fast-changing transactional data to the stream.
 
 ## Insert data into tables
 
@@ -136,7 +158,15 @@ Most data in Materialize will stream in via an external system, but a [table](/s
 
 ```js
 const { Client } = require('pg');
-const client = new Client('postgres://materialize@localhost:6875/materialize');
+
+const client = new Client({
+    user: MATERIALIZE_USERNAME,
+    password: MATERIALIZE_PASSWORD,
+    host: MATERIALIZE_HOST,
+    port: 6875,
+    database: 'materialize',
+    ssl: true
+});
 
 const text = 'INSERT INTO countries(code, name) VALUES($1, $2);';
 const values = ['GH', 'GHANA'];
@@ -158,7 +188,15 @@ Typically, you create sources, views, and indexes when deploying Materialize, bu
 
 ```js
 const { Client } = require('pg');
-const client = new Client('postgres://materialize@localhost:6875/materialize');
+
+const client = new Client({
+    user: MATERIALIZE_USERNAME,
+    password: MATERIALIZE_PASSWORD,
+    host: MATERIALIZE_HOST,
+    port: 6875,
+    database: 'materialize',
+    ssl: true
+});
 
 async function main() {
     await client.connect();
@@ -177,7 +215,15 @@ For more information, see [`CREATE SOURCE`](/sql/create-source/).
 
 ```js
 const { Client } = require('pg');
-const client = new Client('postgres://materialize@localhost:6875/materialize');
+
+const client = new Client({
+    user: MATERIALIZE_USERNAME,
+    password: MATERIALIZE_PASSWORD,
+    host: MATERIALIZE_HOST,
+    port: 6875,
+    database: "materialize",
+    ssl: true,
+});
 
 async function main() {
     await client.connect();

--- a/doc/user/content/integrations/php.md
+++ b/doc/user/content/integrations/php.md
@@ -13,7 +13,7 @@ Materialize is **wire-compatible** with PostgreSQL, which means that PHP applica
 
 ## Connect
 
-To [connect](https://www.php.net/manual/en/ref.pdo-pgsql.connection.php) to a local Materialize instance using `PDO_PGSQL`:
+To [connect](https://www.php.net/manual/en/ref.pdo-pgsql.connection.php) to Materialize using `PDO_PGSQL`:
 
 ```php
 <?php
@@ -35,7 +35,7 @@ function connect(string $host, int $port, string $db, string $user, string $pass
     }
 }
 
-$connection = connect('localhost', 6875, 'materialize', 'materialize', 'materialize');
+$connection = connect('MATERIALIZE_HOST', 6875, 'materialize', 'MATERIALIZE_USERNAME', 'MATERIALIZE_PASSWORD');
 ```
 
 You can add the above code to a `config.php` file and then include it in your application with `require 'connect.php';`.
@@ -101,7 +101,7 @@ An `mz_diff` value of `-1` indicates Materialize is deleting one row with the in
 
 Querying Materialize is identical to querying a PostgreSQL database: PHP executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
-Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+Because Materialize keeps results incrementally updated, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
 To query a view `my_view` using a `SELECT` statement:
 

--- a/doc/user/content/integrations/python.md
+++ b/doc/user/content/integrations/python.md
@@ -21,7 +21,7 @@ To [connect](https://www.psycopg.org/docs/usage.html) to a local Materialize ins
 import psycopg2
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg2.connect(dsn)
 ```
 
@@ -37,7 +37,7 @@ To read a stream of updates from an existing materialized view, open a long-live
 import psycopg2
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg2.connect(dsn)
 
 with conn.cursor() as cur:
@@ -77,7 +77,7 @@ it provides has a `stream` feature where rows are not buffered, which allows you
 import psycopg3
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg3.connect(dsn)
 
 conn = psycopg3.connect(dsn)
@@ -90,7 +90,7 @@ with conn.cursor() as cur:
 
 Querying Materialize is identical to querying a PostgreSQL database: Python executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
-Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+Because Materialize keeps results incrementally updated, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
 To query a view `my_view` with a `SELECT` statement:
 
@@ -100,7 +100,7 @@ To query a view `my_view` with a `SELECT` statement:
 import psycopg2
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg2.connect(dsn)
 
 with conn.cursor() as cur:
@@ -123,7 +123,7 @@ Most data in Materialize will stream in via an external system, but a [table](/s
 import psycopg2
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg2.connect(dsn)
 
 cur = conn.cursor()
@@ -153,7 +153,7 @@ Typically, you create sources, views, and indexes when deploying Materialize, al
 import psycopg2
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg2.connect(dsn)
 conn.autocommit = True
 
@@ -177,7 +177,7 @@ For more information, see [`CREATE SOURCE`](/sql/create-source/).
 import psycopg2
 import sys
 
-dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+dsn = "postgresql://MATERIALIZE_USERNAME:MATERIALIZE_PASSWORD@MATERIALIZE_HOST:6875/materialize?sslmode=enabled"
 conn = psycopg2.connect(dsn)
 conn.autocommit = True
 

--- a/doc/user/content/integrations/ruby.md
+++ b/doc/user/content/integrations/ruby.md
@@ -13,12 +13,12 @@ Materialize is **wire-compatible** with PostgreSQL, which means that Ruby applic
 
 ## Connect
 
-To connect to a local instance of Materialize using `pg`:
+To connect to Materialize using `pg`:
 
 ```ruby
 require 'pg'
 
-conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
+conn = PG.connect(host:"MATERIALIZE_HOST", port: 6875, user: "MATERIALIZE_USERNAME", password: "MATERIALIZE_PASSWORD")
 ```
 
 If you don't have a `pg` gem, you can install it with:
@@ -37,7 +37,7 @@ To read a stream of updates from an existing materialized view, open a long-live
 require 'pg'
 
 # Locally running instance:
-conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
+conn = PG.connect(host:"MATERIALIZE_HOST", port: 6875, user: "MATERIALIZE_USERNAME", password: "MATERIALIZE_PASSWORD")
 conn.exec('BEGIN')
 conn.exec('DECLARE c CURSOR FOR TAIL my_view')
 
@@ -68,14 +68,14 @@ An `mz_diff` value of `-1` indicates Materialize is deleting one row with the in
 
 Querying Materialize is identical to querying a PostgreSQL database: Ruby executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
-Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+Because Materialize keeps results incrementally updated, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
 To query a view `my_view` using a `SELECT` statement:
 
 ```ruby
 require 'pg'
 
-conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
+conn = PG.connect(host:"MATERIALIZE_HOST", port: 6875, user: "MATERIALIZE_USERNAME", password: "MATERIALIZE_PASSWORD")
 
 res  = conn.exec('SELECT * FROM my_view')
 
@@ -95,7 +95,7 @@ Most data in Materialize will stream in via an external system, but a [table](/s
 ```ruby
 require 'pg'
 
-conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
+conn = PG.connect(host:"MATERIALIZE_HOST", port: 6875, user: "MATERIALIZE_USERNAME", password: "MATERIALIZE_PASSWORD")
 
 conn.exec("INSERT INTO my_table (my_column) VALUES ('some_value')")
 
@@ -115,7 +115,7 @@ Typically, you create sources, views, and indexes when deploying Materialize, bu
 ```ruby
 require 'pg'
 
-conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
+conn = PG.connect(host:"MATERIALIZE_HOST", port: 6875, user: "MATERIALIZE_USERNAME", password: "MATERIALIZE_PASSWORD")
 
 # Create a source
 src = conn.exec(
@@ -138,7 +138,7 @@ For more information, see [`CREATE SOURCE`](/sql/create-source/).
 ```ruby
 require 'pg'
 
-conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
+conn = PG.connect(host:"MATERIALIZE_HOST", port: 6875, user: "MATERIALIZE_USERNAME", password: "MATERIALIZE_PASSWORD")
 
 # Create a view
 view = conn.exec(


### PR DESCRIPTION
Language cheatsheets were still using local connections. Adapted to nu Materialize based on the updated examples in the [`connection-examples` repo](https://github.com/MaterializeInc/connection-examples/tree/unstable).