### PR TITLE
doc/user: document `DROP` and `SHOW` commands for clusters and cluster replicas

### DIFF
--- a/doc/user/content/sql/drop-cluster-replica.md
+++ b/doc/user/content/sql/drop-cluster-replica.md
@@ -1,0 +1,42 @@
+---
+title: "DROP CLUSTER REPLICA"
+description: "`DROP CLUSTER REPLICA` removes an existing replica for the specified cluster."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`DROP CLUSTER REPLICA` removes an existing replica for the specified cluster. To remove all active replicas for a cluster, use the [`DROP CLUSTER`](/sql/drop-cluster) command.
+
+## Syntax
+
+{{< diagram "drop-cluster-replica.svg" >}}
+
+Field | Use
+------|-----
+**IF EXISTS** | Do not return an error if the specified cluster replica does not exist.
+_cluster_name_ | The cluster you want to remove a replica from. For available clusters, see [`SHOW CLUSTERS`](../show-clusters).
+_replica&lowbar;name_ | The cluster replica you want to drop. For available cluster replicas, see [`SHOW CLUSTER REPLICAS`](../show-cluster-replicas).
+**CASCADE** | Remove the cluster replica and any objects depending on its introspection tables.
+**RESTRICT** | Do not drop the cluster replica if it has dependencies. _(Default)_
+
+## Examples
+
+```sql
+SHOW CLUSTER REPLICAS WHERE cluster = 'auction_house';
+```
+
+```nofmt
+    cluster    | replica
+---------------+---------
+ auction_house | bigger
+```
+
+```sql
+DROP CLUSTER REPLICA auction_house.bigger;
+```
+
+## Related pages
+
+- [`SHOW CLUSTER REPLICAS`](../show-cluster-replicas)

--- a/doc/user/content/sql/drop-cluster.md
+++ b/doc/user/content/sql/drop-cluster.md
@@ -1,0 +1,59 @@
+---
+title: "DROP CLUSTER"
+description: "`DROP CLUSTER` removes an existing cluster from Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`DROP CLUSTER` removes an existing cluster from Materialize. If there are indexes or materialized views depending on the cluster, you must explicitly drop them first, or use the `CASCADE` option.
+
+## Syntax
+
+{{< diagram "drop-cluster.svg" >}}
+
+Field | Use
+------|-----
+**IF EXISTS** | Do not return an error if the specified cluster does not exist.
+_cluster&lowbar;name_ | The cluster you want to drop. For available clusters, see [`SHOW CLUSTERS`](../show-clusters).
+**CASCADE** | Remove the cluster and its dependent objects.
+**RESTRICT** | Do not drop the cluster if it has dependencies. _(Default)_
+
+## Examples
+
+### Dropping a cluster with no dependencies
+
+To drop an existing cluster, run:
+
+```sql
+DROP CLUSTER auction_house;
+```
+
+To avoid issuing an error if the specified cluster does not exist, use the `IF EXISTS` option:
+
+```sql
+DROP CLUSTER IF EXISTS auction_house;
+```
+
+### Dropping a cluster with dependencies
+
+If the cluster has dependencies, Materialize will throw an error similar to:
+
+```sql
+DROP CLUSTER auction_house;
+```
+
+```nofmt
+ERROR:  cannot drop cluster with active indexes or materialized views
+```
+
+, and you'll have to explicitly ask to also remove any dependent objects using the `CASCADE` option:
+
+```sql
+DROP CLUSTER auction_house CASCADE;
+```
+
+## Related pages
+
+- [`SHOW CLUSTERS`](../show-clusters)

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -1,0 +1,43 @@
+---
+title: "SHOW CLUSTER REPLICAS"
+description: "`SHOW CLUSTER REPLICAS` lists the replicas for each cluster configured in Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `default_replica` will exist in every environment; this cluster can be dropped at any time.
+
+## Syntax
+
+{{< diagram "show-cluster-replicas.svg" >}}
+
+## Examples
+
+```sql
+SHOW CLUSTER REPLICAS;
+```
+
+```nofmt
+    cluster    |     replica
+---------------+-----------------
+ auction_house | bigger
+ default       | default_replica
+```
+
+```sql
+SHOW CLUSTER REPLICAS WHERE cluster='default';
+```
+
+```nofmt
+    cluster    |     replica
+---------------+-----------------
+ default       | default_replica
+```
+
+
+## Related pages
+
+- [`CREATE CLUSTER REPLICA`](../create-cluster-replica)
+- [`DROP CLUSTER REPLICA`](../drop-cluster-replica)

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -1,0 +1,43 @@
+---
+title: "SHOW CLUSTERS"
+description: "`SHOW CLUSTERS` lists the clusters configured in Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `default_replica` will exist in every environment; this cluster can be dropped at any time.
+
+## Syntax
+
+{{< diagram "show-clusters.svg" >}}
+
+## Examples
+
+```sql
+SHOW CLUSTERS;
+```
+
+```nofmt
+       name
+---------------------
+ default
+ auction_house
+```
+
+```sql
+SHOW CLUSTERS LIKE 'auction_%';
+```
+
+```nofmt
+       name
+---------------------
+ auction_house
+```
+
+
+## Related pages
+
+- [`CREATE CLUSTER`](../create-cluster)
+- [`DROP CLUSTER`](../drop-cluster)

--- a/doc/user/layouts/partials/sql-grammar/drop-cluster-replica.svg
+++ b/doc/user/layouts/partials/sql-grammar/drop-cluster-replica.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="463" height="211">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="60" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">DROP</text>
+   <rect x="111" y="3" width="84" height="32" rx="10"/>
+   <rect x="109"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="21">CLUSTER</text>
+   <rect x="215" y="3" width="80" height="32" rx="10"/>
+   <rect x="213"
+         y="1"
+         width="80"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="223" y="21">REPLICA</text>
+   <rect x="335" y="35" width="86" height="32" rx="10"/>
+   <rect x="333"
+         y="33"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="53">IF EXISTS</text>
+   <rect x="87" y="101" width="198" height="32"/>
+   <rect x="85" y="99" width="198" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="95" y="119">cluster_name.replica_name</text>
+   <rect x="325" y="133" width="90" height="32" rx="10"/>
+   <rect x="323"
+         y="131"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="333" y="151">CASCADE</text>
+   <rect x="325" y="177" width="90" height="32" rx="10"/>
+   <rect x="323"
+         y="175"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="333" y="195">RESTRICT</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m198 0 h10 m20 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -76 h-3"/>
+   <polygon points="453 115 461 111 461 119"/>
+   <polygon points="453 115 445 111 445 119"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/drop-cluster.svg
+++ b/doc/user/layouts/partials/sql-grammar/drop-cluster.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="491" height="199">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="60" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">DROP</text>
+   <rect x="111" y="3" width="84" height="32" rx="10"/>
+   <rect x="109"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="21">CLUSTER</text>
+   <rect x="235" y="35" width="86" height="32" rx="10"/>
+   <rect x="233"
+         y="33"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="53">IF EXISTS</text>
+   <rect x="361" y="3" width="108" height="32"/>
+   <rect x="359" y="1" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="369" y="21">cluster_name</text>
+   <rect x="353" y="121" width="90" height="32" rx="10"/>
+   <rect x="351"
+         y="119"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="361" y="139">CASCADE</text>
+   <rect x="353" y="165" width="90" height="32" rx="10"/>
+   <rect x="351"
+         y="163"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="361" y="183">RESTRICT</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m84 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m108 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -76 h-3"/>
+   <polygon points="481 103 489 99 489 107"/>
+   <polygon points="481 103 473 99 473 107"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/show-cluster-replicas.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-cluster-replicas.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="535" height="113">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="84" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">CLUSTER</text>
+   <rect x="219" y="3" width="88" height="32" rx="10"/>
+   <rect x="217"
+         y="1"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="227" y="21">REPLICAS</text>
+   <rect x="347" y="35" width="50" height="32" rx="10"/>
+   <rect x="345"
+         y="33"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="355" y="53">LIKE</text>
+   <rect x="417" y="35" width="70" height="32" rx="10"/>
+   <rect x="415"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="425" y="53">pattern</text>
+   <rect x="347" y="79" width="70" height="32" rx="10"/>
+   <rect x="345"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="355" y="97">WHERE</text>
+   <rect x="437" y="79" width="48" height="32"/>
+   <rect x="435" y="77" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="445" y="97">expr</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
+   <polygon points="525 17 533 13 533 21"/>
+   <polygon points="525 17 517 13 517 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/show-clusters.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-clusters.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="437" height="113">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="94" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">CLUSTERS</text>
+   <rect x="249" y="35" width="50" height="32" rx="10"/>
+   <rect x="247"
+         y="33"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="53">LIKE</text>
+   <rect x="319" y="35" width="70" height="32" rx="10"/>
+   <rect x="317"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="327" y="53">pattern</text>
+   <rect x="249" y="79" width="70" height="32" rx="10"/>
+   <rect x="247"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="257" y="97">WHERE</text>
+   <rect x="339" y="79" width="48" height="32"/>
+   <rect x="337" y="77" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="347" y="97">expr</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m94 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
+   <polygon points="427 17 435 13 435 21"/>
+   <polygon points="427 17 419 13 419 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -154,6 +154,8 @@ drop_connection ::=
     'DROP' 'CONNECTION' ('IF EXISTS')? connection_name ('CASCADE' | 'RESTRICT')?
 drop_cluster ::=
   'DROP' 'CLUSTER' ('IF EXISTS')? cluster_name ('CASCADE' | 'RESTRICT')?
+drop_cluster_replica ::=
+  'DROP' 'CLUSTER' 'REPLICA' ('IF EXISTS')? cluster_name.replica_name ('CASCADE' | 'RESTRICT')?
 drop_database ::=
     'DROP' 'DATABASE' ('IF EXISTS')? database_name ('CASCADE' | 'RESTRICT')?
 drop_index ::=
@@ -304,6 +306,9 @@ show_connections ::=
   ('LIKE' 'pattern' | 'WHERE' expr)?
 show_clusters ::=
   'SHOW' 'CLUSTERS'
+  ('LIKE' 'pattern' | 'WHERE' expr)?
+show_cluster_replicas ::=
+  'SHOW' 'CLUSTER' 'REPLICAS'
   ('LIKE' 'pattern' | 'WHERE' expr)?
 show_create_connection ::=
   'SHOW' 'CREATE' 'CONNECTION' connection_name

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -152,6 +152,8 @@ discard ::=
   'DISCARD' ('TEMP' | 'TEMPORARY' | 'ALL')
 drop_connection ::=
     'DROP' 'CONNECTION' ('IF EXISTS')? connection_name ('CASCADE' | 'RESTRICT')?
+drop_cluster ::=
+  'DROP' 'CLUSTER' ('IF EXISTS')? cluster_name ('CASCADE' | 'RESTRICT')?
 drop_database ::=
     'DROP' 'DATABASE' ('IF EXISTS')? database_name ('CASCADE' | 'RESTRICT')?
 drop_index ::=
@@ -299,6 +301,9 @@ show_columns ::=
 show_connections ::=
   'SHOW' 'CONNECTIONS'
   ('FROM' schema_name)?
+  ('LIKE' 'pattern' | 'WHERE' expr)?
+show_clusters ::=
+  'SHOW' 'CLUSTERS'
   ('LIKE' 'pattern' | 'WHERE' expr)?
 show_create_connection ::=
   'SHOW' 'CREATE' 'CONNECTION' connection_name


### PR DESCRIPTION
Adding reference documentation for the `SHOW CLUSTERS`, `DROP CLUSTER`, `SHOW CLUSTER REPLICAS`, `DROP CLUSTER REPLICA` SQL commands.

Nit (raised [here](https://materializeinc.slack.com/archives/C02FWJ94HME/p1664192883635249?thread_ts=1664189686.941239&cid=C02FWJ94HME)): for `DROP CLUSTER REPLICA`, we support `CASCADE` ([#13935](https://github.com/MaterializeInc/materialize/issues/13935)) but according to [#14724](https://github.com/MaterializeInc/materialize/issues/14724), introspection tables can’t be used in views. AFAIU, this means that there will never be a scenario where `CASCADE` is applicable as is (at least until introspection tables are stabilised).