### PR TITLE
storage: add TPCH load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,6 +4223,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "csv-core",
+ "dec",
  "derivative",
  "differential-dataflow",
  "fail",

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -28,8 +28,10 @@ Field | Use
 _src_name_  | The name for the source.
 **COUNTER** | Use the [counter](#counter) load generator.
 **AUCTION** | Use the [auction](#auction) load generator.
+| **TPCH** | Use the [tpch](#tpch) load generator.
 **IF NOT EXISTS**  | Do nothing (except issuing a notice) if a source with the same name already exists.
 **TICK INTERVAL**  | The interval at which the next datum should be emitted. Defaults to one second.
+**SCALE FACTOR**  | The scale factor for the `TPCH` generator. Defaults to `0.01` (~ 10MB).
 **FOR ALL TABLES** | Creates subsources for all tables in the load generator.
 **FOR TABLES** _table_name_ | Creates subsources for specific tables in the load generator.
 
@@ -104,6 +106,11 @@ create the following subsources:
 The organizations, users, and accounts are fixed at the time the source
 is created. Each tick interval, either a new auction is started, or a new bid
 is placed in the currently ongoing auction.
+
+### TPCH
+
+The TPCH load generator implements the TPC-H benchmark specification.
+The TPCH source must be used with `FOR ALL TABLES`, which will create the standard TPCH relations.
 
 ## Examples
 

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -91,13 +91,14 @@ create_source_kinesis ::=
   ('ENVELOPE NONE')?
 create_source_load_generator ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
-  ('(' (col_name) ( ( ',' col_name ) )*)?
-  'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER')
+  'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER' | 'TPCH')
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
   ('FOR ALL TABLES' | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
+  'FOR ALL TABLES'?
 load_generator_option ::=
     'TICK INTERVAL' interval
+    | 'SCALE FACTOR' scale_factor
 create_source_postgres ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   'FROM' 'POSTGRES' 'CONNECTION' connection_name

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -79,3 +79,36 @@ cast_from!(isize, i64);
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 cast_from!(isize, i128);
+
+/// Returns `Some` if `f` can losslessly be converted to an i64.
+pub fn f64_to_i64(f: f64) -> Option<i64> {
+    let i = f as i64;
+    let i_as_f = i as f64;
+    if f == i_as_f {
+        Some(i)
+    } else {
+        None
+    }
+}
+
+#[test]
+fn test_f64_to_i64() {
+    let cases = vec![
+        (0.0, Some(0)),
+        (1.0, Some(1)),
+        (1.5, None),
+        (f64::INFINITY, None),
+        (f64::NAN, None),
+        (f64::EPSILON, None),
+        (f64::MAX, None),
+        (f64::MIN, None),
+        (9223372036854775807f64, Some(i64::MAX)),
+        (-9223372036854775808f64, Some(i64::MIN)),
+        (9223372036854775807f64 + 10_000f64, None),
+        (-9223372036854775808f64 - 10_000f64, None),
+    ];
+    for (f, expect) in cases {
+        let r = f64_to_i64(f);
+        assert_eq!(r, expect, "input: {f}");
+    }
+}

--- a/src/repr/src/adt/date.rs
+++ b/src/repr/src/adt/date.rs
@@ -108,6 +108,16 @@ impl Date {
         // result of this.
         self.days + Self::UNIX_EPOCH_TO_PG_EPOCH
     }
+
+    /// Returns this date with `days` added to it.
+    pub fn checked_add(self, days: i32) -> Result<Date, DateError> {
+        let days = if let Some(days) = self.days.checked_add(days) {
+            days
+        } else {
+            return Err(DateError::OutOfRange);
+        };
+        Self::from_pg_epoch(days)
+    }
 }
 
 impl Sub for Date {

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1045,6 +1045,7 @@ impl_display_t!(CreateSourceConnection);
 pub enum LoadGenerator {
     Counter,
     Auction,
+    Tpch,
 }
 
 impl AstDisplay for LoadGenerator {
@@ -1052,6 +1053,7 @@ impl AstDisplay for LoadGenerator {
         match self {
             Self::Counter => f.write_str("COUNTER"),
             Self::Auction => f.write_str("AUCTION"),
+            Self::Tpch => f.write_str("TPCH"),
         }
     }
 }
@@ -1059,12 +1061,14 @@ impl_display!(LoadGenerator);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LoadGeneratorOptionName {
+    ScaleFactor,
     TickInterval,
 }
 
 impl AstDisplay for LoadGeneratorOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
+            LoadGeneratorOptionName::ScaleFactor => "SCALE FACTOR",
             LoadGeneratorOptionName::TickInterval => "TICK INTERVAL",
         })
     }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -282,6 +282,7 @@ Row
 Rows
 S3
 Sasl
+Scale
 Scan
 Schema
 Schemas
@@ -336,6 +337,7 @@ Timestamp
 To
 Token
 Topic
+Tpch
 Trace
 Trailing
 Transaction

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2527,9 +2527,10 @@ impl<'a> Parser<'a> {
             }
             LOAD => {
                 self.expect_keyword(GENERATOR)?;
-                let generator = match self.expect_one_of_keywords(&[COUNTER, AUCTION])? {
+                let generator = match self.expect_one_of_keywords(&[COUNTER, AUCTION, TPCH])? {
                     COUNTER => LoadGenerator::Counter,
                     AUCTION => LoadGenerator::Auction,
+                    TPCH => LoadGenerator::Tpch,
                     _ => unreachable!(),
                 };
                 let options = if self.consume_token(&Token::LParen) {
@@ -2565,7 +2566,11 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_load_generator_option(&mut self) -> Result<LoadGeneratorOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[TICK])? {
+        let name = match self.expect_one_of_keywords(&[SCALE, TICK])? {
+            SCALE => {
+                self.expect_keyword(FACTOR)?;
+                LoadGeneratorOptionName::ScaleFactor
+            }
             TICK => {
                 self.expect_keyword(INTERVAL)?;
                 LoadGeneratorOptionName::TickInterval

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -216,6 +216,27 @@ impl ImpliedValue for bool {
     }
 }
 
+impl TryFromValue<Value> for f64 {
+    fn try_from_value(v: Value) -> Result<Self, PlanError> {
+        match v {
+            Value::Number(v) => v
+                .parse::<f64>()
+                .map_err(|e| sql_err!("invalid numeric value: {e}")),
+            _ => sql_bail!("cannot use value as number"),
+        }
+    }
+
+    fn name() -> String {
+        "float8".to_string()
+    }
+}
+
+impl ImpliedValue for f64 {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide a float value")
+    }
+}
+
 impl TryFromValue<Value> for i32 {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         match v {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -22,6 +22,7 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.22", default-features = false, features = ["std"] }
 crossbeam-channel = { version = "0.5.6" }
 csv-core = { version = "0.1.10" }
+dec = "0.4.8"
 derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.1", features = ["failpoints"] }

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -26,14 +26,29 @@ use crate::types::sources::{
 
 mod auction;
 mod counter;
+mod tpch;
 
 pub use auction::Auction;
 pub use counter::Counter;
+pub use tpch::Tpch;
 
 pub fn as_generator(g: &LoadGenerator) -> Box<dyn Generator> {
     match g {
         LoadGenerator::Auction => Box::new(Auction {}),
         LoadGenerator::Counter => Box::new(Counter {}),
+        LoadGenerator::Tpch {
+            count_supplier,
+            count_part,
+            count_customer,
+            count_orders,
+            count_clerk,
+        } => Box::new(Tpch {
+            count_supplier: *count_supplier,
+            count_part: *count_part,
+            count_customer: *count_customer,
+            count_orders: *count_orders,
+            count_clerk: *count_clerk,
+        }),
     }
 }
 

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -1,0 +1,622 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Display;
+use std::iter;
+use std::ops::RangeInclusive;
+
+use chrono::NaiveDate;
+use dec::OrderedDecimal;
+use mz_repr::adt::date::Date;
+use mz_repr::adt::numeric::{self, DecimalLike, Numeric, NumericMaxScale};
+use once_cell::sync::Lazy;
+use rand::distributions::{Alphanumeric, DistString};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+
+use mz_ore::now::NowFn;
+use mz_repr::{Datum, RelationDesc, Row, ScalarType};
+
+use crate::types::sources::encoding::DataEncodingInner;
+use crate::types::sources::{Generator, GeneratorMessageType};
+
+#[derive(Clone, Debug)]
+pub struct Tpch {
+    pub count_supplier: i64,
+    pub count_part: i64,
+    pub count_customer: i64,
+    pub count_orders: i64,
+    pub count_clerk: i64,
+}
+
+const SUPPLIER_OUTPUT: usize = 1;
+const PART_OUTPUT: usize = 2;
+const PARTSUPP_OUTPUT: usize = 3;
+const CUSTOMER_OUTPUT: usize = 4;
+const ORDERS_OUTPUT: usize = 5;
+const LINEITEM_OUTPUT: usize = 6;
+const NATION_OUTPUT: usize = 7;
+const REGION_OUTPUT: usize = 8;
+
+impl Generator for Tpch {
+    fn data_encoding_inner(&self) -> DataEncodingInner {
+        DataEncodingInner::RowCodec(RelationDesc::empty())
+    }
+
+    fn views(&self) -> Vec<(&str, RelationDesc)> {
+        let identifier = ScalarType::Int64.nullable(false);
+        let decimal = ScalarType::Numeric {
+            max_scale: Some(NumericMaxScale::try_from(2i64).unwrap()),
+        }
+        .nullable(false);
+        vec![
+            (
+                "supplier",
+                RelationDesc::empty()
+                    .with_column("s_suppkey", identifier.clone())
+                    .with_column("s_name", ScalarType::String.nullable(false))
+                    .with_column("s_address", ScalarType::String.nullable(false))
+                    .with_column("s_nationkey", identifier.clone())
+                    .with_column("s_phone", ScalarType::String.nullable(false))
+                    .with_column("s_acctbal", decimal.clone())
+                    .with_column("s_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+            (
+                "part",
+                RelationDesc::empty()
+                    .with_column("p_partkey", identifier.clone())
+                    .with_column("p_name", ScalarType::String.nullable(false))
+                    .with_column("p_mfgr", ScalarType::String.nullable(false))
+                    .with_column("p_brand", ScalarType::String.nullable(false))
+                    .with_column("p_type", ScalarType::String.nullable(false))
+                    .with_column("p_size", ScalarType::Int32.nullable(false))
+                    .with_column("p_container", ScalarType::String.nullable(false))
+                    .with_column("p_retailprice", decimal.clone())
+                    .with_column("p_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+            (
+                "partsupp",
+                RelationDesc::empty()
+                    .with_column("ps_partkey", identifier.clone())
+                    .with_column("ps_suppkey", identifier.clone())
+                    .with_column("ps_availqty", ScalarType::Int32.nullable(false))
+                    .with_column("ps_supplycost", decimal.clone())
+                    .with_column("ps_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0, 1]),
+            ),
+            (
+                "customer",
+                RelationDesc::empty()
+                    .with_column("c_custkey", identifier.clone())
+                    .with_column("c_name", ScalarType::String.nullable(false))
+                    .with_column("c_address", ScalarType::String.nullable(false))
+                    .with_column("c_nationkey", identifier.clone())
+                    .with_column("c_phone", ScalarType::String.nullable(false))
+                    .with_column("c_acctbal", decimal.clone())
+                    .with_column("c_mktsegment", ScalarType::String.nullable(false))
+                    .with_column("c_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+            (
+                "orders",
+                RelationDesc::empty()
+                    .with_column("o_orderkey", identifier.clone())
+                    .with_column("o_custkey", identifier.clone())
+                    .with_column("o_orderstatus", ScalarType::String.nullable(false))
+                    .with_column("o_totalprice", decimal.clone())
+                    .with_column("o_orderdate", ScalarType::Date.nullable(false))
+                    .with_column("o_orderpriority", ScalarType::String.nullable(false))
+                    .with_column("o_clerk", ScalarType::String.nullable(false))
+                    .with_column("o_shippriority", ScalarType::Int32.nullable(false))
+                    .with_column("o_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+            (
+                "lineitem",
+                RelationDesc::empty()
+                    .with_column("l_orderkey", identifier.clone())
+                    .with_column("l_partkey", identifier.clone())
+                    .with_column("l_suppkey", identifier.clone())
+                    .with_column("l_linenumber", ScalarType::Int32.nullable(false))
+                    .with_column("l_quantity", decimal.clone())
+                    .with_column("l_extendedprice", decimal.clone())
+                    .with_column("l_discount", decimal.clone())
+                    .with_column("l_tax", decimal)
+                    .with_column("l_returnflag", ScalarType::String.nullable(false))
+                    .with_column("l_linestatus", ScalarType::String.nullable(false))
+                    .with_column("l_shipdate", ScalarType::Date.nullable(false))
+                    .with_column("l_commitdate", ScalarType::Date.nullable(false))
+                    .with_column("l_receiptdate", ScalarType::Date.nullable(false))
+                    .with_column("l_shipinstruct", ScalarType::String.nullable(false))
+                    .with_column("l_shipmode", ScalarType::String.nullable(false))
+                    .with_column("l_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0, 3]),
+            ),
+            (
+                "nation",
+                RelationDesc::empty()
+                    .with_column("n_nationkey", identifier.clone())
+                    .with_column("n_name", ScalarType::String.nullable(false))
+                    .with_column("n_regionkey", identifier.clone())
+                    .with_column("n_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+            (
+                "region",
+                RelationDesc::empty()
+                    .with_column("r_regionkey", identifier)
+                    .with_column("r_name", ScalarType::String.nullable(false))
+                    .with_column("r_comment", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+        ]
+    }
+
+    fn by_seed(
+        &self,
+        _: NowFn,
+        seed: Option<u64>,
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row)>> {
+        let Self {
+            count_supplier,
+            count_part,
+            count_customer,
+            count_orders,
+            count_clerk,
+        } = self.clone();
+        let count_nation: i64 = NATIONS.len().try_into().unwrap();
+        let count_region: i64 = REGIONS.len().try_into().unwrap();
+
+        let mut rows = (0..count_supplier)
+            .map(|i| (SUPPLIER_OUTPUT, i))
+            .chain((1..=count_part).map(|i| (PART_OUTPUT, i)))
+            .chain((1..=count_customer).map(|i| (CUSTOMER_OUTPUT, i)))
+            .chain((1..=count_orders).map(|i| (ORDERS_OUTPUT, i)))
+            .chain((0..count_nation).map(|i| (NATION_OUTPUT, i)))
+            .chain((0..count_region).map(|i| (REGION_OUTPUT, i)))
+            .peekable();
+
+        let mut rng = StdRng::seed_from_u64(seed.unwrap_or_default());
+        // Some rows need to generate other rows from their values; hold those
+        // here.
+        let mut pending = Vec::new();
+        let mut cx = numeric::cx_datum();
+        let decimal_one = Numeric::lossy_from(1);
+        let decimal_neg_one = Numeric::lossy_from(-1);
+        // TODO: Use a text generator closer to the spec.
+        let text_string_source = Alphanumeric.sample_string(&mut rng, 3 << 20);
+
+        Box::new(iter::from_fn(move || {
+            if let Some((output, row)) = pending.pop() {
+                // InProgress is safe to use here because REGIONS is the last
+                // table, and it doesn't use pending.
+                return Some((output, GeneratorMessageType::InProgress, row));
+            }
+            rows.next().map(|(output, key)| {
+                let row = match output {
+                    SUPPLIER_OUTPUT => {
+                        let nation = rng.gen_range(0..(NATIONS.len() as i64));
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(&pad_nine("Supplier", key)),
+                            Datum::String(&v_string(&mut rng, 10, 40)), // address
+                            Datum::Int64(nation),
+                            Datum::String(&phone(&mut rng, nation)),
+                            Datum::Numeric(decimal(&mut rng, &mut cx, -999_99, 9_999_99, 100)), // acctbal
+                            // TODO: add customer complaints and recommends, see 4.2.3.
+                            Datum::String(text_string(&mut rng, &text_string_source, 25, 100)),
+                        ])
+                    }
+                    PART_OUTPUT => {
+                        let name: String = PARTNAMES
+                            .choose_multiple(&mut rng, 5)
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join("  ");
+                        let m = rng.gen_range(1..=5);
+                        let n = rng.gen_range(1..=5);
+                        for _ in 1..=4 {
+                            let suppkey = (key
+                                + (rng.gen_range(0..=3)
+                                    * ((count_supplier / 4) + (key - 1) / count_supplier)))
+                                % count_supplier
+                                + 1;
+                            let row = Row::pack_slice(&[
+                                Datum::Int64(key),
+                                Datum::Int64(suppkey),
+                                Datum::Int32(rng.gen_range(1..=9_999)), // availqty
+                                Datum::Numeric(decimal(&mut rng, &mut cx, 1_00, 1_000_00, 100)), // supplycost
+                                Datum::String(text_string(&mut rng, &text_string_source, 49, 198)),
+                            ]);
+                            pending.push((PARTSUPP_OUTPUT, row));
+                        }
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(&name),
+                            Datum::String(&format!("Manufacturer#{m}")),
+                            Datum::String(&format!("Brand#{m}{n}")),
+                            Datum::String(&syllables(&mut rng, TYPES)),
+                            Datum::Int32(rng.gen_range(1..=50)), // size
+                            Datum::String(&syllables(&mut rng, CONTAINERS)),
+                            Datum::Numeric(partkey_retailprice(key)),
+                            Datum::String(text_string(&mut rng, &text_string_source, 49, 198)),
+                        ])
+                    }
+                    CUSTOMER_OUTPUT => {
+                        let nation = rng.gen_range(0..(NATIONS.len() as i64));
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(&pad_nine("Customer", key)),
+                            Datum::String(&v_string(&mut rng, 10, 40)), // address
+                            Datum::Int64(nation),
+                            Datum::String(&phone(&mut rng, nation)),
+                            Datum::Numeric(decimal(&mut rng, &mut cx, -999_99, 9_999_99, 100)), // acctbal
+                            Datum::String(SEGMENTS.choose(&mut rng).unwrap()),
+                            Datum::String(text_string(&mut rng, &text_string_source, 29, 116)),
+                        ])
+                    }
+                    ORDERS_OUTPUT => {
+                        let key = order_key(key);
+                        let custkey = loop {
+                            let custkey = rng.gen_range(1..=count_customer);
+                            if custkey % 3 != 0 {
+                                break custkey;
+                            }
+                        };
+                        let orderdate = date(&mut rng, &*START_DATE, 1..=*ORDER_END_DAYS);
+                        let mut totalprice = Numeric::lossy_from(0);
+                        let mut orderstatus = None;
+
+                        for linenumber in 1..=rng.gen_range(1..=7) {
+                            let partkey = rng.gen_range(1..=count_part);
+                            let suppkey = (partkey
+                                + (rng.gen_range(0..=3)
+                                    * ((count_supplier / 4) + (partkey - 1) / count_supplier)))
+                                % count_supplier
+                                + 1;
+                            let quantity = Numeric::from(rng.gen_range(1..=50));
+                            let mut extendedprice = quantity;
+                            cx.mul(&mut extendedprice, &partkey_retailprice(partkey).0);
+                            let mut discount = decimal(&mut rng, &mut cx, 0, 8, 100);
+                            let mut tax = decimal(&mut rng, &mut cx, 0, 10, 100);
+                            let shipdate = date(&mut rng, &orderdate, 1..=121);
+                            let receiptdate = date(&mut rng, &shipdate, 1..=30);
+                            let linestatus = if shipdate > *CURRENT_DATE { "O" } else { "F" };
+                            let row = Row::pack_slice(&[
+                                Datum::Int64(key),
+                                Datum::Int64(partkey),
+                                Datum::Int64(suppkey),
+                                Datum::Int32(linenumber),
+                                Datum::Numeric(OrderedDecimal(quantity)),
+                                Datum::Numeric(OrderedDecimal(extendedprice)),
+                                Datum::Numeric(discount),
+                                Datum::Numeric(tax),
+                                Datum::String(if receiptdate <= *CURRENT_DATE {
+                                    ["R", "A"].choose(&mut rng).unwrap()
+                                } else {
+                                    "N"
+                                }), // returnflag
+                                Datum::String(linestatus),
+                                Datum::Date(shipdate),
+                                Datum::Date(date(&mut rng, &orderdate, 30..=90)), // commitdate
+                                Datum::Date(receiptdate),
+                                Datum::String(INSTRUCTIONS.choose(&mut rng).unwrap()),
+                                Datum::String(MODES.choose(&mut rng).unwrap()),
+                                Datum::String(text_string(&mut rng, &text_string_source, 10, 43)),
+                            ]);
+                            pending.push((LINEITEM_OUTPUT, row));
+                            // totalprice += extendedprice * (1.0 + tax) * (1.0 - discount)
+                            cx.add(&mut tax.0, &decimal_one);
+                            cx.sub(&mut discount.0, &decimal_neg_one);
+                            cx.abs(&mut discount.0);
+                            cx.mul(&mut extendedprice, &tax.0);
+                            cx.mul(&mut extendedprice, &discount.0);
+                            cx.add(&mut totalprice, &extendedprice);
+                            if let Some(status) = orderstatus {
+                                if status != linestatus {
+                                    orderstatus = Some("P");
+                                }
+                            } else {
+                                orderstatus = Some(linestatus);
+                            }
+                        }
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::Int64(custkey),
+                            Datum::String(orderstatus.unwrap()),
+                            Datum::Numeric(OrderedDecimal(totalprice)),
+                            Datum::Date(orderdate),
+                            Datum::String(PRIORITIES.choose(&mut rng).unwrap()),
+                            Datum::String(&pad_nine("Clerk", rng.gen_range(1..=count_clerk))),
+                            Datum::Int32(0), // shippriority
+                            Datum::String(text_string(&mut rng, &text_string_source, 19, 78)),
+                        ])
+                    }
+                    NATION_OUTPUT => {
+                        let (name, region) = NATIONS[key as usize];
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(name),
+                            Datum::Int64(region),
+                            Datum::String(text_string(&mut rng, &text_string_source, 31, 114)),
+                        ])
+                    }
+                    REGION_OUTPUT => Row::pack_slice(&[
+                        Datum::Int64(key),
+                        Datum::String(REGIONS[key as usize]),
+                        Datum::String(text_string(&mut rng, &text_string_source, 31, 115)),
+                    ]),
+                    _ => unreachable!("{output}"),
+                };
+                let typ = if rows.peek().is_some() {
+                    GeneratorMessageType::InProgress
+                } else {
+                    GeneratorMessageType::Finalized
+                };
+                (output, typ, row)
+            })
+        }))
+    }
+}
+
+fn partkey_retailprice(key: i64) -> OrderedDecimal<Numeric> {
+    let price = (90000 + ((key / 10) % 20001) + 100 * (key % 1000)) / 100;
+    OrderedDecimal(Numeric::from(price))
+}
+
+fn pad_nine<S: Display>(prefix: &str, s: S) -> String {
+    format!("{}#{s:09}", prefix)
+}
+
+pub static START_DATE: Lazy<Date> =
+    Lazy::new(|| Date::try_from(NaiveDate::from_ymd(1992, 1, 1)).unwrap());
+pub static CURRENT_DATE: Lazy<Date> =
+    Lazy::new(|| Date::try_from(NaiveDate::from_ymd(1995, 6, 17)).unwrap());
+pub static END_DATE: Lazy<Date> =
+    Lazy::new(|| Date::try_from(NaiveDate::from_ymd(1998, 12, 31)).unwrap());
+pub static ORDER_END_DAYS: Lazy<i32> = Lazy::new(|| *END_DATE - *START_DATE - 151);
+
+fn text_string<'a, R: Rng + ?Sized>(
+    rng: &mut R,
+    source: &'a str,
+    min: usize,
+    max: usize,
+) -> &'a str {
+    let start = rng.gen_range(0..=(source.len() - max));
+    let len = rng.gen_range(min..=max);
+    &source[start..(start + len)]
+}
+
+fn date<R: Rng + ?Sized>(rng: &mut R, start: &Date, days: RangeInclusive<i32>) -> Date {
+    let days = rng.gen_range(days);
+    start.checked_add(days).expect("must fit")
+}
+
+// See mk_sparse in dbgen's build.c.
+fn order_key(mut i: i64) -> i64 {
+    const SPARSE_BITS: usize = 2;
+    const SPARSE_KEEP: usize = 3;
+    let low_bits = i & ((1 << SPARSE_KEEP) - 1);
+    i >>= SPARSE_KEEP;
+    i <<= SPARSE_BITS;
+    // build.c has a `i += seq` here which allows generating multiple data sets
+    // in flat files.
+    i <<= SPARSE_KEEP;
+    i += low_bits;
+    i
+}
+
+fn syllables<R: Rng + ?Sized>(rng: &mut R, syllables: &[&[&str]]) -> String {
+    let mut s = String::new();
+    for (i, syllable) in syllables.iter().enumerate() {
+        if i > 0 {
+            s.push(' ');
+        }
+        s.push_str(syllable.choose(rng).unwrap());
+    }
+    s
+}
+
+fn decimal<R: Rng + ?Sized>(
+    rng: &mut R,
+    cx: &mut dec::Context<Numeric>,
+    min: i64,
+    max: i64,
+    div: i64,
+) -> OrderedDecimal<Numeric> {
+    let n = rng.gen_range(min..=max);
+    let mut n = Numeric::lossy_from(n);
+    cx.div(&mut n, &Numeric::lossy_from(div));
+    OrderedDecimal(n)
+}
+
+fn phone<R: Rng + ?Sized>(rng: &mut R, nation: i64) -> String {
+    let mut s = String::with_capacity(15);
+    s.push_str(&(nation + 10).to_string());
+    s.push('-');
+    s.push_str(&rng.gen_range(100..=999).to_string());
+    s.push('-');
+    s.push_str(&rng.gen_range(100..=999).to_string());
+    s.push('-');
+    s.push_str(&rng.gen_range(1000..=9999).to_string());
+    s
+}
+
+fn v_string<R: Rng + ?Sized>(rng: &mut R, min: usize, max: usize) -> String {
+    const ALPHABET: [char; 64] = [
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '1', '2',
+        '3', '4', '5', '6', '7', '8', '9', '0', ',', ' ',
+    ];
+    let take = rng.gen_range(min..=max);
+    let mut s = String::with_capacity(take);
+    for _ in 0..take {
+        s.push(*ALPHABET.choose(rng).unwrap());
+    }
+    s
+}
+
+const INSTRUCTIONS: &[&str] = &[
+    "DELIVER IN PERSON",
+    "COLLECT COD",
+    "NONE",
+    "TAKE BACK RETURN",
+];
+
+const MODES: &[&str] = &["REG AIR", "AIR", "RAIL", "SHIP", "TRUCK", "MAIL", "FOB"];
+
+const PARTNAMES: &[&str] = &[
+    "almond",
+    "antique",
+    "aquamarine",
+    "azure",
+    "beige",
+    "bisque",
+    "black",
+    "blanched",
+    "blue",
+    "blush",
+    "brown",
+    "burlywood",
+    "burnished",
+    "chartreuse",
+    "chiffon",
+    "chocolate",
+    "coral",
+    "cornflower",
+    "cornsilk",
+    "cream",
+    "cyan",
+    "dark",
+    "deep",
+    "dim",
+    "dodger",
+    "drab",
+    "firebrick",
+    "floral",
+    "forest",
+    "frosted",
+    "gainsboro",
+    "ghost",
+    "goldenrod",
+    "green",
+    "grey",
+    "honeydew",
+    "hot",
+    "indian",
+    "ivory",
+    "khaki",
+    "lace",
+    "lavender",
+    "lawn",
+    "lemon",
+    "light",
+    "lime",
+    "linen",
+    "magenta",
+    "maroon",
+    "medium",
+    "metallic",
+    "midnight",
+    "mint",
+    "misty",
+    "moccasin",
+    "navajo",
+    "navy",
+    "olive",
+    "orange",
+    "orchid",
+    "pale",
+    "papaya",
+    "peach",
+    "peru",
+    "pink",
+    "plum",
+    "powder",
+    "puff",
+    "purple",
+    "red",
+    "rose",
+    "rosy",
+    "royal",
+    "saddle",
+    "salmon",
+    "sandy",
+    "seashell",
+    "sienna",
+    "sky",
+    "slate",
+    "smoke",
+    "snow",
+    "spring",
+    "steel",
+    "tan",
+    "thistle",
+    "tomato",
+    "turquoise",
+    "violet",
+    "wheat",
+    "white",
+    "yellow",
+];
+
+const PRIORITIES: &[&str] = &["1-URGENT", "2-HIGH", "3-MEDIUM", "4-NOT SPECIFIED"];
+
+const TYPES: &[&[&str]] = &[
+    &["STANDARD", "SMALL", "MEDIUM", "LARGE", "ECONOMY", "PROMO"],
+    &["ANODIZED", "BURNISHED", "PLATED", "POLISHED", "BRUSHED"],
+    &["TIN", "NICKEL", "BRASS", "STEEL", "COPPER"],
+];
+
+const CONTAINERS: &[&[&str]] = &[
+    &["SM", "MED", "JUMBO", "WRAP"],
+    &["BOX", "BAG", "JAR", "PKG", "PACK", "CAN", "DRUM"],
+];
+
+const SEGMENTS: &[&str] = &[
+    "AUTOMOBILE",
+    "BUILDING",
+    "FURNITURE",
+    "MACHINERY",
+    "HOUSEHOLD",
+];
+
+const REGIONS: &[&str] = &["AFRICA", "AMERICA", "ASIA", "EUROPE", "MIDDLE EAST"];
+
+const NATIONS: &[(&str, i64)] = &[
+    ("ALGERIA", 0),
+    ("ARGENTINA", 1),
+    ("BRAZIL", 1),
+    ("CANADA", 1),
+    ("EGYPT", 4),
+    ("ETHIOPIA", 0),
+    ("FRANCE", 3),
+    ("GERMANY", 3),
+    ("INDIA", 2),
+    ("INDONESIA", 2),
+    ("IRAN", 4),
+    ("IRAQ", 4),
+    ("JAPAN", 2),
+    ("JORDAN", 4),
+    ("KENYA", 0),
+    ("MOROCCO", 0),
+    ("MOZAMBIQUE", 0),
+    ("PERU", 1),
+    ("CHINA", 2),
+    ("ROMANIA", 3),
+    ("SAUDI ARABIA", 4),
+    ("VIETNAM", 2),
+    ("RUSSIA", 3),
+    ("UNITED KINGDOM", 3),
+    ("UNITED STATES", 1),
+];

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -214,6 +214,7 @@ message ProtoLoadGeneratorSourceConnection {
     oneof generator {
         google.protobuf.Empty counter = 1;
         google.protobuf.Empty auction = 3;
+        ProtoTpchLoadGenerator tpch = 4;
     }
     optional uint64 tick_micros = 2;
 }
@@ -222,6 +223,14 @@ message ProtoTestScriptSourceConnection {
     string desc_json = 1;
 }
 
+
+message ProtoTpchLoadGenerator {
+    int64 count_supplier = 1;
+    int64 count_part = 2;
+    int64 count_customer = 3;
+    int64 count_orders = 4;
+    int64 count_clerk = 5;
+}
 
 message ProtoS3SourceConnection {
     mz_repr.global_id.ProtoGlobalId connection_id = 5;

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -1777,6 +1777,13 @@ impl crate::source::types::SourceConnection for LoadGeneratorSourceConnection {
 pub enum LoadGenerator {
     Auction,
     Counter,
+    Tpch {
+        count_supplier: i64,
+        count_part: i64,
+        count_customer: i64,
+        count_orders: i64,
+        count_clerk: i64,
+    },
 }
 
 pub trait Generator {
@@ -1804,9 +1811,22 @@ pub enum GeneratorMessageType {
 impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnection {
     fn into_proto(&self) -> ProtoLoadGeneratorSourceConnection {
         ProtoLoadGeneratorSourceConnection {
-            generator: Some(match self.load_generator {
+            generator: Some(match &self.load_generator {
                 LoadGenerator::Auction => ProtoGenerator::Auction(()),
                 LoadGenerator::Counter => ProtoGenerator::Counter(()),
+                LoadGenerator::Tpch {
+                    count_supplier,
+                    count_part,
+                    count_customer,
+                    count_orders,
+                    count_clerk,
+                } => ProtoGenerator::Tpch(ProtoTpchLoadGenerator {
+                    count_supplier: *count_supplier,
+                    count_part: *count_part,
+                    count_customer: *count_customer,
+                    count_orders: *count_orders,
+                    count_clerk: *count_clerk,
+                }),
             }),
             tick_micros: self.tick_micros,
         }
@@ -1820,6 +1840,19 @@ impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnect
             load_generator: match generator {
                 ProtoGenerator::Auction(()) => LoadGenerator::Auction,
                 ProtoGenerator::Counter(()) => LoadGenerator::Counter,
+                ProtoGenerator::Tpch(ProtoTpchLoadGenerator {
+                    count_supplier,
+                    count_part,
+                    count_customer,
+                    count_orders,
+                    count_clerk,
+                }) => LoadGenerator::Tpch {
+                    count_supplier,
+                    count_part,
+                    count_customer,
+                    count_orders,
+                    count_clerk,
+                },
             },
             tick_micros: proto.tick_micros,
         })

--- a/test/testdrive/tpch.td
+++ b/test/testdrive/tpch.td
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test the cardinality of TPCH tables. For tables that have a random
+# cardinality, don't depend on exact count that could change if the rng
+# implementation changes, just check that it's within the spec range.
+
+! CREATE SOURCE gen FROM LOAD GENERATOR TPCH (SCALE FACTOR 0)
+contains: multi-output sources require a FOR TABLES (..) or FOR ALL TABLES statement
+
+! CREATE SOURCE gen FROM LOAD GENERATOR TPCH (SCALE FACTOR 9223372036854775807) FOR ALL TABLES
+contains: unsupported scale factor 9223372036854776000
+
+! CREATE SOURCE gen FROM LOAD GENERATOR TPCH (SCALE FACTOR -1) FOR ALL TABLES
+contains: unsupported scale factor -1
+
+> CREATE SOURCE gen FROM LOAD GENERATOR TPCH (SCALE FACTOR .001) FOR ALL TABLES
+
+$ set-from-sql var=source-size
+SELECT size FROM mz_sources WHERE name = 'gen'
+
+> SHOW SOURCES
+name         type       size
+--------------------------------
+ customer  subsource       <null>
+ gen       load-generator  ${source-size}
+ lineitem  subsource       <null>
+ nation    subsource       <null>
+ orders    subsource       <null>
+ part      subsource       <null>
+ partsupp  subsource       <null>
+ region    subsource       <null>
+ supplier  subsource       <null>
+
+# SF * 150,000
+> SELECT count(*) FROM customer
+150
+
+# For each row in the ORDERS table, a random number of rows within [1 .. 7] in the LINEITEM table
+> SELECT count(*) >= 1500 AND count(*) <= 1500 * 7 FROM lineitem
+true
+
+# 25 rows in the NATION table
+> SELECT count(*) FROM nation
+25
+
+# For each row in the CUSTOMER table, ten rows in the ORDERS table
+> SELECT count(*) FROM orders
+1500
+
+# SF * 200,000
+> SELECT count(*) FROM part
+200
+
+# For each row in the PART table, four rows in PartSupp table
+> SELECT count(*) FROM partsupp
+800
+
+# 5 rows in the REGION table
+> SELECT count(*) FROM region
+5
+
+# SF * 10,000
+> SELECT count(*) FROM supplier
+10


### PR DESCRIPTION
Implement a TPCH load generator. It's got a few things not exactly to spec: comment text and some supplier comment exceptions. (Cockroach has the same exceptions, so perhaps not a huge deal.) On my machine, loads SF 1 in 16s with 1.86 million rows generated.

Refactor the load generator source to produce rows with an extra message if it's an end-of-txn row. Previously this was done with a vec, but because we need to produce the entire TPCH set in a single txn, we needed a way to do that without allocating them all first.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
