### PR TITLE
sql: remove default ENVELOPE DEBEZIUM for sinks

### DIFF
--- a/doc/user/content/releases/v0.27.0.md
+++ b/doc/user/content/releases/v0.27.0.md
@@ -40,6 +40,9 @@ substantial breaking changes from [v0.26 LTS].
 
 * Rename `TAIL` to [`SUBSCRIBE`](/sql/subscribe).
 
+* `CREATE SINK` no longer defaults to `ENVELOPE DEBEZIUM`. You must explicitly
+  specify the envelope to use.
+
 ## Upgrade guide
 
 Following are several examples of how to adapt source and view definitions

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -46,7 +46,7 @@ _item&lowbar;name_ | The name of the source or view you want to send to the sink
 **TOPIC** _topic&lowbar;prefix_ | The prefix used to generate the Kafka topic name to create and write to.
 **KEY (** _key&lowbar;column_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
 _sink&lowbar;with&lowbar;options_ | Options affecting sink creation. For more detail, see [`WITH` options](#with-options).
-**ENVELOPE DEBEZIUM** | The generated schemas have a [Debezium-style diff envelope](#debezium-envelope-details) to capture changes in the input view or source. This is the default.
+**ENVELOPE DEBEZIUM** | The generated schemas have a [Debezium-style diff envelope](#debezium-envelope-details) to capture changes in the input view or source.
 **ENVELOPE UPSERT** | The sink emits data with upsert semantics: updates and inserts for the given key are expressed as a value, and deletes are expressed as a null value payload in Kafka. For more detail, see [Handling upserts](/sql/create-source/kafka/#handling-upserts).
 
 ### `WITH` options
@@ -159,7 +159,8 @@ CREATE SINK quotes_sink
 FROM quotes
 INTO KAFKA CONNECTION kafka_connection (TOPIC 'quotes-sink')
 FORMAT AVRO USING
-    CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection;
+    CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
+ENVELOPE DEBEZIUM;
 ```
 
 #### From materialized views
@@ -180,7 +181,8 @@ CREATE SINK frank_quotes_sink
 FROM frank_quotes
 INTO KAFKA CONNECTION kafka_connection (TOPIC 'frank-quotes-sink')
 FORMAT AVRO USING
-    CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection;
+    CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
+ENVELOPE DEBEZIUM;
 ```
 
 #### Get actual Kafka topic names
@@ -212,7 +214,8 @@ FORMAT AVRO USING
 CREATE SINK quotes_sink
 FROM quotes
 INTO KAFKA CONNECTION kafka_connection (TOPIC 'quotes-sink')
-FORMAT JSON;
+FORMAT JSON
+ENVELOPE DEBEZIUM;
 ```
 
 #### From materialized views
@@ -232,7 +235,8 @@ CREATE MATERIALIZED VIEW frank_quotes AS
 CREATE SINK frank_quotes_sink
 FROM frank_quotes
 INTO KAFKA CONNECTION kafka_connection (TOPIC 'frank-quotes-sink')
-FORMAT JSON;
+FORMAT JSON
+ENVELOPE DEBEZIUM;
 ```
 
 

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -35,7 +35,7 @@ SHOW CREATE SINK my_view_sink;
 ```nofmt
                name              |                                                                                                        create_sql
 ---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- materialize.public.my_view_sink | CREATE SINK "materialize"."public"."my_view_sink" FROM "materialize"."public"."my_view" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" (TOPIC 'my_view_sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
+ materialize.public.my_view_sink | CREATE SINK "materialize"."public"."my_view_sink" FROM "materialize"."public"."my_view" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" (TOPIC 'my_view_sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection ENVELOPE DEBEZIUM
 ```
 
 ## Related pages

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -70,7 +70,7 @@ create_sink ::=
     'FROM' item_name
     'INTO' sink_kafka_connector
     ('FORMAT' sink_format_spec)?
-    ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))?
+    ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))
     ('WITH' with_options)?
 create_source_kafka ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -71,6 +71,7 @@ class SinkUpsert(Check):
                 > CREATE SINK sink_sink1 FROM sink_source_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink1')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
                 """
             )
         )
@@ -92,6 +93,7 @@ class SinkUpsert(Check):
                 > CREATE SINK sink_sink2 FROM sink_source_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink2')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
                 """,
                 """
                 $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
@@ -102,6 +104,7 @@ class SinkUpsert(Check):
                 > CREATE SINK sink_sink3 FROM sink_source_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink3')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
                 """,
             ]
         ]
@@ -205,7 +208,8 @@ class SinkTables(Check):
 
                 > CREATE SINK sink_large_transaction_sink1 FROM sink_large_transaction_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}')
-                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM;
                 """
             )
         )

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -58,7 +58,8 @@ class CreateSink(Action):
 
                 > CREATE SINK {self.sink.name} FROM {self.source_view.name}
                   INTO KAFKA CONNECTION {self.sink.name}_kafka_conn (TOPIC 'sink-{self.sink.name}')
-                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn;
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn
+                  ENVELOPE DEBEZIUM;
 
                 # Ingest the sink again in order to be able to validate its contents
 

--- a/src/billing-demo/src/bin/billing-demo/mz.rs
+++ b/src/billing-demo/src/bin/billing-demo/mz.rs
@@ -86,7 +86,8 @@ pub async fn create_kafka_sink(
 
     let query = format!(
             "CREATE SINK {sink} FROM billing_monthly_statement INTO KAFKA CONNECTION {sink}_kafka_conn (TOPIC '{topic}') \
-             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {sink}_csr_conn",
+             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {sink}_csr_conn
+             ENVELOPE DEBEZIUM",
              sink = sink_name,
              topic = sink_topic_name,
          );

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1536,8 +1536,7 @@ pub fn plan_create_sink(
     } = stmt;
 
     let envelope = match envelope {
-        // Sinks default to ENVELOPE DEBEZIUM. Not sure that's good, though...
-        None => SinkEnvelope::Debezium,
+        None => sql_bail!("ENVELOPE clause is required"),
         Some(Envelope::Debezium(mz_sql_parser::ast::DbzMode::Plain)) => SinkEnvelope::Debezium,
         Some(Envelope::Upsert) => SinkEnvelope::Upsert,
         Some(Envelope::CdcV2) => bail_unsupported!("CDCv2 sinks"),

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -201,6 +201,7 @@ A
 > CREATE SINK sink1 FROM v1mat
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink1')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.sink1 sort-messages=true
 {"before": null, "after": {"row":{"c1": 3}}}

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -1047,6 +1047,7 @@ URL '${{testdrive.schema-registry-url}}';
   INTO KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
   KEY (f1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # Wait until all the records have been emited from the sink, as observed by the sink1_check source
 
@@ -1306,6 +1307,7 @@ URL '${{testdrive.schema-registry-url}}';
   INTO KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-sink-output-${{testdrive.seed}}')
   KEY (f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_csr_conn
+  ENVELOPE DEBEZIUM
 """
             for i in range(0, self.n())
         )

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -96,6 +96,7 @@ $ kafka-create-topic topic=input
 > CREATE SINK output FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=input schema=${schema}
 {"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}

--- a/test/kafka-multi-broker/01-init.td
+++ b/test/kafka-multi-broker/01-init.td
@@ -49,3 +49,4 @@ $ kafka-ingest format=avro topic=kafka-multi-broker schema=${schema} timestamp=6
   FROM kafka_multi_broker
   INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = 2, PARTITION COUNT = 2, TOPIC 'testdrive-kafka-multi-broker-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM

--- a/test/kafka-resumption/setup.td
+++ b/test/kafka-resumption/setup.td
@@ -35,3 +35,4 @@ New York,NY,10004
 > CREATE SINK output FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-byo-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -60,6 +60,7 @@ a
   FROM data
   INTO KAFKA CONNECTION kafka_sasl (TOPIC 'testdrive-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
 {"before": null, "after": {"row": {"a": 1}}}

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -64,6 +64,7 @@ a
 > CREATE SINK snk FROM data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
 {"before": null, "after": {"row":{"a": 1}}}

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -75,6 +75,7 @@ a
 > CREATE SINK snk FROM data
   INTO KAFKA CONNECTION kafka_ssl (TOPIC 'snk')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
 {"before": null, "after": {"row":{"a": 1}}}
@@ -91,6 +92,7 @@ $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
 ! CREATE SINK no_basic_auth FROM data
   INTO KAFKA CONNECTION kafka_ssl (TOPIC 'snk')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION no_basic_auth_conn
+  ENVELOPE DEBEZIUM
 contains:error publishing kafka schemas for sink: unable to publish value schema to registry in kafka sink: server error 401: Unauthorized
 
 > CREATE CONNECTION csr_without_ssl

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -468,7 +468,8 @@ class KafkaSinks(Generator):
                      > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
                      > CREATE SINK s{i} FROM v{i}
                        INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink-{i}')
-                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                       ENVELOPE DEBEZIUM;
                      """
                 )
             )
@@ -513,6 +514,7 @@ class KafkaSinksSameSource(Generator):
                      > CREATE SINK s{i} FROM v1
                        INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink-same-source-{i}')
                        FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+                       ENVELOPE DEBEZIUM
                      """
                 )
             )

--- a/test/persistence/failpoints/before.td
+++ b/test/persistence/failpoints/before.td
@@ -54,6 +54,7 @@ $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschem
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-failpoint-sink-${testdrive.seed}')
   KEY (f1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "c${kafka-ingest.iteration}"} {"f2": "c${kafka-ingest.iteration}"}

--- a/test/persistence/kafka-sources/exactly-once-sink-before.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-before.td
@@ -45,7 +45,8 @@ $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keysc
 
 > CREATE SINK exactly_once_sink FROM exactly_once
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM;
 
 $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2 start-iteration=10
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}

--- a/test/persistence/user-tables/table-persistence-before-sinks.td
+++ b/test/persistence/user-tables/table-persistence-before-sinks.td
@@ -23,6 +23,7 @@
 
 > CREATE SINK sink_sink FROM sink_table
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM;
 
 > INSERT INTO sink_table VALUES (2);

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -291,7 +291,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 > CREATE SINK snk FROM source_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-catalog-sink-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM;
 
 > SHOW OBJECTS
 name        type

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -113,6 +113,7 @@ $ kafka-create-topic topic=nums
 > CREATE SINK nums_sink FROM nums
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'nums-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # ==> Test consolidation.
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -112,19 +112,23 @@ contains:unknown catalog item 'test4'
 > CREATE SINK s1 FROM s
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 ! CREATE SINK s1 FROM s
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:catalog item 's1' already exists
 
 > CREATE SINK IF NOT EXISTS s1 FROM s
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v2-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK s2 FROM s
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v3-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # Test that sinks cannot be depended upon.
 ! CREATE VIEW v2 AS SELECT * FROM s1;

--- a/test/testdrive/disabled/kafka-avro-debezium-transaction.td
+++ b/test/testdrive/disabled/kafka-avro-debezium-transaction.td
@@ -228,6 +228,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-sink-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -25,6 +25,7 @@
 > CREATE SINK data_sink FROM data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.data_sink sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}}
@@ -122,6 +123,7 @@ $ kafka-create-topic topic=input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'non-keyed-sink-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE VIEW max_view AS SELECT a, MAX(b) as b FROM input GROUP BY a
 
@@ -131,21 +133,25 @@ $ kafka-create-topic topic=input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'non-keyed-sink-of-keyed-relation-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK keyed_sink FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'keyed-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK keyed_sink_of_keyed_relation FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'keyed-sink-of-keyed-relation-${testdrive.seed}') KEY (b)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK multi_keyed_sink FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'multi-keyed-sink-${testdrive.seed}') KEY (b, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=input schema=${schema}
 {"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -54,6 +54,7 @@
 > CREATE SINK datetime_data_sink FROM datetime_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-datetime-data-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messages=true
 {"before": null, "after": {"row": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}}
@@ -64,6 +65,7 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messa
 > CREATE SINK time_data_sink FROM time_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-time-data-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=true
 {"before": null, "after": {"row": {"time": 3723000000}}}
@@ -78,6 +80,7 @@ $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-json-data-sink-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # Test map
 
@@ -86,6 +89,7 @@ $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=
 > CREATE SINK map_sink FROM map_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-map-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.map_sink sort-messages=true
 {"before": null, "after": {"row": {"map": {"a": {"int": 1}, "b": {"int": 2}}}}}
@@ -95,6 +99,7 @@ $ kafka-verify format=avro sink=materialize.public.map_sink sort-messages=true
 > CREATE SINK list_sink FROM list_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-list-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.list_sink sort-messages=true
 {"before": null, "after": {"row": {"list": [{"int": 1}, {"int": 2}]}}}
@@ -106,6 +111,7 @@ $ kafka-verify format=avro sink=materialize.public.list_sink sort-messages=true
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-namespace-value-sink-${testdrive.seed}')
   FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'abc.def.ghi')
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify-schema format=avro sink=materialize.public.namespace_value_sink
 {"type":"record","name":"ghi","namespace":"abc.def","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"namespace","type":"int"}]}]},{"name":"after","type":["null","row"]}]}
@@ -120,6 +126,7 @@ $ kafka-verify format=avro sink=materialize.public.namespace_value_sink sort-mes
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-namespace-key-value-sink-${testdrive.seed}')
   KEY (b)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.foo', AVRO VALUE FULLNAME = 'some.neat.class.bar')
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify-schema format=avro sink=materialize.public.namespace_key_value_sink
 {"type":"record","name":"foo","namespace":"some.neat.class","fields":[{"name":"b","type":"int"}]}
@@ -136,24 +143,29 @@ $ kafka-verify format=avro sink=materialize.public.namespace_key_value_sink sort
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}') KEY (a, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:Repeated column name in sink key: a
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'some.neat.class.foo', AVRO KEY FULLNAME = 'some.neat.class.bar')
+  ENVELOPE DEBEZIUM
 contains:Cannot specify AVRO KEY FULLNAME without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.bar')
+  ENVELOPE DEBEZIUM
 contains:Cannot specify AVRO KEY FULLNAME without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.bar')
+  ENVELOPE DEBEZIUM
 contains:Must specify both AVRO KEY FULLNAME and AVRO VALUE FULLNAME when specifying generated schema names
 
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'some.neat.class.bar')
+  ENVELOPE DEBEZIUM
 contains:Must specify both AVRO KEY FULLNAME and AVRO VALUE FULLNAME when specifying generated schema names

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -40,11 +40,13 @@ $ kafka-ingest format=avro topic=topic1 schema=${schema} repeat=1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
   KEY (f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK sink1 FROM source1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
   KEY (f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 
 

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -203,52 +203,64 @@ New York,NY,10004
 > CREATE SINK output1 FROM input_kafka_cdcv2
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output1-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output2 FROM input_kafka_dbz
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output2-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output3 FROM input_table
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output3-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output4 FROM input_kafka_cdcv2_mview
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output4-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output4_view FROM input_kafka_cdcv2_mview_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output4b-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 ! CREATE SINK output5 FROM input_kafka_dbz_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output5-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:input_kafka_dbz_view is a view, which cannot be exported as a sink
 
 > CREATE SINK output5_view FROM input_kafka_dbz_view_mview
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output5b-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output6 FROM input_table_mview
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output6-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 ! CREATE SINK output7 FROM input_values_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output7-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:input_values_view is a view, which cannot be exported as a sink
 
 > CREATE SINK output8 FROM input_values_mview
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output8-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output12 FROM input_kafka_dbz_derived_table
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output12-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK output13 FROM input_csv
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output13-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # We need some data -- any data -- to start creating timestamp bindings
 $ kafka-ingest format=avro topic=input_cdcv2 schema=${cdcv2-schema}

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -21,6 +21,7 @@
 > CREATE SINK simple_view_sink FROM simple_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-cols-sink-${testdrive.seed}')
   FORMAT JSON
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=json sink=materialize.public.simple_view_sink key=false
 {"before": null, "after": {"a": 1, "b": 2, "c": 3}}
@@ -55,6 +56,7 @@ $ kafka-verify format=json sink=materialize.public.simple_view_upsert key=true
 > CREATE SINK types_sink FROM types_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-types-sink-${testdrive.seed}')
   FORMAT JSON
+  ENVELOPE DEBEZIUM
 
 # Due to limitations in $ kafka-verify, the entire expected JSON output needs to be provided on a single line
 $ kafka-verify format=json sink=materialize.public.types_sink key=false
@@ -68,6 +70,7 @@ $ kafka-verify format=json sink=materialize.public.types_sink key=false
 > CREATE SINK special_characters_sink FROM special_characters_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-special-characters-sink-${testdrive.seed}')
   FORMAT JSON
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=json sink=materialize.public.special_characters_sink key=false
 {"before":null,"after":{"c1":"текст","c2":"\"","c3":"'","c4":"\\","c5":"a\n\tb"}}
@@ -79,6 +82,7 @@ $ kafka-verify format=json sink=materialize.public.special_characters_sink key=f
 > CREATE SINK record_sink FROM record_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-record-sink-${testdrive.seed}')
   FORMAT JSON
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=json sink=materialize.public.record_sink key=false
 {"before":null,"after":{"simple_view":{"a":1,"b":2,"c":3}}}
@@ -105,6 +109,7 @@ contains:column "a" specified more than once
 > CREATE SINK complex_type_sink FROM complex_type_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-complex-type-sink-${testdrive.seed}')
   FORMAT JSON
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=json sink=materialize.public.complex_type_sink key=false
 {"before": null, "after": {"c1": [[1,2],[3,4]], "c2": {"a":{"b":1, "c":2}, "d": {"e":3, "f":4}}}}

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -23,32 +23,38 @@
 ! CREATE SINK invalid_partition_count FROM v1
   INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:invalid PARTITION COUNT: cannot use value as number
 
 ! CREATE SINK invalid_partition_count FROM v1
   INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:PARTION COUNT for sink topics must be a positive integer or -1 for broker default
 
 ! CREATE SINK invalid_replication_factor FROM v1
   INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:invalid REPLICATION FACTOR: cannot use value as number
 
 ! CREATE SINK invalid_replication_factor FROM v1
   INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:REPLICATION FACTOR for sink topics must be a positive integer or -1 for broker default
 
 ! CREATE SINK invalid_acks FROM v1
   INTO KAFKA CONNECTION kafka_conn (ACKS = foo, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:Invalid value for configuration property "request.required.acks" acks foo
 
 ! CREATE SINK invalid_key FROM v1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   KEY(f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:No such column: f2
 
 #
@@ -57,21 +63,25 @@ contains:No such column: f2
 ! CREATE SINK invalid_retention_ms FROM v1
   INTO KAFKA CONNECTION kafka_conn (RETENTION MS = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:invalid RETENTION MS: cannot use value as number
 
 ! CREATE SINK invalid_retention_ms FROM v1
   INTO KAFKA CONNECTION kafka_conn (RETENTION MS = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:RETENTION MS for sink topics must be greater than or equal to -1
 
 ! CREATE SINK invalid_retention_bytes FROM v1
   INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:invalid RETENTION BYTES: cannot use value as number
 
 ! CREATE SINK invalid_retention_bytes FROM v1
   INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:RETENTION BYTES for sink topics must be greater than or equal to -1
 
 #
@@ -81,10 +91,12 @@ contains:RETENTION BYTES for sink topics must be greater than or equal to -1
 > CREATE SINK s1 FROM v1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 ! CREATE SINK s2 FROM s1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 
 ! CREATE VIEW v2 AS SELECT * FROM s1
@@ -104,12 +116,19 @@ nonsense
 
 ! CREATE SINK invalid_format FROM v1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  ENVELOPE DEBEZIUM
 contains:sink without format not yet supported
 
 ! CREATE SINK invalid_format FROM v1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT NO_SUCH_FORMAT
+  ENVELOPE DEBEZIUM
 contains:found identifier "no_such_format"
+
+! CREATE SINK invalid_envelope FROM v1
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  FORMAT JSON
+contains:ENVELOPE clause is required
 
 # Expect empty output
 > SHOW SINKS

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -147,6 +147,7 @@ a  b
 ! CREATE SINK not_mat_sink2 FROM data_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-view2-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:data_view is a view, which cannot be exported as a sink
 
 # Can create indexed view from unmaterialized view.
@@ -158,6 +159,7 @@ contains:data_view is a view, which cannot be exported as a sink
 ! CREATE SINK not_mat_sink2 FROM test5
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-view2-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 contains:test5 is a view, which cannot be exported as a sink
 
 $ set-regex match=(\s\(u\d+\)|\n) replacement=

--- a/test/testdrive/materialized-views.td
+++ b/test/testdrive/materialized-views.td
@@ -61,6 +61,7 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 > CREATE SINK sink1 FROM v1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-materialized-views-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SOURCE sink1_check
   FROM KAFKA CONNECTION kafka_conn (

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -39,6 +39,7 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
 > CREATE SINK sink1 FROM mz_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE VIEW mz_view AS
     SELECT * FROM mz_data
@@ -208,7 +209,7 @@ materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"de
 > SHOW CREATE SINK renamed_sink
 name                            create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-snk1-${testdrive.seed}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-snk1-${testdrive.seed}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" ENVELOPE DEBEZIUM"
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -94,14 +94,17 @@ name
 > CREATE SINK snk1 FROM src
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK snk2 FROM src_materialized
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk2-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > CREATE SINK snk3 FROM v3
   INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = 1000000000000, TOPIC 'testdrive-snk3-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 > SHOW SINKS
 name
@@ -128,6 +131,7 @@ $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
 > CREATE SINK snk_unsigned FROM unsigned
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk2')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 $ kafka-verify format=avro sink=materialize.public.snk_unsigned sort-messages=true
 {"before": null, "after": {"row":{"a": [0, 1], "b": [0, 2], "c": [0, 0, 0, 3], "d": [0, 0, 0, 4], "e": [0, 0, 0, 0, 0, 0, 0, 5], "f": [0, 0, 0, 0, 0, 0, 0, 6]}}}
 
@@ -139,6 +143,7 @@ $ kafka-verify format=avro sink=materialize.public.snk_unsigned sort-messages=tr
 > CREATE SINK snk4 FROM v4
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk4-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.snk4
 {"before": null, "after": {"row":{"c": true}}}
@@ -154,11 +159,13 @@ $ kafka-verify format=avro sink=materialize.public.snk4
 > CREATE SINK snk5 FROM src_materialized
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk5-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
   WITH (SNAPSHOT = false)
 
 > CREATE SINK snk6 FROM src_materialized
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk6-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
   WITH (SNAPSHOT = true)
 
 $ kafka-ingest topic=test format=bytes
@@ -179,11 +186,13 @@ $ kafka-verify format=avro sink=materialize.public.snk6 sort-messages=true
 > CREATE SINK snk7 FROM foo
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk7-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
   WITH (SNAPSHOT = false)
 
 > CREATE SINK snk8 FROM foo
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk8-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
   WITH (SNAPSHOT)
 
 $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
@@ -208,23 +217,28 @@ snk_unsigned
 > CREATE SINK snk9 FROM foo
   INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, TOPIC 'testdrive-snk9-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # test explicit replication factor
 > CREATE SINK snk10 FROM foo
   INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR=1, TOPIC 'testdrive-snk10-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # test explicit partition count and replication factor
 > CREATE SINK snk11 FROM foo
   INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, REPLICATION FACTOR=1, TOPIC 'testdrive-snk11-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # test broker defaulted partition count and replication factor
 > CREATE SINK snk12 FROM foo
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk12-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 # test explicit request for broker defaulted partition count and replication factor
 > CREATE SINK snk13 FROM foo
   INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=-1, REPLICATION FACTOR=-1, TOPIC 'testdrive-snk13-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -95,6 +95,7 @@ contains:unknown catalog item 'UID'
 > CREATE SINK sort_messages_sink FROM sort_messages
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sort-messages-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.sort_messages_sink sort-messages=true
 {"before": null, "after": {"row": {"a": 1}}}
@@ -181,6 +182,7 @@ $ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-s
 > CREATE SINK kafka_verify_regexp_sink FROM kafka_verify_regexp
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-verify-regexp-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.kafka_verify_regexp_sink sort-messages=true
 {"before": null, "after": {"row": {"a": "UID"}}}

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -62,6 +62,7 @@ u      false     uuid
 > CREATE SINK uuid_sink_${testdrive.seed} FROM data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sort-messages=true sink=materialize.public.uuid_sink_${testdrive.seed}
 {"before": null, "after": {"row":{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -10,4 +10,4 @@
 
 
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'upgrade-kafka-sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'upgrade-kafka-sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" ENVELOPE DEBEZIUM"

--- a/test/upgrade/create-in-current_source-kafka-sink.td
+++ b/test/upgrade/create-in-current_source-kafka-sink.td
@@ -19,3 +19,4 @@
 > CREATE SINK upgrade_kafka_sink FROM static_view
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'upgrade-kafka-sink')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM


### PR DESCRIPTION
Instead users must explicitly choose an envelope.  Unlike sources, where `ENVELOPE NONE` is a reasonable default, sinks have no natural default; both `ENVELOPE DEBEZIUM` and `ENVELOPE UPSERT` have pros and cons, and neither is particularly more fundamental than the other.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing ~code~ per a conversation on Slack ([link](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1664206063722139?thread_ts=1664205811.335529&cid=CU7ELJ6E9)).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
