### PR TITLE
ci: Add complete testdrive run inside K8s

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -31,6 +31,7 @@ steps:
           - { value: testdrive-partitions-5 }
           - { value: testdrive-replicas-4}
           - { value: testdrive-replica-size-4}
+          - { value: testdrive-in-cloudtest}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
@@ -247,6 +248,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-2, --replica-size=4]
+
+  - id: testdrive-in-cloudtest
+    label: Full Testdrive in Cloudtest (K8s)
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/cloudtest:
+          args: [-m=long, test/cloudtest/test_full_testdrive.py]
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -539,7 +539,7 @@ steps:
     inputs: [test/cloudtest]
     plugins:
       - ./ci/plugins/cloudtest:
-          args: [test/cloudtest/]
+          args: [-m, "not long", test/cloudtest/]
 
   - id: lang-csharp
     label: ":csharp: tests"

--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -7,9 +7,21 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.config import Config
+
 import pytest
 
 from materialize.cloudtest.application import MaterializeApplication
+
+
+def pytest_configure(config: "Config") -> None:
+    config.addinivalue_line(
+        "markers",
+        "long: A long running test. Select with -m=long, deselect with -m 'not long'",
+    )
 
 
 @pytest.fixture(scope="session")

--- a/test/cloudtest/test_full_testdrive.py
+++ b/test/cloudtest/test_full_testdrive.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -8,7 +6,13 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-#
-# mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")"/../../bin/pytest -m 'not long' "$@"
+import pytest
+
+from materialize.cloudtest.application import MaterializeApplication
+
+
+@pytest.mark.long
+def test_full_testdrive(mz: MaterializeApplication) -> None:
+    mz.testdrive.copy("test/testdrive", "/workdir")
+    mz.testdrive.run("testdrive/*.td")


### PR DESCRIPTION
- use the cloudtest infrastructure to run a complete testdrive
- mark the cloudtest test as 'long' so that it does not run as part of the normal CI

## Motivation

  * This PR adds a feature that has not yet been specified.

We were not running our full complement of tests in a K8s environment.