### PR TITLE
Make a certain Testdrive error message less confusing.

### DIFF
--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -220,9 +220,12 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         "bytes" => Format::Bytes { terminator: None },
         f => bail!("unknown format: {}", f),
     };
+    let key_schema = cmd.args.opt_string("key-schema");
     let key_format = match cmd.args.opt_string("key-format").as_deref() {
         Some("avro") => Some(Format::Avro {
-            schema: cmd.args.string("key-schema")?,
+            schema: key_schema
+                .take()
+                .ok_or_else(|| anyhow!("key-schema parameter required when key-format is present")),
             confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true),
         }),
         Some("protobuf") => {
@@ -249,6 +252,9 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         Some(f) => bail!("unknown key format: {}", f),
         None => None,
     };
+    if key_schema.is_some() {
+        anyhow::bail!("key-schema specified without a matching key-format");
+    }
 
     let timestamp = cmd.args.opt_parse("timestamp")?;
 

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -220,12 +220,12 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         "bytes" => Format::Bytes { terminator: None },
         f => bail!("unknown format: {}", f),
     };
-    let key_schema = cmd.args.opt_string("key-schema");
+    let mut key_schema = cmd.args.opt_string("key-schema");
     let key_format = match cmd.args.opt_string("key-format").as_deref() {
         Some("avro") => Some(Format::Avro {
-            schema: key_schema
-                .take()
-                .ok_or_else(|| anyhow!("key-schema parameter required when key-format is present")),
+            schema: key_schema.take().ok_or_else(|| {
+                anyhow!("key-schema parameter required when key-format is present")
+            })?,
             confluent_wire_format: cmd.args.opt_bool("confluent-wire-format")?.unwrap_or(true),
         }),
         Some("protobuf") => {


### PR DESCRIPTION
When specifying key-schema without key-format, the error message was "unknown parameter key-schema". This is confusing because key-schema _is_ a valid parameter, but only when key-format is specified.