### PR TITLE
cloudtest: Allow running .td files with testdrive

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -78,6 +78,14 @@ class K8sPod(K8sResource):
         core_v1_api = self.api()
         core_v1_api.create_namespaced_pod(body=self.pod, namespace=self.namespace())
 
+    def name(self) -> str:
+        assert self.pod.metadata is not None
+        assert self.pod.metadata.name is not None
+        return self.pod.metadata.name
+
+    def copy(self, source: str, destination: str) -> None:
+        self.kubectl("cp", source, f"{self.name()}:{destination}")
+
 
 class K8sService(K8sResource):
     service: V1Service

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -29,8 +29,12 @@ class Testdrive(K8sPod):
         pod_spec = V1PodSpec(containers=[container])
         self.pod = V1Pod(metadata=metadata, spec=pod_spec)
 
-    def run_string(
-        self, input: str, no_reset: bool = False, seed: Optional[int] = None
+    def run(
+        self,
+        *args: str,
+        input: Optional[str] = None,
+        no_reset: bool = False,
+        seed: Optional[int] = None,
     ) -> None:
         wait(condition="condition=Ready", resource="pod/testdrive")
         subprocess.run(
@@ -53,6 +57,7 @@ class Testdrive(K8sPod):
                 "--aws-secret-access-key=minio123",
                 *(["--no-reset"] if no_reset else []),
                 *([f"--seed={seed}"] if seed else []),
+                *args,
             ],
             check=True,
             input=input,

--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -21,8 +21,8 @@ CLUSTER_SIZE = 4
 
 
 def populate(mz: MaterializeApplication, seed: int) -> None:
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             f"""
             > CREATE CLUSTER shared_fate REPLICAS (shared_fate_replica (SIZE '{CLUSTER_SIZE}-1'));
             > SET cluster = shared_fate;
@@ -63,8 +63,8 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
 
 
 def validate(mz: MaterializeApplication, seed: int) -> None:
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             > SET cluster = shared_fate;
 

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -16,8 +16,8 @@ from materialize.cloudtest.wait import wait
 
 
 def populate(mz: MaterializeApplication, seed: int) -> None:
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             > CREATE TABLE t1 (f1 INTEGER);
 
@@ -56,8 +56,8 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
 
 
 def validate(mz: MaterializeApplication, seed: int) -> None:
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             > INSERT INTO t1 VALUES (345);
 
@@ -113,8 +113,8 @@ def test_crash_computed(mz: MaterializeApplication) -> None:
     )
     mz.environmentd.sql("INSERT INTO crash_table VALUES ('forced panic')")
 
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             > DROP MATERIALIZED VIEW crash_view
             """

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -14,8 +14,8 @@ from materialize.cloudtest.wait import wait
 
 
 def test_secrets(mz: MaterializeApplication) -> None:
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             > CREATE SECRET username AS '123';
             > CREATE SECRET password AS '234';

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -25,8 +25,11 @@ def test_sql(mz: MaterializeApplication) -> None:
 
 
 def test_testdrive(mz: MaterializeApplication) -> None:
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.copy("test/testdrive", "/workdir")
+    mz.testdrive.run("testdrive/testdrive.td")
+
+    mz.testdrive.run(
+        input=dedent(
             """
                 $ kafka-create-topic topic=test
 

--- a/test/cloudtest/test_storaged.py
+++ b/test/cloudtest/test_storaged.py
@@ -16,8 +16,8 @@ from materialize.cloudtest.wait import wait
 
 def test_storaged_creation(mz: MaterializeApplication) -> None:
     """Test that creating multiple sources causes multiple storageds to be spawned."""
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             $ kafka-create-topic topic=test
 
@@ -56,8 +56,8 @@ def test_storaged_creation(mz: MaterializeApplication) -> None:
 
 def test_storaged_resizing(mz: MaterializeApplication) -> None:
     """Test that resizing a given source causes the storaged to be replaced."""
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             $ kafka-create-topic topic=test
 
@@ -82,8 +82,8 @@ def test_storaged_resizing(mz: MaterializeApplication) -> None:
 
     wait(condition="condition=Ready", resource=storaged)
 
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             > ALTER SOURCE resize_storaged
               SET (SIZE '16');
@@ -104,8 +104,8 @@ def test_storaged_resizing(mz: MaterializeApplication) -> None:
 
 def test_storaged_shutdown(mz: MaterializeApplication) -> None:
     """Test that dropping a source causes its respective storaged to shut down."""
-    mz.testdrive.run_string(
-        dedent(
+    mz.testdrive.run(
+        input=dedent(
             """
             $ kafka-create-topic topic=test
 


### PR DESCRIPTION
- provide a `copy()` method to transfer files into a pod
- allow testdrive to be called both with files/glob as an argument or with the testdrive string as input.

### Motivation

  * This PR adds a feature that has not yet been specified.

Running `.td` files in cloudtest is required for Antithesis testing and is generally a good thing to have.