### PR TITLE
deps: upgrade to latest segment release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5775,8 +5775,9 @@ dependencies = [
 
 [[package]]
 name = "segment"
-version = "0.2.0"
-source = "git+https://github.com/MaterializeInc/segment.git#d8ad043a0f4ef907293a2e4a4c9c312e26092fa6"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fc91c898e0487ff3e471d0849bbaf7d38a00ff5e3531009d386b0bab9b6b12"
 dependencies = [
  "async-trait",
  "reqwest",

--- a/deny.toml
+++ b/deny.toml
@@ -153,9 +153,6 @@ allow-git = [
     # release.
     "https://github.com/MaterializeInc/pprof-rs.git",
 
-    # Waiting on https://github.com/meilisearch/segment/pull/9.
-    "https://github.com/MaterializeInc/segment.git",
-
     # Waiting on https://github.com/AltSysrq/proptest/pull/264.
     "https://github.com/MaterializeInc/proptest.git",
 

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 mz-ore = { path = "../ore", features = ["task"] }
-segment = { git = "https://github.com/MaterializeInc/segment.git", features = ["native-tls-vendored"], default-features = false }
+segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
 serde_json = "1.0.85"
 tokio = { version = "1.19.2", features = ["sync"] }
 tracing = "0.1.36"


### PR DESCRIPTION
Upstream has shipped the PR we need in a release.

