### PR TITLE
storage: rename IngestSources/ExportSinks => CreateSources/CreateSinks

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -57,7 +57,7 @@ use mz_stash::{self, StashError, TypedCollection};
 
 use crate::controller::hosts::{StorageHosts, StorageHostsConfig};
 use crate::protocol::client::{
-    ExportSinkCommand, IngestSourceCommand, ProtoStorageCommand, ProtoStorageResponse,
+    CreateSinkCommand, CreateSourceCommand, ProtoStorageCommand, ProtoStorageResponse,
     StorageCommand, StorageResponse, Update,
 };
 use crate::types::errors::DataflowError;
@@ -974,7 +974,7 @@ where
                     .storage_metadata
                     .get_resume_upper(&persist_client, &desc.desc.envelope)
                     .await;
-                let augmented_ingestion = IngestSourceCommand {
+                let augmented_ingestion = CreateSourceCommand {
                     id,
                     description: desc,
                     resume_upper,
@@ -990,7 +990,7 @@ where
                         ),
                     )
                     .await?;
-                client.send(StorageCommand::IngestSources(vec![augmented_ingestion]));
+                client.send(StorageCommand::CreateSources(vec![augmented_ingestion]));
             }
         }
 
@@ -1072,7 +1072,7 @@ where
                 .initial_as_of
                 .maybe_fast_forward(&from_since);
 
-            let cmd = ExportSinkCommand {
+            let cmd = CreateSinkCommand {
                 id,
                 description: StorageSinkDesc {
                     from,
@@ -1095,7 +1095,7 @@ where
             // Provision a storage host for the ingestion.
             let client = self.hosts.provision(id, host_config).await?;
 
-            client.send(StorageCommand::ExportSinks(vec![cmd]));
+            client.send(StorageCommand::CreateSinks(vec![cmd]));
         }
         Ok(())
     }

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -39,7 +39,7 @@ use mz_repr::{Diff, GlobalId};
 use mz_service::client::GenericClient;
 
 use crate::protocol::client::{
-    ExportSinkCommand, IngestSourceCommand, StorageClient, StorageCommand, StorageGrpcClient,
+    CreateSinkCommand, CreateSourceCommand, StorageClient, StorageCommand, StorageGrpcClient,
     StorageResponse,
 };
 use crate::types::sources::SourceData;
@@ -73,8 +73,8 @@ where
             build_info,
             command_rx,
             response_tx,
-            ingestions: BTreeMap::new(),
-            exports: BTreeMap::new(),
+            sources: BTreeMap::new(),
+            sinks: BTreeMap::new(),
             uppers: HashMap::new(),
             initialized: false,
             persist,
@@ -110,10 +110,10 @@ struct RehydrationTask<T> {
     command_rx: UnboundedReceiver<StorageCommand<T>>,
     /// A channel upon which responses from the storage host are delivered.
     response_tx: UnboundedSender<StorageResponse<T>>,
-    /// The ingestions that have been observed.
-    ingestions: BTreeMap<GlobalId, IngestSourceCommand<T>>,
+    /// The sources that have been observed.
+    sources: BTreeMap<GlobalId, CreateSourceCommand<T>>,
     /// The exports that have been observed.
-    exports: BTreeMap<GlobalId, ExportSinkCommand<T>>,
+    sinks: BTreeMap<GlobalId, CreateSinkCommand<T>>,
     /// The upper frontier information received.
     uppers: HashMap<GlobalId, Antichain<T>>,
     /// Set to `true` once [`StorageCommand::InitializationComplete`] has been
@@ -170,7 +170,7 @@ where
             .await
             .expect("retry retries forever");
 
-        for ingest in self.ingestions.values_mut() {
+        for ingest in self.sources.values_mut() {
             let mut persist_clients = self.persist.lock().await;
             let persist_client = persist_clients
                 .open(ingest.description.storage_metadata.persist_location.clone())
@@ -184,7 +184,7 @@ where
                 .await;
         }
 
-        for export in self.exports.values_mut() {
+        for export in self.sinks.values_mut() {
             let mut persist_clients = self.persist.lock().await;
             let persist_client = persist_clients
                 .open(
@@ -213,8 +213,8 @@ where
 
         // Rehydrate all commands.
         let mut commands = vec![
-            StorageCommand::IngestSources(self.ingestions.values().cloned().collect()),
-            StorageCommand::ExportSinks(self.exports.values().cloned().collect()),
+            StorageCommand::CreateSources(self.sources.values().cloned().collect()),
+            StorageCommand::CreateSinks(self.sinks.values().cloned().collect()),
         ];
         if self.initialized {
             commands.push(StorageCommand::InitializationComplete)
@@ -290,17 +290,17 @@ where
     fn absorb_command(&mut self, command: &StorageCommand<T>) {
         match command {
             StorageCommand::InitializationComplete => self.initialized = true,
-            StorageCommand::IngestSources(ingestions) => {
+            StorageCommand::CreateSources(ingestions) => {
                 for ingestion in ingestions {
-                    self.ingestions.insert(ingestion.id, ingestion.clone());
+                    self.sources.insert(ingestion.id, ingestion.clone());
                     // Initialize the uppers we are tracking
                     self.uppers
                         .insert(ingestion.id, Antichain::from_elem(T::minimum()));
                 }
             }
-            StorageCommand::ExportSinks(exports) => {
+            StorageCommand::CreateSinks(exports) => {
                 for export in exports {
-                    self.exports.insert(export.id, export.clone());
+                    self.sinks.insert(export.id, export.clone());
                     // Initialize the uppers we are tracking
                     self.uppers
                         .insert(export.id, Antichain::from_elem(T::minimum()));
@@ -309,7 +309,7 @@ where
             StorageCommand::AllowCompaction(frontiers) => {
                 for (id, frontier) in frontiers {
                     if frontier.is_empty() {
-                        self.ingestions.remove(id);
+                        self.sources.remove(id);
                         self.uppers.remove(id);
                     }
                 }

--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -32,23 +32,23 @@ message ProtoAllowCompaction {
     repeated ProtoCompaction collections = 1;
 }
 
-message ProtoIngestSourceCommand {
+message ProtoCreateSourceCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_storage.types.sources.ProtoIngestionDescription description = 2;
     mz_repr.antichain.ProtoU64Antichain resume_upper = 3;
 }
 
-message ProtoIngestSources {
-    repeated ProtoIngestSourceCommand ingestions = 1;
+message ProtoCreateSources {
+    repeated ProtoCreateSourceCommand sources = 1;
 }
 
-message ProtoExportSinkCommand {
+message ProtoCreateSinkCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_storage.types.sinks.ProtoStorageSinkDesc description = 2;
 }
 
-message ProtoExportSinks {
-    repeated ProtoExportSinkCommand exports = 1;
+message ProtoCreateSinks {
+    repeated ProtoCreateSinkCommand sinks = 1;
 }
 
 message ProtoFrontierUppersKind {
@@ -62,10 +62,10 @@ message ProtoTrace {
 
 message ProtoStorageCommand {
     oneof kind {
-        ProtoIngestSources ingest_sources = 1;
+        ProtoCreateSources create_sources = 1;
         ProtoAllowCompaction allow_compaction = 2;
         google.protobuf.Empty initialization_complete = 3;
-        ProtoExportSinks export_sinks = 4;
+        ProtoCreateSinks create_sinks = 4;
     }
 }
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -161,7 +161,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
     pub fn handle_storage_command(&mut self, cmd: StorageCommand) {
         match cmd {
             StorageCommand::InitializationComplete => (),
-            StorageCommand::IngestSources(ingestions) => {
+            StorageCommand::CreateSources(ingestions) => {
                 for ingestion in ingestions {
                     // Remember the ingestion description to facilitate possible
                     // reconciliation later.
@@ -191,7 +191,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     );
                 }
             }
-            StorageCommand::ExportSinks(exports) => {
+            StorageCommand::CreateSinks(exports) => {
                 for export in exports {
                     self.storage_state
                         .exports
@@ -323,7 +323,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let mut stale_exports = self.storage_state.exports.keys().collect::<HashSet<_>>();
         for command in &mut commands {
             match command {
-                StorageCommand::IngestSources(ingestions) => {
+                StorageCommand::CreateSources(ingestions) => {
                     ingestions.retain_mut(|ingestion| {
                         if let Some(existing) = self.storage_state.ingestions.get(&ingestion.id) {
                             stale_ingestions.remove(&ingestion.id);
@@ -341,7 +341,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         }
                     })
                 }
-                StorageCommand::ExportSinks(exports) => {
+                StorageCommand::CreateSinks(exports) => {
                     exports.retain_mut(|export| {
                         if let Some(existing) = self.storage_state.exports.get(&export.id) {
                             stale_exports.remove(&export.id);


### PR DESCRIPTION
"Ingest" and "export" are not symmetric. Sidestep the problem and use the verb "create" instead, which applies equally well to sources and sinks.

Fixes #13782.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
