### PR TITLE
[system] Create mz_kafka_connections table

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1075,6 +1075,10 @@ pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable 
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
+        .with_column(
+            "brokers",
+            ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
+        )
         .with_column("progress_topic", ScalarType::String.nullable(true)),
 });
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1070,6 +1070,13 @@ pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("progress_topic", ScalarType::String.nullable(true))
         .with_key(vec![0]),
 });
+pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_kafka_connections",
+    schema: MZ_CATALOG_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("progress_topic", ScalarType::String.nullable(true)),
+});
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_databases",
     schema: MZ_CATALOG_SCHEMA,
@@ -2274,6 +2281,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_VIEW_KEYS),
         Builtin::Table(&MZ_VIEW_FOREIGN_KEYS),
         Builtin::Table(&MZ_KAFKA_SINKS),
+        Builtin::Table(&MZ_KAFKA_CONNECTIONS),
         Builtin::Table(&MZ_DATABASES),
         Builtin::Table(&MZ_SCHEMAS),
         Builtin::Table(&MZ_COLUMNS),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -367,9 +367,20 @@ impl CatalogState {
             Some(ref topic) => Datum::String(&topic),
             None => Datum::Null,
         };
+        let mut row = Row::default();
+        row.packer()
+            .push_array(
+                &[ArrayDimension {
+                    lower_bound: 1,
+                    length: kafka.brokers.len(),
+                }],
+                kafka.brokers.iter().map(|id| Datum::String(&id)),
+            )
+            .unwrap();
+        let brokers = row.unpack_first();
         vec![BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_KAFKA_CONNECTIONS),
-            row: Row::pack_slice(&[Datum::String(&id.to_string()), progress_topic]),
+            row: Row::pack_slice(&[Datum::String(&id.to_string()), brokers, progress_topic]),
             diff,
         }]
     }

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -467,6 +467,7 @@ mz_databases
 mz_functions
 mz_index_columns
 mz_indexes
+mz_kafka_connections
 mz_kafka_sinks
 mz_list_types
 mz_map_types

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -588,7 +588,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-30
+31
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -33,10 +33,10 @@ name   create_sql
 ---------------------------------
 materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER = '${testdrive.kafka-addr}'"
 
-> SELECT progress_topic FROM mz_kafka_connections
-progress_topic
---------------
-<null>
+> SELECT brokers, progress_topic FROM mz_kafka_connections
+brokers                     progress_topic
+------------------------------------------
+{${testdrive.kafka-addr}} <null>
 
 > DROP CONNECTION testconn
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -33,6 +33,10 @@ name   create_sql
 ---------------------------------
 materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER = '${testdrive.kafka-addr}'"
 
+> SELECT progress_topic FROM mz_kafka_connections
+progress_topic
+--------------
+<null>
 
 > DROP CONNECTION testconn
 


### PR DESCRIPTION
Create a new system table for kafka connections that contains the list of brokers and the (optional) progress topic.  This is so that `mz_kafka_sinks` can reference this table instead of inlining the `progress_topic` into its own system table.

### Motivation
Fixes #14957 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - new system table