### PR TITLE
integrate Sentry into telemetry stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
+ "serde",
  "uuid",
 ]
 
@@ -2241,6 +2242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,6 +3347,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rlimit",
+ "sentry",
  "serde",
  "serde_json",
  "shell-words",
@@ -3668,6 +3687,8 @@ dependencies = [
  "paste",
  "pin-project",
  "prometheus",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "smallvec",
@@ -4241,6 +4262,7 @@ dependencies = [
  "rand",
  "rdkafka",
  "regex",
+ "sentry",
  "serde",
  "serde_json",
  "thiserror",
@@ -5828,6 +5850,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
+name = "sentry"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73642819e7fa63eb264abc818a2f65ac8764afbe4870b5ee25bcecc491be0d4c"
+dependencies = [
+ "httpdate",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "tokio",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bafa55eefc6dbc04c7dac91e8c8ab9e89e9414f3193c105cabd991bbc75134"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63317c4051889e73f0b00ce4024cae3e6a225f2e18a27d2c1522eb9ce2743da"
+dependencies = [
+ "hostname",
+ "libc",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a4591a2d128af73b1b819ab95f143bc6a2fbe48cd23a4c45e1ee32177e66ae6"
+dependencies = [
+ "once_cell",
+ "rand",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea50bcf843510179a7ba41c9fe4d83a8958e9f8adf707ec731ff999297536344"
+dependencies = [
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
+dependencies = [
+ "debugid",
+ "getrandom",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "seq-macro"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6869,6 +6982,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "uncased"

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -96,8 +96,12 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let tracing_target_callbacks =
-        mz_ore::tracing::configure("computed", &args.tracing).await?;
+    let (tracing_target_callbacks, _sentry_guard) = mz_ore::tracing::configure(
+        "computed",
+        &args.tracing,
+        (BUILD_INFO.version, BUILD_INFO.sha, BUILD_INFO.time),
+    )
+    .await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -96,7 +96,8 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let tracing_target_callbacks = mz_ore::tracing::configure("computed", &args.tracing).await?;
+    let tracing_target_callbacks =
+        mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -59,6 +59,7 @@ rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features =
 rand = "0.8.5"
 reqwest = { version = "0.11.12", features = ["json"] }
 rlimit = "0.8.3"
+sentry = { version = "0.27.0", optional = true }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 shell-words = "1.1.0"

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -599,7 +599,10 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         &metrics_registry,
     );
     let persist_clients = Arc::new(Mutex::new(persist_clients));
-    let orchestrator = Arc::new(TracingOrchestrator::new(orchestrator, args.tracing.clone()));
+    let orchestrator = Arc::new(TracingOrchestrator::new(
+        orchestrator,
+        args.tracing.clone(),
+    ));
     let controller = ControllerConfig {
         build_info: &mz_environmentd::BUILD_INFO,
         orchestrator,

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -34,7 +34,9 @@ use mz_orchestrator::{
 use mz_ore::cli::{DefaultTrue, KeyValueArg};
 #[cfg(feature = "tokio-console")]
 use mz_ore::tracing::TokioConsoleConfig;
-use mz_ore::tracing::{OpenTelemetryConfig, StderrLogConfig, TracingConfig};
+use mz_ore::tracing::{
+    OpenTelemetryConfig, StderrLogConfig, TracingConfig,
+};
 
 /// Command line arguments for application tracing.
 ///
@@ -237,7 +239,10 @@ impl TracingOrchestrator {
     ///
     /// All services created by the orchestrator **must** embed the
     /// [`TracingCliArgs`] in their command-line argument parser.
-    pub fn new(inner: Arc<dyn Orchestrator>, tracing_args: TracingCliArgs) -> TracingOrchestrator {
+    pub fn new(
+        inner: Arc<dyn Orchestrator>,
+        tracing_args: TracingCliArgs,
+    ) -> TracingOrchestrator {
         TracingOrchestrator {
             inner,
             tracing_args,

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -312,7 +312,10 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
                 for kv in opentelemetry_resource {
                     args.push(format!("--opentelemetry-resource={}={}", kv.key, kv.value));
                 }
-                args.push(format!("--opentelemetry-enabled={}", opentelemetry_enabled));
+                args.push(format!(
+                    "--opentelemetry-enabled={}",
+                    opentelemetry_enabled
+                ));
             }
             #[cfg(feature = "tokio-console")]
             if let Some(port) = tokio_console_port {

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -31,6 +31,7 @@ pin-project = "1.0.12"
 prometheus = { version = "0.13.2", default-features = false, optional = true }
 smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
+sentry = { version = "0.27.0", optional = true }
 serde = { version = "1.0.145", features = ["derive"], optional = true }
 serde_json = { version = "1.0.86", optional = true }
 ssh-key = { version = "0.4.3", optional = true }
@@ -59,6 +60,7 @@ hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"], optional = true }
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
 console-subscriber = { version = "0.1.8", optional = true }
+sentry-tracing = { version = "0.27.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.20.2", features = ["macros"] }
@@ -83,6 +85,8 @@ tracing_ = [
   "opentelemetry",
   "opentelemetry-otlp",
   "tonic",
+  "sentry",
+  "sentry-tracing",
 ]
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing"]
 cli = ["clap"]

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -16,6 +16,7 @@
 
 //! Persist command-line utilities
 
+use mz_build_info::DUMMY_BUILD_INFO;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::task::RuntimeExt;
@@ -61,6 +62,11 @@ fn main() {
         .block_on(mz_ore::tracing::configure(
             "persist-open-loop",
             TracingConfig::from(&args.tracing),
+            (
+                DUMMY_BUILD_INFO.version,
+                DUMMY_BUILD_INFO.sha,
+                DUMMY_BUILD_INFO.time,
+            ),
         ))
         .expect("failed to init tracing");
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -61,6 +61,7 @@ prost = { version = "0.11.0", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.6.0" }
+sentry = { version = "0.27.0", optional = true }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = { version = "1.0.86" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -127,7 +127,8 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let tracing_target_callbacks = mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let tracing_target_callbacks =
+        mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -127,8 +127,12 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let tracing_target_callbacks =
-        mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let (tracing_target_callbacks, _sentry_guard) = mz_ore::tracing::configure(
+        "storaged",
+        &args.tracing,
+        (BUILD_INFO.version, BUILD_INFO.sha, BUILD_INFO.time),
+    )
+    .await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Bit of a skunkworks project, mostly to start a conversation -- this PR integrates Sentry into envd/storaged/computed. It adds in an optional `SENTRY_DSN` param that, when set, will send `error!` logs and and `panic`s to Sentry. Seems like it could help us keep better track of the crashes we see in staging/prod

It builds off of https://github.com/MaterializeInc/materialize/pull/14969 so until that PR is merged, the diff shows a bit more than it needs to. The last commit has the most relevant changes.

### Motivation

  * This PR adds a known-desirable feature.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
