### PR TITLE
adapter: rework sink progress topic exposure in system catalog

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -72,7 +72,7 @@ they occur. To only see results after the sink is created, specify `WITHOUT SNAP
 ## Detail
 
 - Materialize currently only supports Avro or JSON-formatted sinks that write to a Kafka topic.
-- Materialize stores information about actual topic names in the `mz_kafka_sinks` log sources. See the [examples](#examples) below for more details.
+- Materialize stores information about the sink's topic name in the [`mz_kafka_sinks`](/sql/system-catalog/#mz_kafka_sinks) system table. See the [examples](#examples) below for more details.
 - For Avro-formatted sinks, Materialize generates Avro schemas for views and sources that are stored in the sink. If needed, the fullnames for these schemas can be specified with the `avro_key_fullname` and `avro_value_fullname` options.
 
 ### Debezium envelope details
@@ -134,7 +134,7 @@ If the topic does not exist, Materialize will use the Kafka Admin API to create 
 
 For Avro-encoded sinks, Materialize will publish the sink's Avro schema to the Confluent Schema Registry. Materialize will not publish schemas for JSON-encoded sinks.
 
-You can find the topic name and other metadata for each Kafka sink by querying `mz_kafka_sinks`.
+You can find the topic name and other metadata for each Kafka sink by querying [`mz_kafka_sinks`](/sql/system-catalog/#mz_kafka_sinks).
 
 {{< note >}}
 {{% kafka-sink-drop  %}}
@@ -183,19 +183,19 @@ FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection;
 ```
 
-#### Get actual Kafka topic names
+#### Get Kafka topic names
 
 ```sql
 SELECT sink_id, name, topic
 FROM mz_sinks
-JOIN mz_kafka_sinks ON mz_sinks.id = mz_kafka_sinks.sink_id
+JOIN mz_kafka_sinks USING (id);
 ```
 
 ```nofmt
-  sink_id  |              name                    |                        topic
------------+--------------------------------------+------------------------------------------------------
- u5        | materialize.public.quotes_sink       | quotes-sink-u6-1586024632-15401700525642547992
- u6        | materialize.public.frank_quotes_sink | frank-quotes-sink-u5-1586024632-15401700525642547992
+  sink_id  |              name                    |       topic
+-----------+--------------------------------------+---------------------
+ u5        | materialize.public.quotes_sink       | quotes
+ u6        | materialize.public.frank_quotes_sink | frank-quotes
 ```
 
 ### JSON sinks

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -149,15 +149,25 @@ Field            | Type        | Meaning
 `on_expression`  | [`text`]    | If not `NULL`, specifies a SQL expression that is evaluated to compute the value of this index column. The expression may contain references to any of the columns of the relation.
 `nullable`       | [`boolean`] | Can this column of the index evaluate to `NULL`?
 
+### `mz_kafka_connections`
+
+The `mz_kafka_connections` table contains a row for each Kafka connection in the
+system.
+
+Field                 | Type           | Meaning
+----------------------|----------------|--------
+`id`                  | [`text`]       | The ID of the connection.
+`brokers`             | [`text array`] | The addresses of the Kafka brokers to connect to.
+`sink_progress_topic` | [`text`]       | The name of the Kafka topic where any sinks associated with this connection will track their progress information and other metadata. The contents of this topic are unspecified.
+
 ### `mz_kafka_sinks`
 
 The `mz_kafka_sinks` table contains a row for each Kafka sink in the system.
 
 Field                | Type     | Meaning
 ---------------------|----------|--------
-`sink_id`            | [`text`] | The ID of the sink.
+`id`                 | [`text`] | The ID of the sink.
 `topic`              | [`text`] | The name of the Kafka topic into which the sink is writing.
-`progress_topic`     | [`text`] | The name of the Kafka topic where the sink will track its progress information and other metadata. The contents of this topic are unspecified. If no progress topic name was specified for the given connection, Materialize will use a default based on the environment name and Kafka connection ID.
 
 ### `mz_list_types`
 
@@ -261,6 +271,7 @@ Field            | Type        | Meaning
 `schema_id`      | [`bigint`]  | The ID of the schema to which the sink belongs.
 `name`           | [`text`]    | The name of the sink.
 `type`           | [`text`]    | The type of the sink: `kafka`.
+`connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any.
 
 ### `mz_sources`
 
@@ -273,6 +284,7 @@ Field            | Type       | Meaning
 `schema_id`      | [`bigint`] | The ID of the schema to which the source belongs.
 `name`           | [`text`]   | The name of the source.
 `type`           | [`text`]   | The type of the source: `kafka` or `postgres`.
+`connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
 
 ### `mz_storage_usage`
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1252,6 +1252,9 @@ impl Table {
 #[derive(Debug, Clone, Serialize)]
 pub struct Source {
     pub create_sql: String,
+    pub connection_id: Option<GlobalId>,
+    // TODO(benesch): this field contains connection information that could be
+    // derived from the connection ID. Too hard to fix at the moment.
     pub source_desc: SourceDesc,
     pub desc: RelationDesc,
     pub timeline: Timeline,
@@ -1263,6 +1266,9 @@ pub struct Source {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
+    pub connection_id: Option<GlobalId>,
+    // TODO(benesch): this field duplicates information that could be derived
+    // from the connection ID. Too hard to fix at the moment.
     pub connection: StorageSinkConnectionState,
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
@@ -4267,6 +4273,7 @@ impl<S: Append> Catalog<S> {
                 ..
             }) => CatalogItem::Source(Source {
                 create_sql: source.create_sql,
+                connection_id: source.connection_id,
                 source_desc: source.source_desc,
                 desc: source.desc,
                 timeline,
@@ -4314,6 +4321,7 @@ impl<S: Append> Catalog<S> {
             }) => CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
                 from: sink.from,
+                connection_id: sink.connection_id,
                 connection: StorageSinkConnectionState::Pending(sink.connection_builder),
                 envelope: sink.envelope,
                 with_snapshot,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1065,9 +1065,8 @@ pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_kafka_sinks",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("sink_id", ScalarType::String.nullable(false))
+        .with_column("id", ScalarType::String.nullable(false))
         .with_column("topic", ScalarType::String.nullable(false))
-        .with_column("progress_topic", ScalarType::String.nullable(true))
         .with_key(vec![0]),
 });
 pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1079,7 +1078,7 @@ pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable 
             "brokers",
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
         )
-        .with_column("progress_topic", ScalarType::String.nullable(true)),
+        .with_column("sink_progress_topic", ScalarType::String.nullable(false)),
 });
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_databases",
@@ -1166,7 +1165,8 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("type", ScalarType::String.nullable(false)),
+        .with_column("type", ScalarType::String.nullable(false))
+        .with_column("connection_id", ScalarType::String.nullable(true)),
 });
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sinks",
@@ -1176,7 +1176,8 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("type", ScalarType::String.nullable(false)),
+        .with_column("type", ScalarType::String.nullable(false))
+        .with_column("connection_id", ScalarType::String.nullable(true)),
 });
 pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_views",

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -426,6 +426,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let host_config = self.catalog.resolve_storage_host_config(plan.host_config)?;
         let source = catalog::Source {
             create_sql: plan.source.create_sql,
+            connection_id: plan.source.connection_id,
             source_desc: plan.source.source_desc,
             desc: plan.source.desc,
             timeline: plan.timeline,
@@ -1091,6 +1092,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let catalog_sink = catalog::Sink {
             create_sql: sink.create_sql,
             from: sink.from,
+            connection_id: sink.connection_id,
             connection: StorageSinkConnectionState::Pending(StorageSinkConnectionBuilder::Kafka(
                 connection_builder,
             )),

--- a/src/billing-demo/src/bin/billing-demo/main.rs
+++ b/src/billing-demo/src/bin/billing-demo/main.rs
@@ -187,7 +187,7 @@ async fn create_mz_objects(config: MzConfig) -> Result<()> {
         if config.low_memory {
             mz::drop_indexes(&client).await?;
         }
-        let sink_topic = mz::create_kafka_sink(
+        mz::create_kafka_sink(
             &client,
             &config.kafka_url,
             config::KAFKA_SINK_TOPIC_NAME,
@@ -201,7 +201,7 @@ async fn create_mz_objects(config: MzConfig) -> Result<()> {
                 &config.kafka_url,
                 &config.schema_registry_url,
                 config::REINGESTED_SINK_SOURCE_NAME,
-                &sink_topic,
+                config::KAFKA_SINK_TOPIC_NAME,
             )
             .await?;
             mz::init_sink_views(&client, config::REINGESTED_SINK_SOURCE_NAME).await?;

--- a/src/billing-demo/src/bin/billing-demo/mz.rs
+++ b/src/billing-demo/src/bin/billing-demo/mz.rs
@@ -62,7 +62,7 @@ pub async fn create_kafka_sink(
     sink_topic_name: &str,
     sink_name: &str,
     schema_registry_url: &str,
-) -> Result<String> {
+) -> Result<()> {
     let query = format!(
         "CREATE CONNECTION IF NOT EXISTS {sink}_kafka_conn
             FOR KAFKA BROKER '{kafka_url}'",
@@ -94,15 +94,7 @@ pub async fn create_kafka_sink(
     debug!("creating sink=> {}", query);
     mz_client::execute(&mz_client, &query).await?;
 
-    // Get the topic for the newly-created sink.
-    let row = mz_client
-        .query_one(
-            "SELECT topic FROM mz_kafka_sinks JOIN mz_sinks ON mz_kafka_sinks.sink_id = mz_sinks.id \
-                 WHERE name = $1",
-            &[&sink_name],
-        )
-        .await?;
-    Ok(row.get("topic"))
+    Ok(())
 }
 
 pub async fn create_price_table(

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -220,6 +220,17 @@ pub struct CatalogConfig {
     pub now: NowFn,
 }
 
+impl CatalogConfig {
+    /// Returns the default progress topic name for a Kafka sink for a given
+    /// connection.
+    pub fn default_kafka_sink_progress_topic(&self, connection_id: GlobalId) -> String {
+        format!(
+            "_materialize-progress-{}-{connection_id}",
+            self.environment_id
+        )
+    }
+}
+
 /// A database in a [`SessionCatalog`].
 pub trait CatalogDatabase {
     /// Returns a fully-specified name of the database.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -649,6 +649,7 @@ pub struct Table {
 #[derive(Clone, Debug)]
 pub struct Source {
     pub create_sql: String,
+    pub connection_id: Option<GlobalId>,
     pub source_desc: SourceDesc,
     pub desc: RelationDesc,
 }
@@ -669,6 +670,7 @@ pub struct Secret {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
+    pub connection_id: Option<GlobalId>,
     pub connection_builder: StorageSinkConnectionBuilder,
     pub envelope: SinkEnvelope,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -367,7 +367,7 @@ pub fn plan_create_source(
         bail_unsupported!("INCLUDE metadata with non-Kafka sources");
     }
 
-    let (external_connection, encoding) = match connection {
+    let (external_connection, connection_id, encoding) = match connection {
         CreateSourceConnection::Kafka(mz_sql_parser::ast::KafkaSourceConnection {
             connection:
                 mz_sql_parser::ast::KafkaConnection {
@@ -490,7 +490,7 @@ pub fn plan_create_source(
 
             let connection = SourceConnection::Kafka(connection);
 
-            (connection, encoding)
+            (connection, Some(item.id()), encoding)
         }
         CreateSourceConnection::Kinesis {
             connection: aws_connection,
@@ -526,7 +526,7 @@ pub fn plan_create_source(
             let encoding = get_encoding(scx, format, &envelope, &connection)?;
             let connection =
                 SourceConnection::Kinesis(KinesisSourceConnection { stream_name, aws });
-            (connection, encoding)
+            (connection, Some(item.id()), encoding)
         }
         CreateSourceConnection::S3 {
             connection: aws_connection,
@@ -581,7 +581,7 @@ pub fn plan_create_source(
                     Compression::None => mz_storage::types::sources::Compression::None,
                 },
             });
-            (connection, encoding)
+            (connection, Some(item.id()), encoding)
         }
         CreateSourceConnection::Postgres {
             connection,
@@ -613,7 +613,7 @@ pub fn plan_create_source(
 
             let encoding =
                 SourceDataEncoding::Single(DataEncoding::new(DataEncodingInner::Postgres));
-            (connection, encoding)
+            (connection, Some(item.id()), encoding)
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
             let load_generator = match generator {
@@ -633,7 +633,7 @@ pub fn plan_create_source(
                 load_generator,
                 tick_micros,
             });
-            (connection, generator.data_encoding())
+            (connection, None, generator.data_encoding())
         }
     };
     let (key_desc, value_desc) = encoding.desc()?;
@@ -782,6 +782,7 @@ pub fn plan_create_source(
 
     let source = Source {
         create_sql,
+        connection_id,
         source_desc: SourceDesc {
             connection: external_connection,
             encoding,
@@ -1613,7 +1614,7 @@ pub fn plan_create_sink(
         return Err(PlanError::UpsertSinkWithoutKey);
     }
 
-    let connection_builder = match connection {
+    let (connection_id, connection_builder) = match connection {
         CreateSinkConnection::Kafka { connection, .. } => kafka_sink_builder(
             scx,
             connection,
@@ -1632,6 +1633,7 @@ pub fn plan_create_sink(
         sink: Sink {
             create_sql,
             from: from.id(),
+            connection_id: Some(connection_id),
             connection_builder,
             envelope,
         },
@@ -1705,7 +1707,7 @@ fn kafka_sink_builder(
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     value_desc: RelationDesc,
     envelope: SinkEnvelope,
-) -> Result<StorageSinkConnectionBuilder, PlanError> {
+) -> Result<(GlobalId, StorageSinkConnectionBuilder), PlanError> {
     let item = scx.get_item_by_resolved_name(&connection)?;
     // Get Kafka connection
     let connection = match item.connection()? {
@@ -1813,12 +1815,12 @@ fn kafka_sink_builder(
         None => bail_unsupported!("sink without format"),
     };
 
-    let environment_id = &scx.catalog.config().environment_id;
     let consistency_config = KafkaConsistencyConfig::Progress {
-        topic: connection
-            .progress_topic
-            .clone()
-            .unwrap_or_else(|| format!("_materialize-progress-{environment_id}-{connection_id}")),
+        topic: connection.progress_topic.clone().unwrap_or_else(|| {
+            scx.catalog
+                .config()
+                .default_kafka_sink_progress_topic(connection_id)
+        }),
     };
 
     if partition_count == 0 || partition_count < -1 {
@@ -1846,8 +1848,9 @@ fn kafka_sink_builder(
         bytes: retention_bytes,
     };
 
-    Ok(StorageSinkConnectionBuilder::Kafka(
-        KafkaSinkConnectionBuilder {
+    Ok((
+        connection_id,
+        StorageSinkConnectionBuilder::Kafka(KafkaSinkConnectionBuilder {
             connection_id,
             connection,
             options: config_options,
@@ -1861,7 +1864,7 @@ fn kafka_sink_builder(
             key_desc_and_indices,
             value_desc,
             retention,
-        },
+        }),
     ))
 }
 

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -1495,7 +1495,7 @@ pub struct LoadGeneratorSourceConnection {
 
 impl crate::source::types::SourceConnection for LoadGeneratorSourceConnection {
     fn name(&self) -> &'static str {
-        "loadgen"
+        "load-generator"
     }
 }
 

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -130,7 +130,7 @@ async fn get_topic(
 ) -> Result<String, anyhow::Error> {
     let query = format!(
         "SELECT {} FROM mz_sinks JOIN mz_kafka_sinks \
-        ON mz_sinks.id = mz_kafka_sinks.sink_id \
+        ON mz_sinks.id = mz_kafka_sinks.id \
         JOIN mz_schemas s ON s.id = mz_sinks.schema_id \
         LEFT JOIN mz_databases d ON d.id = s.database_id \
         WHERE d.name = $1 \

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -33,12 +33,26 @@ name   create_sql
 ---------------------------------
 materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER = '${testdrive.kafka-addr}'"
 
-> SELECT brokers, progress_topic FROM mz_kafka_connections
-brokers                     progress_topic
-------------------------------------------
-{${testdrive.kafka-addr}} <null>
+> SELECT
+      brokers,
+      sink_progress_topic = '_materialize-progress-' || mz_environment_id() || '-' || id
+  FROM mz_kafka_connections
+  JOIN mz_connections USING (id)
+  WHERE name = 'testconn'
+{${testdrive.kafka-addr}}   true
 
 > DROP CONNECTION testconn
+
+> CREATE CONNECTION progress_override
+  FOR KAFKA BROKER '${testdrive.kafka-addr}',
+  PROGRESS TOPIC 'override_topic'
+
+> SELECT
+    brokers, sink_progress_topic
+  FROM mz_kafka_connections
+  JOIN mz_connections USING (id)
+  WHERE name = 'progress_override'
+{${testdrive.kafka-addr}}   override_topic
 
 ###
 # Test that connections work in creating a source


### PR DESCRIPTION
Now that mz_kafka_connections exists (#15013), we can restructure the mz_sinks table to refer to the connection by ID, rather than directly including the progress topic, for a more normalized schema. For consistency, apply the same change to mz_sources.

Also rename the mz_kafka_connections.progress_topic column to sink_progress_topic, to better reflect that it only applies to sinks created on the connection.

Fix #14647.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
