### PR TITLE
storage: Add a dedicated test for bounded memory usage

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -46,6 +46,7 @@ steps:
           - { value: checks-oneatatime-restart-postgres-backend }
           - { value: persist-maelstrom-single-node }
           - { value: persist-maelstrom-multi-node }
+          - { value: bounded-memory }
           - { value: unused-deps }
         multiple: true
         required: false
@@ -398,6 +399,16 @@ steps:
           composition: persistence
           run: failpoints
     skip: Persistence tests disabled
+
+  - id: bounded-memory
+    label: Bounded memory test
+    timeout_in_minutes: 300
+    artifact_paths: junit_mzcompose_*.xml
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: bounded-memory
 
   - id: unused-deps
     label: Unused dependencies

--- a/test/bounded-memory/bounded-memory-after-restart.td
+++ b/test/bounded-memory/bounded-memory-after-restart.td
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT * FROM v2;
+1025
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DELETE FROM t1;
+
+> SELECT * FROM v2;
+0

--- a/test/bounded-memory/bounded-memory-before-restart.td
+++ b/test/bounded-memory/bounded-memory-before-restart.td
@@ -1,0 +1,357 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Create a large snapshot and follow-up transactions
+#
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg FOR POSTGRES
+  HOST postgres,
+  DATABASE postgres,
+  USER postgres,
+  PASSWORD SECRET pgpass
+
+# Insert data pre-snapshot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 SERIAL PRIMARY KEY, f2 INTEGER DEFAULT 0, f3 TEXT);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+INSERT INTO t1 (f3) SELECT REPEAT('a', 1024 * 1024) FROM generate_series(1, 16);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source');
+
+> SELECT mz_internal.mz_sleep(10);
+<null>
+
+> SELECT COUNT(*) > 0 FROM mz_source;
+true
+
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+# > CREATE MATERIALIZED VIEW v1 AS SELECT f1 + 1, f2 FROM t1;
+
+> CREATE MATERIALIZED VIEW v2 AS SELECT COUNT(*) FROM t1;
+
+# Update data post-snapshot
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+UPDATE t1 SET f2 = f2 + 1;
+INSERT INTO t1 (f3) VALUES ('eof');
+
+> SELECT * FROM v2;
+17

--- a/test/bounded-memory/mzcompose
+++ b/test/bounded-memory/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import Materialized, Postgres, Testdrive
+
+SERVICES = [
+    Materialized(
+# memory="2Gb",
+ extra_ports=["2104:2104"], allow_host_ports=True),
+    Testdrive(no_reset=True, seed=1, default_timeout="3600s"),
+    Postgres(),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    """Use a Mz instance with 2Gb of RAM to ingest a >10G Postgres dataset"""
+
+    c.up("materialized", "postgres")
+    c.wait_for_materialized()
+    c.wait_for_postgres()
+    c.run("testdrive", "bounded-memory-before-restart.td")
+
+    # Restart Mz to confirm that re-hydration is also bounded memory
+    c.kill("materialized")
+    c.up("materialized")
+    c.wait_for_materialized()
+
+    c.run("testdrive", "bounded-memory-after-restart.td")


### PR DESCRIPTION
Start a Mz container limited to 512Mb of memory and attempt to ingest a >10Gb Postgres dataset.

Restart Mz in the middle of the test to also exercise rehydration.

Relates to #13039

### Motivation
  * This PR adds a feature that has not yet been specified.
A test is needed for #13039

### Tips for reviewer

@pH14 this implements your original idea to snapshot a large Postgres source and then proceed for perform updates.

It is currently using the file blob store, I will try to get this test to use S3/minio for added realism.

What I have observed so far:
- no OOM kills
- `top`'s `VIRT` for storaged is 30gb, 12gb for computed. Initially I thought this is OK as long as `RSS` is low, but `iotop` reports excessive `SWAPIN` and filesystem activity, so I do not think the workload is healthy
- It is **slow** , like glacially slow. Even if I nerf the test to use 2x1GB inserts, it still takes 4 minutes to fully ingest . The default test with 2x10gb can not even complete and I have waited for more than 1 hour. 
- the /mzdata directory contains 31Gb worth of stuff, which I think is OK. As time goes by, storaged nor computed both stop writing any appreciable amounts of data to it.

The workload (at least up to the last `DELETE`) should not, in my naive opinion, be causing any trashing - after all, we ingest rows that are all unique, so no upsert key modifications, we materialize them slightly modified and finally we do `COUNT(*)` on them.