### PR TITLE
adapter: allow purification to define subsources

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -198,7 +198,15 @@ pub struct CreateSourceStatementReady {
     pub session: Session,
     #[derivative(Debug = "ignore")]
     pub tx: ClientTransmitter<ExecuteResponse>,
-    pub result: Result<CreateSourceStatement<Aug>, AdapterError>,
+    /// Contains the purified source statement and a list of subsources that must be created before
+    /// executing the final create source statement
+    pub result: Result<
+        (
+            Vec<CreateSourceStatement<Raw>>,
+            CreateSourceStatement<mz_sql::names::Either<Aug, Raw>>,
+        ),
+        AdapterError,
+    >,
     pub params: Params,
     pub depends_on: Vec<GlobalId>,
     pub original_stmt: Statement<Raw>,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -198,15 +198,7 @@ pub struct CreateSourceStatementReady {
     pub session: Session,
     #[derivative(Debug = "ignore")]
     pub tx: ClientTransmitter<ExecuteResponse>,
-    /// Contains the purified source statement and a list of subsources that must be created before
-    /// executing the final create source statement
-    pub result: Result<
-        (
-            Vec<CreateSourceStatement<Raw>>,
-            CreateSourceStatement<mz_sql::names::Either<Aug, Raw>>,
-        ),
-        AdapterError,
-    >,
+    pub result: Result<Vec<(GlobalId, CreateSourceStatement<Aug>)>, AdapterError>,
     pub params: Params,
     pub depends_on: Vec<GlobalId>,
     pub original_stmt: Statement<Raw>,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -23,6 +23,7 @@ use mz_repr::GlobalId;
 
 use crate::ast::display::{AstDisplay, AstFormatter};
 use crate::ast::fold::{Fold, FoldNode};
+use crate::ast::visit::{Visit, VisitNode};
 use crate::ast::visit_mut::VisitMut;
 use crate::ast::{
     self, AstInfo, Cte, Ident, Query, Raw, RawClusterName, RawDataType, RawObjectName, Statement,
@@ -610,6 +611,45 @@ impl AstInfo for Aug {
     type CteId = LocalId;
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum Either<A, B> {
+    Left(A),
+    Right(B),
+}
+
+impl<A: AstInfo, B: AstInfo> AstInfo for Either<A, B> {
+    type NestedStatement = Either<A::NestedStatement, B::NestedStatement>;
+    type ObjectName = Either<A::ObjectName, B::ObjectName>;
+    type SchemaName = Either<A::SchemaName, B::SchemaName>;
+    type DatabaseName = Either<A::DatabaseName, B::DatabaseName>;
+    type ClusterName = Either<A::ClusterName, B::ClusterName>;
+    type DataType = Either<A::DataType, B::DataType>;
+    type CteId = Either<A::CteId, B::CteId>;
+}
+
+impl<A: AstDisplay, B: AstDisplay> AstDisplay for Either<A, B> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            Either::Left(a) => a.fmt(f),
+            Either::Right(b) => b.fmt(f),
+        }
+    }
+
+    fn to_ast_string(&self) -> String {
+        match self {
+            Either::Left(a) => a.to_ast_string(),
+            Either::Right(b) => b.to_ast_string(),
+        }
+    }
+
+    fn to_ast_string_stable(&self) -> String {
+        match self {
+            Either::Left(a) => a.to_ast_string_stable(),
+            Either::Right(b) => b.to_ast_string_stable(),
+        }
+    }
+}
+
 /// The identifier for a schema.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SchemaId(pub u64);
@@ -1129,6 +1169,244 @@ where
     let result = node.fold(&mut resolver);
     resolver.status?;
     Ok((result, resolver.ids))
+}
+
+/// Converts an AST into a state where additional raw nodes can be inserted by wrapping each `Aug`
+/// node into an `Either::Left(_)` node.
+pub fn either_aug_raw<N>(node: N) -> N::Folded
+where
+    N: FoldNode<Aug, Either<Aug, Raw>>,
+{
+    node.fold(&mut LeftWrapper)
+}
+
+/// Finalizes name resolution of a partially resolved AST node.
+pub fn finalize_resolve<N>(
+    catalog: &dyn SessionCatalog,
+    node: N,
+) -> Result<(N::Folded, HashSet<GlobalId>), PlanError>
+where
+    N: FoldNode<Either<Aug, Raw>, Aug>,
+    N::Folded: for<'ast> VisitNode<'ast, Aug>,
+{
+    let resolver = NameResolver::new(catalog);
+    let mut folder = EitherUnwrapper::new(resolver);
+    let result = node.fold(&mut folder);
+
+    folder.inner.status?;
+
+    let mut dep_visitor = DependencyVisitor::default();
+    result.visit(&mut dep_visitor);
+
+    Ok((result, dep_visitor.ids))
+}
+
+#[derive(Debug)]
+pub struct LeftWrapper;
+
+impl<A: AstInfo, B: AstInfo> Fold<A, Either<A, B>> for LeftWrapper {
+    fn fold_nested_statement(
+        &mut self,
+        stmt: A::NestedStatement,
+    ) -> <Either<A, B> as AstInfo>::NestedStatement {
+        Either::Left(stmt)
+    }
+
+    fn fold_query(&mut self, q: Query<A>) -> Query<Either<A, B>> {
+        Query {
+            ctes: q.ctes.into_iter().map(|c| self.fold_cte(c)).collect(),
+            body: self.fold_set_expr(q.body),
+            limit: q.limit.map(|l| self.fold_limit(l)),
+            offset: q.offset.map(|l| self.fold_expr(l)),
+            order_by: q
+                .order_by
+                .into_iter()
+                .map(|c| self.fold_order_by_expr(c))
+                .collect(),
+        }
+    }
+
+    fn fold_cte_id(&mut self, id: A::CteId) -> <Either<A, B> as AstInfo>::CteId {
+        Either::Left(id)
+    }
+
+    fn fold_object_name(
+        &mut self,
+        object_name: A::ObjectName,
+    ) -> <Either<A, B> as AstInfo>::ObjectName {
+        Either::Left(object_name)
+    }
+
+    fn fold_data_type(&mut self, data_type: A::DataType) -> <Either<A, B> as AstInfo>::DataType {
+        Either::Left(data_type)
+    }
+
+    fn fold_schema_name(&mut self, name: A::SchemaName) -> <Either<A, B> as AstInfo>::SchemaName {
+        Either::Left(name)
+    }
+
+    fn fold_database_name(
+        &mut self,
+        database_name: A::DatabaseName,
+    ) -> <Either<A, B> as AstInfo>::DatabaseName {
+        Either::Left(database_name)
+    }
+
+    fn fold_cluster_name(
+        &mut self,
+        cluster_name: A::ClusterName,
+    ) -> <Either<A, B> as AstInfo>::ClusterName {
+        Either::Left(cluster_name)
+    }
+
+    fn fold_with_option_value(
+        &mut self,
+        node: mz_sql_parser::ast::WithOptionValue<A>,
+    ) -> mz_sql_parser::ast::WithOptionValue<Either<A, B>> {
+        use mz_sql_parser::ast::WithOptionValue::*;
+        match node {
+            Value(v) => Value(Fold::<A, Either<A, B>>::fold_value(self, v)),
+            Ident(i) => Ident(Fold::<A, Either<A, B>>::fold_ident(self, i)),
+            DataType(dt) => DataType(Fold::<A, Either<A, B>>::fold_data_type(self, dt)),
+            Secret(secret) => Secret(Fold::<A, Either<A, B>>::fold_object_name(self, secret)),
+            Object(obj) => Object(Fold::<A, Either<A, B>>::fold_object_name(self, obj)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EitherUnwrapper<F> {
+    inner: F,
+}
+
+impl<F> EitherUnwrapper<F> {
+    fn new(inner: F) -> Self {
+        Self { inner }
+    }
+}
+
+impl<A: AstInfo, B: AstInfo, F: Fold<B, A>> Fold<Either<A, B>, A> for EitherUnwrapper<F> {
+    fn fold_nested_statement(
+        &mut self,
+        stmt: <Either<A, B> as AstInfo>::NestedStatement,
+    ) -> A::NestedStatement {
+        match stmt {
+            Either::Left(stmt) => stmt,
+            Either::Right(stmt) => self.inner.fold_nested_statement(stmt),
+        }
+    }
+
+    fn fold_query(&mut self, q: Query<Either<A, B>>) -> Query<A> {
+        Query {
+            ctes: q.ctes.into_iter().map(|c| self.fold_cte(c)).collect(),
+            body: self.fold_set_expr(q.body),
+            limit: q.limit.map(|l| self.fold_limit(l)),
+            offset: q.offset.map(|l| self.fold_expr(l)),
+            order_by: q
+                .order_by
+                .into_iter()
+                .map(|c| self.fold_order_by_expr(c))
+                .collect(),
+        }
+    }
+
+    fn fold_cte_id(&mut self, id: <Either<A, B> as AstInfo>::CteId) -> A::CteId {
+        match id {
+            Either::Left(id) => id,
+            Either::Right(id) => self.inner.fold_cte_id(id),
+        }
+    }
+
+    fn fold_object_name(
+        &mut self,
+        object_name: <Either<A, B> as AstInfo>::ObjectName,
+    ) -> A::ObjectName {
+        match object_name {
+            Either::Left(object_name) => object_name,
+            Either::Right(object_name) => self.inner.fold_object_name(object_name),
+        }
+    }
+
+    fn fold_data_type(&mut self, data_type: <Either<A, B> as AstInfo>::DataType) -> A::DataType {
+        match data_type {
+            Either::Left(data_type) => data_type,
+            Either::Right(data_type) => self.inner.fold_data_type(data_type),
+        }
+    }
+
+    fn fold_schema_name(
+        &mut self,
+        schema_name: <Either<A, B> as AstInfo>::SchemaName,
+    ) -> A::SchemaName {
+        match schema_name {
+            Either::Left(schema_name) => schema_name,
+            Either::Right(schema_name) => self.inner.fold_schema_name(schema_name),
+        }
+    }
+
+    fn fold_database_name(
+        &mut self,
+        database_name: <Either<A, B> as AstInfo>::DatabaseName,
+    ) -> A::DatabaseName {
+        match database_name {
+            Either::Left(database_name) => database_name,
+            Either::Right(database_name) => self.inner.fold_database_name(database_name),
+        }
+    }
+
+    fn fold_cluster_name(
+        &mut self,
+        cluster_name: <Either<A, B> as AstInfo>::ClusterName,
+    ) -> A::ClusterName {
+        match cluster_name {
+            Either::Left(cluster_name) => cluster_name,
+            Either::Right(cluster_name) => self.inner.fold_cluster_name(cluster_name),
+        }
+    }
+
+    fn fold_with_option_value(
+        &mut self,
+        node: mz_sql_parser::ast::WithOptionValue<Either<A, B>>,
+    ) -> mz_sql_parser::ast::WithOptionValue<A> {
+        use mz_sql_parser::ast::WithOptionValue::*;
+        match node {
+            Value(v) => Value(Fold::<Either<A, B>, A>::fold_value(self, v)),
+            Ident(i) => Ident(Fold::<Either<A, B>, A>::fold_ident(self, i)),
+            DataType(dt) => DataType(Fold::<Either<A, B>, A>::fold_data_type(self, dt)),
+            Secret(secret) => Secret(Fold::<Either<A, B>, A>::fold_object_name(self, secret)),
+            Object(obj) => Object(Fold::<Either<A, B>, A>::fold_object_name(self, obj)),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DependencyVisitor {
+    ids: HashSet<GlobalId>,
+}
+
+impl<'ast> Visit<'ast, Aug> for DependencyVisitor {
+    fn visit_object_name(&mut self, object_name: &'ast <Aug as AstInfo>::ObjectName) {
+        if let ResolvedObjectName::Object { id, .. } = object_name {
+            self.ids.insert(*id);
+        }
+    }
+
+    fn visit_data_type(&mut self, data_type: &'ast <Aug as AstInfo>::DataType) {
+        match data_type {
+            ResolvedDataType::AnonymousList(data_type) => self.visit_data_type(data_type),
+            ResolvedDataType::AnonymousMap {
+                key_type,
+                value_type,
+            } => {
+                self.visit_data_type(key_type);
+                self.visit_data_type(value_type);
+            }
+            ResolvedDataType::Named { id, .. } => {
+                self.ids.insert(*id);
+            }
+            ResolvedDataType::Error => {}
+        }
+    }
 }
 
 // Used when displaying a view's source for human creation. If the name


### PR DESCRIPTION
### Motivation

As part of postgres demultiplexing we need to be able to have sources that ingest data into multiple independent subsources without the user having to go through multiple SQL commands. In other words it should be possible for a user to type `CREATE SOURCE "foo" FROM POSTGRES ..."` and, assuming that the upstream postgres database has two tables available named `"table_1"` and `"table_2"`, pretend that the user typed something like:

```sql
CREATE SOURCE "table_1" (col1 int);
CREATE SOURCE "table_2" (col1 text);
CREATE SOURCE "foo" FROM POSTGRES ... INTO SUBSOURCE "table_1", "table_2"
```

The syntax above is just for illustration purposes. The actual challenge is that the user typed a `CREATE SOURCE` statement that did NOT reference any other objects, and that we would like to purify that statement into one that references objects that are not yet created! This is a problem because purification outputs a name resolved statement (i.e a `Statement<Aug>`) but if we want that statement to reference yet-uncreated objects it's impossible because the `Aug` sets `ObjectName` to be a resolved object with a valid `GlobalId` etc.

The solution this PR implements is to first define a new type of `AstInfo` called `Either<A: AstInfo, B: AstInfo>` which, as the name implies, allows an AST tree to be one of the two `AstInfo` types on a per-node basis. This allows purification to require a `Statement<Aug>` to work on but output a `Statement<Either<Aug, Raw>>` that keeps all previous choices on name resolution but introduces some additional name resolution that needs to happen after subsources have been created.

Specifically, purification is now tasked with converting a `Statement<Aug>` statement into a list of `Statement<Raw>` statements, one for each subsource that this source happens to have, and one `Statement<Either<Aug, Raw>>` which is the original purified statement with extra references to the object names created in the previous step.

When the coordinator processes the result of purification it will first resolve and plan all the subsources in one go to ensure that they can go through and then it will sequence the final create source plan after finalizing its name resolution state which will take the `Statement<Either<Aug, Raw>>` to `Statement<Aug>`.

### Tips for the reviewer

I recommend reviewing commit by commit

* The first commit implements the mechanics of `Either<A: AstInfo, B: AstInfo>`
* The second commit changes purification and the adapter to support subsources


### One last note

While the approach above may sound complex it has a very appealing property. When all is said and done the catalog is in a very natural state with no exceptions or "if this is a subsource do this weird logic" things. This means no special cases need to be written for bootstrapping or dependency tracking, both of which were considered as alternative approaches before settling on this one.