### PR TITLE
persist: batch part read metrics

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -12,11 +12,13 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::anyhow;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
+use mz_ore::cast::CastFrom;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -28,7 +30,7 @@ use mz_persist_types::{Codec, Codec64};
 
 use crate::error::InvalidUsage;
 use crate::internal::machine::retry_external;
-use crate::internal::metrics::Metrics;
+use crate::internal::metrics::{Metrics, ReadMetrics};
 use crate::internal::paths::PartialBatchKey;
 use crate::read::{ReadHandle, ReaderId};
 use crate::ShardId;
@@ -92,8 +94,14 @@ where
             );
         }
 
-        let (part, fetched_part) =
-            fetch_leased_part(part, self.blob.as_ref(), Arc::clone(&self.metrics), None).await;
+        let (part, fetched_part) = fetch_leased_part(
+            part,
+            self.blob.as_ref(),
+            Arc::clone(&self.metrics),
+            &self.metrics.read.batch_fetcher,
+            None,
+        )
+        .await;
         (part, Ok(fetched_part))
     }
 }
@@ -150,6 +158,7 @@ pub(crate) async fn fetch_leased_part<K, V, T, D>(
     part: LeasedBatchPart<T>,
     blob: &(dyn Blob + Send + Sync),
     metrics: Arc<Metrics>,
+    read_metrics: &ReadMetrics,
     reader_id: Option<&ReaderId>,
 ) -> (LeasedBatchPart<T>, FetchedPart<K, V, T, D>)
 where
@@ -170,25 +179,32 @@ where
         }
     };
 
-    let encoded_part = fetch_batch_part(&part.shard_id, blob, &metrics, &part.key, &part.desc)
-        .await
-        .unwrap_or_else(|err| {
-            // Ideally, readers should never encounter a missing blob. They place a seqno
-            // hold as they consume their snapshot/listen, preventing any blobs they need
-            // from being deleted by garbage collection, and all blob implementations are
-            // linearizable so there should be no possibility of stale reads.
-            //
-            // If we do have a bug and a reader does encounter a missing blob, the state
-            // cannot be recovered, and our best option is to panic and retry the whole
-            // process.
-            panic!(
-                "{} could not fetch batch part: {}",
-                reader_id
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "batch fetcher".to_string()),
-                err
-            )
-        });
+    let encoded_part = fetch_batch_part(
+        &part.shard_id,
+        blob,
+        &metrics,
+        read_metrics,
+        &part.key,
+        &part.desc,
+    )
+    .await
+    .unwrap_or_else(|err| {
+        // Ideally, readers should never encounter a missing blob. They place a seqno
+        // hold as they consume their snapshot/listen, preventing any blobs they need
+        // from being deleted by garbage collection, and all blob implementations are
+        // linearizable so there should be no possibility of stale reads.
+        //
+        // If we do have a bug and a reader does encounter a missing blob, the state
+        // cannot be recovered, and our best option is to panic and retry the whole
+        // process.
+        panic!(
+            "{} could not fetch batch part: {}",
+            reader_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "batch fetcher".to_string()),
+            err
+        )
+    });
     let fetched_part = FetchedPart {
         metrics,
         ts_filter,
@@ -203,12 +219,14 @@ pub(crate) async fn fetch_batch_part<T>(
     shard_id: &ShardId,
     blob: &(dyn Blob + Send + Sync),
     metrics: &Metrics,
+    read_metrics: &ReadMetrics,
     key: &PartialBatchKey,
     registered_desc: &Description<T>,
 ) -> Result<EncodedPart<T>, anyhow::Error>
 where
     T: Timestamp + Lattice + Codec64,
 {
+    let now = Instant::now();
     let get_span = debug_span!("fetch_batch::get");
     let value = retry_external(&metrics.retries.external.fetch_batch_get, || async {
         blob.get(&key.complete(shard_id)).await
@@ -228,6 +246,9 @@ where
     };
     drop(get_span);
 
+    read_metrics.part_count.inc();
+    read_metrics.part_bytes.inc_by(u64::cast_from(value.len()));
+
     let part = trace_span!("fetch_batch::decode").in_scope(|| {
         let part = metrics
             .codecs
@@ -242,9 +263,12 @@ where
 
         // Drop the encoded representation as soon as we can to reclaim memory.
         drop(value);
+        read_metrics.part_goodbytes.inc_by(u64::cast_from(part.updates.iter().map(|x| x.goodbytes()).sum()));
 
         EncodedPart::new(key, registered_desc.clone(), part)
     });
+
+    read_metrics.seconds.inc_by(now.elapsed().as_secs_f64());
 
     Ok(part)
 }

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -263,7 +263,9 @@ where
 
         // Drop the encoded representation as soon as we can to reclaim memory.
         drop(value);
-        read_metrics.part_goodbytes.inc_by(u64::cast_from(part.updates.iter().map(|x| x.goodbytes()).sum()));
+        read_metrics.part_goodbytes.inc_by(u64::cast_from(
+            part.updates.iter().map(|x| x.goodbytes()).sum(),
+        ));
 
         EncodedPart::new(key, registered_desc.clone(), part)
     });

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -463,9 +463,15 @@ where
         // populate our heap with the updates from the first part of each run
         for (index, (part_desc, parts)) in runs.iter_mut().enumerate() {
             if let Some(part) = parts.next() {
-                let mut part =
-                    fetch_batch_part(&shard_id, blob.as_ref(), &metrics, &part.key, part_desc)
-                        .await?;
+                let mut part = fetch_batch_part(
+                    &shard_id,
+                    blob.as_ref(),
+                    &metrics,
+                    &metrics.read.compaction,
+                    &part.key,
+                    part_desc,
+                )
+                .await?;
                 while let Some((k, v, mut t, d)) = part.next() {
                     t.advance_by(desc.since().borrow());
                     let d = D::decode(d);
@@ -487,9 +493,15 @@ where
                 // repopulate from the originating run, if any parts remain
                 let (part_desc, parts) = &mut runs[index];
                 if let Some(part) = parts.next() {
-                    let mut part =
-                        fetch_batch_part(&shard_id, blob.as_ref(), &metrics, &part.key, part_desc)
-                            .await?;
+                    let mut part = fetch_batch_part(
+                        &shard_id,
+                        blob.as_ref(),
+                        &metrics,
+                        &metrics.read.compaction,
+                        &part.key,
+                        part_desc,
+                    )
+                    .await?;
                     while let Some((k, v, mut t, d)) = part.next() {
                         t.advance_by(desc.since().borrow());
                         let d = D::decode(d);

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -986,6 +986,7 @@ pub mod datadriven {
                 &datadriven.shard_id,
                 datadriven.client.blob.as_ref(),
                 datadriven.client.metrics.as_ref(),
+                &datadriven.client.metrics.read.batch_fetcher,
                 &part.key,
                 &batch.desc,
             )
@@ -1135,6 +1136,7 @@ pub mod datadriven {
                     &datadriven.shard_id,
                     datadriven.client.blob.as_ref(),
                     datadriven.client.metrics.as_ref(),
+                    &datadriven.client.metrics.read.batch_fetcher,
                     &part.key,
                     &batch.desc,
                 )

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -277,12 +277,12 @@ impl MetricsVecs {
             )),
 
             read_part_bytes: registry.register(metric!(
-                name: "mz_persist_read_part_bytes",
+                name: "mz_persist_read_batch_part_bytes",
                 help: "total encoded size of batch parts read",
                 var_labels: ["op"],
             )),
             read_part_goodbytes: registry.register(metric!(
-                name: "mz_persist_read_part_goodbytes",
+                name: "mz_persist_read_batch_part_goodbytes",
                 help: "total logical size of batch parts read",
                 var_labels: ["op"],
             )),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -330,6 +330,7 @@ where
                 part,
                 self.handle.blob.as_ref(),
                 Arc::clone(&self.handle.metrics),
+                &self.handle.metrics.read.listen,
                 Some(&self.handle.reader_id),
             )
             .await;
@@ -544,6 +545,7 @@ where
                 part,
                 self.blob.as_ref(),
                 Arc::clone(&self.metrics),
+                &self.metrics.read.snapshot,
                 Some(&self.reader_id),
             )
             .await;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This adds metrics for batch parts read / bytes read / time spent fetching parts broken down by listen vs snapshot vs batch_fetcher vs compaction.

### Motivation

  * This PR adds a known-desirable feature.
 
A piece from the M2 checklist, tackles part of:

```Metrics for snapshots, listens, batches fetched, seqno leases, etc```

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
