### PR TITLE
test: add cloudtest-based test for ssh tunnels

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -18,8 +18,10 @@ from materialize.cloudtest.k8s.environmentd import (
 )
 from materialize.cloudtest.k8s.minio import Minio
 from materialize.cloudtest.k8s.postgres import POSTGRES_RESOURCES
+from materialize.cloudtest.k8s.postgres_source import POSTGRES_SOURCE_RESOURCES
 from materialize.cloudtest.k8s.redpanda import REDPANDA_RESOURCES
 from materialize.cloudtest.k8s.role_binding import AdminRoleBinding
+from materialize.cloudtest.k8s.ssh import SSH_RESOURCES
 from materialize.cloudtest.k8s.testdrive import Testdrive
 from materialize.cloudtest.wait import wait
 
@@ -67,7 +69,9 @@ class MaterializeApplication(Application):
 
         self.resources = [
             *POSTGRES_RESOURCES,
+            *POSTGRES_SOURCE_RESOURCES,
             *REDPANDA_RESOURCES,
+            *SSH_RESOURCES,
             Minio(),
             AdminRoleBinding(),
             EnvironmentdStatefulSet(),
@@ -75,7 +79,7 @@ class MaterializeApplication(Application):
             self.testdrive,
         ]
 
-        self.images = ["environmentd", "computed", "storaged", "testdrive"]
+        self.images = ["environmentd", "computed", "storaged", "testdrive", "postgres"]
 
         # Label the minicube nodes in a way that mimics Materialize cloud
         for node in [

--- a/misc/python/materialize/cloudtest/k8s/postgres_source.py
+++ b/misc/python/materialize/cloudtest/k8s/postgres_source.py
@@ -1,0 +1,81 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from kubernetes.client import (
+    V1Container,
+    V1ContainerPort,
+    V1Deployment,
+    V1DeploymentSpec,
+    V1EnvVar,
+    V1LabelSelector,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from materialize.cloudtest.k8s import K8sDeployment, K8sService
+
+
+class PostgresSourceService(K8sService):
+    def __init__(self) -> None:
+        service_port = V1ServicePort(name="sql", port=5432)
+
+        self.service = V1Service(
+            api_version="v1",
+            kind="Service",
+            metadata=V1ObjectMeta(
+                name="postgres-source", labels={"app": "postgres-source"}
+            ),
+            spec=V1ServiceSpec(
+                type="NodePort",
+                ports=[service_port],
+                selector={"app": "postgres-source"},
+            ),
+        )
+
+
+class PostgresSourceDeployment(K8sDeployment):
+    def __init__(self) -> None:
+        env = [
+            V1EnvVar(name="POSTGRESDB", value="postgres"),
+            V1EnvVar(name="POSTGRES_PASSWORD", value="postgres"),
+        ]
+        ports = [V1ContainerPort(container_port=5432, name="sql")]
+        container = V1Container(
+            name="postgres-source",
+            image=self.image("postgres"),
+            args=["-c", "wal_level=logical"],
+            env=env,
+            ports=ports,
+        )
+
+        template = V1PodTemplateSpec(
+            metadata=V1ObjectMeta(labels={"app": "postgres-source"}),
+            spec=V1PodSpec(containers=[container]),
+        )
+
+        selector = V1LabelSelector(match_labels={"app": "postgres-source"})
+
+        spec = V1DeploymentSpec(replicas=1, template=template, selector=selector)
+
+        self.deployment = V1Deployment(
+            api_version="apps/v1",
+            kind="Deployment",
+            metadata=V1ObjectMeta(name="postgres-source"),
+            spec=spec,
+        )
+
+
+POSTGRES_SOURCE_RESOURCES = [
+    PostgresSourceService(),
+    PostgresSourceDeployment(),
+]

--- a/misc/python/materialize/cloudtest/k8s/ssh.py
+++ b/misc/python/materialize/cloudtest/k8s/ssh.py
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from kubernetes.client import (
+    V1Container,
+    V1ContainerPort,
+    V1Deployment,
+    V1DeploymentSpec,
+    V1EnvVar,
+    V1LabelSelector,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from materialize.cloudtest.k8s import K8sDeployment, K8sService
+
+
+class SshDeployment(K8sDeployment):
+    def __init__(self) -> None:
+        env = [
+            V1EnvVar(name="SSH_USERS", value="mz:1000:1000"),
+            V1EnvVar(name="TCP_FORWARDING", value="true"),
+        ]
+        ports = [V1ContainerPort(container_port=22, name="ssh")]
+        container = V1Container(
+            name="ssh-bastion-host",
+            image="panubo/sshd:1.5.0",
+            env=env,
+            ports=ports,
+        )
+
+        template = V1PodTemplateSpec(
+            metadata=V1ObjectMeta(labels={"app": "ssh-bastion-host"}),
+            spec=V1PodSpec(containers=[container]),
+        )
+
+        selector = V1LabelSelector(match_labels={"app": "ssh-bastion-host"})
+
+        spec = V1DeploymentSpec(replicas=1, template=template, selector=selector)
+
+        self.deployment = V1Deployment(
+            api_version="apps/v1",
+            kind="Deployment",
+            metadata=V1ObjectMeta(name="ssh-bastion-host"),
+            spec=spec,
+        )
+
+
+class SshService(K8sService):
+    def __init__(self) -> None:
+        ports = [
+            V1ServicePort(name="ssh", port=22),
+        ]
+
+        self.service = V1Service(
+            metadata=V1ObjectMeta(
+                name="ssh-bastion-host", labels={"app": "ssh-bastion-host"}
+            ),
+            spec=V1ServiceSpec(
+                type="NodePort", ports=ports, selector={"app": "ssh-bastion-host"}
+            ),
+        )
+
+
+SSH_RESOURCES = [SshDeployment(), SshService()]

--- a/test/cloudtest/test_ssh_tunnels.py
+++ b/test/cloudtest/test_ssh_tunnels.py
@@ -1,0 +1,134 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.wait import wait
+
+
+def test_ssh_tunnels(mz: MaterializeApplication) -> None:
+    mz.testdrive.run_string(
+        dedent(
+            """
+            > CREATE CONNECTION IF NOT EXISTS ssh_conn
+                FOR SSH TUNNEL
+                    HOST 'ssh-bastion-host',
+                    USER 'mz',
+                    PORT 22;
+            """
+        )
+    )
+
+    (id, public_key) = mz.environmentd.sql_query(
+        "SELECT id, public_key_1 FROM mz_ssh_tunnel_connections"
+    )[0]
+    assert id is not None
+
+    secret = f"user-managed-{id}"
+
+    # If the secret didn't exist, this would throw an exception
+    mz.kubectl("describe", "secret", secret)
+
+    # Add public key to SSH bastion host
+    mz.kubectl(
+        "exec",
+        "svc/ssh-bastion-host",
+        "--",
+        "bash",
+        "-c",
+        f"echo '{public_key}' > /etc/authorized_keys/mz",
+    )
+
+    mz.testdrive.run_string(
+        dedent(
+            """
+        > CREATE SECRET pgpass AS 'postgres'
+        > CREATE CONNECTION pg FOR POSTGRES
+          HOST 'postgres-source',
+          DATABASE postgres,
+          USER postgres,
+          PASSWORD SECRET pgpass,
+          SSL MODE require,
+          SSH TUNNEL ssh_conn
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+        ALTER USER postgres WITH replication;
+        DROP SCHEMA IF EXISTS public CASCADE;
+        DROP PUBLICATION IF EXISTS mz_source;
+        CREATE SCHEMA public;
+
+        CREATE TABLE t1 (f1 INTEGER);
+        ALTER TABLE t1 REPLICA IDENTITY FULL;
+        INSERT INTO t1 VALUES (1);
+
+        CREATE PUBLICATION mz_source FOR TABLE t1;
+
+        > CREATE SOURCE mz_source
+          FROM POSTGRES CONNECTION pg
+          PUBLICATION 'mz_source';
+
+        > SELECT COUNT(*) = 1 FROM mz_source;
+        true
+
+        > CREATE VIEWS FROM SOURCE mz_source;
+
+        > SELECT f1 FROM t1;
+        1
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+        INSERT INTO t1 VALUES (1), (2);
+
+        > SELECT f1 FROM t1 ORDER BY f1 ASC;
+        1
+        1
+        2
+        """
+        ),
+        no_reset=True,
+    )
+
+    environmentd_pod_name = f"pod/environmentd-0"
+
+    # Kill environmentd to force a restart, to test reloading secrets on restart
+    mz.kubectl(
+        "exec",
+        environmentd_pod_name,
+        "--",
+        "bash",
+        "-c",
+        "kill -9 `pidof environmentd`",
+    )
+
+    mz.testdrive.run_string(
+        dedent(
+            """
+        > SELECT f1 FROM t1 ORDER BY f1 ASC;
+        1
+        1
+        2
+
+        $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+        INSERT INTO t1 VALUES (3), (4);
+
+        > SELECT f1 FROM t1 ORDER BY f1 ASC;
+        1
+        1
+        2
+        3
+        4
+        """
+        ),
+        no_reset=True,
+    )
+
+    mz.environmentd.sql("DROP CONNECTION ssh_conn CASCADE")
+
+    # Verify that secret associated with the SSH tunnel is deleted from k8s
+    wait(condition="delete", resource=f"secret/{secret}")


### PR DESCRIPTION
Includes a simple test flow to serve as a foundation for further cloudtest-based tests.
It includes a new `PostgresSource` pod with a Postgres database ready to be used as a source, using the same mzbuild-based Postgres image that we use on mzcompose tests.

### Motivation
   * This PR adds more tests for an existing feature, SSH tunnels.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
