### PR TITLE
storage: commit kafka offsets upstream

### DIFF
--- a/src/testdrive/src/action/kafka/commit.rs
+++ b/src/testdrive/src/action/kafka/commit.rs
@@ -73,6 +73,11 @@ impl Action for VerifyCommitAction {
             "group.id",
             format!("materialize-{}-kafka-{}", env_id, source_id),
         );
+        println!(
+            "Verifying committed kafka offset for topic ({}) and consumer group ({})",
+            topic,
+            config.get("group.id").unwrap()
+        );
         Retry::default()
             .max_duration(state.default_timeout)
             .retry_async_canceling(|_| async {

--- a/test/testdrive/auto-commit.td
+++ b/test/testdrive/auto-commit.td
@@ -7,9 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# This testdrive file uses the deprecated syntax, but is otherwise identical to upsert-kafka-new.td
-#
-# This file can be deleted when/if we finish the deprecation and perform the removal of the old syntax.
+# Test that auto-commit for kafka sources works.
+# This test should probably be removed.
 
 $ kafka-create-topic topic=auto_topic partitions=1
 

--- a/test/testdrive/kafka-commit.td
+++ b/test/testdrive/kafka-commit.td
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that committing kafka offsets works
+
+$ kafka-create-topic topic=topic partitions=1
+
+$ kafka-ingest format=bytes topic=topic
+one
+two
+three
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+> CREATE SOURCE topic
+  FROM KAFKA CONNECTION conn (
+    TOPIC 'testdrive-topic-${testdrive.seed}'
+  )
+  FORMAT BYTES
+  INCLUDE OFFSET
+  ENVELOPE NONE
+
+> SELECT * from topic
+data         offset
+-----------------------------------
+one          0
+two          1
+three        2
+
+$ kafka-verify-commit source=topic topic=topic partition=0
+3


### PR DESCRIPTION
Similar to https://github.com/MaterializeInc/materialize/pull/14961, we can now commit kafka offsets upstream. We also test this behavior in a td file

### Motivation
  * This PR adds a known-desirable feature.
https://github.com/MaterializeInc/materialize/issues/13534

### Tips for reviewer
- Note that we actually commit 1 past the max offset of data we have persisted. Will start slack conversation about this

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - We now commit kafka offsets upstream, as we process topics. 
    - Note to @morsapaes: I am not documenting the `group.id` right now, as it will change shortly
