### PR TITLE
adapter,repr: finalize `EXPLAIN AS TEXT` rendering

### DIFF
--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -105,23 +105,17 @@ impl<'a> Displayable<'a, HirRelationExpr> {
                     head = body.as_ref();
                 }
 
-                // The body comes first in the text output format in order to
-                // align with the format convention the dataflow is rendered
-                // top to bottom
-                writeln!(f, "{}Let", ctx.indent)?;
+                writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    Displayable::from(head).fmt_text(f, ctx)?;
-                    writeln!(f, "{}Where", ctx.indent)?;
-                    ctx.indented(|ctx| {
-                        for (id, value) in bindings.iter().rev() {
-                            // TODO: print the name and not the id
-                            writeln!(f, "{}{} =", ctx.indent, *id)?;
-                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
-                        }
-                        Ok(())
-                    })?;
+                    for (id, value) in bindings.iter() {
+                        // TODO: print the name and not the id
+                        writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                        ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                    }
                     Ok(())
                 })?;
+                writeln!(f, "{}Return", ctx.indent)?;
+                ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
             }
             Get { id, .. } => match id {
                 Id::Local(id) => {

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -115,21 +115,16 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, Plan> {
                     head = body.as_ref();
                 }
 
-                // The body comes first in the text output format in order to
-                // align with the format convention the dataflow is rendered
-                // top to bottom
-                writeln!(f, "{}Let", ctx.indent)?;
+                writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    Displayable::from(head).fmt_text(f, ctx)?;
-                    writeln!(f, "{}Where", ctx.indent)?;
-                    ctx.indented(|ctx| {
-                        for (id, value) in bindings.iter().rev() {
-                            writeln!(f, "{}{} =", ctx.indent, *id)?;
-                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
-                        }
-                        Ok(())
-                    })
+                    for (id, value) in bindings.iter() {
+                        writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                        ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                    }
+                    Ok(())
                 })?;
+                writeln!(f, "{}Return", ctx.indent)?;
+                ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
             }
             Mfp {
                 input,

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -56,6 +56,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
         // method as its HirRelationExpr counterpart
         self.fmt_raw_syntax(f, ctx)
     }
+
     fn fmt_raw_syntax(
         &self,
         f: &mut fmt::Formatter<'_>,
@@ -92,8 +93,8 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                 // top to bottom
                 write!(f, "{}Let", ctx.indent)?;
                 self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
                 ctx.indented(|ctx| {
-                    Displayable::from(head).fmt_text(f, ctx)?;
                     writeln!(f, "{}Where", ctx.indent)?;
                     ctx.indented(|ctx| {
                         for (id, value) in bindings.iter().rev() {

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -238,40 +238,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                                     Ok(())
                                 })?;
                             }
-                            JoinImplementation::IndexedFilter(_, key, rows) => {
-                                debug_assert_eq!(inputs.len(), 2);
-                                writeln!(f, "{}implementation", ctx.indent)?;
-                                ctx.indented(|ctx| {
-                                    writeln!(
-                                        f,
-                                        "{}lookup {}",
-                                        ctx.indent,
-                                        separated(
-                                            " OR ",
-                                            rows.iter().map(|row| {
-                                                bracketed(
-                                                    "(",
-                                                    ")",
-                                                    separated(
-                                                        " AND ",
-                                                        std::iter::zip(key, row.unpack()).map(
-                                                            |(expr, lit)| {
-                                                                closure_to_display(move |fmt| {
-                                                                    write!(
-                                                                        fmt,
-                                                                        "{} = {}",
-                                                                        expr, lit
-                                                                    )
-                                                                })
-                                                            },
-                                                        ),
-                                                    ),
-                                                )
-                                            })
-                                        )
-                                    )
-                                })?;
-                            }
+                            JoinImplementation::IndexedFilter(_, _, _) => {}
                             JoinImplementation::Unimplemented => {}
                         }
                         Ok(())

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -88,23 +88,17 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                     head = body.as_ref();
                 }
 
-                // The body comes first in the text output format in order to
-                // align with the format convention the dataflow is rendered
-                // top to bottom
-                write!(f, "{}Let", ctx.indent)?;
-                self.fmt_attributes(f, ctx)?;
-                ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
+                writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    writeln!(f, "{}Where", ctx.indent)?;
-                    ctx.indented(|ctx| {
-                        for (id, value) in bindings.iter().rev() {
-                            writeln!(f, "{}{} =", ctx.indent, *id)?;
-                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
-                        }
-                        Ok(())
-                    })?;
+                    for (id, value) in bindings.iter() {
+                        writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                        ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                    }
                     Ok(())
                 })?;
+                write!(f, "{}Return", ctx.indent)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
             }
             Get { id, .. } => {
                 match id {

--- a/src/repr/src/explain_new/mod.rs
+++ b/src/repr/src/explain_new/mod.rs
@@ -365,6 +365,8 @@ pub struct ExplainConfig {
     pub join_impls: bool,
     /// Show the sets of unique keys.
     pub keys: bool,
+    /// Restrict output trees to linear chains. Ignored if `raw_plans` is set.
+    pub linear_chains: bool,
     /// Show the `non_negative` in the explanation if it is supported by the backing IR.
     pub non_negative: bool,
     /// Show the slow path plan even if a fast path plan was created. Useful for debugging.
@@ -389,29 +391,30 @@ impl ExplainConfig {
 
 impl TryFrom<HashSet<String>> for ExplainConfig {
     type Error = anyhow::Error;
-    fn try_from(mut config_flags: HashSet<String>) -> Result<Self, anyhow::Error> {
+    fn try_from(mut flags: HashSet<String>) -> Result<Self, anyhow::Error> {
         // If `WITH(raw)` is specified, ensure that the config will be as
         // representative for the original plan as possible.
-        if config_flags.remove("raw") {
-            config_flags.insert("raw_plans".into());
-            config_flags.insert("raw_syntax".into());
+        if flags.remove("raw") {
+            flags.insert("raw_plans".into());
+            flags.insert("raw_syntax".into());
         }
         let result = ExplainConfig {
-            arity: config_flags.remove("arity"),
-            join_impls: config_flags.remove("join_impls"),
-            keys: config_flags.remove("keys"),
-            non_negative: config_flags.remove("non_negative"),
-            no_fast_path: config_flags.remove("no_fast_path"),
-            raw_plans: config_flags.remove("raw_plans"),
-            raw_syntax: config_flags.remove("raw_syntax"),
-            subtree_size: config_flags.remove("subtree_size"),
-            timing: config_flags.remove("timing"),
-            types: config_flags.remove("types"),
+            arity: flags.remove("arity"),
+            join_impls: flags.remove("join_impls"),
+            keys: flags.remove("keys"),
+            linear_chains: flags.remove("linear_chains") && !flags.contains("raw_plans"),
+            non_negative: flags.remove("non_negative"),
+            no_fast_path: flags.remove("no_fast_path"),
+            raw_plans: flags.remove("raw_plans"),
+            raw_syntax: flags.remove("raw_syntax"),
+            subtree_size: flags.remove("subtree_size"),
+            timing: flags.remove("timing"),
+            types: flags.remove("types"),
         };
-        if config_flags.is_empty() {
+        if flags.is_empty() {
             Ok(result)
         } else {
-            anyhow::bail!("unsupported 'EXPLAIN ... WITH' flags: {:?}", config_flags)
+            anyhow::bail!("unsupported 'EXPLAIN ... WITH' flags: {:?}", flags)
         }
     }
 }
@@ -763,6 +766,7 @@ mod tests {
             arity: false,
             join_impls: false,
             keys: false,
+            linear_chains: false,
             non_negative: false,
             no_fast_path: false,
             raw_plans: false,

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -43,7 +43,18 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR VIEW test1
 ----
 Explained Query:
-  Let // { arity: 4 }
+  With
+    cte l0 =
+      FlatMap generate_series(#0, #1, 1) // { arity: 3 }
+        Get materialize.public.t // { arity: 2 }
+    cte l1 =
+      Project (#0..=#3) // { arity: 4 }
+        Join on=(#0 = #4) type=differential // { arity: 5 }
+          Filter (#0) IS NOT NULL // { arity: 3 }
+            Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Get materialize.public.u // { arity: 2 }
+  Return // { arity: 4 }
     Threshold // { arity: 4 }
       Union // { arity: 4 }
         Negate // { arity: 4 }
@@ -66,17 +77,6 @@ Explained Query:
                     Get l1 // { arity: 4 }
         Constant // { arity: 4 }
           - (1, 2, 11, 12)
-    Where
-      l1 =
-        Project (#0..=#3) // { arity: 4 }
-          Join on=(#0 = #4) type=differential // { arity: 5 }
-            Filter (#0) IS NOT NULL // { arity: 3 }
-              Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Get materialize.public.u // { arity: 2 }
-      l0 =
-        FlatMap generate_series(#0, #1, 1) // { arity: 3 }
-          Get materialize.public.t // { arity: 2 }
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -105,18 +105,18 @@ WITH u AS (select u.c + 1 as g from u)
 SELECT u.g as g, w.g as h FROM u, u as w WHERE u.g = w.g
 ----
 Explained Query:
-  Let // { arity: 2 }
+  With
+    cte l0 =
+      Project (#2) // { arity: 1 }
+        Filter (#0) IS NOT NULL // { arity: 3 }
+          Map ((#0 + 1)) // { arity: 3 }
+            Get materialize.public.u // { arity: 2 }
+  Return // { arity: 2 }
     Project (#0, #0) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         Get l0 // { arity: 1 }
-    Where
-      l0 =
-        Project (#2) // { arity: 1 }
-          Filter (#0) IS NOT NULL // { arity: 3 }
-            Map ((#0 + 1)) // { arity: 3 }
-              Get materialize.public.u // { arity: 2 }
 
 Used Indexes:
   - materialize.public.u_d_idx
@@ -130,7 +130,18 @@ EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
 SELECT * FROM u WHERE (SELECT f FROM v WHERE v.e = u.d) = 1
 ----
 Explained Query:
-  Let // { arity: 2 }
+  With
+    cte l0 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Distinct group_by=[#0] // { arity: 1 }
+              Project (#1) // { arity: 1 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  Get materialize.public.u // { arity: 2 }
+          Filter (#0) IS NOT NULL // { arity: 2 }
+            Get materialize.public.v // { arity: 2 }
+  Return // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Join on=(#1 = #2) type=differential // { arity: 3 }
         ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -144,17 +155,6 @@ Explained Query:
               Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 2 }
-    Where
-      l0 =
-        Project (#0, #2) // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Filter (#1) IS NOT NULL // { arity: 2 }
-                    Get materialize.public.u // { arity: 2 }
-            Filter (#0) IS NOT NULL // { arity: 2 }
-              Get materialize.public.v // { arity: 2 }
 
 Source materialize.public.v
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -79,7 +79,16 @@ EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR
 SELECT t.* FROM u LEFT OUTER JOIN t on t.a = u.d
 ----
 Explained Query:
-  Let // { types: "(integer?, text?, date?)" }
+  With
+    cte l0 =
+      Project (#0, #2, #3) // { types: "(integer, text?, date?)" }
+        Join on=(#0 = #1) type=differential // { types: "(integer, integer, text?, date?)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer)" }
+            Filter (#0) IS NOT NULL // { types: "(integer)" }
+              Get materialize.public.u // { types: "(integer?)" }
+          Filter (#0) IS NOT NULL // { types: "(integer, text?, date?)" }
+            Get materialize.public.t // { types: "(integer?, text?, date?)" }
+  Return // { types: "(integer?, text?, date?)" }
     Union // { types: "(integer?, text?, date?)" }
       Map (null, null, null) // { types: "(integer?, text?, date?)" }
         Union // { types: "()" }
@@ -94,15 +103,6 @@ Explained Query:
           Project () // { types: "()" }
             Get materialize.public.u // { types: "(integer?)" }
       Get l0 // { types: "(integer, text?, date?)" }
-    Where
-      l0 =
-        Project (#0, #2, #3) // { types: "(integer, text?, date?)" }
-          Join on=(#0 = #1) type=differential // { types: "(integer, integer, text?, date?)" }
-            ArrangeBy keys=[[#0]] // { types: "(integer)" }
-              Filter (#0) IS NOT NULL // { types: "(integer)" }
-                Get materialize.public.u // { types: "(integer?)" }
-            Filter (#0) IS NOT NULL // { types: "(integer, text?, date?)" }
-              Get materialize.public.t // { types: "(integer?, text?, date?)" }
 
 Source materialize.public.t
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -25,7 +25,12 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR SELECT sum(a) FROM t
 ----
 Explained Query:
-  Let // { keys: "([])" }
+  With
+    cte l0 =
+      Reduce aggregates=[sum(#0)] // { keys: "([])" }
+        Project (#0) // { keys: "()" }
+          Get materialize.public.t // { keys: "()" }
+  Return // { keys: "([])" }
     Union // { keys: "([])" }
       Get l0 // { keys: "([])" }
       Map (null) // { keys: "()" }
@@ -35,11 +40,6 @@ Explained Query:
               Get l0 // { keys: "([])" }
           Constant // { keys: "([])" }
             - ()
-    Where
-      l0 =
-        Reduce aggregates=[sum(#0)] // { keys: "([])" }
-          Project (#0) // { keys: "()" }
-            Get materialize.public.t // { keys: "()" }
 
 Source materialize.public.t
   project=(#0, #2)
@@ -145,7 +145,22 @@ EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR
 SELECT 1 = (Select * FROM generate_series(1, 100000) limit 3)
 ----
 Explained Query:
-  Let // { keys: "()" }
+  With
+    cte l0 =
+      TopK limit=3 monotonic=true // { keys: "()" }
+        FlatMap generate_series(1, 100000, 1) // { keys: "()" }
+          Constant // { keys: "([])" }
+            - ()
+    cte l1 =
+      Union // { keys: "()" }
+        Get l0 // { keys: "()" }
+        Map (error("more than one record produced in subquery")) // { keys: "([])" }
+          Project () // { keys: "([])" }
+            Filter (#0 > 1) // { keys: "([])" }
+              Reduce aggregates=[count(true)] // { keys: "([])" }
+                Project () // { keys: "()" }
+                  Get l0 // { keys: "()" }
+  Return // { keys: "()" }
     Project (#1) // { keys: "()" }
       Map ((#0 = 1)) // { keys: "()" }
         Union // { keys: "()" }
@@ -158,20 +173,5 @@ Explained Query:
                     Get l1 // { keys: "()" }
               Constant // { keys: "([])" }
                 - ()
-    Where
-      l1 =
-        Union // { keys: "()" }
-          Get l0 // { keys: "()" }
-          Map (error("more than one record produced in subquery")) // { keys: "([])" }
-            Project () // { keys: "([])" }
-              Filter (#0 > 1) // { keys: "([])" }
-                Reduce aggregates=[count(true)] // { keys: "([])" }
-                  Project () // { keys: "()" }
-                    Get l0 // { keys: "()" }
-      l0 =
-        TopK limit=3 monotonic=true // { keys: "()" }
-          FlatMap generate_series(1, 100000, 1) // { keys: "()" }
-            Constant // { keys: "([])" }
-              - ()
 
 EOF

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -31,7 +31,7 @@ mode cockroach
 
 # Test constant error.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT 1 / 0
 ----
 {
@@ -56,267 +56,12 @@ SELECT 1 / 0
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Constant": {
-                  "rows": {
-                    "Ok": [
-                      [
-                        {
-                          "data": []
-                        },
-                        1
-                      ]
-                    ]
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Project": {
+      "Project": {
+        "input": {
+          "Map": {
             "input": {
-              "Map": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Local": 1
-                    },
-                    "typ": {
-                      "column_types": [],
-                      "keys": [
-                        []
-                      ]
-                    }
-                  }
-                },
-                "scalars": [
-                  {
-                    "CallBinary": {
-                      "func": "DivInt32",
-                      "expr1": {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                4,
-                                1,
-                                0,
-                                0,
-                                0
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          }
-                        ]
-                      },
-                      "expr2": {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                4,
-                                0,
-                                0,
-                                0,
-                                0
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            "outputs": [
-              0
-            ]
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test constant with two elements.
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-(SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Constant": {
-                  "rows": {
-                    "Ok": [
-                      [
-                        {
-                          "data": []
-                        },
-                        1
-                      ]
-                    ]
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Project": {
-                "input": {
-                  "Map": {
-                    "input": {
-                      "Map": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 1
-                            },
-                            "typ": {
-                              "column_types": [],
-                              "keys": [
-                                []
-                              ]
-                            }
-                          }
-                        },
-                        "scalars": [
-                          {
-                            "Literal": [
-                              {
-                                "Ok": {
-                                  "data": [
-                                    4,
-                                    1,
-                                    0,
-                                    0,
-                                    0
-                                  ]
-                                }
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": false
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    },
-                    "scalars": [
-                      {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                4,
-                                2,
-                                0,
-                                0,
-                                0
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "outputs": [
-                  0,
-                  1
-                ]
-              }
-            },
-            "body": {
               "Let": {
-                "id": 3,
+                "id": 1,
                 "value": {
                   "Join": {
                     "inputs": [
@@ -357,334 +102,247 @@ EXPLAIN DECORRELATED PLAN AS JSON FOR
                   }
                 },
                 "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Project": {
-                        "input": {
-                          "Map": {
-                            "input": {
-                              "Map": {
-                                "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 3
-                                    },
-                                    "typ": {
-                                      "column_types": [],
-                                      "keys": [
-                                        []
-                                      ]
-                                    }
-                                  }
-                                },
-                                "scalars": [
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            4,
-                                            1,
-                                            0,
-                                            0,
-                                            0
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "scalars": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        4,
-                                        2,
-                                        0,
-                                        0,
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1
-                        ]
-                      }
+                  "Get": {
+                    "id": {
+                      "Local": 1
                     },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Union": {
-                            "base": {
-                              "Project": {
-                                "input": {
-                                  "Project": {
-                                    "input": {
-                                      "Map": {
-                                        "input": {
-                                          "Map": {
-                                            "input": {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 2
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    }
-                                                  ],
-                                                  "keys": [
-                                                    []
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            "scalars": [
-                                              {
-                                                "Column": 0
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "scalars": [
-                                          {
-                                            "Column": 1
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1,
-                                      2,
-                                      3
-                                    ]
-                                  }
-                                },
-                                "outputs": [
-                                  2,
-                                  3
-                                ]
-                              }
-                            },
-                            "inputs": [
-                              {
-                                "Project": {
-                                  "input": {
-                                    "Project": {
-                                      "input": {
-                                        "Map": {
-                                          "input": {
-                                            "Map": {
-                                              "input": {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 4
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": false
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": false
-                                                      }
-                                                    ],
-                                                    "keys": [
-                                                      []
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "scalars": [
-                                                {
-                                                  "Column": 0
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "scalars": [
-                                            {
-                                              "Column": 1
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "outputs": [
-                                        0,
-                                        1,
-                                        2,
-                                        3
-                                      ]
-                                    }
-                                  },
-                                  "outputs": [
-                                    2,
-                                    3
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "body": {
+                    "typ": {
+                      "column_types": [],
+                      "keys": [
+                        []
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "scalars": [
+              {
+                "CallBinary": {
+                  "func": "DivInt32",
+                  "expr1": {
+                    "Literal": [
+                      {
+                        "Ok": {
+                          "data": [
+                            4,
+                            1,
+                            0,
+                            0,
+                            0
+                          ]
+                        }
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": false
+                      }
+                    ]
+                  },
+                  "expr2": {
+                    "Literal": [
+                      {
+                        "Ok": {
+                          "data": [
+                            4,
+                            0,
+                            0,
+                            0,
+                            0
+                          ]
+                        }
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": false
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "outputs": [
+          0
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test constant with two elements.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+(SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Union": {
+        "base": {
+          "Project": {
+            "input": {
+              "Project": {
+                "input": {
+                  "Map": {
+                    "input": {
+                      "Map": {
+                        "input": {
                           "Let": {
-                            "id": 6,
+                            "id": 5,
                             "value": {
-                              "Join": {
-                                "inputs": [
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 0
-                                      },
-                                      "typ": {
-                                        "column_types": [],
-                                        "keys": [
-                                          []
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Constant": {
-                                      "rows": {
-                                        "Ok": [
-                                          [
-                                            {
-                                              "data": []
-                                            },
-                                            1
-                                          ]
-                                        ]
-                                      },
-                                      "typ": {
-                                        "column_types": [],
-                                        "keys": []
-                                      }
-                                    }
-                                  }
-                                ],
-                                "equivalences": [],
-                                "implementation": "Unimplemented"
-                              }
-                            },
-                            "body": {
-                              "Let": {
-                                "id": 7,
-                                "value": {
+                              "Union": {
+                                "base": {
                                   "Project": {
                                     "input": {
-                                      "Map": {
-                                        "input": {
-                                          "Map": {
-                                            "input": {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 6
-                                                },
-                                                "typ": {
-                                                  "column_types": [],
-                                                  "keys": [
-                                                    []
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            "scalars": [
-                                              {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        4,
-                                                        3,
-                                                        0,
-                                                        0,
-                                                        0
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "scalars": [
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    4,
-                                                    4,
-                                                    0,
-                                                    0,
-                                                    0
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1
-                                    ]
-                                  }
-                                },
-                                "body": {
-                                  "Union": {
-                                    "base": {
                                       "Project": {
                                         "input": {
-                                          "Project": {
+                                          "Map": {
                                             "input": {
                                               "Map": {
                                                 "input": {
-                                                  "Map": {
-                                                    "input": {
+                                                  "Let": {
+                                                    "id": 2,
+                                                    "value": {
+                                                      "Project": {
+                                                        "input": {
+                                                          "Map": {
+                                                            "input": {
+                                                              "Map": {
+                                                                "input": {
+                                                                  "Let": {
+                                                                    "id": 1,
+                                                                    "value": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 0
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [],
+                                                                                "keys": [
+                                                                                  []
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Constant": {
+                                                                              "rows": {
+                                                                                "Ok": [
+                                                                                  [
+                                                                                    {
+                                                                                      "data": []
+                                                                                    },
+                                                                                    1
+                                                                                  ]
+                                                                                ]
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [],
+                                                                                "keys": []
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
+                                                                    },
+                                                                    "body": {
+                                                                      "Get": {
+                                                                        "id": {
+                                                                          "Local": 1
+                                                                        },
+                                                                        "typ": {
+                                                                          "column_types": [],
+                                                                          "keys": [
+                                                                            []
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "scalars": [
+                                                                  {
+                                                                    "Literal": [
+                                                                      {
+                                                                        "Ok": {
+                                                                          "data": [
+                                                                            4,
+                                                                            1,
+                                                                            0,
+                                                                            0,
+                                                                            0
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "scalar_type": "Int32",
+                                                                        "nullable": false
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "scalars": [
+                                                              {
+                                                                "Literal": [
+                                                                  {
+                                                                    "Ok": {
+                                                                      "data": [
+                                                                        4,
+                                                                        2,
+                                                                        0,
+                                                                        0,
+                                                                        0
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": false
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "outputs": [
+                                                          0,
+                                                          1
+                                                        ]
+                                                      }
+                                                    },
+                                                    "body": {
                                                       "Get": {
                                                         "id": {
-                                                          "Local": 5
+                                                          "Local": 2
                                                         },
                                                         "typ": {
                                                           "column_types": [
@@ -697,51 +355,173 @@ EXPLAIN DECORRELATED PLAN AS JSON FOR
                                                               "nullable": false
                                                             }
                                                           ],
-                                                          "keys": []
+                                                          "keys": [
+                                                            []
+                                                          ]
                                                         }
                                                       }
-                                                    },
-                                                    "scalars": [
-                                                      {
-                                                        "Column": 0
-                                                      }
-                                                    ]
+                                                    }
                                                   }
                                                 },
                                                 "scalars": [
                                                   {
-                                                    "Column": 1
+                                                    "Column": 0
                                                   }
                                                 ]
                                               }
                                             },
-                                            "outputs": [
-                                              0,
-                                              1,
-                                              2,
-                                              3
+                                            "scalars": [
+                                              {
+                                                "Column": 1
+                                              }
                                             ]
                                           }
                                         },
                                         "outputs": [
+                                          0,
+                                          1,
                                           2,
                                           3
                                         ]
                                       }
                                     },
-                                    "inputs": [
-                                      {
+                                    "outputs": [
+                                      2,
+                                      3
+                                    ]
+                                  }
+                                },
+                                "inputs": [
+                                  {
+                                    "Project": {
+                                      "input": {
                                         "Project": {
                                           "input": {
-                                            "Project": {
+                                            "Map": {
                                               "input": {
                                                 "Map": {
                                                   "input": {
-                                                    "Map": {
-                                                      "input": {
+                                                    "Let": {
+                                                      "id": 4,
+                                                      "value": {
+                                                        "Project": {
+                                                          "input": {
+                                                            "Map": {
+                                                              "input": {
+                                                                "Map": {
+                                                                  "input": {
+                                                                    "Let": {
+                                                                      "id": 3,
+                                                                      "value": {
+                                                                        "Join": {
+                                                                          "inputs": [
+                                                                            {
+                                                                              "Get": {
+                                                                                "id": {
+                                                                                  "Local": 0
+                                                                                },
+                                                                                "typ": {
+                                                                                  "column_types": [],
+                                                                                  "keys": [
+                                                                                    []
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "Constant": {
+                                                                                "rows": {
+                                                                                  "Ok": [
+                                                                                    [
+                                                                                      {
+                                                                                        "data": []
+                                                                                      },
+                                                                                      1
+                                                                                    ]
+                                                                                  ]
+                                                                                },
+                                                                                "typ": {
+                                                                                  "column_types": [],
+                                                                                  "keys": []
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ],
+                                                                          "equivalences": [],
+                                                                          "implementation": "Unimplemented"
+                                                                        }
+                                                                      },
+                                                                      "body": {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Local": 3
+                                                                          },
+                                                                          "typ": {
+                                                                            "column_types": [],
+                                                                            "keys": [
+                                                                              []
+                                                                            ]
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "scalars": [
+                                                                    {
+                                                                      "Literal": [
+                                                                        {
+                                                                          "Ok": {
+                                                                            "data": [
+                                                                              4,
+                                                                              1,
+                                                                              0,
+                                                                              0,
+                                                                              0
+                                                                            ]
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "scalars": [
+                                                                {
+                                                                  "Literal": [
+                                                                    {
+                                                                      "Ok": {
+                                                                        "data": [
+                                                                          4,
+                                                                          2,
+                                                                          0,
+                                                                          0,
+                                                                          0
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "outputs": [
+                                                            0,
+                                                            1
+                                                          ]
+                                                        }
+                                                      },
+                                                      "body": {
                                                         "Get": {
                                                           "id": {
-                                                            "Local": 7
+                                                            "Local": 4
                                                           },
                                                           "typ": {
                                                             "column_types": [
@@ -759,50 +539,270 @@ EXPLAIN DECORRELATED PLAN AS JSON FOR
                                                             ]
                                                           }
                                                         }
-                                                      },
-                                                      "scalars": [
-                                                        {
-                                                          "Column": 0
-                                                        }
-                                                      ]
+                                                      }
                                                     }
                                                   },
                                                   "scalars": [
                                                     {
-                                                      "Column": 1
+                                                      "Column": 0
                                                     }
                                                   ]
                                                 }
                                               },
-                                              "outputs": [
-                                                0,
-                                                1,
-                                                2,
-                                                3
+                                              "scalars": [
+                                                {
+                                                  "Column": 1
+                                                }
                                               ]
                                             }
                                           },
                                           "outputs": [
+                                            0,
+                                            1,
                                             2,
                                             3
                                           ]
                                         }
+                                      },
+                                      "outputs": [
+                                        2,
+                                        3
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "body": {
+                              "Get": {
+                                "id": {
+                                  "Local": 5
+                                },
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": false
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": false
+                                    }
+                                  ],
+                                  "keys": []
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "scalars": [
+                          {
+                            "Column": 0
+                          }
+                        ]
+                      }
+                    },
+                    "scalars": [
+                      {
+                        "Column": 1
+                      }
+                    ]
+                  }
+                },
+                "outputs": [
+                  0,
+                  1,
+                  2,
+                  3
+                ]
+              }
+            },
+            "outputs": [
+              2,
+              3
+            ]
+          }
+        },
+        "inputs": [
+          {
+            "Project": {
+              "input": {
+                "Project": {
+                  "input": {
+                    "Map": {
+                      "input": {
+                        "Map": {
+                          "input": {
+                            "Let": {
+                              "id": 7,
+                              "value": {
+                                "Project": {
+                                  "input": {
+                                    "Map": {
+                                      "input": {
+                                        "Map": {
+                                          "input": {
+                                            "Let": {
+                                              "id": 6,
+                                              "value": {
+                                                "Join": {
+                                                  "inputs": [
+                                                    {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Local": 0
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [],
+                                                          "keys": [
+                                                            []
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Constant": {
+                                                        "rows": {
+                                                          "Ok": [
+                                                            [
+                                                              {
+                                                                "data": []
+                                                              },
+                                                              1
+                                                            ]
+                                                          ]
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [],
+                                                          "keys": []
+                                                        }
+                                                      }
+                                                    }
+                                                  ],
+                                                  "equivalences": [],
+                                                  "implementation": "Unimplemented"
+                                                }
+                                              },
+                                              "body": {
+                                                "Get": {
+                                                  "id": {
+                                                    "Local": 6
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [],
+                                                    "keys": [
+                                                      []
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "scalars": [
+                                            {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      4,
+                                                      3,
+                                                      0,
+                                                      0,
+                                                      0
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "scalars": [
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  4,
+                                                  4,
+                                                  0,
+                                                  0,
+                                                  0
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "outputs": [
+                                    0,
+                                    1
+                                  ]
+                                }
+                              },
+                              "body": {
+                                "Get": {
+                                  "id": {
+                                    "Local": 7
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": false
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": false
                                       }
+                                    ],
+                                    "keys": [
+                                      []
                                     ]
                                   }
                                 }
                               }
                             }
-                          }
+                          },
+                          "scalars": [
+                            {
+                              "Column": 0
+                            }
+                          ]
                         }
-                      }
+                      },
+                      "scalars": [
+                        {
+                          "Column": 1
+                        }
+                      ]
                     }
-                  }
+                  },
+                  "outputs": [
+                    0,
+                    1,
+                    2,
+                    3
+                  ]
                 }
-              }
+              },
+              "outputs": [
+                2,
+                3
+              ]
             }
           }
-        }
+        ]
       }
     }
   }
@@ -811,7 +811,7 @@ EOF
 
 # Test basic linear chains.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
 ----
 {
@@ -836,169 +836,169 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Filter": {
-            "input": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 5
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": false
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "predicates": [
-              {
-                "CallVariadic": {
-                  "func": "And",
-                  "exprs": [
-                    {
-                      "CallVariadic": {
-                        "func": "And",
-                        "exprs": [
-                          {
-                            "CallBinary": {
-                              "func": "Gt",
-                              "expr1": {
-                                "Column": 0
-                              },
-                              "expr2": {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        4,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "CallBinary": {
-                              "func": "Lt",
-                              "expr1": {
-                                "Column": 1
-                              },
-                              "expr2": {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        4,
-                                        0,
-                                        0,
-                                        0,
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "CallBinary": {
-                        "func": "Gt",
-                        "expr1": {
-                          "CallBinary": {
-                            "func": "AddInt32",
-                            "expr1": {
-                              "Column": 0
-                            },
-                            "expr2": {
-                              "Column": 1
-                            }
-                          }
-                        },
-                        "expr2": {
-                          "Literal": [
-                            {
-                              "Ok": {
-                                "data": [
-                                  4,
-                                  0,
-                                  0,
-                                  0,
-                                  0
-                                ]
-                              }
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "body": {
+      "Project": {
+        "input": {
           "Project": {
             "input": {
-              "Project": {
+              "Map": {
                 "input": {
                   "Map": {
                     "input": {
-                      "Map": {
-                        "input": {
+                      "Let": {
+                        "id": 1,
+                        "value": {
+                          "Filter": {
+                            "input": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "typ": {
+                                        "column_types": [],
+                                        "keys": [
+                                          []
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Global": {
+                                          "User": 5
+                                        }
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "predicates": [
+                              {
+                                "CallVariadic": {
+                                  "func": "And",
+                                  "exprs": [
+                                    {
+                                      "CallVariadic": {
+                                        "func": "And",
+                                        "exprs": [
+                                          {
+                                            "CallBinary": {
+                                              "func": "Gt",
+                                              "expr1": {
+                                                "Column": 0
+                                              },
+                                              "expr2": {
+                                                "Literal": [
+                                                  {
+                                                    "Ok": {
+                                                      "data": [
+                                                        4,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "CallBinary": {
+                                              "func": "Lt",
+                                              "expr1": {
+                                                "Column": 1
+                                              },
+                                              "expr2": {
+                                                "Literal": [
+                                                  {
+                                                    "Ok": {
+                                                      "data": [
+                                                        4,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0
+                                                      ]
+                                                    }
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "CallBinary": {
+                                        "func": "Gt",
+                                        "expr1": {
+                                          "CallBinary": {
+                                            "func": "AddInt32",
+                                            "expr1": {
+                                              "Column": 0
+                                            },
+                                            "expr2": {
+                                              "Column": 1
+                                            }
+                                          }
+                                        },
+                                        "expr2": {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  4,
+                                                  0,
+                                                  0,
+                                                  0,
+                                                  0
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "body": {
                           "Get": {
                             "id": {
                               "Local": 1
@@ -1017,59 +1017,59 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
                               "keys": []
                             }
                           }
-                        },
-                        "scalars": [
-                          {
-                            "Literal": [
-                              {
-                                "Ok": {
-                                  "data": [
-                                    4,
-                                    1,
-                                    0,
-                                    0,
-                                    0
-                                  ]
-                                }
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": false
-                              }
-                            ]
-                          }
-                        ]
+                        }
                       }
                     },
                     "scalars": [
                       {
-                        "CallBinary": {
-                          "func": "AddInt32",
-                          "expr1": {
-                            "Column": 0
+                        "Literal": [
+                          {
+                            "Ok": {
+                              "data": [
+                                4,
+                                1,
+                                0,
+                                0,
+                                0
+                              ]
+                            }
                           },
-                          "expr2": {
-                            "Column": 1
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": false
                           }
-                        }
+                        ]
                       }
                     ]
                   }
                 },
-                "outputs": [
-                  0,
-                  1,
-                  2,
-                  3
+                "scalars": [
+                  {
+                    "CallBinary": {
+                      "func": "AddInt32",
+                      "expr1": {
+                        "Column": 0
+                      },
+                      "expr2": {
+                        "Column": 1
+                      }
+                    }
+                  }
                 ]
               }
             },
             "outputs": [
+              0,
+              1,
               2,
               3
             ]
           }
-        }
+        },
+        "outputs": [
+          2,
+          3
+        ]
       }
     }
   }
@@ -1078,7 +1078,7 @@ EOF
 
 # Test table functions in the select clause (FlatMap).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT generate_series(a, b) from t
 ----
 {
@@ -1103,54 +1103,54 @@ SELECT generate_series(a, b) from t
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
+      "Project": {
+        "input": {
+          "Let": {
+            "id": 1,
+            "value": {
+              "Join": {
+                "inputs": [
+                  {
+                    "Get": {
+                      "id": {
+                        "Local": 0
+                      },
+                      "typ": {
+                        "column_types": [],
+                        "keys": [
+                          []
+                        ]
+                      }
                     }
                   },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
+                  {
+                    "Get": {
+                      "id": {
+                        "Global": {
+                          "User": 1
+                        }
                       },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
+                      "typ": {
+                        "column_types": [
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": true
+                          },
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": true
+                          }
+                        ],
+                        "keys": []
                       }
-                    ],
-                    "keys": []
+                    }
                   }
-                }
+                ],
+                "equivalences": [],
+                "implementation": "Unimplemented"
               }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Project": {
-            "input": {
+            },
+            "body": {
               "Filter": {
                 "input": {
                   "FlatMap": {
@@ -1222,12 +1222,12 @@ SELECT generate_series(a, b) from t
                   }
                 ]
               }
-            },
-            "outputs": [
-              2
-            ]
+            }
           }
-        }
+        },
+        "outputs": [
+          2
+        ]
       }
     }
   }
@@ -1236,7 +1236,7 @@ EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
 {
@@ -1261,185 +1261,51 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Project": {
-            "input": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "outputs": [
-              0
-            ]
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Project": {
+      "Threshold": {
+        "input": {
+          "Union": {
+            "base": {
+              "Reduce": {
                 "input": {
-                  "Join": {
-                    "inputs": [
-                      {
-                        "Get": {
-                          "id": {
-                            "Local": 0
-                          },
-                          "typ": {
-                            "column_types": [],
-                            "keys": [
-                              []
-                            ]
-                          }
-                        }
-                      },
-                      {
-                        "Get": {
-                          "id": {
-                            "Global": {
-                              "User": 5
-                            }
-                          },
-                          "typ": {
-                            "column_types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": false
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              }
-                            ],
-                            "keys": []
-                          }
-                        }
-                      }
-                    ],
-                    "equivalences": [],
-                    "implementation": "Unimplemented"
-                  }
-                },
-                "outputs": [
-                  1
-                ]
-              }
-            },
-            "body": {
-              "Threshold": {
-                "input": {
-                  "Union": {
-                    "base": {
-                      "Reduce": {
+                  "Project": {
+                    "input": {
+                      "Project": {
                         "input": {
-                          "Project": {
+                          "Map": {
                             "input": {
-                              "Project": {
-                                "input": {
-                                  "Map": {
+                              "Let": {
+                                "id": 1,
+                                "value": {
+                                  "Project": {
                                     "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 1
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": []
-                                        }
-                                      }
-                                    },
-                                    "scalars": [
-                                      {
-                                        "Column": 0
-                                      }
-                                    ]
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  1
-                                ]
-                              }
-                            },
-                            "outputs": [
-                              1
-                            ]
-                          }
-                        },
-                        "group_key": [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        "aggregates": [],
-                        "monotonic": false,
-                        "expected_group_size": null
-                      }
-                    },
-                    "inputs": [
-                      {
-                        "Negate": {
-                          "input": {
-                            "Reduce": {
-                              "input": {
-                                "Project": {
-                                  "input": {
-                                    "Project": {
-                                      "input": {
-                                        "Map": {
-                                          "input": {
+                                      "Join": {
+                                        "inputs": [
+                                          {
                                             "Get": {
                                               "id": {
-                                                "Local": 2
+                                                "Local": 0
+                                              },
+                                              "typ": {
+                                                "column_types": [],
+                                                "keys": [
+                                                  []
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Global": {
+                                                  "User": 1
+                                                }
                                               },
                                               "typ": {
                                                 "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
                                                   {
                                                     "scalar_type": "Int32",
                                                     "nullable": true
@@ -1448,42 +1314,176 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                                                 "keys": []
                                               }
                                             }
-                                          },
-                                          "scalars": [
-                                            {
-                                              "Column": 0
+                                          }
+                                        ],
+                                        "equivalences": [],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    },
+                                    "outputs": [
+                                      0
+                                    ]
+                                  }
+                                },
+                                "body": {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 1
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ],
+                                      "keys": []
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "scalars": [
+                              {
+                                "Column": 0
+                              }
+                            ]
+                          }
+                        },
+                        "outputs": [
+                          0,
+                          1
+                        ]
+                      }
+                    },
+                    "outputs": [
+                      1
+                    ]
+                  }
+                },
+                "group_key": [
+                  {
+                    "Column": 0
+                  }
+                ],
+                "aggregates": [],
+                "monotonic": false,
+                "expected_group_size": null
+              }
+            },
+            "inputs": [
+              {
+                "Negate": {
+                  "input": {
+                    "Reduce": {
+                      "input": {
+                        "Project": {
+                          "input": {
+                            "Project": {
+                              "input": {
+                                "Map": {
+                                  "input": {
+                                    "Let": {
+                                      "id": 2,
+                                      "value": {
+                                        "Project": {
+                                          "input": {
+                                            "Join": {
+                                              "inputs": [
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 0
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [],
+                                                      "keys": [
+                                                        []
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Global": {
+                                                        "User": 5
+                                                      }
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": false
+                                                        },
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        }
+                                                      ],
+                                                      "keys": []
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "equivalences": [],
+                                              "implementation": "Unimplemented"
                                             }
+                                          },
+                                          "outputs": [
+                                            1
                                           ]
                                         }
                                       },
-                                      "outputs": [
-                                        0,
-                                        1
-                                      ]
+                                      "body": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 2
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      }
                                     }
                                   },
-                                  "outputs": [
-                                    1
+                                  "scalars": [
+                                    {
+                                      "Column": 0
+                                    }
                                   ]
                                 }
                               },
-                              "group_key": [
-                                {
-                                  "Column": 0
-                                }
-                              ],
-                              "aggregates": [],
-                              "monotonic": false,
-                              "expected_group_size": null
+                              "outputs": [
+                                0,
+                                1
+                              ]
                             }
-                          }
+                          },
+                          "outputs": [
+                            1
+                          ]
                         }
-                      }
-                    ]
+                      },
+                      "group_key": [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      "aggregates": [],
+                      "monotonic": false,
+                      "expected_group_size": null
+                    }
                   }
                 }
               }
-            }
+            ]
           }
         }
       }
@@ -1494,7 +1494,7 @@ EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 {
@@ -1519,171 +1519,49 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Project": {
-            "input": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "outputs": [
-              0
-            ]
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
+      "Threshold": {
+        "input": {
+          "Union": {
+            "base": {
               "Project": {
                 "input": {
-                  "Join": {
-                    "inputs": [
-                      {
-                        "Get": {
-                          "id": {
-                            "Local": 0
-                          },
-                          "typ": {
-                            "column_types": [],
-                            "keys": [
-                              []
-                            ]
-                          }
-                        }
-                      },
-                      {
-                        "Get": {
-                          "id": {
-                            "Global": {
-                              "User": 5
-                            }
-                          },
-                          "typ": {
-                            "column_types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": false
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": true
-                              }
-                            ],
-                            "keys": []
-                          }
-                        }
-                      }
-                    ],
-                    "equivalences": [],
-                    "implementation": "Unimplemented"
-                  }
-                },
-                "outputs": [
-                  1
-                ]
-              }
-            },
-            "body": {
-              "Threshold": {
-                "input": {
-                  "Union": {
-                    "base": {
-                      "Project": {
+                  "Project": {
+                    "input": {
+                      "Map": {
                         "input": {
-                          "Project": {
-                            "input": {
-                              "Map": {
+                          "Let": {
+                            "id": 1,
+                            "value": {
+                              "Project": {
                                 "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 1
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        }
-                                      ],
-                                      "keys": []
-                                    }
-                                  }
-                                },
-                                "scalars": [
-                                  {
-                                    "Column": 0
-                                  }
-                                ]
-                              }
-                            },
-                            "outputs": [
-                              0,
-                              1
-                            ]
-                          }
-                        },
-                        "outputs": [
-                          1
-                        ]
-                      }
-                    },
-                    "inputs": [
-                      {
-                        "Negate": {
-                          "input": {
-                            "Project": {
-                              "input": {
-                                "Project": {
-                                  "input": {
-                                    "Map": {
-                                      "input": {
+                                  "Join": {
+                                    "inputs": [
+                                      {
                                         "Get": {
                                           "id": {
-                                            "Local": 2
+                                            "Local": 0
+                                          },
+                                          "typ": {
+                                            "column_types": [],
+                                            "keys": [
+                                              []
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Global": {
+                                              "User": 1
+                                            }
                                           },
                                           "typ": {
                                             "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
                                               {
                                                 "scalar_type": "Int32",
                                                 "nullable": true
@@ -1692,32 +1570,154 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                                             "keys": []
                                           }
                                         }
-                                      },
-                                      "scalars": [
-                                        {
-                                          "Column": 0
+                                      }
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
+                                  }
+                                },
+                                "outputs": [
+                                  0
+                                ]
+                              }
+                            },
+                            "body": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ],
+                                  "keys": []
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "scalars": [
+                          {
+                            "Column": 0
+                          }
+                        ]
+                      }
+                    },
+                    "outputs": [
+                      0,
+                      1
+                    ]
+                  }
+                },
+                "outputs": [
+                  1
+                ]
+              }
+            },
+            "inputs": [
+              {
+                "Negate": {
+                  "input": {
+                    "Project": {
+                      "input": {
+                        "Project": {
+                          "input": {
+                            "Map": {
+                              "input": {
+                                "Let": {
+                                  "id": 2,
+                                  "value": {
+                                    "Project": {
+                                      "input": {
+                                        "Join": {
+                                          "inputs": [
+                                            {
+                                              "Get": {
+                                                "id": {
+                                                  "Local": 0
+                                                },
+                                                "typ": {
+                                                  "column_types": [],
+                                                  "keys": [
+                                                    []
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "Get": {
+                                                "id": {
+                                                  "Global": {
+                                                    "User": 5
+                                                  }
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": false
+                                                    },
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": []
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "equivalences": [],
+                                          "implementation": "Unimplemented"
                                         }
+                                      },
+                                      "outputs": [
+                                        1
                                       ]
                                     }
                                   },
-                                  "outputs": [
-                                    0,
-                                    1
-                                  ]
+                                  "body": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 2
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
                                 }
                               },
-                              "outputs": [
-                                1
+                              "scalars": [
+                                {
+                                  "Column": 0
+                                }
                               ]
                             }
-                          }
+                          },
+                          "outputs": [
+                            0,
+                            1
+                          ]
                         }
-                      }
-                    ]
+                      },
+                      "outputs": [
+                        1
+                      ]
+                    }
                   }
                 }
               }
-            }
+            ]
           }
         }
       }
@@ -1728,7 +1728,7 @@ EOF
 
 # Test TopK.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 VIEW ov
 ----
 {
@@ -1829,7 +1829,7 @@ EOF
 
 # Test Finish.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 {
@@ -1902,7 +1902,7 @@ EOF
 
 # Test Reduce (global).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
 {
@@ -1927,171 +1927,22 @@ SELECT abs(min(a) - max(a)) FROM t
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Reduce": {
+      "Project": {
+        "input": {
+          "Project": {
             "input": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "group_key": [],
-            "aggregates": [
-              {
-                "func": "MinInt32",
-                "expr": {
-                  "Column": 0
-                },
-                "distinct": false
-              },
-              {
-                "func": "MaxInt32",
-                "expr": {
-                  "Column": 0
-                },
-                "distinct": false
-              }
-            ],
-            "monotonic": false,
-            "expected_group_size": null
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Union": {
-                "base": {
-                  "Get": {
-                    "id": {
-                      "Local": 1
-                    },
-                    "typ": {
-                      "column_types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
-                      ],
-                      "keys": [
-                        []
-                      ]
-                    }
-                  }
-                },
-                "inputs": [
-                  {
-                    "Join": {
-                      "inputs": [
-                        {
-                          "Project": {
+              "Map": {
+                "input": {
+                  "Let": {
+                    "id": 2,
+                    "value": {
+                      "Let": {
+                        "id": 1,
+                        "value": {
+                          "Reduce": {
                             "input": {
                               "Join": {
                                 "inputs": [
-                                  {
-                                    "Union": {
-                                      "base": {
-                                        "Negate": {
-                                          "input": {
-                                            "Reduce": {
-                                              "input": {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 1
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      }
-                                                    ],
-                                                    "keys": [
-                                                      []
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "group_key": [],
-                                              "aggregates": [],
-                                              "monotonic": false,
-                                              "expected_group_size": null
-                                            }
-                                          }
-                                        }
-                                      },
-                                      "inputs": [
-                                        {
-                                          "Reduce": {
-                                            "input": {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 0
-                                                },
-                                                "typ": {
-                                                  "column_types": [],
-                                                  "keys": [
-                                                    []
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            "group_key": [],
-                                            "aggregates": [],
-                                            "monotonic": false,
-                                            "expected_group_size": null
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
                                   {
                                     "Get": {
                                       "id": {
@@ -2104,115 +1955,264 @@ SELECT abs(min(a) - max(a)) FROM t
                                         ]
                                       }
                                     }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Global": {
+                                          "User": 1
+                                        }
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
                                   }
                                 ],
                                 "equivalences": [],
                                 "implementation": "Unimplemented"
                               }
                             },
-                            "outputs": []
+                            "group_key": [],
+                            "aggregates": [
+                              {
+                                "func": "MinInt32",
+                                "expr": {
+                                  "Column": 0
+                                },
+                                "distinct": false
+                              },
+                              {
+                                "func": "MaxInt32",
+                                "expr": {
+                                  "Column": 0
+                                },
+                                "distinct": false
+                              }
+                            ],
+                            "monotonic": false,
+                            "expected_group_size": null
                           }
                         },
-                        {
-                          "Constant": {
-                            "rows": {
-                              "Ok": [
-                                [
-                                  {
-                                    "data": [
-                                      0,
-                                      0
-                                    ]
-                                  },
-                                  1
-                                ]
-                              ]
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
+                        "body": {
+                          "Union": {
+                            "base": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
                                 },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ],
+                                  "keys": [
+                                    []
+                                  ]
                                 }
-                              ],
-                              "keys": []
-                            }
+                              }
+                            },
+                            "inputs": [
+                              {
+                                "Join": {
+                                  "inputs": [
+                                    {
+                                      "Project": {
+                                        "input": {
+                                          "Join": {
+                                            "inputs": [
+                                              {
+                                                "Union": {
+                                                  "base": {
+                                                    "Negate": {
+                                                      "input": {
+                                                        "Reduce": {
+                                                          "input": {
+                                                            "Get": {
+                                                              "id": {
+                                                                "Local": 1
+                                                              },
+                                                              "typ": {
+                                                                "column_types": [
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  },
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  }
+                                                                ],
+                                                                "keys": [
+                                                                  []
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          "group_key": [],
+                                                          "aggregates": [],
+                                                          "monotonic": false,
+                                                          "expected_group_size": null
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "inputs": [
+                                                    {
+                                                      "Reduce": {
+                                                        "input": {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 0
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [],
+                                                              "keys": [
+                                                                []
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        "group_key": [],
+                                                        "aggregates": [],
+                                                        "monotonic": false,
+                                                        "expected_group_size": null
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "Get": {
+                                                  "id": {
+                                                    "Local": 0
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [],
+                                                    "keys": [
+                                                      []
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "equivalences": [],
+                                            "implementation": "Unimplemented"
+                                          }
+                                        },
+                                        "outputs": []
+                                      }
+                                    },
+                                    {
+                                      "Constant": {
+                                        "rows": {
+                                          "Ok": [
+                                            [
+                                              {
+                                                "data": [
+                                                  0,
+                                                  0
+                                                ]
+                                              },
+                                              1
+                                            ]
+                                          ]
+                                        },
+                                        "typ": {
+                                          "column_types": [
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            }
+                                          ],
+                                          "keys": []
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "equivalences": [],
+                                  "implementation": "Unimplemented"
+                                }
+                              }
+                            ]
                           }
                         }
-                      ],
-                      "equivalences": [],
-                      "implementation": "Unimplemented"
+                      }
+                    },
+                    "body": {
+                      "Get": {
+                        "id": {
+                          "Local": 2
+                        },
+                        "typ": {
+                          "column_types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ],
+                          "keys": []
+                        }
+                      }
+                    }
+                  }
+                },
+                "scalars": [
+                  {
+                    "CallUnary": {
+                      "func": {
+                        "AbsInt32": null
+                      },
+                      "expr": {
+                        "CallBinary": {
+                          "func": "SubInt32",
+                          "expr1": {
+                            "Column": 0
+                          },
+                          "expr2": {
+                            "Column": 1
+                          }
+                        }
+                      }
                     }
                   }
                 ]
               }
             },
-            "body": {
-              "Project": {
-                "input": {
-                  "Project": {
-                    "input": {
-                      "Map": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 2
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            }
-                          }
-                        },
-                        "scalars": [
-                          {
-                            "CallUnary": {
-                              "func": {
-                                "AbsInt32": null
-                              },
-                              "expr": {
-                                "CallBinary": {
-                                  "func": "SubInt32",
-                                  "expr1": {
-                                    "Column": 0
-                                  },
-                                  "expr2": {
-                                    "Column": 1
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      1,
-                      2
-                    ]
-                  }
-                },
-                "outputs": [
-                  2
-                ]
-              }
-            }
+            "outputs": [
+              0,
+              1,
+              2
+            ]
           }
-        }
+        },
+        "outputs": [
+          2
+        ]
       }
     }
   }
@@ -2221,7 +2221,7 @@ EOF
 
 # Test Reduce (local).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
 {
@@ -2246,190 +2246,190 @@ SELECT abs(min(a) - max(a)) FROM t GROUP BY b
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Reduce": {
+      "Project": {
+        "input": {
+          "Project": {
+            "input": {
+              "Map": {
                 "input": {
-                  "Project": {
-                    "input": {
-                      "Map": {
+                  "Let": {
+                    "id": 2,
+                    "value": {
+                      "Reduce": {
                         "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 1
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            }
-                          }
-                        },
-                        "scalars": [
-                          {
-                            "Column": 1
-                          }
-                        ]
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      1,
-                      2
-                    ]
-                  }
-                },
-                "group_key": [
-                  {
-                    "Column": 2
-                  }
-                ],
-                "aggregates": [
-                  {
-                    "func": "MinInt32",
-                    "expr": {
-                      "Column": 0
-                    },
-                    "distinct": false
-                  },
-                  {
-                    "func": "MaxInt32",
-                    "expr": {
-                      "Column": 0
-                    },
-                    "distinct": false
-                  }
-                ],
-                "monotonic": false,
-                "expected_group_size": null
-              }
-            },
-            "body": {
-              "Project": {
-                "input": {
-                  "Project": {
-                    "input": {
-                      "Map": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 2
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": [
-                                [
-                                  0
-                                ]
-                              ]
-                            }
-                          }
-                        },
-                        "scalars": [
-                          {
-                            "CallUnary": {
-                              "func": {
-                                "AbsInt32": null
-                              },
-                              "expr": {
-                                "CallBinary": {
-                                  "func": "SubInt32",
-                                  "expr1": {
-                                    "Column": 1
-                                  },
-                                  "expr2": {
-                                    "Column": 2
+                          "Project": {
+                            "input": {
+                              "Map": {
+                                "input": {
+                                  "Let": {
+                                    "id": 1,
+                                    "value": {
+                                      "Join": {
+                                        "inputs": [
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 0
+                                              },
+                                              "typ": {
+                                                "column_types": [],
+                                                "keys": [
+                                                  []
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Global": {
+                                                  "User": 1
+                                                }
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "equivalences": [],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    },
+                                    "body": {
+                                      "Get": {
+                                        "id": {
+                                          "Local": 1
+                                        },
+                                        "typ": {
+                                          "column_types": [
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            }
+                                          ],
+                                          "keys": []
+                                        }
+                                      }
+                                    }
                                   }
-                                }
+                                },
+                                "scalars": [
+                                  {
+                                    "Column": 1
+                                  }
+                                ]
                               }
-                            }
+                            },
+                            "outputs": [
+                              0,
+                              1,
+                              2
+                            ]
                           }
-                        ]
+                        },
+                        "group_key": [
+                          {
+                            "Column": 2
+                          }
+                        ],
+                        "aggregates": [
+                          {
+                            "func": "MinInt32",
+                            "expr": {
+                              "Column": 0
+                            },
+                            "distinct": false
+                          },
+                          {
+                            "func": "MaxInt32",
+                            "expr": {
+                              "Column": 0
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        "monotonic": false,
+                        "expected_group_size": null
                       }
                     },
-                    "outputs": [
-                      0,
-                      1,
-                      2,
-                      3
-                    ]
+                    "body": {
+                      "Get": {
+                        "id": {
+                          "Local": 2
+                        },
+                        "typ": {
+                          "column_types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ],
+                          "keys": [
+                            [
+                              0
+                            ]
+                          ]
+                        }
+                      }
+                    }
                   }
                 },
-                "outputs": [
-                  3
+                "scalars": [
+                  {
+                    "CallUnary": {
+                      "func": {
+                        "AbsInt32": null
+                      },
+                      "expr": {
+                        "CallBinary": {
+                          "func": "SubInt32",
+                          "expr1": {
+                            "Column": 1
+                          },
+                          "expr2": {
+                            "Column": 2
+                          }
+                        }
+                      }
+                    }
+                  }
                 ]
               }
-            }
+            },
+            "outputs": [
+              0,
+              1,
+              2,
+              3
+            ]
           }
-        }
+        },
+        "outputs": [
+          3
+        ]
       }
     }
   }
@@ -2438,7 +2438,7 @@ EOF
 
 # Test EXISTS subqueries.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 {
@@ -2463,11 +2463,2212 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
       }
     },
     "body": {
-      "Let": {
-        "id": 1,
-        "value": {
+      "Project": {
+        "input": {
           "Filter": {
             "input": {
+              "Let": {
+                "id": 4,
+                "value": {
+                  "Project": {
+                    "input": {
+                      "Filter": {
+                        "input": {
+                          "Let": {
+                            "id": 1,
+                            "value": {
+                              "Filter": {
+                                "input": {
+                                  "Join": {
+                                    "inputs": [
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 0
+                                          },
+                                          "typ": {
+                                            "column_types": [],
+                                            "keys": [
+                                              []
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Global": {
+                                              "User": 1
+                                            }
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
+                                  }
+                                },
+                                "predicates": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": "And",
+                                      "exprs": [
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  2
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "Bool",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  2
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "Bool",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "body": {
+                              "Let": {
+                                "id": 2,
+                                "value": {
+                                  "Reduce": {
+                                    "input": {
+                                      "Get": {
+                                        "id": {
+                                          "Local": 1
+                                        },
+                                        "typ": {
+                                          "column_types": [
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            }
+                                          ],
+                                          "keys": []
+                                        }
+                                      }
+                                    },
+                                    "group_key": [
+                                      {
+                                        "Column": 0
+                                      }
+                                    ],
+                                    "aggregates": [],
+                                    "monotonic": false,
+                                    "expected_group_size": null
+                                  }
+                                },
+                                "body": {
+                                  "Project": {
+                                    "input": {
+                                      "Join": {
+                                        "inputs": [
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 1
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Let": {
+                                              "id": 3,
+                                              "value": {
+                                                "Join": {
+                                                  "inputs": [
+                                                    {
+                                                      "Reduce": {
+                                                        "input": {
+                                                          "Filter": {
+                                                            "input": {
+                                                              "Join": {
+                                                                "inputs": [
+                                                                  {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Local": 2
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": [
+                                                                          [
+                                                                            0
+                                                                          ]
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Global": {
+                                                                          "User": 5
+                                                                        }
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": false
+                                                                          },
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": []
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "equivalences": [],
+                                                                "implementation": "Unimplemented"
+                                                              }
+                                                            },
+                                                            "predicates": [
+                                                              {
+                                                                "CallBinary": {
+                                                                  "func": "Lt",
+                                                                  "expr1": {
+                                                                    "Column": 0
+                                                                  },
+                                                                  "expr2": {
+                                                                    "Column": 1
+                                                                  }
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "group_key": [
+                                                          {
+                                                            "Column": 0
+                                                          }
+                                                        ],
+                                                        "aggregates": [],
+                                                        "monotonic": false,
+                                                        "expected_group_size": null
+                                                      }
+                                                    },
+                                                    {
+                                                      "Constant": {
+                                                        "rows": {
+                                                          "Ok": [
+                                                            [
+                                                              {
+                                                                "data": [
+                                                                  2
+                                                                ]
+                                                              },
+                                                              1
+                                                            ]
+                                                          ]
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
+                                                            {
+                                                              "scalar_type": "Bool",
+                                                              "nullable": false
+                                                            }
+                                                          ],
+                                                          "keys": []
+                                                        }
+                                                      }
+                                                    }
+                                                  ],
+                                                  "equivalences": [],
+                                                  "implementation": "Unimplemented"
+                                                }
+                                              },
+                                              "body": {
+                                                "Union": {
+                                                  "base": {
+                                                    "Get": {
+                                                      "id": {
+                                                        "Local": 3
+                                                      },
+                                                      "typ": {
+                                                        "column_types": [
+                                                          {
+                                                            "scalar_type": "Int32",
+                                                            "nullable": false
+                                                          },
+                                                          {
+                                                            "scalar_type": "Bool",
+                                                            "nullable": false
+                                                          }
+                                                        ],
+                                                        "keys": [
+                                                          [
+                                                            0
+                                                          ]
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  "inputs": [
+                                                    {
+                                                      "Join": {
+                                                        "inputs": [
+                                                          {
+                                                            "Project": {
+                                                              "input": {
+                                                                "Join": {
+                                                                  "inputs": [
+                                                                    {
+                                                                      "Union": {
+                                                                        "base": {
+                                                                          "Negate": {
+                                                                            "input": {
+                                                                              "Reduce": {
+                                                                                "input": {
+                                                                                  "Get": {
+                                                                                    "id": {
+                                                                                      "Local": 3
+                                                                                    },
+                                                                                    "typ": {
+                                                                                      "column_types": [
+                                                                                        {
+                                                                                          "scalar_type": "Int32",
+                                                                                          "nullable": false
+                                                                                        },
+                                                                                        {
+                                                                                          "scalar_type": "Bool",
+                                                                                          "nullable": false
+                                                                                        }
+                                                                                      ],
+                                                                                      "keys": [
+                                                                                        [
+                                                                                          0
+                                                                                        ]
+                                                                                      ]
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "group_key": [
+                                                                                  {
+                                                                                    "Column": 0
+                                                                                  }
+                                                                                ],
+                                                                                "aggregates": [],
+                                                                                "monotonic": false,
+                                                                                "expected_group_size": null
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Reduce": {
+                                                                              "input": {
+                                                                                "Get": {
+                                                                                  "id": {
+                                                                                    "Local": 2
+                                                                                  },
+                                                                                  "typ": {
+                                                                                    "column_types": [
+                                                                                      {
+                                                                                        "scalar_type": "Int32",
+                                                                                        "nullable": true
+                                                                                      }
+                                                                                    ],
+                                                                                    "keys": [
+                                                                                      [
+                                                                                        0
+                                                                                      ]
+                                                                                    ]
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "group_key": [
+                                                                                {
+                                                                                  "Column": 0
+                                                                                }
+                                                                              ],
+                                                                              "aggregates": [],
+                                                                              "monotonic": false,
+                                                                              "expected_group_size": null
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "Get": {
+                                                                        "id": {
+                                                                          "Local": 2
+                                                                        },
+                                                                        "typ": {
+                                                                          "column_types": [
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            }
+                                                                          ],
+                                                                          "keys": [
+                                                                            [
+                                                                              0
+                                                                            ]
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ],
+                                                                  "equivalences": [
+                                                                    [
+                                                                      {
+                                                                        "Column": 0
+                                                                      },
+                                                                      {
+                                                                        "Column": 1
+                                                                      }
+                                                                    ]
+                                                                  ],
+                                                                  "implementation": "Unimplemented"
+                                                                }
+                                                              },
+                                                              "outputs": [
+                                                                0
+                                                              ]
+                                                            }
+                                                          },
+                                                          {
+                                                            "Constant": {
+                                                              "rows": {
+                                                                "Ok": [
+                                                                  [
+                                                                    {
+                                                                      "data": [
+                                                                        1
+                                                                      ]
+                                                                    },
+                                                                    1
+                                                                  ]
+                                                                ]
+                                                              },
+                                                              "typ": {
+                                                                "column_types": [
+                                                                  {
+                                                                    "scalar_type": "Bool",
+                                                                    "nullable": false
+                                                                  }
+                                                                ],
+                                                                "keys": []
+                                                              }
+                                                            }
+                                                          }
+                                                        ],
+                                                        "equivalences": [],
+                                                        "implementation": "Unimplemented"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "equivalences": [
+                                          [
+                                            {
+                                              "Column": 0
+                                            },
+                                            {
+                                              "Column": 2
+                                            }
+                                          ]
+                                        ],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    },
+                                    "outputs": [
+                                      0,
+                                      1,
+                                      3
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "predicates": [
+                          {
+                            "Column": 2
+                          }
+                        ]
+                      }
+                    },
+                    "outputs": [
+                      0,
+                      1
+                    ]
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 5,
+                    "value": {
+                      "Reduce": {
+                        "input": {
+                          "Get": {
+                            "id": {
+                              "Local": 4
+                            },
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                }
+                              ],
+                              "keys": []
+                            }
+                          }
+                        },
+                        "group_key": [
+                          {
+                            "Column": 1
+                          }
+                        ],
+                        "aggregates": [],
+                        "monotonic": false,
+                        "expected_group_size": null
+                      }
+                    },
+                    "body": {
+                      "Project": {
+                        "input": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 4
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  }
+                                }
+                              },
+                              {
+                                "Let": {
+                                  "id": 6,
+                                  "value": {
+                                    "Join": {
+                                      "inputs": [
+                                        {
+                                          "Reduce": {
+                                            "input": {
+                                              "Filter": {
+                                                "input": {
+                                                  "Join": {
+                                                    "inputs": [
+                                                      {
+                                                        "Get": {
+                                                          "id": {
+                                                            "Local": 5
+                                                          },
+                                                          "typ": {
+                                                            "column_types": [
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": true
+                                                              }
+                                                            ],
+                                                            "keys": [
+                                                              [
+                                                                0
+                                                              ]
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "Get": {
+                                                          "id": {
+                                                            "Global": {
+                                                              "User": 5
+                                                            }
+                                                          },
+                                                          "typ": {
+                                                            "column_types": [
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": false
+                                                              },
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": true
+                                                              }
+                                                            ],
+                                                            "keys": []
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "equivalences": [],
+                                                    "implementation": "Unimplemented"
+                                                  }
+                                                },
+                                                "predicates": [
+                                                  {
+                                                    "CallBinary": {
+                                                      "func": "Gt",
+                                                      "expr1": {
+                                                        "Column": 0
+                                                      },
+                                                      "expr2": {
+                                                        "Column": 2
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "group_key": [
+                                              {
+                                                "Column": 0
+                                              }
+                                            ],
+                                            "aggregates": [],
+                                            "monotonic": false,
+                                            "expected_group_size": null
+                                          }
+                                        },
+                                        {
+                                          "Constant": {
+                                            "rows": {
+                                              "Ok": [
+                                                [
+                                                  {
+                                                    "data": [
+                                                      2
+                                                    ]
+                                                  },
+                                                  1
+                                                ]
+                                              ]
+                                            },
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Bool",
+                                                  "nullable": false
+                                                }
+                                              ],
+                                              "keys": []
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "equivalences": [],
+                                      "implementation": "Unimplemented"
+                                    }
+                                  },
+                                  "body": {
+                                    "Union": {
+                                      "base": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 6
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": false
+                                              },
+                                              {
+                                                "scalar_type": "Bool",
+                                                "nullable": false
+                                              }
+                                            ],
+                                            "keys": [
+                                              [
+                                                0
+                                              ]
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "inputs": [
+                                        {
+                                          "Join": {
+                                            "inputs": [
+                                              {
+                                                "Project": {
+                                                  "input": {
+                                                    "Join": {
+                                                      "inputs": [
+                                                        {
+                                                          "Union": {
+                                                            "base": {
+                                                              "Negate": {
+                                                                "input": {
+                                                                  "Reduce": {
+                                                                    "input": {
+                                                                      "Get": {
+                                                                        "id": {
+                                                                          "Local": 6
+                                                                        },
+                                                                        "typ": {
+                                                                          "column_types": [
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": false
+                                                                            },
+                                                                            {
+                                                                              "scalar_type": "Bool",
+                                                                              "nullable": false
+                                                                            }
+                                                                          ],
+                                                                          "keys": [
+                                                                            [
+                                                                              0
+                                                                            ]
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "group_key": [
+                                                                      {
+                                                                        "Column": 0
+                                                                      }
+                                                                    ],
+                                                                    "aggregates": [],
+                                                                    "monotonic": false,
+                                                                    "expected_group_size": null
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "inputs": [
+                                                              {
+                                                                "Reduce": {
+                                                                  "input": {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Local": 5
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
+                                                                          }
+                                                                        ],
+                                                                        "keys": [
+                                                                          [
+                                                                            0
+                                                                          ]
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "group_key": [
+                                                                    {
+                                                                      "Column": 0
+                                                                    }
+                                                                  ],
+                                                                  "aggregates": [],
+                                                                  "monotonic": false,
+                                                                  "expected_group_size": null
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 5
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": true
+                                                                }
+                                                              ],
+                                                              "keys": [
+                                                                [
+                                                                  0
+                                                                ]
+                                                              ]
+                                                            }
+                                                          }
+                                                        }
+                                                      ],
+                                                      "equivalences": [
+                                                        [
+                                                          {
+                                                            "Column": 0
+                                                          },
+                                                          {
+                                                            "Column": 1
+                                                          }
+                                                        ]
+                                                      ],
+                                                      "implementation": "Unimplemented"
+                                                    }
+                                                  },
+                                                  "outputs": [
+                                                    0
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "Constant": {
+                                                  "rows": {
+                                                    "Ok": [
+                                                      [
+                                                        {
+                                                          "data": [
+                                                            1
+                                                          ]
+                                                        },
+                                                        1
+                                                      ]
+                                                    ]
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Bool",
+                                                        "nullable": false
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "equivalences": [],
+                                            "implementation": "Unimplemented"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "equivalences": [
+                              [
+                                {
+                                  "Column": 1
+                                },
+                                {
+                                  "Column": 2
+                                }
+                              ]
+                            ],
+                            "implementation": "Unimplemented"
+                          }
+                        },
+                        "outputs": [
+                          0,
+                          1,
+                          3
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "predicates": [
+              {
+                "Column": 2
+              }
+            ]
+          }
+        },
+        "outputs": [
+          0,
+          1
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test SELECT subqueries.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Project": {
+            "input": {
+              "Map": {
+                "input": {
+                  "Map": {
+                    "input": {
+                      "Let": {
+                        "id": 1,
+                        "value": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 0
+                                  },
+                                  "typ": {
+                                    "column_types": [],
+                                    "keys": [
+                                      []
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Global": {
+                                      "User": 1
+                                    }
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  }
+                                }
+                              }
+                            ],
+                            "equivalences": [],
+                            "implementation": "Unimplemented"
+                          }
+                        },
+                        "body": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 1
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  }
+                                }
+                              },
+                              {
+                                "Let": {
+                                  "id": 2,
+                                  "value": {
+                                    "Reduce": {
+                                      "input": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 1
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      },
+                                      "group_key": [
+                                        {
+                                          "Column": 0
+                                        },
+                                        {
+                                          "Column": 1
+                                        }
+                                      ],
+                                      "aggregates": [],
+                                      "monotonic": false,
+                                      "expected_group_size": null
+                                    }
+                                  },
+                                  "body": {
+                                    "Let": {
+                                      "id": 3,
+                                      "value": {
+                                        "Reduce": {
+                                          "input": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 2
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": [
+                                                  [
+                                                    0,
+                                                    1
+                                                  ]
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "group_key": [
+                                            {
+                                              "Column": 1
+                                            }
+                                          ],
+                                          "aggregates": [],
+                                          "monotonic": false,
+                                          "expected_group_size": null
+                                        }
+                                      },
+                                      "body": {
+                                        "Project": {
+                                          "input": {
+                                            "Join": {
+                                              "inputs": [
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 2
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        },
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        }
+                                                      ],
+                                                      "keys": [
+                                                        [
+                                                          0,
+                                                          1
+                                                        ]
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "Let": {
+                                                    "id": 5,
+                                                    "value": {
+                                                      "Let": {
+                                                        "id": 4,
+                                                        "value": {
+                                                          "Project": {
+                                                            "input": {
+                                                              "TopK": {
+                                                                "input": {
+                                                                  "Filter": {
+                                                                    "input": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 3
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": [
+                                                                                  [
+                                                                                    0
+                                                                                  ]
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Global": {
+                                                                                  "User": 3
+                                                                                }
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": false
+                                                                                  },
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": []
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
+                                                                    },
+                                                                    "predicates": [
+                                                                      {
+                                                                        "CallBinary": {
+                                                                          "func": "Eq",
+                                                                          "expr1": {
+                                                                            "Column": 2
+                                                                          },
+                                                                          "expr2": {
+                                                                            "Column": 0
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "group_key": [
+                                                                  0
+                                                                ],
+                                                                "order_key": [],
+                                                                "limit": 1,
+                                                                "offset": 0,
+                                                                "monotonic": false
+                                                              }
+                                                            },
+                                                            "outputs": [
+                                                              0,
+                                                              1
+                                                            ]
+                                                          }
+                                                        },
+                                                        "body": {
+                                                          "Union": {
+                                                            "base": {
+                                                              "Get": {
+                                                                "id": {
+                                                                  "Local": 4
+                                                                },
+                                                                "typ": {
+                                                                  "column_types": [
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    }
+                                                                  ],
+                                                                  "keys": [
+                                                                    [
+                                                                      0
+                                                                    ]
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "inputs": [
+                                                              {
+                                                                "Map": {
+                                                                  "input": {
+                                                                    "Project": {
+                                                                      "input": {
+                                                                        "Filter": {
+                                                                          "input": {
+                                                                            "Reduce": {
+                                                                              "input": {
+                                                                                "Get": {
+                                                                                  "id": {
+                                                                                    "Local": 4
+                                                                                  },
+                                                                                  "typ": {
+                                                                                    "column_types": [
+                                                                                      {
+                                                                                        "scalar_type": "Int32",
+                                                                                        "nullable": false
+                                                                                      },
+                                                                                      {
+                                                                                        "scalar_type": "Int32",
+                                                                                        "nullable": false
+                                                                                      }
+                                                                                    ],
+                                                                                    "keys": [
+                                                                                      [
+                                                                                        0
+                                                                                      ]
+                                                                                    ]
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "group_key": [
+                                                                                {
+                                                                                  "Column": 0
+                                                                                }
+                                                                              ],
+                                                                              "aggregates": [
+                                                                                {
+                                                                                  "func": "Count",
+                                                                                  "expr": {
+                                                                                    "Literal": [
+                                                                                      {
+                                                                                        "Ok": {
+                                                                                          "data": [
+                                                                                            2
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      {
+                                                                                        "scalar_type": "Bool",
+                                                                                        "nullable": false
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  "distinct": false
+                                                                                }
+                                                                              ],
+                                                                              "monotonic": false,
+                                                                              "expected_group_size": null
+                                                                            }
+                                                                          },
+                                                                          "predicates": [
+                                                                            {
+                                                                              "CallBinary": {
+                                                                                "func": "Gt",
+                                                                                "expr1": {
+                                                                                  "Column": 1
+                                                                                },
+                                                                                "expr2": {
+                                                                                  "Literal": [
+                                                                                    {
+                                                                                      "Ok": {
+                                                                                        "data": [
+                                                                                          5,
+                                                                                          1,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0
+                                                                                        ]
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "scalar_type": "Int64",
+                                                                                      "nullable": false
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "outputs": [
+                                                                        0
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "scalars": [
+                                                                    {
+                                                                      "Literal": [
+                                                                        {
+                                                                          "Err": "MultipleRowsFromSubquery"
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "body": {
+                                                      "Union": {
+                                                        "base": {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 5
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": false
+                                                                },
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": false
+                                                                }
+                                                              ],
+                                                              "keys": []
+                                                            }
+                                                          }
+                                                        },
+                                                        "inputs": [
+                                                          {
+                                                            "Join": {
+                                                              "inputs": [
+                                                                {
+                                                                  "Project": {
+                                                                    "input": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Union": {
+                                                                              "base": {
+                                                                                "Negate": {
+                                                                                  "input": {
+                                                                                    "Reduce": {
+                                                                                      "input": {
+                                                                                        "Get": {
+                                                                                          "id": {
+                                                                                            "Local": 5
+                                                                                          },
+                                                                                          "typ": {
+                                                                                            "column_types": [
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": false
+                                                                                              },
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "keys": []
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "group_key": [
+                                                                                        {
+                                                                                          "Column": 0
+                                                                                        }
+                                                                                      ],
+                                                                                      "aggregates": [],
+                                                                                      "monotonic": false,
+                                                                                      "expected_group_size": null
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "inputs": [
+                                                                                {
+                                                                                  "Reduce": {
+                                                                                    "input": {
+                                                                                      "Get": {
+                                                                                        "id": {
+                                                                                          "Local": 3
+                                                                                        },
+                                                                                        "typ": {
+                                                                                          "column_types": [
+                                                                                            {
+                                                                                              "scalar_type": "Int32",
+                                                                                              "nullable": true
+                                                                                            }
+                                                                                          ],
+                                                                                          "keys": [
+                                                                                            [
+                                                                                              0
+                                                                                            ]
+                                                                                          ]
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "group_key": [
+                                                                                      {
+                                                                                        "Column": 0
+                                                                                      }
+                                                                                    ],
+                                                                                    "aggregates": [],
+                                                                                    "monotonic": false,
+                                                                                    "expected_group_size": null
+                                                                                  }
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 3
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": [
+                                                                                  [
+                                                                                    0
+                                                                                  ]
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [
+                                                                          [
+                                                                            {
+                                                                              "Column": 0
+                                                                            },
+                                                                            {
+                                                                              "Column": 1
+                                                                            }
+                                                                          ]
+                                                                        ],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
+                                                                    },
+                                                                    "outputs": [
+                                                                      0
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "Constant": {
+                                                                    "rows": {
+                                                                      "Ok": [
+                                                                        [
+                                                                          {
+                                                                            "data": [
+                                                                              0
+                                                                            ]
+                                                                          },
+                                                                          1
+                                                                        ]
+                                                                      ]
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "equivalences": [],
+                                                              "implementation": "Unimplemented"
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "equivalences": [
+                                                [
+                                                  {
+                                                    "Column": 1
+                                                  },
+                                                  {
+                                                    "Column": 2
+                                                  }
+                                                ]
+                                              ],
+                                              "implementation": "Unimplemented"
+                                            }
+                                          },
+                                          "outputs": [
+                                            0,
+                                            1,
+                                            3
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "Let": {
+                                  "id": 6,
+                                  "value": {
+                                    "Reduce": {
+                                      "input": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 1
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      },
+                                      "group_key": [
+                                        {
+                                          "Column": 0
+                                        },
+                                        {
+                                          "Column": 1
+                                        }
+                                      ],
+                                      "aggregates": [],
+                                      "monotonic": false,
+                                      "expected_group_size": null
+                                    }
+                                  },
+                                  "body": {
+                                    "Let": {
+                                      "id": 7,
+                                      "value": {
+                                        "Reduce": {
+                                          "input": {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 6
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": [
+                                                  [
+                                                    0,
+                                                    1
+                                                  ]
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "group_key": [
+                                            {
+                                              "Column": 1
+                                            }
+                                          ],
+                                          "aggregates": [],
+                                          "monotonic": false,
+                                          "expected_group_size": null
+                                        }
+                                      },
+                                      "body": {
+                                        "Project": {
+                                          "input": {
+                                            "Join": {
+                                              "inputs": [
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 6
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        },
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        }
+                                                      ],
+                                                      "keys": [
+                                                        [
+                                                          0,
+                                                          1
+                                                        ]
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "Let": {
+                                                    "id": 9,
+                                                    "value": {
+                                                      "Let": {
+                                                        "id": 8,
+                                                        "value": {
+                                                          "Project": {
+                                                            "input": {
+                                                              "TopK": {
+                                                                "input": {
+                                                                  "Filter": {
+                                                                    "input": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 7
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": [
+                                                                                  [
+                                                                                    0
+                                                                                  ]
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Global": {
+                                                                                  "User": 5
+                                                                                }
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": false
+                                                                                  },
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": []
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
+                                                                    },
+                                                                    "predicates": [
+                                                                      {
+                                                                        "CallBinary": {
+                                                                          "func": "Eq",
+                                                                          "expr1": {
+                                                                            "Column": 2
+                                                                          },
+                                                                          "expr2": {
+                                                                            "Column": 0
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "group_key": [
+                                                                  0
+                                                                ],
+                                                                "order_key": [],
+                                                                "limit": 1,
+                                                                "offset": 0,
+                                                                "monotonic": false
+                                                              }
+                                                            },
+                                                            "outputs": [
+                                                              0,
+                                                              1
+                                                            ]
+                                                          }
+                                                        },
+                                                        "body": {
+                                                          "Union": {
+                                                            "base": {
+                                                              "Get": {
+                                                                "id": {
+                                                                  "Local": 8
+                                                                },
+                                                                "typ": {
+                                                                  "column_types": [
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": false
+                                                                    }
+                                                                  ],
+                                                                  "keys": [
+                                                                    [
+                                                                      0
+                                                                    ]
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            "inputs": [
+                                                              {
+                                                                "Map": {
+                                                                  "input": {
+                                                                    "Project": {
+                                                                      "input": {
+                                                                        "Filter": {
+                                                                          "input": {
+                                                                            "Reduce": {
+                                                                              "input": {
+                                                                                "Get": {
+                                                                                  "id": {
+                                                                                    "Local": 8
+                                                                                  },
+                                                                                  "typ": {
+                                                                                    "column_types": [
+                                                                                      {
+                                                                                        "scalar_type": "Int32",
+                                                                                        "nullable": false
+                                                                                      },
+                                                                                      {
+                                                                                        "scalar_type": "Int32",
+                                                                                        "nullable": false
+                                                                                      }
+                                                                                    ],
+                                                                                    "keys": [
+                                                                                      [
+                                                                                        0
+                                                                                      ]
+                                                                                    ]
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "group_key": [
+                                                                                {
+                                                                                  "Column": 0
+                                                                                }
+                                                                              ],
+                                                                              "aggregates": [
+                                                                                {
+                                                                                  "func": "Count",
+                                                                                  "expr": {
+                                                                                    "Literal": [
+                                                                                      {
+                                                                                        "Ok": {
+                                                                                          "data": [
+                                                                                            2
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      {
+                                                                                        "scalar_type": "Bool",
+                                                                                        "nullable": false
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  "distinct": false
+                                                                                }
+                                                                              ],
+                                                                              "monotonic": false,
+                                                                              "expected_group_size": null
+                                                                            }
+                                                                          },
+                                                                          "predicates": [
+                                                                            {
+                                                                              "CallBinary": {
+                                                                                "func": "Gt",
+                                                                                "expr1": {
+                                                                                  "Column": 1
+                                                                                },
+                                                                                "expr2": {
+                                                                                  "Literal": [
+                                                                                    {
+                                                                                      "Ok": {
+                                                                                        "data": [
+                                                                                          5,
+                                                                                          1,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0,
+                                                                                          0
+                                                                                        ]
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "scalar_type": "Int64",
+                                                                                      "nullable": false
+                                                                                    }
+                                                                                  ]
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "outputs": [
+                                                                        0
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "scalars": [
+                                                                    {
+                                                                      "Literal": [
+                                                                        {
+                                                                          "Err": "MultipleRowsFromSubquery"
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "body": {
+                                                      "Union": {
+                                                        "base": {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 9
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": false
+                                                                },
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": false
+                                                                }
+                                                              ],
+                                                              "keys": []
+                                                            }
+                                                          }
+                                                        },
+                                                        "inputs": [
+                                                          {
+                                                            "Join": {
+                                                              "inputs": [
+                                                                {
+                                                                  "Project": {
+                                                                    "input": {
+                                                                      "Join": {
+                                                                        "inputs": [
+                                                                          {
+                                                                            "Union": {
+                                                                              "base": {
+                                                                                "Negate": {
+                                                                                  "input": {
+                                                                                    "Reduce": {
+                                                                                      "input": {
+                                                                                        "Get": {
+                                                                                          "id": {
+                                                                                            "Local": 9
+                                                                                          },
+                                                                                          "typ": {
+                                                                                            "column_types": [
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": false
+                                                                                              },
+                                                                                              {
+                                                                                                "scalar_type": "Int32",
+                                                                                                "nullable": false
+                                                                                              }
+                                                                                            ],
+                                                                                            "keys": []
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "group_key": [
+                                                                                        {
+                                                                                          "Column": 0
+                                                                                        }
+                                                                                      ],
+                                                                                      "aggregates": [],
+                                                                                      "monotonic": false,
+                                                                                      "expected_group_size": null
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "inputs": [
+                                                                                {
+                                                                                  "Reduce": {
+                                                                                    "input": {
+                                                                                      "Get": {
+                                                                                        "id": {
+                                                                                          "Local": 7
+                                                                                        },
+                                                                                        "typ": {
+                                                                                          "column_types": [
+                                                                                            {
+                                                                                              "scalar_type": "Int32",
+                                                                                              "nullable": true
+                                                                                            }
+                                                                                          ],
+                                                                                          "keys": [
+                                                                                            [
+                                                                                              0
+                                                                                            ]
+                                                                                          ]
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "group_key": [
+                                                                                      {
+                                                                                        "Column": 0
+                                                                                      }
+                                                                                    ],
+                                                                                    "aggregates": [],
+                                                                                    "monotonic": false,
+                                                                                    "expected_group_size": null
+                                                                                  }
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "Get": {
+                                                                              "id": {
+                                                                                "Local": 7
+                                                                              },
+                                                                              "typ": {
+                                                                                "column_types": [
+                                                                                  {
+                                                                                    "scalar_type": "Int32",
+                                                                                    "nullable": true
+                                                                                  }
+                                                                                ],
+                                                                                "keys": [
+                                                                                  [
+                                                                                    0
+                                                                                  ]
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "equivalences": [
+                                                                          [
+                                                                            {
+                                                                              "Column": 0
+                                                                            },
+                                                                            {
+                                                                              "Column": 1
+                                                                            }
+                                                                          ]
+                                                                        ],
+                                                                        "implementation": "Unimplemented"
+                                                                      }
+                                                                    },
+                                                                    "outputs": [
+                                                                      0
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "Constant": {
+                                                                    "rows": {
+                                                                      "Ok": [
+                                                                        [
+                                                                          {
+                                                                            "data": [
+                                                                              0
+                                                                            ]
+                                                                          },
+                                                                          1
+                                                                        ]
+                                                                      ]
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "equivalences": [],
+                                                              "implementation": "Unimplemented"
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "equivalences": [
+                                                [
+                                                  {
+                                                    "Column": 1
+                                                  },
+                                                  {
+                                                    "Column": 2
+                                                  }
+                                                ]
+                                              ],
+                                              "implementation": "Unimplemented"
+                                            }
+                                          },
+                                          "outputs": [
+                                            0,
+                                            1,
+                                            3
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "equivalences": [
+                              [
+                                {
+                                  "Column": 0
+                                },
+                                {
+                                  "Column": 2
+                                },
+                                {
+                                  "Column": 5
+                                }
+                              ],
+                              [
+                                {
+                                  "Column": 1
+                                },
+                                {
+                                  "Column": 3
+                                },
+                                {
+                                  "Column": 6
+                                }
+                              ]
+                            ],
+                            "implementation": "Unimplemented"
+                          }
+                        }
+                      }
+                    },
+                    "scalars": [
+                      {
+                        "Column": 4
+                      }
+                    ]
+                  }
+                },
+                "scalars": [
+                  {
+                    "Column": 7
+                  }
+                ]
+              }
+            },
+            "outputs": [
+              0,
+              1,
+              8,
+              9
+            ]
+          }
+        },
+        "outputs": [
+          2,
+          3
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test CrossJoin derived from a comma join without a predicate.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT t1.a, t2.a FROM t as t1, t as t2
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Let": {
+            "id": 1,
+            "value": {
               "Join": {
                 "inputs": [
                   {
@@ -2510,186 +4711,41 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                 "implementation": "Unimplemented"
               }
             },
-            "predicates": [
-              {
-                "CallVariadic": {
-                  "func": "And",
-                  "exprs": [
-                    {
-                      "Literal": [
-                        {
-                          "Ok": {
-                            "data": [
-                              2
-                            ]
-                          }
-                        },
-                        {
-                          "scalar_type": "Bool",
-                          "nullable": false
-                        }
-                      ]
-                    },
-                    {
-                      "Literal": [
-                        {
-                          "Ok": {
-                            "data": [
-                              2
-                            ]
-                          }
-                        },
-                        {
-                          "scalar_type": "Bool",
-                          "nullable": false
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Reduce": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Local": 1
-                    },
-                    "typ": {
-                      "column_types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
-                      ],
-                      "keys": []
-                    }
-                  }
-                },
-                "group_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "aggregates": [],
-                "monotonic": false,
-                "expected_group_size": null
-              }
-            },
             "body": {
               "Let": {
-                "id": 3,
+                "id": 2,
                 "value": {
                   "Join": {
                     "inputs": [
                       {
-                        "Reduce": {
-                          "input": {
-                            "Filter": {
-                              "input": {
-                                "Join": {
-                                  "inputs": [
-                                    {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 2
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": [
-                                            [
-                                              0
-                                            ]
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Get": {
-                                        "id": {
-                                          "Global": {
-                                            "User": 5
-                                          }
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": false
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": []
-                                        }
-                                      }
-                                    }
-                                  ],
-                                  "equivalences": [],
-                                  "implementation": "Unimplemented"
-                                }
-                              },
-                              "predicates": [
-                                {
-                                  "CallBinary": {
-                                    "func": "Lt",
-                                    "expr1": {
-                                      "Column": 0
-                                    },
-                                    "expr2": {
-                                      "Column": 1
-                                    }
-                                  }
-                                }
-                              ]
-                            }
+                        "Get": {
+                          "id": {
+                            "Local": 0
                           },
-                          "group_key": [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          "aggregates": [],
-                          "monotonic": false,
-                          "expected_group_size": null
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
                         }
                       },
                       {
-                        "Constant": {
-                          "rows": {
-                            "Ok": [
-                              [
-                                {
-                                  "data": [
-                                    2
-                                  ]
-                                },
-                                1
-                              ]
-                            ]
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
                           },
                           "typ": {
                             "column_types": [
                               {
-                                "scalar_type": "Bool",
-                                "nullable": false
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
                               }
                             ],
                             "keys": []
@@ -2703,10 +4759,975 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                 },
                 "body": {
                   "Let": {
-                    "id": 4,
+                    "id": 3,
                     "value": {
-                      "Project": {
+                      "Filter": {
                         "input": {
+                          "Project": {
+                            "input": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 1
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 2
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "outputs": [
+                              0,
+                              1,
+                              2,
+                              3
+                            ]
+                          }
+                        },
+                        "predicates": [
+                          {
+                            "Literal": [
+                              {
+                                "Ok": {
+                                  "data": [
+                                    2
+                                  ]
+                                }
+                              },
+                              {
+                                "scalar_type": "Bool",
+                                "nullable": false
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "body": {
+                      "Get": {
+                        "id": {
+                          "Local": 3
+                        },
+                        "typ": {
+                          "column_types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ],
+                          "keys": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "outputs": [
+          0,
+          2
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test CrossJoin derived from an INNER JOIN with a trivial ON clause.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Let": {
+            "id": 1,
+            "value": {
+              "Join": {
+                "inputs": [
+                  {
+                    "Get": {
+                      "id": {
+                        "Local": 0
+                      },
+                      "typ": {
+                        "column_types": [],
+                        "keys": [
+                          []
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "Get": {
+                      "id": {
+                        "Global": {
+                          "User": 1
+                        }
+                      },
+                      "typ": {
+                        "column_types": [
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": true
+                          },
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": true
+                          }
+                        ],
+                        "keys": []
+                      }
+                    }
+                  }
+                ],
+                "equivalences": [],
+                "implementation": "Unimplemented"
+              }
+            },
+            "body": {
+              "Let": {
+                "id": 2,
+                "value": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 3,
+                    "value": {
+                      "Filter": {
+                        "input": {
+                          "Project": {
+                            "input": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 1
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 2
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "outputs": [
+                              0,
+                              1,
+                              2,
+                              3
+                            ]
+                          }
+                        },
+                        "predicates": [
+                          {
+                            "Literal": [
+                              {
+                                "Ok": {
+                                  "data": [
+                                    2
+                                  ]
+                                }
+                              },
+                              {
+                                "scalar_type": "Bool",
+                                "nullable": false
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "body": {
+                      "Get": {
+                        "id": {
+                          "Local": 3
+                        },
+                        "typ": {
+                          "column_types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ],
+                          "keys": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "outputs": [
+          0,
+          2
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test InnerJoin (comma syntax).
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT t1.a, t2.a
+FROM
+  t as t1,
+  t as t2,
+  t as t3
+WHERE t1.b = t2.b AND t2.b = t3.b
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Filter": {
+            "input": {
+              "Let": {
+                "id": 4,
+                "value": {
+                  "Let": {
+                    "id": 1,
+                    "value": {
+                      "Join": {
+                        "inputs": [
+                          {
+                            "Get": {
+                              "id": {
+                                "Local": 0
+                              },
+                              "typ": {
+                                "column_types": [],
+                                "keys": [
+                                  []
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "Get": {
+                              "id": {
+                                "Global": {
+                                  "User": 1
+                                }
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ],
+                                "keys": []
+                              }
+                            }
+                          }
+                        ],
+                        "equivalences": [],
+                        "implementation": "Unimplemented"
+                      }
+                    },
+                    "body": {
+                      "Let": {
+                        "id": 2,
+                        "value": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 0
+                                  },
+                                  "typ": {
+                                    "column_types": [],
+                                    "keys": [
+                                      []
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Global": {
+                                      "User": 1
+                                    }
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  }
+                                }
+                              }
+                            ],
+                            "equivalences": [],
+                            "implementation": "Unimplemented"
+                          }
+                        },
+                        "body": {
+                          "Let": {
+                            "id": 3,
+                            "value": {
+                              "Filter": {
+                                "input": {
+                                  "Project": {
+                                    "input": {
+                                      "Join": {
+                                        "inputs": [
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 1
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 2
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "equivalences": [],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    },
+                                    "outputs": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ]
+                                  }
+                                },
+                                "predicates": [
+                                  {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            2
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "Bool",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "body": {
+                              "Get": {
+                                "id": {
+                                  "Local": 3
+                                },
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ],
+                                  "keys": []
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 5,
+                    "value": {
+                      "Join": {
+                        "inputs": [
+                          {
+                            "Get": {
+                              "id": {
+                                "Local": 0
+                              },
+                              "typ": {
+                                "column_types": [],
+                                "keys": [
+                                  []
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "Get": {
+                              "id": {
+                                "Global": {
+                                  "User": 1
+                                }
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ],
+                                "keys": []
+                              }
+                            }
+                          }
+                        ],
+                        "equivalences": [],
+                        "implementation": "Unimplemented"
+                      }
+                    },
+                    "body": {
+                      "Let": {
+                        "id": 6,
+                        "value": {
+                          "Filter": {
+                            "input": {
+                              "Project": {
+                                "input": {
+                                  "Join": {
+                                    "inputs": [
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 4
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 5
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
+                                  }
+                                },
+                                "outputs": [
+                                  0,
+                                  1,
+                                  2,
+                                  3,
+                                  4,
+                                  5
+                                ]
+                              }
+                            },
+                            "predicates": [
+                              {
+                                "Literal": [
+                                  {
+                                    "Ok": {
+                                      "data": [
+                                        2
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "scalar_type": "Bool",
+                                    "nullable": false
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "body": {
+                          "Get": {
+                            "id": {
+                              "Local": 6
+                            },
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                }
+                              ],
+                              "keys": []
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "predicates": [
+              {
+                "CallVariadic": {
+                  "func": "And",
+                  "exprs": [
+                    {
+                      "CallBinary": {
+                        "func": "Eq",
+                        "expr1": {
+                          "Column": 1
+                        },
+                        "expr2": {
+                          "Column": 3
+                        }
+                      }
+                    },
+                    {
+                      "CallBinary": {
+                        "func": "Eq",
+                        "expr1": {
+                          "Column": 3
+                        },
+                        "expr2": {
+                          "Column": 5
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "outputs": [
+          0,
+          2
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test InnerJoin (ON syntax).
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT t1.a, t2.a
+FROM t as t1
+INNER JOIN t as t2 ON t1.b = t2.b
+INNER JOIN t as t3 ON t2.b = t3.b
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Let": {
+            "id": 4,
+            "value": {
+              "Let": {
+                "id": 1,
+                "value": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 2,
+                    "value": {
+                      "Join": {
+                        "inputs": [
+                          {
+                            "Get": {
+                              "id": {
+                                "Local": 0
+                              },
+                              "typ": {
+                                "column_types": [],
+                                "keys": [
+                                  []
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "Get": {
+                              "id": {
+                                "Global": {
+                                  "User": 1
+                                }
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ],
+                                "keys": []
+                              }
+                            }
+                          }
+                        ],
+                        "equivalences": [],
+                        "implementation": "Unimplemented"
+                      }
+                    },
+                    "body": {
+                      "Let": {
+                        "id": 3,
+                        "value": {
                           "Filter": {
                             "input": {
                               "Project": {
@@ -2734,6 +5755,1653 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                         }
                                       },
                                       {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 2
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
+                                  }
+                                },
+                                "outputs": [
+                                  0,
+                                  1,
+                                  2,
+                                  3
+                                ]
+                              }
+                            },
+                            "predicates": [
+                              {
+                                "CallBinary": {
+                                  "func": "Eq",
+                                  "expr1": {
+                                    "Column": 1
+                                  },
+                                  "expr2": {
+                                    "Column": 3
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "body": {
+                          "Get": {
+                            "id": {
+                              "Local": 3
+                            },
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": false
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": false
+                                }
+                              ],
+                              "keys": []
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "body": {
+              "Let": {
+                "id": 5,
+                "value": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 6,
+                    "value": {
+                      "Filter": {
+                        "input": {
+                          "Project": {
+                            "input": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 4
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 5
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "outputs": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
+                            ]
+                          }
+                        },
+                        "predicates": [
+                          {
+                            "CallBinary": {
+                              "func": "Eq",
+                              "expr1": {
+                                "Column": 3
+                              },
+                              "expr2": {
+                                "Column": 5
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "body": {
+                      "Get": {
+                        "id": {
+                          "Local": 6
+                        },
+                        "typ": {
+                          "column_types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": false
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": false
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": false
+                            }
+                          ],
+                          "keys": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "outputs": [
+          0,
+          2
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test InnerJoin (ON syntax).
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT t1.a, t2.a
+FROM t as t1
+LEFT JOIN t as t2 ON t1.b = t2.b
+RIGHT JOIN t as t3 ON t2.b = t3.b
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Let": {
+            "id": 5,
+            "value": {
+              "Let": {
+                "id": 1,
+                "value": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 2,
+                    "value": {
+                      "Join": {
+                        "inputs": [
+                          {
+                            "Get": {
+                              "id": {
+                                "Local": 0
+                              },
+                              "typ": {
+                                "column_types": [],
+                                "keys": [
+                                  []
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "Get": {
+                              "id": {
+                                "Global": {
+                                  "User": 1
+                                }
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ],
+                                "keys": []
+                              }
+                            }
+                          }
+                        ],
+                        "equivalences": [],
+                        "implementation": "Unimplemented"
+                      }
+                    },
+                    "body": {
+                      "Let": {
+                        "id": 3,
+                        "value": {
+                          "Filter": {
+                            "input": {
+                              "Project": {
+                                "input": {
+                                  "Join": {
+                                    "inputs": [
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 1
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 2
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "equivalences": [],
+                                    "implementation": "Unimplemented"
+                                  }
+                                },
+                                "outputs": [
+                                  0,
+                                  1,
+                                  2,
+                                  3
+                                ]
+                              }
+                            },
+                            "predicates": [
+                              {
+                                "CallBinary": {
+                                  "func": "Eq",
+                                  "expr1": {
+                                    "Column": 1
+                                  },
+                                  "expr2": {
+                                    "Column": 3
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "body": {
+                          "Let": {
+                            "id": 4,
+                            "value": {
+                              "Reduce": {
+                                "input": {
+                                  "Project": {
+                                    "input": {
+                                      "Get": {
+                                        "id": {
+                                          "Local": 3
+                                        },
+                                        "typ": {
+                                          "column_types": [
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": false
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": false
+                                            }
+                                          ],
+                                          "keys": []
+                                        }
+                                      }
+                                    },
+                                    "outputs": [
+                                      1
+                                    ]
+                                  }
+                                },
+                                "group_key": [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                "aggregates": [],
+                                "monotonic": false,
+                                "expected_group_size": null
+                              }
+                            },
+                            "body": {
+                              "Union": {
+                                "base": {
+                                  "Map": {
+                                    "input": {
+                                      "Union": {
+                                        "base": {
+                                          "Negate": {
+                                            "input": {
+                                              "Project": {
+                                                "input": {
+                                                  "Join": {
+                                                    "inputs": [
+                                                      {
+                                                        "Get": {
+                                                          "id": {
+                                                            "Local": 1
+                                                          },
+                                                          "typ": {
+                                                            "column_types": [
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": true
+                                                              },
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": true
+                                                              }
+                                                            ],
+                                                            "keys": []
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "Get": {
+                                                          "id": {
+                                                            "Local": 4
+                                                          },
+                                                          "typ": {
+                                                            "column_types": [
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": false
+                                                              }
+                                                            ],
+                                                            "keys": [
+                                                              [
+                                                                0
+                                                              ]
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "equivalences": [
+                                                      [
+                                                        {
+                                                          "Column": 1
+                                                        },
+                                                        {
+                                                          "Column": 2
+                                                        }
+                                                      ]
+                                                    ],
+                                                    "implementation": "Unimplemented"
+                                                  }
+                                                },
+                                                "outputs": [
+                                                  0,
+                                                  1
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "inputs": [
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 1
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "scalars": [
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 3
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": false
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "body": {
+              "Let": {
+                "id": 6,
+                "value": {
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
+                          }
+                        }
+                      }
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
+                  }
+                },
+                "body": {
+                  "Let": {
+                    "id": 7,
+                    "value": {
+                      "Filter": {
+                        "input": {
+                          "Project": {
+                            "input": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 5
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 6
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "outputs": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4,
+                              5
+                            ]
+                          }
+                        },
+                        "predicates": [
+                          {
+                            "CallBinary": {
+                              "func": "Eq",
+                              "expr1": {
+                                "Column": 3
+                              },
+                              "expr2": {
+                                "Column": 5
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "body": {
+                      "Let": {
+                        "id": 8,
+                        "value": {
+                          "Reduce": {
+                            "input": {
+                              "Project": {
+                                "input": {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 7
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        }
+                                      ],
+                                      "keys": []
+                                    }
+                                  }
+                                },
+                                "outputs": [
+                                  3
+                                ]
+                              }
+                            },
+                            "group_key": [
+                              {
+                                "Column": 0
+                              }
+                            ],
+                            "aggregates": [],
+                            "monotonic": false,
+                            "expected_group_size": null
+                          }
+                        },
+                        "body": {
+                          "Union": {
+                            "base": {
+                              "Project": {
+                                "input": {
+                                  "Map": {
+                                    "input": {
+                                      "Union": {
+                                        "base": {
+                                          "Negate": {
+                                            "input": {
+                                              "Project": {
+                                                "input": {
+                                                  "Join": {
+                                                    "inputs": [
+                                                      {
+                                                        "Get": {
+                                                          "id": {
+                                                            "Local": 6
+                                                          },
+                                                          "typ": {
+                                                            "column_types": [
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": true
+                                                              },
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": true
+                                                              }
+                                                            ],
+                                                            "keys": []
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "Get": {
+                                                          "id": {
+                                                            "Local": 8
+                                                          },
+                                                          "typ": {
+                                                            "column_types": [
+                                                              {
+                                                                "scalar_type": "Int32",
+                                                                "nullable": false
+                                                              }
+                                                            ],
+                                                            "keys": [
+                                                              [
+                                                                0
+                                                              ]
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    ],
+                                                    "equivalences": [
+                                                      [
+                                                        {
+                                                          "Column": 1
+                                                        },
+                                                        {
+                                                          "Column": 2
+                                                        }
+                                                      ]
+                                                    ],
+                                                    "implementation": "Unimplemented"
+                                                  }
+                                                },
+                                                "outputs": [
+                                                  0,
+                                                  1
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "inputs": [
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 6
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  },
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "scalars": [
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Literal": [
+                                          {
+                                            "Ok": {
+                                              "data": [
+                                                0
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "outputs": [
+                                  2,
+                                  3,
+                                  4,
+                                  5,
+                                  0,
+                                  1
+                                ]
+                              }
+                            },
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 7
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": false
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": false
+                                      }
+                                    ],
+                                    "keys": []
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "outputs": [
+          0,
+          2
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test a single CTE.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Project": {
+        "input": {
+          "Let": {
+            "id": 2,
+            "value": {
+              "Project": {
+                "input": {
+                  "Project": {
+                    "input": {
+                      "Map": {
+                        "input": {
+                          "Let": {
+                            "id": 1,
+                            "value": {
+                              "Join": {
+                                "inputs": [
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "typ": {
+                                        "column_types": [],
+                                        "keys": [
+                                          []
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "Get": {
+                                      "id": {
+                                        "Global": {
+                                          "User": 1
+                                        }
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  }
+                                ],
+                                "equivalences": [],
+                                "implementation": "Unimplemented"
+                              }
+                            },
+                            "body": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ],
+                                  "keys": []
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "scalars": [
+                          {
+                            "CallBinary": {
+                              "func": "MulInt32",
+                              "expr1": {
+                                "Column": 0
+                              },
+                              "expr2": {
+                                "Column": 1
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "outputs": [
+                      0,
+                      1,
+                      2
+                    ]
+                  }
+                },
+                "outputs": [
+                  2
+                ]
+              }
+            },
+            "body": {
+              "Project": {
+                "input": {
+                  "Map": {
+                    "input": {
+                      "Let": {
+                        "id": 4,
+                        "value": {
+                          "Let": {
+                            "id": 3,
+                            "value": {
+                              "Filter": {
+                                "input": {
+                                  "Project": {
+                                    "input": {
+                                      "Join": {
+                                        "inputs": [
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 2
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "Get": {
+                                              "id": {
+                                                "Local": 2
+                                              },
+                                              "typ": {
+                                                "column_types": [
+                                                  {
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
+                                                  }
+                                                ],
+                                                "keys": []
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "equivalences": [],
+                                        "implementation": "Unimplemented"
+                                      }
+                                    },
+                                    "outputs": [
+                                      0,
+                                      1
+                                    ]
+                                  }
+                                },
+                                "predicates": [
+                                  {
+                                    "Literal": [
+                                      {
+                                        "Ok": {
+                                          "data": [
+                                            2
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "scalar_type": "Bool",
+                                        "nullable": false
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "body": {
+                              "Get": {
+                                "id": {
+                                  "Local": 3
+                                },
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ],
+                                  "keys": []
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "body": {
+                          "Get": {
+                            "id": {
+                              "Local": 4
+                            },
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                }
+                              ],
+                              "keys": []
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "scalars": [
+                      {
+                        "CallBinary": {
+                          "func": "AddInt32",
+                          "expr1": {
+                            "Column": 0
+                          },
+                          "expr2": {
+                            "Column": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "outputs": [
+                  0,
+                  1,
+                  2
+                ]
+              }
+            }
+          }
+        },
+        "outputs": [
+          2
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# Test multiple CTEs: a case where we cannot pull the let statement up through
+# the join because the local l0 is correlated against the lhs of the enclosing join.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
+SELECT
+  *
+FROM
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r2 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r2 WHERE r2.m != r1.a
+  ) as r3
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
+  ) as r5;
+----
+{
+  "Let": {
+    "id": 0,
+    "value": {
+      "Constant": {
+        "rows": {
+          "Ok": [
+            [
+              {
+                "data": []
+              },
+              1
+            ]
+          ]
+        },
+        "typ": {
+          "column_types": [],
+          "keys": []
+        }
+      }
+    },
+    "body": {
+      "Let": {
+        "id": 5,
+        "value": {
+          "Let": {
+            "id": 1,
+            "value": {
+              "Join": {
+                "inputs": [
+                  {
+                    "Get": {
+                      "id": {
+                        "Local": 0
+                      },
+                      "typ": {
+                        "column_types": [],
+                        "keys": [
+                          []
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "Get": {
+                      "id": {
+                        "Global": {
+                          "User": 1
+                        }
+                      },
+                      "typ": {
+                        "column_types": [
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": true
+                          },
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": true
+                          }
+                        ],
+                        "keys": []
+                      }
+                    }
+                  }
+                ],
+                "equivalences": [],
+                "implementation": "Unimplemented"
+              }
+            },
+            "body": {
+              "Filter": {
+                "input": {
+                  "Let": {
+                    "id": 2,
+                    "value": {
+                      "Reduce": {
+                        "input": {
+                          "Get": {
+                            "id": {
+                              "Local": 1
+                            },
+                            "typ": {
+                              "column_types": [
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                },
+                                {
+                                  "scalar_type": "Int32",
+                                  "nullable": true
+                                }
+                              ],
+                              "keys": []
+                            }
+                          }
+                        },
+                        "group_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "aggregates": [],
+                        "monotonic": false,
+                        "expected_group_size": null
+                      }
+                    },
+                    "body": {
+                      "Project": {
+                        "input": {
+                          "Join": {
+                            "inputs": [
+                              {
+                                "Get": {
+                                  "id": {
+                                    "Local": 1
+                                  },
+                                  "typ": {
+                                    "column_types": [
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      },
+                                      {
+                                        "scalar_type": "Int32",
+                                        "nullable": true
+                                      }
+                                    ],
+                                    "keys": []
+                                  }
+                                }
+                              },
+                              {
+                                "Let": {
+                                  "id": 4,
+                                  "value": {
+                                    "Let": {
+                                      "id": 3,
+                                      "value": {
+                                        "Reduce": {
+                                          "input": {
+                                            "Join": {
+                                              "inputs": [
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 2
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        }
+                                                      ],
+                                                      "keys": [
+                                                        [
+                                                          0
+                                                        ]
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Global": {
+                                                        "User": 1
+                                                      }
+                                                    },
+                                                    "typ": {
+                                                      "column_types": [
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        },
+                                                        {
+                                                          "scalar_type": "Int32",
+                                                          "nullable": true
+                                                        }
+                                                      ],
+                                                      "keys": []
+                                                    }
+                                                  }
+                                                }
+                                              ],
+                                              "equivalences": [],
+                                              "implementation": "Unimplemented"
+                                            }
+                                          },
+                                          "group_key": [
+                                            {
+                                              "Column": 0
+                                            }
+                                          ],
+                                          "aggregates": [
+                                            {
+                                              "func": "MaxInt32",
+                                              "expr": {
+                                                "CallBinary": {
+                                                  "func": "MulInt32",
+                                                  "expr1": {
+                                                    "Column": 0
+                                                  },
+                                                  "expr2": {
+                                                    "Column": 1
+                                                  }
+                                                }
+                                              },
+                                              "distinct": false
+                                            }
+                                          ],
+                                          "monotonic": false,
+                                          "expected_group_size": null
+                                        }
+                                      },
+                                      "body": {
                                         "Union": {
                                           "base": {
                                             "Get": {
@@ -2744,11 +7412,11 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                 "column_types": [
                                                   {
                                                     "scalar_type": "Int32",
-                                                    "nullable": false
+                                                    "nullable": true
                                                   },
                                                   {
-                                                    "scalar_type": "Bool",
-                                                    "nullable": false
+                                                    "scalar_type": "Int32",
+                                                    "nullable": true
                                                   }
                                                 ],
                                                 "keys": [
@@ -2783,11 +7451,11 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                                               "column_types": [
                                                                                 {
                                                                                   "scalar_type": "Int32",
-                                                                                  "nullable": false
+                                                                                  "nullable": true
                                                                                 },
                                                                                 {
-                                                                                  "scalar_type": "Bool",
-                                                                                  "nullable": false
+                                                                                  "scalar_type": "Int32",
+                                                                                  "nullable": true
                                                                                 }
                                                                               ],
                                                                               "keys": [
@@ -2892,7 +7560,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                           [
                                                             {
                                                               "data": [
-                                                                1
+                                                                0
                                                               ]
                                                             },
                                                             1
@@ -2902,8 +7570,8 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                       "typ": {
                                                         "column_types": [
                                                           {
-                                                            "scalar_type": "Bool",
-                                                            "nullable": false
+                                                            "scalar_type": "Int32",
+                                                            "nullable": true
                                                           }
                                                         ],
                                                         "keys": []
@@ -2918,573 +7586,102 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                           ]
                                         }
                                       }
-                                    ],
-                                    "equivalences": [
-                                      [
+                                    }
+                                  },
+                                  "body": {
+                                    "Filter": {
+                                      "input": {
+                                        "Get": {
+                                          "id": {
+                                            "Local": 4
+                                          },
+                                          "typ": {
+                                            "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              }
+                                            ],
+                                            "keys": []
+                                          }
+                                        }
+                                      },
+                                      "predicates": [
                                         {
-                                          "Column": 0
-                                        },
-                                        {
-                                          "Column": 2
+                                          "CallBinary": {
+                                            "func": "NotEq",
+                                            "expr1": {
+                                              "Column": 1
+                                            },
+                                            "expr2": {
+                                              "Column": 0
+                                            }
+                                          }
                                         }
                                       ]
-                                    ],
-                                    "implementation": "Unimplemented"
+                                    }
                                   }
+                                }
+                              }
+                            ],
+                            "equivalences": [
+                              [
+                                {
+                                  "Column": 0
                                 },
-                                "outputs": [
-                                  0,
-                                  1,
-                                  3
-                                ]
-                              }
-                            },
-                            "predicates": [
-                              {
-                                "Column": 2
-                              }
-                            ]
+                                {
+                                  "Column": 2
+                                }
+                              ]
+                            ],
+                            "implementation": "Unimplemented"
                           }
                         },
                         "outputs": [
                           0,
-                          1
+                          1,
+                          3
                         ]
                       }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Reduce": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Local": 4
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
-                                }
-                              }
-                            },
-                            "group_key": [
-                              {
-                                "Column": 1
-                              }
-                            ],
-                            "aggregates": [],
-                            "monotonic": false,
-                            "expected_group_size": null
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Join": {
-                                "inputs": [
-                                  {
-                                    "Reduce": {
-                                      "input": {
-                                        "Filter": {
-                                          "input": {
-                                            "Join": {
-                                              "inputs": [
-                                                {
-                                                  "Get": {
-                                                    "id": {
-                                                      "Local": 5
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": [
-                                                        [
-                                                          0
-                                                        ]
-                                                      ]
-                                                    }
-                                                  }
-                                                },
-                                                {
-                                                  "Get": {
-                                                    "id": {
-                                                      "Global": {
-                                                        "User": 5
-                                                      }
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": false
-                                                        },
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": []
-                                                    }
-                                                  }
-                                                }
-                                              ],
-                                              "equivalences": [],
-                                              "implementation": "Unimplemented"
-                                            }
-                                          },
-                                          "predicates": [
-                                            {
-                                              "CallBinary": {
-                                                "func": "Gt",
-                                                "expr1": {
-                                                  "Column": 0
-                                                },
-                                                "expr2": {
-                                                  "Column": 2
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "group_key": [
-                                        {
-                                          "Column": 0
-                                        }
-                                      ],
-                                      "aggregates": [],
-                                      "monotonic": false,
-                                      "expected_group_size": null
-                                    }
-                                  },
-                                  {
-                                    "Constant": {
-                                      "rows": {
-                                        "Ok": [
-                                          [
-                                            {
-                                              "data": [
-                                                2
-                                              ]
-                                            },
-                                            1
-                                          ]
-                                        ]
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Bool",
-                                            "nullable": false
-                                          }
-                                        ],
-                                        "keys": []
-                                      }
-                                    }
-                                  }
-                                ],
-                                "equivalences": [],
-                                "implementation": "Unimplemented"
-                              }
-                            },
-                            "body": {
-                              "Project": {
-                                "input": {
-                                  "Filter": {
-                                    "input": {
-                                      "Project": {
-                                        "input": {
-                                          "Join": {
-                                            "inputs": [
-                                              {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 4
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      }
-                                                    ],
-                                                    "keys": []
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "Union": {
-                                                  "base": {
-                                                    "Get": {
-                                                      "id": {
-                                                        "Local": 6
-                                                      },
-                                                      "typ": {
-                                                        "column_types": [
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": false
-                                                          },
-                                                          {
-                                                            "scalar_type": "Bool",
-                                                            "nullable": false
-                                                          }
-                                                        ],
-                                                        "keys": [
-                                                          [
-                                                            0
-                                                          ]
-                                                        ]
-                                                      }
-                                                    }
-                                                  },
-                                                  "inputs": [
-                                                    {
-                                                      "Join": {
-                                                        "inputs": [
-                                                          {
-                                                            "Project": {
-                                                              "input": {
-                                                                "Join": {
-                                                                  "inputs": [
-                                                                    {
-                                                                      "Union": {
-                                                                        "base": {
-                                                                          "Negate": {
-                                                                            "input": {
-                                                                              "Reduce": {
-                                                                                "input": {
-                                                                                  "Get": {
-                                                                                    "id": {
-                                                                                      "Local": 6
-                                                                                    },
-                                                                                    "typ": {
-                                                                                      "column_types": [
-                                                                                        {
-                                                                                          "scalar_type": "Int32",
-                                                                                          "nullable": false
-                                                                                        },
-                                                                                        {
-                                                                                          "scalar_type": "Bool",
-                                                                                          "nullable": false
-                                                                                        }
-                                                                                      ],
-                                                                                      "keys": [
-                                                                                        [
-                                                                                          0
-                                                                                        ]
-                                                                                      ]
-                                                                                    }
-                                                                                  }
-                                                                                },
-                                                                                "group_key": [
-                                                                                  {
-                                                                                    "Column": 0
-                                                                                  }
-                                                                                ],
-                                                                                "aggregates": [],
-                                                                                "monotonic": false,
-                                                                                "expected_group_size": null
-                                                                              }
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        "inputs": [
-                                                                          {
-                                                                            "Reduce": {
-                                                                              "input": {
-                                                                                "Get": {
-                                                                                  "id": {
-                                                                                    "Local": 5
-                                                                                  },
-                                                                                  "typ": {
-                                                                                    "column_types": [
-                                                                                      {
-                                                                                        "scalar_type": "Int32",
-                                                                                        "nullable": true
-                                                                                      }
-                                                                                    ],
-                                                                                    "keys": [
-                                                                                      [
-                                                                                        0
-                                                                                      ]
-                                                                                    ]
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              "group_key": [
-                                                                                {
-                                                                                  "Column": 0
-                                                                                }
-                                                                              ],
-                                                                              "aggregates": [],
-                                                                              "monotonic": false,
-                                                                              "expected_group_size": null
-                                                                            }
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "Get": {
-                                                                        "id": {
-                                                                          "Local": 5
-                                                                        },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            }
-                                                                          ],
-                                                                          "keys": [
-                                                                            [
-                                                                              0
-                                                                            ]
-                                                                          ]
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ],
-                                                                  "equivalences": [
-                                                                    [
-                                                                      {
-                                                                        "Column": 0
-                                                                      },
-                                                                      {
-                                                                        "Column": 1
-                                                                      }
-                                                                    ]
-                                                                  ],
-                                                                  "implementation": "Unimplemented"
-                                                                }
-                                                              },
-                                                              "outputs": [
-                                                                0
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "Constant": {
-                                                              "rows": {
-                                                                "Ok": [
-                                                                  [
-                                                                    {
-                                                                      "data": [
-                                                                        1
-                                                                      ]
-                                                                    },
-                                                                    1
-                                                                  ]
-                                                                ]
-                                                              },
-                                                              "typ": {
-                                                                "column_types": [
-                                                                  {
-                                                                    "scalar_type": "Bool",
-                                                                    "nullable": false
-                                                                  }
-                                                                ],
-                                                                "keys": []
-                                                              }
-                                                            }
-                                                          }
-                                                        ],
-                                                        "equivalences": [],
-                                                        "implementation": "Unimplemented"
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            ],
-                                            "equivalences": [
-                                              [
-                                                {
-                                                  "Column": 1
-                                                },
-                                                {
-                                                  "Column": 2
-                                                }
-                                              ]
-                                            ],
-                                            "implementation": "Unimplemented"
-                                          }
-                                        },
-                                        "outputs": [
-                                          0,
-                                          1,
-                                          3
-                                        ]
-                                      }
-                                    },
-                                    "predicates": [
-                                      {
-                                        "Column": 2
-                                      }
-                                    ]
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  1
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test SELECT subqueries.
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Reduce": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Local": 1
-                    },
-                    "typ": {
-                      "column_types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
-                      ],
-                      "keys": []
                     }
                   }
                 },
-                "group_key": [
+                "predicates": [
                   {
-                    "Column": 0
-                  },
-                  {
-                    "Column": 1
+                    "Literal": [
+                      {
+                        "Ok": {
+                          "data": [
+                            2
+                          ]
+                        }
+                      },
+                      {
+                        "scalar_type": "Bool",
+                        "nullable": false
+                      }
+                    ]
                   }
-                ],
-                "aggregates": [],
-                "monotonic": false,
-                "expected_group_size": null
+                ]
               }
-            },
-            "body": {
+            }
+          }
+        },
+        "body": {
+          "Filter": {
+            "input": {
               "Let": {
-                "id": 3,
+                "id": 6,
                 "value": {
                   "Reduce": {
                     "input": {
                       "Get": {
                         "id": {
-                          "Local": 2
+                          "Local": 5
                         },
                         "typ": {
                           "column_types": [
@@ -3495,20 +7692,19 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                             {
                               "scalar_type": "Int32",
                               "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": false
                             }
                           ],
-                          "keys": [
-                            [
-                              0,
-                              1
-                            ]
-                          ]
+                          "keys": []
                         }
                       }
                     },
                     "group_key": [
                       {
-                        "Column": 1
+                        "Column": 0
                       }
                     ],
                     "aggregates": [],
@@ -3517,24 +7713,131 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                   }
                 },
                 "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Project": {
-                        "input": {
-                          "TopK": {
-                            "input": {
-                              "Filter": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
-                                      {
+                  "Project": {
+                    "input": {
+                      "Join": {
+                        "inputs": [
+                          {
+                            "Get": {
+                              "id": {
+                                "Local": 5
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": false
+                                  }
+                                ],
+                                "keys": []
+                              }
+                            }
+                          },
+                          {
+                            "Let": {
+                              "id": 8,
+                              "value": {
+                                "Let": {
+                                  "id": 7,
+                                  "value": {
+                                    "Reduce": {
+                                      "input": {
+                                        "Join": {
+                                          "inputs": [
+                                            {
+                                              "Get": {
+                                                "id": {
+                                                  "Local": 6
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": [
+                                                    [
+                                                      0
+                                                    ]
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "Get": {
+                                                "id": {
+                                                  "Global": {
+                                                    "User": 1
+                                                  }
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    },
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": []
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "equivalences": [],
+                                          "implementation": "Unimplemented"
+                                        }
+                                      },
+                                      "group_key": [
+                                        {
+                                          "Column": 0
+                                        }
+                                      ],
+                                      "aggregates": [
+                                        {
+                                          "func": "MaxInt32",
+                                          "expr": {
+                                            "CallBinary": {
+                                              "func": "MulInt32",
+                                              "expr1": {
+                                                "Column": 0
+                                              },
+                                              "expr2": {
+                                                "Column": 1
+                                              }
+                                            }
+                                          },
+                                          "distinct": false
+                                        }
+                                      ],
+                                      "monotonic": false,
+                                      "expected_group_size": null
+                                    }
+                                  },
+                                  "body": {
+                                    "Union": {
+                                      "base": {
                                         "Get": {
                                           "id": {
-                                            "Local": 3
+                                            "Local": 7
                                           },
                                           "typ": {
                                             "column_types": [
+                                              {
+                                                "scalar_type": "Int32",
+                                                "nullable": true
+                                              },
                                               {
                                                 "scalar_type": "Int32",
                                                 "nullable": true
@@ -3548,4331 +7851,32 @@ SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE m
                                           }
                                         }
                                       },
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Global": {
-                                              "User": 3
-                                            }
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": false
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          }
-                                        }
-                                      }
-                                    ],
-                                    "equivalences": [],
-                                    "implementation": "Unimplemented"
-                                  }
-                                },
-                                "predicates": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "Eq",
-                                      "expr1": {
-                                        "Column": 2
-                                      },
-                                      "expr2": {
-                                        "Column": 0
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "group_key": [
-                              0
-                            ],
-                            "order_key": [],
-                            "limit": 1,
-                            "offset": 0,
-                            "monotonic": false
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1
-                        ]
-                      }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Union": {
-                            "base": {
-                              "Get": {
-                                "id": {
-                                  "Local": 4
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ],
-                                  "keys": [
-                                    [
-                                      0
-                                    ]
-                                  ]
-                                }
-                              }
-                            },
-                            "inputs": [
-                              {
-                                "Map": {
-                                  "input": {
-                                    "Project": {
-                                      "input": {
-                                        "Filter": {
-                                          "input": {
-                                            "Reduce": {
-                                              "input": {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 4
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": false
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": false
-                                                      }
-                                                    ],
-                                                    "keys": [
-                                                      [
-                                                        0
-                                                      ]
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "group_key": [
-                                                {
-                                                  "Column": 0
-                                                }
-                                              ],
-                                              "aggregates": [
-                                                {
-                                                  "func": "Count",
-                                                  "expr": {
-                                                    "Literal": [
-                                                      {
-                                                        "Ok": {
-                                                          "data": [
-                                                            2
-                                                          ]
-                                                        }
-                                                      },
-                                                      {
-                                                        "scalar_type": "Bool",
-                                                        "nullable": false
-                                                      }
-                                                    ]
-                                                  },
-                                                  "distinct": false
-                                                }
-                                              ],
-                                              "monotonic": false,
-                                              "expected_group_size": null
-                                            }
-                                          },
-                                          "predicates": [
-                                            {
-                                              "CallBinary": {
-                                                "func": "Gt",
-                                                "expr1": {
-                                                  "Column": 1
-                                                },
-                                                "expr2": {
-                                                  "Literal": [
-                                                    {
-                                                      "Ok": {
-                                                        "data": [
-                                                          5,
-                                                          1,
-                                                          0,
-                                                          0,
-                                                          0,
-                                                          0,
-                                                          0,
-                                                          0,
-                                                          0
-                                                        ]
-                                                      }
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int64",
-                                                      "nullable": false
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "outputs": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  "scalars": [
-                                    {
-                                      "Literal": [
+                                      "inputs": [
                                         {
-                                          "Err": "MultipleRowsFromSubquery"
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Reduce": {
-                                "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 1
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        }
-                                      ],
-                                      "keys": []
-                                    }
-                                  }
-                                },
-                                "group_key": [
-                                  {
-                                    "Column": 0
-                                  },
-                                  {
-                                    "Column": 1
-                                  }
-                                ],
-                                "aggregates": [],
-                                "monotonic": false,
-                                "expected_group_size": null
-                              }
-                            },
-                            "body": {
-                              "Let": {
-                                "id": 7,
-                                "value": {
-                                  "Reduce": {
-                                    "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 6
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": [
-                                            [
-                                              0,
-                                              1
-                                            ]
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "group_key": [
-                                      {
-                                        "Column": 1
-                                      }
-                                    ],
-                                    "aggregates": [],
-                                    "monotonic": false,
-                                    "expected_group_size": null
-                                  }
-                                },
-                                "body": {
-                                  "Let": {
-                                    "id": 8,
-                                    "value": {
-                                      "Project": {
-                                        "input": {
-                                          "TopK": {
-                                            "input": {
-                                              "Filter": {
-                                                "input": {
-                                                  "Join": {
-                                                    "inputs": [
-                                                      {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 7
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": [
-                                                              [
-                                                                0
-                                                              ]
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Global": {
-                                                              "User": 5
-                                                            }
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": false
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
-                                                          }
-                                                        }
-                                                      }
-                                                    ],
-                                                    "equivalences": [],
-                                                    "implementation": "Unimplemented"
-                                                  }
-                                                },
-                                                "predicates": [
-                                                  {
-                                                    "CallBinary": {
-                                                      "func": "Eq",
-                                                      "expr1": {
-                                                        "Column": 2
-                                                      },
-                                                      "expr2": {
-                                                        "Column": 0
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            },
-                                            "group_key": [
-                                              0
-                                            ],
-                                            "order_key": [],
-                                            "limit": 1,
-                                            "offset": 0,
-                                            "monotonic": false
-                                          }
-                                        },
-                                        "outputs": [
-                                          0,
-                                          1
-                                        ]
-                                      }
-                                    },
-                                    "body": {
-                                      "Let": {
-                                        "id": 9,
-                                        "value": {
-                                          "Union": {
-                                            "base": {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 8
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    }
-                                                  ],
-                                                  "keys": [
-                                                    [
-                                                      0
-                                                    ]
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            "inputs": [
-                                              {
-                                                "Map": {
-                                                  "input": {
-                                                    "Project": {
-                                                      "input": {
-                                                        "Filter": {
-                                                          "input": {
-                                                            "Reduce": {
-                                                              "input": {
-                                                                "Get": {
-                                                                  "id": {
-                                                                    "Local": 8
-                                                                  },
-                                                                  "typ": {
-                                                                    "column_types": [
-                                                                      {
-                                                                        "scalar_type": "Int32",
-                                                                        "nullable": false
-                                                                      },
-                                                                      {
-                                                                        "scalar_type": "Int32",
-                                                                        "nullable": false
-                                                                      }
-                                                                    ],
-                                                                    "keys": [
-                                                                      [
-                                                                        0
-                                                                      ]
-                                                                    ]
-                                                                  }
-                                                                }
-                                                              },
-                                                              "group_key": [
-                                                                {
-                                                                  "Column": 0
-                                                                }
-                                                              ],
-                                                              "aggregates": [
-                                                                {
-                                                                  "func": "Count",
-                                                                  "expr": {
-                                                                    "Literal": [
-                                                                      {
-                                                                        "Ok": {
-                                                                          "data": [
-                                                                            2
-                                                                          ]
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "scalar_type": "Bool",
-                                                                        "nullable": false
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  "distinct": false
-                                                                }
-                                                              ],
-                                                              "monotonic": false,
-                                                              "expected_group_size": null
-                                                            }
-                                                          },
-                                                          "predicates": [
-                                                            {
-                                                              "CallBinary": {
-                                                                "func": "Gt",
-                                                                "expr1": {
-                                                                  "Column": 1
-                                                                },
-                                                                "expr2": {
-                                                                  "Literal": [
-                                                                    {
-                                                                      "Ok": {
-                                                                        "data": [
-                                                                          5,
-                                                                          1,
-                                                                          0,
-                                                                          0,
-                                                                          0,
-                                                                          0,
-                                                                          0,
-                                                                          0,
-                                                                          0
-                                                                        ]
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "scalar_type": "Int64",
-                                                                      "nullable": false
-                                                                    }
-                                                                  ]
-                                                                }
-                                                              }
-                                                            }
-                                                          ]
-                                                        }
-                                                      },
-                                                      "outputs": [
-                                                        0
-                                                      ]
-                                                    }
-                                                  },
-                                                  "scalars": [
-                                                    {
-                                                      "Literal": [
-                                                        {
-                                                          "Err": "MultipleRowsFromSubquery"
-                                                        },
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": false
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "body": {
-                                          "Project": {
-                                            "input": {
-                                              "Project": {
-                                                "input": {
-                                                  "Map": {
-                                                    "input": {
-                                                      "Map": {
-                                                        "input": {
-                                                          "Join": {
-                                                            "inputs": [
-                                                              {
-                                                                "Get": {
-                                                                  "id": {
-                                                                    "Local": 1
-                                                                  },
-                                                                  "typ": {
-                                                                    "column_types": [
-                                                                      {
-                                                                        "scalar_type": "Int32",
-                                                                        "nullable": true
-                                                                      },
-                                                                      {
-                                                                        "scalar_type": "Int32",
-                                                                        "nullable": true
-                                                                      }
-                                                                    ],
-                                                                    "keys": []
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "Project": {
-                                                                  "input": {
-                                                                    "Join": {
-                                                                      "inputs": [
-                                                                        {
-                                                                          "Get": {
-                                                                            "id": {
-                                                                              "Local": 2
-                                                                            },
-                                                                            "typ": {
-                                                                              "column_types": [
-                                                                                {
-                                                                                  "scalar_type": "Int32",
-                                                                                  "nullable": true
-                                                                                },
-                                                                                {
-                                                                                  "scalar_type": "Int32",
-                                                                                  "nullable": true
-                                                                                }
-                                                                              ],
-                                                                              "keys": [
-                                                                                [
-                                                                                  0,
-                                                                                  1
-                                                                                ]
-                                                                              ]
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "Union": {
-                                                                            "base": {
-                                                                              "Get": {
-                                                                                "id": {
-                                                                                  "Local": 5
-                                                                                },
-                                                                                "typ": {
-                                                                                  "column_types": [
-                                                                                    {
-                                                                                      "scalar_type": "Int32",
-                                                                                      "nullable": false
-                                                                                    },
-                                                                                    {
-                                                                                      "scalar_type": "Int32",
-                                                                                      "nullable": false
-                                                                                    }
-                                                                                  ],
-                                                                                  "keys": []
-                                                                                }
-                                                                              }
-                                                                            },
-                                                                            "inputs": [
-                                                                              {
-                                                                                "Join": {
-                                                                                  "inputs": [
-                                                                                    {
-                                                                                      "Project": {
-                                                                                        "input": {
-                                                                                          "Join": {
-                                                                                            "inputs": [
-                                                                                              {
-                                                                                                "Union": {
-                                                                                                  "base": {
-                                                                                                    "Negate": {
-                                                                                                      "input": {
-                                                                                                        "Reduce": {
-                                                                                                          "input": {
-                                                                                                            "Get": {
-                                                                                                              "id": {
-                                                                                                                "Local": 5
-                                                                                                              },
-                                                                                                              "typ": {
-                                                                                                                "column_types": [
-                                                                                                                  {
-                                                                                                                    "scalar_type": "Int32",
-                                                                                                                    "nullable": false
-                                                                                                                  },
-                                                                                                                  {
-                                                                                                                    "scalar_type": "Int32",
-                                                                                                                    "nullable": false
-                                                                                                                  }
-                                                                                                                ],
-                                                                                                                "keys": []
-                                                                                                              }
-                                                                                                            }
-                                                                                                          },
-                                                                                                          "group_key": [
-                                                                                                            {
-                                                                                                              "Column": 0
-                                                                                                            }
-                                                                                                          ],
-                                                                                                          "aggregates": [],
-                                                                                                          "monotonic": false,
-                                                                                                          "expected_group_size": null
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  },
-                                                                                                  "inputs": [
-                                                                                                    {
-                                                                                                      "Reduce": {
-                                                                                                        "input": {
-                                                                                                          "Get": {
-                                                                                                            "id": {
-                                                                                                              "Local": 3
-                                                                                                            },
-                                                                                                            "typ": {
-                                                                                                              "column_types": [
-                                                                                                                {
-                                                                                                                  "scalar_type": "Int32",
-                                                                                                                  "nullable": true
-                                                                                                                }
-                                                                                                              ],
-                                                                                                              "keys": [
-                                                                                                                [
-                                                                                                                  0
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                            }
-                                                                                                          }
-                                                                                                        },
-                                                                                                        "group_key": [
-                                                                                                          {
-                                                                                                            "Column": 0
-                                                                                                          }
-                                                                                                        ],
-                                                                                                        "aggregates": [],
-                                                                                                        "monotonic": false,
-                                                                                                        "expected_group_size": null
-                                                                                                      }
-                                                                                                    }
-                                                                                                  ]
-                                                                                                }
-                                                                                              },
-                                                                                              {
-                                                                                                "Get": {
-                                                                                                  "id": {
-                                                                                                    "Local": 3
-                                                                                                  },
-                                                                                                  "typ": {
-                                                                                                    "column_types": [
-                                                                                                      {
-                                                                                                        "scalar_type": "Int32",
-                                                                                                        "nullable": true
-                                                                                                      }
-                                                                                                    ],
-                                                                                                    "keys": [
-                                                                                                      [
-                                                                                                        0
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            ],
-                                                                                            "equivalences": [
-                                                                                              [
-                                                                                                {
-                                                                                                  "Column": 0
-                                                                                                },
-                                                                                                {
-                                                                                                  "Column": 1
-                                                                                                }
-                                                                                              ]
-                                                                                            ],
-                                                                                            "implementation": "Unimplemented"
-                                                                                          }
-                                                                                        },
-                                                                                        "outputs": [
-                                                                                          0
-                                                                                        ]
-                                                                                      }
-                                                                                    },
-                                                                                    {
-                                                                                      "Constant": {
-                                                                                        "rows": {
-                                                                                          "Ok": [
-                                                                                            [
-                                                                                              {
-                                                                                                "data": [
-                                                                                                  0
-                                                                                                ]
-                                                                                              },
-                                                                                              1
-                                                                                            ]
-                                                                                          ]
-                                                                                        },
-                                                                                        "typ": {
-                                                                                          "column_types": [
-                                                                                            {
-                                                                                              "scalar_type": "Int32",
-                                                                                              "nullable": true
-                                                                                            }
-                                                                                          ],
-                                                                                          "keys": []
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  ],
-                                                                                  "equivalences": [],
-                                                                                  "implementation": "Unimplemented"
-                                                                                }
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      ],
-                                                                      "equivalences": [
-                                                                        [
-                                                                          {
-                                                                            "Column": 1
-                                                                          },
-                                                                          {
-                                                                            "Column": 2
-                                                                          }
-                                                                        ]
-                                                                      ],
-                                                                      "implementation": "Unimplemented"
-                                                                    }
-                                                                  },
-                                                                  "outputs": [
-                                                                    0,
-                                                                    1,
-                                                                    3
-                                                                  ]
-                                                                }
-                                                              },
-                                                              {
-                                                                "Project": {
-                                                                  "input": {
-                                                                    "Join": {
-                                                                      "inputs": [
-                                                                        {
-                                                                          "Get": {
-                                                                            "id": {
-                                                                              "Local": 6
-                                                                            },
-                                                                            "typ": {
-                                                                              "column_types": [
-                                                                                {
-                                                                                  "scalar_type": "Int32",
-                                                                                  "nullable": true
-                                                                                },
-                                                                                {
-                                                                                  "scalar_type": "Int32",
-                                                                                  "nullable": true
-                                                                                }
-                                                                              ],
-                                                                              "keys": [
-                                                                                [
-                                                                                  0,
-                                                                                  1
-                                                                                ]
-                                                                              ]
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "Union": {
-                                                                            "base": {
-                                                                              "Get": {
-                                                                                "id": {
-                                                                                  "Local": 9
-                                                                                },
-                                                                                "typ": {
-                                                                                  "column_types": [
-                                                                                    {
-                                                                                      "scalar_type": "Int32",
-                                                                                      "nullable": false
-                                                                                    },
-                                                                                    {
-                                                                                      "scalar_type": "Int32",
-                                                                                      "nullable": false
-                                                                                    }
-                                                                                  ],
-                                                                                  "keys": []
-                                                                                }
-                                                                              }
-                                                                            },
-                                                                            "inputs": [
-                                                                              {
-                                                                                "Join": {
-                                                                                  "inputs": [
-                                                                                    {
-                                                                                      "Project": {
-                                                                                        "input": {
-                                                                                          "Join": {
-                                                                                            "inputs": [
-                                                                                              {
-                                                                                                "Union": {
-                                                                                                  "base": {
-                                                                                                    "Negate": {
-                                                                                                      "input": {
-                                                                                                        "Reduce": {
-                                                                                                          "input": {
-                                                                                                            "Get": {
-                                                                                                              "id": {
-                                                                                                                "Local": 9
-                                                                                                              },
-                                                                                                              "typ": {
-                                                                                                                "column_types": [
-                                                                                                                  {
-                                                                                                                    "scalar_type": "Int32",
-                                                                                                                    "nullable": false
-                                                                                                                  },
-                                                                                                                  {
-                                                                                                                    "scalar_type": "Int32",
-                                                                                                                    "nullable": false
-                                                                                                                  }
-                                                                                                                ],
-                                                                                                                "keys": []
-                                                                                                              }
-                                                                                                            }
-                                                                                                          },
-                                                                                                          "group_key": [
-                                                                                                            {
-                                                                                                              "Column": 0
-                                                                                                            }
-                                                                                                          ],
-                                                                                                          "aggregates": [],
-                                                                                                          "monotonic": false,
-                                                                                                          "expected_group_size": null
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  },
-                                                                                                  "inputs": [
-                                                                                                    {
-                                                                                                      "Reduce": {
-                                                                                                        "input": {
-                                                                                                          "Get": {
-                                                                                                            "id": {
-                                                                                                              "Local": 7
-                                                                                                            },
-                                                                                                            "typ": {
-                                                                                                              "column_types": [
-                                                                                                                {
-                                                                                                                  "scalar_type": "Int32",
-                                                                                                                  "nullable": true
-                                                                                                                }
-                                                                                                              ],
-                                                                                                              "keys": [
-                                                                                                                [
-                                                                                                                  0
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                            }
-                                                                                                          }
-                                                                                                        },
-                                                                                                        "group_key": [
-                                                                                                          {
-                                                                                                            "Column": 0
-                                                                                                          }
-                                                                                                        ],
-                                                                                                        "aggregates": [],
-                                                                                                        "monotonic": false,
-                                                                                                        "expected_group_size": null
-                                                                                                      }
-                                                                                                    }
-                                                                                                  ]
-                                                                                                }
-                                                                                              },
-                                                                                              {
-                                                                                                "Get": {
-                                                                                                  "id": {
-                                                                                                    "Local": 7
-                                                                                                  },
-                                                                                                  "typ": {
-                                                                                                    "column_types": [
-                                                                                                      {
-                                                                                                        "scalar_type": "Int32",
-                                                                                                        "nullable": true
-                                                                                                      }
-                                                                                                    ],
-                                                                                                    "keys": [
-                                                                                                      [
-                                                                                                        0
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            ],
-                                                                                            "equivalences": [
-                                                                                              [
-                                                                                                {
-                                                                                                  "Column": 0
-                                                                                                },
-                                                                                                {
-                                                                                                  "Column": 1
-                                                                                                }
-                                                                                              ]
-                                                                                            ],
-                                                                                            "implementation": "Unimplemented"
-                                                                                          }
-                                                                                        },
-                                                                                        "outputs": [
-                                                                                          0
-                                                                                        ]
-                                                                                      }
-                                                                                    },
-                                                                                    {
-                                                                                      "Constant": {
-                                                                                        "rows": {
-                                                                                          "Ok": [
-                                                                                            [
-                                                                                              {
-                                                                                                "data": [
-                                                                                                  0
-                                                                                                ]
-                                                                                              },
-                                                                                              1
-                                                                                            ]
-                                                                                          ]
-                                                                                        },
-                                                                                        "typ": {
-                                                                                          "column_types": [
-                                                                                            {
-                                                                                              "scalar_type": "Int32",
-                                                                                              "nullable": true
-                                                                                            }
-                                                                                          ],
-                                                                                          "keys": []
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  ],
-                                                                                  "equivalences": [],
-                                                                                  "implementation": "Unimplemented"
-                                                                                }
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      ],
-                                                                      "equivalences": [
-                                                                        [
-                                                                          {
-                                                                            "Column": 1
-                                                                          },
-                                                                          {
-                                                                            "Column": 2
-                                                                          }
-                                                                        ]
-                                                                      ],
-                                                                      "implementation": "Unimplemented"
-                                                                    }
-                                                                  },
-                                                                  "outputs": [
-                                                                    0,
-                                                                    1,
-                                                                    3
-                                                                  ]
-                                                                }
-                                                              }
-                                                            ],
-                                                            "equivalences": [
-                                                              [
-                                                                {
-                                                                  "Column": 0
-                                                                },
-                                                                {
-                                                                  "Column": 2
-                                                                },
-                                                                {
-                                                                  "Column": 5
-                                                                }
-                                                              ],
-                                                              [
-                                                                {
-                                                                  "Column": 1
-                                                                },
-                                                                {
-                                                                  "Column": 3
-                                                                },
-                                                                {
-                                                                  "Column": 6
-                                                                }
-                                                              ]
-                                                            ],
-                                                            "implementation": "Unimplemented"
-                                                          }
-                                                        },
-                                                        "scalars": [
-                                                          {
-                                                            "Column": 4
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    "scalars": [
-                                                      {
-                                                        "Column": 7
-                                                      }
-                                                    ]
-                                                  }
-                                                },
-                                                "outputs": [
-                                                  0,
-                                                  1,
-                                                  8,
-                                                  9
-                                                ]
-                                              }
-                                            },
-                                            "outputs": [
-                                              2,
-                                              3
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test CrossJoin derived from a comma join without a predicate.
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT t1.a, t2.a FROM t as t1, t as t2
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Filter": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 1
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          2,
-                          3
-                        ]
-                      }
-                    },
-                    "predicates": [
-                      {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                2
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Bool",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "body": {
-                  "Project": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 3
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ],
-                          "keys": []
-                        }
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      2
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test CrossJoin derived from an INNER JOIN with a trivial ON clause.
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Filter": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 1
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          2,
-                          3
-                        ]
-                      }
-                    },
-                    "predicates": [
-                      {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                2
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Bool",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "body": {
-                  "Project": {
-                    "input": {
-                      "Get": {
-                        "id": {
-                          "Local": 3
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ],
-                          "keys": []
-                        }
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      2
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test InnerJoin (comma syntax).
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT t1.a, t2.a
-FROM
-  t as t1,
-  t as t2,
-  t as t3
-WHERE t1.b = t2.b AND t2.b = t3.b
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Filter": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 1
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          2,
-                          3
-                        ]
-                      }
-                    },
-                    "predicates": [
-                      {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                2
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Bool",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Get": {
-                        "id": {
-                          "Local": 3
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ],
-                          "keys": []
-                        }
-                      }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "typ": {
-                                    "column_types": [],
-                                    "keys": [
-                                      []
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Global": {
-                                      "User": 1
-                                    }
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Filter": {
-                                "input": {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 4
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 5
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              }
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1,
-                                      2,
-                                      3,
-                                      4,
-                                      5
-                                    ]
-                                  }
-                                },
-                                "predicates": [
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            2
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "Bool",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "body": {
-                              "Project": {
-                                "input": {
-                                  "Filter": {
-                                    "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 6
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": []
-                                        }
-                                      }
-                                    },
-                                    "predicates": [
-                                      {
-                                        "CallVariadic": {
-                                          "func": "And",
-                                          "exprs": [
-                                            {
-                                              "CallBinary": {
-                                                "func": "Eq",
-                                                "expr1": {
-                                                  "Column": 1
-                                                },
-                                                "expr2": {
-                                                  "Column": 3
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "CallBinary": {
-                                                "func": "Eq",
-                                                "expr1": {
-                                                  "Column": 3
-                                                },
-                                                "expr2": {
-                                                  "Column": 5
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    ]
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  2
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test InnerJoin (ON syntax).
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT t1.a, t2.a
-FROM t as t1
-INNER JOIN t as t2 ON t1.b = t2.b
-INNER JOIN t as t3 ON t2.b = t3.b
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Filter": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 1
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          2,
-                          3
-                        ]
-                      }
-                    },
-                    "predicates": [
-                      {
-                        "CallBinary": {
-                          "func": "Eq",
-                          "expr1": {
-                            "Column": 1
-                          },
-                          "expr2": {
-                            "Column": 3
-                          }
-                        }
-                      }
-                    ]
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Get": {
-                        "id": {
-                          "Local": 3
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": false
-                            }
-                          ],
-                          "keys": []
-                        }
-                      }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "typ": {
-                                    "column_types": [],
-                                    "keys": [
-                                      []
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Global": {
-                                      "User": 1
-                                    }
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Filter": {
-                                "input": {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 4
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": false
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": false
-                                                  }
-                                                ],
-                                                "keys": []
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 5
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              }
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0,
-                                      1,
-                                      2,
-                                      3,
-                                      4,
-                                      5
-                                    ]
-                                  }
-                                },
-                                "predicates": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "Eq",
-                                      "expr1": {
-                                        "Column": 3
-                                      },
-                                      "expr2": {
-                                        "Column": 5
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "body": {
-                              "Project": {
-                                "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 6
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        }
-                                      ],
-                                      "keys": []
-                                    }
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  2
-                                ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test InnerJoin (ON syntax).
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT t1.a, t2.a
-FROM t as t1
-LEFT JOIN t as t2 ON t1.b = t2.b
-RIGHT JOIN t as t3 ON t2.b = t3.b
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Filter": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 1
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1,
-                          2,
-                          3
-                        ]
-                      }
-                    },
-                    "predicates": [
-                      {
-                        "CallBinary": {
-                          "func": "Eq",
-                          "expr1": {
-                            "Column": 1
-                          },
-                          "expr2": {
-                            "Column": 3
-                          }
-                        }
-                      }
-                    ]
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Reduce": {
-                        "input": {
-                          "Project": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Local": 3
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ],
-                                  "keys": []
-                                }
-                              }
-                            },
-                            "outputs": [
-                              1
-                            ]
-                          }
-                        },
-                        "group_key": [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        "aggregates": [],
-                        "monotonic": false,
-                        "expected_group_size": null
-                      }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Union": {
-                            "base": {
-                              "Map": {
-                                "input": {
-                                  "Union": {
-                                    "base": {
-                                      "Negate": {
-                                        "input": {
-                                          "Project": {
-                                            "input": {
-                                              "Join": {
-                                                "inputs": [
-                                                  {
-                                                    "Get": {
-                                                      "id": {
-                                                        "Local": 1
-                                                      },
-                                                      "typ": {
-                                                        "column_types": [
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          }
-                                                        ],
-                                                        "keys": []
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "Get": {
-                                                      "id": {
-                                                        "Local": 4
-                                                      },
-                                                      "typ": {
-                                                        "column_types": [
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": false
-                                                          }
-                                                        ],
-                                                        "keys": [
-                                                          [
-                                                            0
-                                                          ]
-                                                        ]
-                                                      }
-                                                    }
-                                                  }
-                                                ],
-                                                "equivalences": [
-                                                  [
-                                                    {
-                                                      "Column": 1
-                                                    },
-                                                    {
-                                                      "Column": 2
-                                                    }
-                                                  ]
-                                                ],
-                                                "implementation": "Unimplemented"
-                                              }
-                                            },
-                                            "outputs": [
-                                              0,
-                                              1
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "inputs": [
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 1
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                },
-                                "scalars": [
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            0
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            0
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 3
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": false
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": false
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Join": {
-                                "inputs": [
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 0
-                                      },
-                                      "typ": {
-                                        "column_types": [],
-                                        "keys": [
-                                          []
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Global": {
-                                          "User": 1
-                                        }
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      }
-                                    }
-                                  }
-                                ],
-                                "equivalences": [],
-                                "implementation": "Unimplemented"
-                              }
-                            },
-                            "body": {
-                              "Let": {
-                                "id": 7,
-                                "value": {
-                                  "Filter": {
-                                    "input": {
-                                      "Project": {
-                                        "input": {
                                           "Join": {
                                             "inputs": [
                                               {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 5
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      }
-                                                    ],
-                                                    "keys": []
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 6
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      }
-                                                    ],
-                                                    "keys": []
-                                                  }
-                                                }
-                                              }
-                                            ],
-                                            "equivalences": [],
-                                            "implementation": "Unimplemented"
-                                          }
-                                        },
-                                        "outputs": [
-                                          0,
-                                          1,
-                                          2,
-                                          3,
-                                          4,
-                                          5
-                                        ]
-                                      }
-                                    },
-                                    "predicates": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "Eq",
-                                          "expr1": {
-                                            "Column": 3
-                                          },
-                                          "expr2": {
-                                            "Column": 5
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                },
-                                "body": {
-                                  "Let": {
-                                    "id": 8,
-                                    "value": {
-                                      "Reduce": {
-                                        "input": {
-                                          "Project": {
-                                            "input": {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 7
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    }
-                                                  ],
-                                                  "keys": []
-                                                }
-                                              }
-                                            },
-                                            "outputs": [
-                                              3
-                                            ]
-                                          }
-                                        },
-                                        "group_key": [
-                                          {
-                                            "Column": 0
-                                          }
-                                        ],
-                                        "aggregates": [],
-                                        "monotonic": false,
-                                        "expected_group_size": null
-                                      }
-                                    },
-                                    "body": {
-                                      "Project": {
-                                        "input": {
-                                          "Union": {
-                                            "base": {
-                                              "Project": {
-                                                "input": {
-                                                  "Map": {
-                                                    "input": {
-                                                      "Union": {
-                                                        "base": {
-                                                          "Negate": {
-                                                            "input": {
-                                                              "Project": {
-                                                                "input": {
-                                                                  "Join": {
-                                                                    "inputs": [
-                                                                      {
-                                                                        "Get": {
-                                                                          "id": {
-                                                                            "Local": 6
-                                                                          },
-                                                                          "typ": {
-                                                                            "column_types": [
-                                                                              {
-                                                                                "scalar_type": "Int32",
-                                                                                "nullable": true
-                                                                              },
-                                                                              {
-                                                                                "scalar_type": "Int32",
-                                                                                "nullable": true
-                                                                              }
-                                                                            ],
-                                                                            "keys": []
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "Get": {
-                                                                          "id": {
-                                                                            "Local": 8
-                                                                          },
-                                                                          "typ": {
-                                                                            "column_types": [
-                                                                              {
-                                                                                "scalar_type": "Int32",
-                                                                                "nullable": false
-                                                                              }
-                                                                            ],
-                                                                            "keys": [
-                                                                              [
-                                                                                0
-                                                                              ]
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ],
-                                                                    "equivalences": [
-                                                                      [
-                                                                        {
-                                                                          "Column": 1
-                                                                        },
-                                                                        {
-                                                                          "Column": 2
-                                                                        }
-                                                                      ]
-                                                                    ],
-                                                                    "implementation": "Unimplemented"
-                                                                  }
-                                                                },
-                                                                "outputs": [
-                                                                  0,
-                                                                  1
-                                                                ]
-                                                              }
-                                                            }
-                                                          }
-                                                        },
-                                                        "inputs": [
-                                                          {
-                                                            "Get": {
-                                                              "id": {
-                                                                "Local": 6
-                                                              },
-                                                              "typ": {
-                                                                "column_types": [
-                                                                  {
-                                                                    "scalar_type": "Int32",
-                                                                    "nullable": true
-                                                                  },
-                                                                  {
-                                                                    "scalar_type": "Int32",
-                                                                    "nullable": true
-                                                                  }
-                                                                ],
-                                                                "keys": []
-                                                              }
-                                                            }
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    "scalars": [
-                                                      {
-                                                        "Literal": [
-                                                          {
-                                                            "Ok": {
-                                                              "data": [
-                                                                0
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "Literal": [
-                                                          {
-                                                            "Ok": {
-                                                              "data": [
-                                                                0
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "Literal": [
-                                                          {
-                                                            "Ok": {
-                                                              "data": [
-                                                                0
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "Literal": [
-                                                          {
-                                                            "Ok": {
-                                                              "data": [
-                                                                0
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                },
-                                                "outputs": [
-                                                  2,
-                                                  3,
-                                                  4,
-                                                  5,
-                                                  0,
-                                                  1
-                                                ]
-                                              }
-                                            },
-                                            "inputs": [
-                                              {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 7
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": false
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": false
-                                                      }
-                                                    ],
-                                                    "keys": []
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "outputs": [
-                                          0,
-                                          2
-                                        ]
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test a single CTE.
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Project": {
-                "input": {
-                  "Project": {
-                    "input": {
-                      "Map": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Local": 1
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            }
-                          }
-                        },
-                        "scalars": [
-                          {
-                            "CallBinary": {
-                              "func": "MulInt32",
-                              "expr1": {
-                                "Column": 0
-                              },
-                              "expr2": {
-                                "Column": 1
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "outputs": [
-                      0,
-                      1,
-                      2
-                    ]
-                  }
-                },
-                "outputs": [
-                  2
-                ]
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Filter": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Join": {
-                            "inputs": [
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              }
-                            ],
-                            "equivalences": [],
-                            "implementation": "Unimplemented"
-                          }
-                        },
-                        "outputs": [
-                          0,
-                          1
-                        ]
-                      }
-                    },
-                    "predicates": [
-                      {
-                        "Literal": [
-                          {
-                            "Ok": {
-                              "data": [
-                                2
-                              ]
-                            }
-                          },
-                          {
-                            "scalar_type": "Bool",
-                            "nullable": false
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Get": {
-                        "id": {
-                          "Local": 3
-                        },
-                        "typ": {
-                          "column_types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ],
-                          "keys": []
-                        }
-                      }
-                    },
-                    "body": {
-                      "Project": {
-                        "input": {
-                          "Project": {
-                            "input": {
-                              "Map": {
-                                "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 4
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        }
-                                      ],
-                                      "keys": []
-                                    }
-                                  }
-                                },
-                                "scalars": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "AddInt32",
-                                      "expr1": {
-                                        "Column": 0
-                                      },
-                                      "expr2": {
-                                        "Column": 1
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "outputs": [
-                              0,
-                              1,
-                              2
-                            ]
-                          }
-                        },
-                        "outputs": [
-                          2
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test multiple CTEs: a case where we cannot pull the let statement up through
-# the join because the local l0 is correlated against the lhs of the enclosing join.
-query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
-SELECT
-  *
-FROM
-  (
-    SELECT * FROM t
-  ) as r1
-  CROSS JOIN LATERAL (
-    WITH r2 as (
-      SELECT MAX(r1.a * t.a) AS m FROM t
-    )
-    SELECT * FROM r2 WHERE r2.m != r1.a
-  ) as r3
-  CROSS JOIN LATERAL (
-    WITH r4 as (
-      SELECT MAX(r1.a * t.a) AS m FROM t
-    )
-    SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
-  ) as r5;
-----
-{
-  "Let": {
-    "id": 0,
-    "value": {
-      "Constant": {
-        "rows": {
-          "Ok": [
-            [
-              {
-                "data": []
-              },
-              1
-            ]
-          ]
-        },
-        "typ": {
-          "column_types": [],
-          "keys": []
-        }
-      }
-    },
-    "body": {
-      "Let": {
-        "id": 1,
-        "value": {
-          "Join": {
-            "inputs": [
-              {
-                "Get": {
-                  "id": {
-                    "Local": 0
-                  },
-                  "typ": {
-                    "column_types": [],
-                    "keys": [
-                      []
-                    ]
-                  }
-                }
-              },
-              {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "typ": {
-                    "column_types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ],
-                    "keys": []
-                  }
-                }
-              }
-            ],
-            "equivalences": [],
-            "implementation": "Unimplemented"
-          }
-        },
-        "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Reduce": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Local": 1
-                    },
-                    "typ": {
-                      "column_types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
-                      ],
-                      "keys": []
-                    }
-                  }
-                },
-                "group_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "aggregates": [],
-                "monotonic": false,
-                "expected_group_size": null
-              }
-            },
-            "body": {
-              "Let": {
-                "id": 3,
-                "value": {
-                  "Reduce": {
-                    "input": {
-                      "Join": {
-                        "inputs": [
-                          {
-                            "Get": {
-                              "id": {
-                                "Local": 2
-                              },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ],
-                                "keys": [
-                                  [
-                                    0
-                                  ]
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "Get": {
-                              "id": {
-                                "Global": {
-                                  "User": 1
-                                }
-                              },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ],
-                                "keys": []
-                              }
-                            }
-                          }
-                        ],
-                        "equivalences": [],
-                        "implementation": "Unimplemented"
-                      }
-                    },
-                    "group_key": [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    "aggregates": [
-                      {
-                        "func": "MaxInt32",
-                        "expr": {
-                          "CallBinary": {
-                            "func": "MulInt32",
-                            "expr1": {
-                              "Column": 0
-                            },
-                            "expr2": {
-                              "Column": 1
-                            }
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    "monotonic": false,
-                    "expected_group_size": null
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Union": {
-                        "base": {
-                          "Get": {
-                            "id": {
-                              "Local": 3
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": [
-                                [
-                                  0
-                                ]
-                              ]
-                            }
-                          }
-                        },
-                        "inputs": [
-                          {
-                            "Join": {
-                              "inputs": [
-                                {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Union": {
-                                              "base": {
-                                                "Negate": {
+                                                "Project": {
                                                   "input": {
-                                                    "Reduce": {
-                                                      "input": {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 3
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": [
-                                                              [
-                                                                0
-                                                              ]
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      "group_key": [
+                                                    "Join": {
+                                                      "inputs": [
                                                         {
-                                                          "Column": 0
-                                                        }
-                                                      ],
-                                                      "aggregates": [],
-                                                      "monotonic": false,
-                                                      "expected_group_size": null
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "inputs": [
-                                                {
-                                                  "Reduce": {
-                                                    "input": {
-                                                      "Get": {
-                                                        "id": {
-                                                          "Local": 2
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            }
-                                                          ],
-                                                          "keys": [
-                                                            [
-                                                              0
-                                                            ]
-                                                          ]
-                                                        }
-                                                      }
-                                                    },
-                                                    "group_key": [
-                                                      {
-                                                        "Column": 0
-                                                      }
-                                                    ],
-                                                    "aggregates": [],
-                                                    "monotonic": false,
-                                                    "expected_group_size": null
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 2
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": [
-                                                  [
-                                                    0
-                                                  ]
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [
-                                          [
-                                            {
-                                              "Column": 0
-                                            },
-                                            {
-                                              "Column": 1
-                                            }
-                                          ]
-                                        ],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0
-                                    ]
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "rows": {
-                                      "Ok": [
-                                        [
-                                          {
-                                            "data": [
-                                              0
-                                            ]
-                                          },
-                                          1
-                                        ]
-                                      ]
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        }
-                                      ],
-                                      "keys": []
-                                    }
-                                  }
-                                }
-                              ],
-                              "equivalences": [],
-                              "implementation": "Unimplemented"
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Filter": {
-                            "input": {
-                              "Project": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 1
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Filter": {
-                                          "input": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 4
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              }
-                                            }
-                                          },
-                                          "predicates": [
-                                            {
-                                              "CallBinary": {
-                                                "func": "NotEq",
-                                                "expr1": {
-                                                  "Column": 1
-                                                },
-                                                "expr2": {
-                                                  "Column": 0
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    ],
-                                    "equivalences": [
-                                      [
-                                        {
-                                          "Column": 0
-                                        },
-                                        {
-                                          "Column": 2
-                                        }
-                                      ]
-                                    ],
-                                    "implementation": "Unimplemented"
-                                  }
-                                },
-                                "outputs": [
-                                  0,
-                                  1,
-                                  3
-                                ]
-                              }
-                            },
-                            "predicates": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        2
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Bool",
-                                    "nullable": false
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Reduce": {
-                                "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 5
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        }
-                                      ],
-                                      "keys": []
-                                    }
-                                  }
-                                },
-                                "group_key": [
-                                  {
-                                    "Column": 0
-                                  }
-                                ],
-                                "aggregates": [],
-                                "monotonic": false,
-                                "expected_group_size": null
-                              }
-                            },
-                            "body": {
-                              "Let": {
-                                "id": 7,
-                                "value": {
-                                  "Reduce": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 6
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": [
-                                                  [
-                                                    0
-                                                  ]
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Global": {
-                                                  "User": 1
-                                                }
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": []
-                                              }
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "group_key": [
-                                      {
-                                        "Column": 0
-                                      }
-                                    ],
-                                    "aggregates": [
-                                      {
-                                        "func": "MaxInt32",
-                                        "expr": {
-                                          "CallBinary": {
-                                            "func": "MulInt32",
-                                            "expr1": {
-                                              "Column": 0
-                                            },
-                                            "expr2": {
-                                              "Column": 1
-                                            }
-                                          }
-                                        },
-                                        "distinct": false
-                                      }
-                                    ],
-                                    "monotonic": false,
-                                    "expected_group_size": null
-                                  }
-                                },
-                                "body": {
-                                  "Let": {
-                                    "id": 8,
-                                    "value": {
-                                      "Union": {
-                                        "base": {
-                                          "Get": {
-                                            "id": {
-                                              "Local": 7
-                                            },
-                                            "typ": {
-                                              "column_types": [
-                                                {
-                                                  "scalar_type": "Int32",
-                                                  "nullable": true
-                                                },
-                                                {
-                                                  "scalar_type": "Int32",
-                                                  "nullable": true
-                                                }
-                                              ],
-                                              "keys": [
-                                                [
-                                                  0
-                                                ]
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "inputs": [
-                                          {
-                                            "Join": {
-                                              "inputs": [
-                                                {
-                                                  "Project": {
-                                                    "input": {
-                                                      "Join": {
-                                                        "inputs": [
-                                                          {
-                                                            "Union": {
-                                                              "base": {
-                                                                "Negate": {
-                                                                  "input": {
-                                                                    "Reduce": {
-                                                                      "input": {
-                                                                        "Get": {
-                                                                          "id": {
-                                                                            "Local": 7
-                                                                          },
-                                                                          "typ": {
-                                                                            "column_types": [
-                                                                              {
-                                                                                "scalar_type": "Int32",
-                                                                                "nullable": true
-                                                                              },
-                                                                              {
-                                                                                "scalar_type": "Int32",
-                                                                                "nullable": true
-                                                                              }
-                                                                            ],
-                                                                            "keys": [
-                                                                              [
-                                                                                0
-                                                                              ]
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      "group_key": [
-                                                                        {
-                                                                          "Column": 0
-                                                                        }
-                                                                      ],
-                                                                      "aggregates": [],
-                                                                      "monotonic": false,
-                                                                      "expected_group_size": null
-                                                                    }
-                                                                  }
-                                                                }
-                                                              },
-                                                              "inputs": [
-                                                                {
+                                                          "Union": {
+                                                            "base": {
+                                                              "Negate": {
+                                                                "input": {
                                                                   "Reduce": {
                                                                     "input": {
                                                                       "Get": {
                                                                         "id": {
-                                                                          "Local": 6
+                                                                          "Local": 7
                                                                         },
                                                                         "typ": {
                                                                           "column_types": [
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            },
                                                                             {
                                                                               "scalar_type": "Int32",
                                                                               "nullable": true
@@ -7896,243 +7900,239 @@ FROM
                                                                     "expected_group_size": null
                                                                   }
                                                                 }
-                                                              ]
-                                                            }
-                                                          },
-                                                          {
-                                                            "Get": {
-                                                              "id": {
-                                                                "Local": 6
-                                                              },
-                                                              "typ": {
-                                                                "column_types": [
-                                                                  {
-                                                                    "scalar_type": "Int32",
-                                                                    "nullable": true
-                                                                  }
-                                                                ],
-                                                                "keys": [
-                                                                  [
-                                                                    0
-                                                                  ]
-                                                                ]
                                                               }
-                                                            }
-                                                          }
-                                                        ],
-                                                        "equivalences": [
-                                                          [
-                                                            {
-                                                              "Column": 0
                                                             },
-                                                            {
-                                                              "Column": 1
-                                                            }
-                                                          ]
-                                                        ],
-                                                        "implementation": "Unimplemented"
-                                                      }
-                                                    },
-                                                    "outputs": [
-                                                      0
-                                                    ]
-                                                  }
-                                                },
-                                                {
-                                                  "Constant": {
-                                                    "rows": {
-                                                      "Ok": [
-                                                        [
-                                                          {
-                                                            "data": [
-                                                              0
-                                                            ]
-                                                          },
-                                                          1
-                                                        ]
-                                                      ]
-                                                    },
-                                                    "typ": {
-                                                      "column_types": [
-                                                        {
-                                                          "scalar_type": "Int32",
-                                                          "nullable": true
-                                                        }
-                                                      ],
-                                                      "keys": []
-                                                    }
-                                                  }
-                                                }
-                                              ],
-                                              "equivalences": [],
-                                              "implementation": "Unimplemented"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "body": {
-                                      "Filter": {
-                                        "input": {
-                                          "Project": {
-                                            "input": {
-                                              "Join": {
-                                                "inputs": [
-                                                  {
-                                                    "Get": {
-                                                      "id": {
-                                                        "Local": 5
-                                                      },
-                                                      "typ": {
-                                                        "column_types": [
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": true
-                                                          },
-                                                          {
-                                                            "scalar_type": "Int32",
-                                                            "nullable": false
-                                                          }
-                                                        ],
-                                                        "keys": []
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "Filter": {
-                                                      "input": {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 8
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
+                                                            "inputs": [
                                                               {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
-                                                          }
-                                                        }
-                                                      },
-                                                      "predicates": [
-                                                        {
-                                                          "CallVariadic": {
-                                                            "func": "Or",
-                                                            "exprs": [
-                                                              {
-                                                                "CallBinary": {
-                                                                  "func": "NotEq",
-                                                                  "expr1": {
-                                                                    "Column": 1
-                                                                  },
-                                                                  "expr2": {
-                                                                    "Column": 0
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "CallVariadic": {
-                                                                  "func": "And",
-                                                                  "exprs": [
-                                                                    {
-                                                                      "CallUnary": {
-                                                                        "func": {
-                                                                          "Not": null
-                                                                        },
-                                                                        "expr": {
-                                                                          "CallUnary": {
-                                                                            "func": {
-                                                                              "IsNull": null
-                                                                            },
-                                                                            "expr": {
-                                                                              "Column": 1
-                                                                            }
+                                                                "Reduce": {
+                                                                  "input": {
+                                                                    "Get": {
+                                                                      "id": {
+                                                                        "Local": 6
+                                                                      },
+                                                                      "typ": {
+                                                                        "column_types": [
+                                                                          {
+                                                                            "scalar_type": "Int32",
+                                                                            "nullable": true
                                                                           }
-                                                                        }
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "CallUnary": {
-                                                                        "func": {
-                                                                          "IsNull": null
-                                                                        },
-                                                                        "expr": {
-                                                                          "Column": 0
-                                                                        }
+                                                                        ],
+                                                                        "keys": [
+                                                                          [
+                                                                            0
+                                                                          ]
+                                                                        ]
                                                                       }
                                                                     }
-                                                                  ]
+                                                                  },
+                                                                  "group_key": [
+                                                                    {
+                                                                      "Column": 0
+                                                                    }
+                                                                  ],
+                                                                  "aggregates": [],
+                                                                  "monotonic": false,
+                                                                  "expected_group_size": null
                                                                 }
                                                               }
                                                             ]
                                                           }
+                                                        },
+                                                        {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 6
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": true
+                                                                }
+                                                              ],
+                                                              "keys": [
+                                                                [
+                                                                  0
+                                                                ]
+                                                              ]
+                                                            }
+                                                          }
                                                         }
-                                                      ]
+                                                      ],
+                                                      "equivalences": [
+                                                        [
+                                                          {
+                                                            "Column": 0
+                                                          },
+                                                          {
+                                                            "Column": 1
+                                                          }
+                                                        ]
+                                                      ],
+                                                      "implementation": "Unimplemented"
                                                     }
-                                                  }
-                                                ],
-                                                "equivalences": [
-                                                  [
-                                                    {
-                                                      "Column": 0
-                                                    },
-                                                    {
-                                                      "Column": 3
-                                                    }
-                                                  ]
-                                                ],
-                                                "implementation": "Unimplemented"
-                                              }
-                                            },
-                                            "outputs": [
-                                              0,
-                                              1,
-                                              2,
-                                              4
-                                            ]
-                                          }
-                                        },
-                                        "predicates": [
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    2
+                                                  },
+                                                  "outputs": [
+                                                    0
                                                   ]
                                                 }
                                               },
                                               {
-                                                "scalar_type": "Bool",
-                                                "nullable": false
+                                                "Constant": {
+                                                  "rows": {
+                                                    "Ok": [
+                                                      [
+                                                        {
+                                                          "data": [
+                                                            0
+                                                          ]
+                                                        },
+                                                        1
+                                                      ]
+                                                    ]
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  }
+                                                }
                                               }
-                                            ]
+                                            ],
+                                            "equivalences": [],
+                                            "implementation": "Unimplemented"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "body": {
+                                "Filter": {
+                                  "input": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 8
+                                      },
+                                      "typ": {
+                                        "column_types": [
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          },
+                                          {
+                                            "scalar_type": "Int32",
+                                            "nullable": true
+                                          }
+                                        ],
+                                        "keys": []
+                                      }
+                                    }
+                                  },
+                                  "predicates": [
+                                    {
+                                      "CallVariadic": {
+                                        "func": "Or",
+                                        "exprs": [
+                                          {
+                                            "CallBinary": {
+                                              "func": "NotEq",
+                                              "expr1": {
+                                                "Column": 1
+                                              },
+                                              "expr2": {
+                                                "Column": 0
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "CallVariadic": {
+                                              "func": "And",
+                                              "exprs": [
+                                                {
+                                                  "CallUnary": {
+                                                    "func": {
+                                                      "Not": null
+                                                    },
+                                                    "expr": {
+                                                      "CallUnary": {
+                                                        "func": {
+                                                          "IsNull": null
+                                                        },
+                                                        "expr": {
+                                                          "Column": 1
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "CallUnary": {
+                                                    "func": {
+                                                      "IsNull": null
+                                                    },
+                                                    "expr": {
+                                                      "Column": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
                                           }
                                         ]
                                       }
                                     }
-                                  }
+                                  ]
                                 }
                               }
                             }
                           }
-                        }
+                        ],
+                        "equivalences": [
+                          [
+                            {
+                              "Column": 0
+                            },
+                            {
+                              "Column": 3
+                            }
+                          ]
+                        ],
+                        "implementation": "Unimplemented"
                       }
-                    }
+                    },
+                    "outputs": [
+                      0,
+                      1,
+                      2,
+                      4
+                    ]
                   }
                 }
               }
-            }
+            },
+            "predicates": [
+              {
+                "Literal": [
+                  {
+                    "Ok": {
+                      "data": [
+                        2
+                      ]
+                    }
+                  },
+                  {
+                    "scalar_type": "Bool",
+                    "nullable": false
+                  }
+                ]
+              }
+            ]
           }
         }
       }
@@ -8145,7 +8145,7 @@ EOF
 # through the join because the local l0 is correlated against the lhs of
 # the enclosing join.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS JSON FOR
+EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
 SELECT
   *
 FROM
@@ -8236,74 +8236,51 @@ FROM
           }
         },
         "body": {
-          "Let": {
-            "id": 2,
-            "value": {
-              "Reduce": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Local": 1
-                    },
-                    "typ": {
-                      "column_types": [
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        },
-                        {
-                          "scalar_type": "Int32",
-                          "nullable": true
-                        }
-                      ],
-                      "keys": []
-                    }
-                  }
-                },
-                "group_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "aggregates": [],
-                "monotonic": false,
-                "expected_group_size": null
-              }
-            },
-            "body": {
+          "Filter": {
+            "input": {
               "Let": {
-                "id": 3,
+                "id": 2,
                 "value": {
                   "Reduce": {
+                    "input": {
+                      "Get": {
+                        "id": {
+                          "Local": 1
+                        },
+                        "typ": {
+                          "column_types": [
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": true
+                            }
+                          ],
+                          "keys": []
+                        }
+                      }
+                    },
+                    "group_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "aggregates": [],
+                    "monotonic": false,
+                    "expected_group_size": null
+                  }
+                },
+                "body": {
+                  "Project": {
                     "input": {
                       "Join": {
                         "inputs": [
                           {
                             "Get": {
                               "id": {
-                                "Local": 2
-                              },
-                              "typ": {
-                                "column_types": [
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ],
-                                "keys": [
-                                  [
-                                    0
-                                  ]
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "Get": {
-                              "id": {
-                                "Global": {
-                                  "User": 1
-                                }
+                                "Local": 1
                               },
                               "typ": {
                                 "column_types": [
@@ -8319,276 +8296,97 @@ FROM
                                 "keys": []
                               }
                             }
-                          }
-                        ],
-                        "equivalences": [],
-                        "implementation": "Unimplemented"
-                      }
-                    },
-                    "group_key": [
-                      {
-                        "Column": 0
-                      }
-                    ],
-                    "aggregates": [
-                      {
-                        "func": "MaxInt32",
-                        "expr": {
-                          "CallBinary": {
-                            "func": "MulInt32",
-                            "expr1": {
-                              "Column": 0
-                            },
-                            "expr2": {
-                              "Column": 1
-                            }
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    "monotonic": false,
-                    "expected_group_size": null
-                  }
-                },
-                "body": {
-                  "Let": {
-                    "id": 4,
-                    "value": {
-                      "Union": {
-                        "base": {
-                          "Get": {
-                            "id": {
-                              "Local": 3
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": [
-                                [
-                                  0
-                                ]
-                              ]
-                            }
-                          }
-                        },
-                        "inputs": [
+                          },
                           {
-                            "Join": {
-                              "inputs": [
-                                {
-                                  "Project": {
-                                    "input": {
-                                      "Join": {
-                                        "inputs": [
-                                          {
-                                            "Union": {
-                                              "base": {
-                                                "Negate": {
-                                                  "input": {
-                                                    "Reduce": {
-                                                      "input": {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 3
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": [
-                                                              [
-                                                                0
-                                                              ]
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      "group_key": [
-                                                        {
-                                                          "Column": 0
-                                                        }
-                                                      ],
-                                                      "aggregates": [],
-                                                      "monotonic": false,
-                                                      "expected_group_size": null
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "inputs": [
-                                                {
-                                                  "Reduce": {
-                                                    "input": {
-                                                      "Get": {
-                                                        "id": {
-                                                          "Local": 2
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Int32",
-                                                              "nullable": true
-                                                            }
-                                                          ],
-                                                          "keys": [
-                                                            [
-                                                              0
-                                                            ]
-                                                          ]
-                                                        }
-                                                      }
-                                                    },
-                                                    "group_key": [
-                                                      {
-                                                        "Column": 0
-                                                      }
-                                                    ],
-                                                    "aggregates": [],
-                                                    "monotonic": false,
-                                                    "expected_group_size": null
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 2
-                                              },
-                                              "typ": {
-                                                "column_types": [
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": true
-                                                  }
-                                                ],
-                                                "keys": [
-                                                  [
-                                                    0
-                                                  ]
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        ],
-                                        "equivalences": [
-                                          [
+                            "Let": {
+                              "id": 4,
+                              "value": {
+                                "Let": {
+                                  "id": 3,
+                                  "value": {
+                                    "Reduce": {
+                                      "input": {
+                                        "Join": {
+                                          "inputs": [
                                             {
-                                              "Column": 0
+                                              "Get": {
+                                                "id": {
+                                                  "Local": 2
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": [
+                                                    [
+                                                      0
+                                                    ]
+                                                  ]
+                                                }
+                                              }
                                             },
                                             {
-                                              "Column": 1
+                                              "Get": {
+                                                "id": {
+                                                  "Global": {
+                                                    "User": 1
+                                                  }
+                                                },
+                                                "typ": {
+                                                  "column_types": [
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    },
+                                                    {
+                                                      "scalar_type": "Int32",
+                                                      "nullable": true
+                                                    }
+                                                  ],
+                                                  "keys": []
+                                                }
+                                              }
                                             }
-                                          ]
-                                        ],
-                                        "implementation": "Unimplemented"
-                                      }
-                                    },
-                                    "outputs": [
-                                      0
-                                    ]
-                                  }
-                                },
-                                {
-                                  "Constant": {
-                                    "rows": {
-                                      "Ok": [
-                                        [
-                                          {
-                                            "data": [
-                                              0
-                                            ]
-                                          },
-                                          1
-                                        ]
-                                      ]
-                                    },
-                                    "typ": {
-                                      "column_types": [
+                                          ],
+                                          "equivalences": [],
+                                          "implementation": "Unimplemented"
+                                        }
+                                      },
+                                      "group_key": [
                                         {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
+                                          "Column": 0
                                         }
                                       ],
-                                      "keys": []
+                                      "aggregates": [
+                                        {
+                                          "func": "MaxInt32",
+                                          "expr": {
+                                            "CallBinary": {
+                                              "func": "MulInt32",
+                                              "expr1": {
+                                                "Column": 0
+                                              },
+                                              "expr2": {
+                                                "Column": 1
+                                              }
+                                            }
+                                          },
+                                          "distinct": false
+                                        }
+                                      ],
+                                      "monotonic": false,
+                                      "expected_group_size": null
                                     }
-                                  }
-                                }
-                              ],
-                              "equivalences": [],
-                              "implementation": "Unimplemented"
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "body": {
-                      "Let": {
-                        "id": 5,
-                        "value": {
-                          "Reduce": {
-                            "input": {
-                              "Get": {
-                                "id": {
-                                  "Local": 4
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
-                                }
-                              }
-                            },
-                            "group_key": [
-                              {
-                                "Column": 1
-                              },
-                              {
-                                "Column": 0
-                              }
-                            ],
-                            "aggregates": [],
-                            "monotonic": false,
-                            "expected_group_size": null
-                          }
-                        },
-                        "body": {
-                          "Let": {
-                            "id": 6,
-                            "value": {
-                              "Reduce": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
-                                      {
+                                  },
+                                  "body": {
+                                    "Union": {
+                                      "base": {
                                         "Get": {
                                           "id": {
-                                            "Local": 5
+                                            "Local": 3
                                           },
                                           "typ": {
                                             "column_types": [
@@ -8603,133 +8401,73 @@ FROM
                                             ],
                                             "keys": [
                                               [
-                                                0,
-                                                1
+                                                0
                                               ]
                                             ]
                                           }
                                         }
                                       },
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Global": {
-                                              "User": 1
-                                            }
-                                          },
-                                          "typ": {
-                                            "column_types": [
+                                      "inputs": [
+                                        {
+                                          "Join": {
+                                            "inputs": [
                                               {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          }
-                                        }
-                                      }
-                                    ],
-                                    "equivalences": [],
-                                    "implementation": "Unimplemented"
-                                  }
-                                },
-                                "group_key": [
-                                  {
-                                    "Column": 0
-                                  },
-                                  {
-                                    "Column": 1
-                                  }
-                                ],
-                                "aggregates": [
-                                  {
-                                    "func": "MaxInt32",
-                                    "expr": {
-                                      "CallBinary": {
-                                        "func": "MulInt32",
-                                        "expr1": {
-                                          "Column": 1
-                                        },
-                                        "expr2": {
-                                          "Column": 2
-                                        }
-                                      }
-                                    },
-                                    "distinct": false
-                                  }
-                                ],
-                                "monotonic": false,
-                                "expected_group_size": null
-                              }
-                            },
-                            "body": {
-                              "Let": {
-                                "id": 7,
-                                "value": {
-                                  "Union": {
-                                    "base": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 6
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            }
-                                          ],
-                                          "keys": [
-                                            [
-                                              0,
-                                              1
-                                            ]
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "inputs": [
-                                      {
-                                        "Join": {
-                                          "inputs": [
-                                            {
-                                              "Project": {
-                                                "input": {
-                                                  "Join": {
-                                                    "inputs": [
-                                                      {
-                                                        "Union": {
-                                                          "base": {
-                                                            "Negate": {
-                                                              "input": {
+                                                "Project": {
+                                                  "input": {
+                                                    "Join": {
+                                                      "inputs": [
+                                                        {
+                                                          "Union": {
+                                                            "base": {
+                                                              "Negate": {
+                                                                "input": {
+                                                                  "Reduce": {
+                                                                    "input": {
+                                                                      "Get": {
+                                                                        "id": {
+                                                                          "Local": 3
+                                                                        },
+                                                                        "typ": {
+                                                                          "column_types": [
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            },
+                                                                            {
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": true
+                                                                            }
+                                                                          ],
+                                                                          "keys": [
+                                                                            [
+                                                                              0
+                                                                            ]
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "group_key": [
+                                                                      {
+                                                                        "Column": 0
+                                                                      }
+                                                                    ],
+                                                                    "aggregates": [],
+                                                                    "monotonic": false,
+                                                                    "expected_group_size": null
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "inputs": [
+                                                              {
                                                                 "Reduce": {
                                                                   "input": {
                                                                     "Get": {
                                                                       "id": {
-                                                                        "Local": 6
+                                                                        "Local": 2
                                                                       },
                                                                       "typ": {
                                                                         "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          },
                                                                           {
                                                                             "scalar_type": "Int32",
                                                                             "nullable": true
@@ -8737,8 +8475,7 @@ FROM
                                                                         ],
                                                                         "keys": [
                                                                           [
-                                                                            0,
-                                                                            1
+                                                                            0
                                                                           ]
                                                                         ]
                                                                       }
@@ -8747,9 +8484,6 @@ FROM
                                                                   "group_key": [
                                                                     {
                                                                       "Column": 0
-                                                                    },
-                                                                    {
-                                                                      "Column": 1
                                                                     }
                                                                   ],
                                                                   "aggregates": [],
@@ -8757,18 +8491,255 @@ FROM
                                                                   "expected_group_size": null
                                                                 }
                                                               }
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "Get": {
+                                                            "id": {
+                                                              "Local": 2
+                                                            },
+                                                            "typ": {
+                                                              "column_types": [
+                                                                {
+                                                                  "scalar_type": "Int32",
+                                                                  "nullable": true
+                                                                }
+                                                              ],
+                                                              "keys": [
+                                                                [
+                                                                  0
+                                                                ]
+                                                              ]
                                                             }
+                                                          }
+                                                        }
+                                                      ],
+                                                      "equivalences": [
+                                                        [
+                                                          {
+                                                            "Column": 0
                                                           },
-                                                          "inputs": [
+                                                          {
+                                                            "Column": 1
+                                                          }
+                                                        ]
+                                                      ],
+                                                      "implementation": "Unimplemented"
+                                                    }
+                                                  },
+                                                  "outputs": [
+                                                    0
+                                                  ]
+                                                }
+                                              },
+                                              {
+                                                "Constant": {
+                                                  "rows": {
+                                                    "Ok": [
+                                                      [
+                                                        {
+                                                          "data": [
+                                                            0
+                                                          ]
+                                                        },
+                                                        1
+                                                      ]
+                                                    ]
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "equivalences": [],
+                                            "implementation": "Unimplemented"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "body": {
+                                "Filter": {
+                                  "input": {
+                                    "Filter": {
+                                      "input": {
+                                        "Let": {
+                                          "id": 5,
+                                          "value": {
+                                            "Reduce": {
+                                              "input": {
+                                                "Get": {
+                                                  "id": {
+                                                    "Local": 4
+                                                  },
+                                                  "typ": {
+                                                    "column_types": [
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      },
+                                                      {
+                                                        "scalar_type": "Int32",
+                                                        "nullable": true
+                                                      }
+                                                    ],
+                                                    "keys": []
+                                                  }
+                                                }
+                                              },
+                                              "group_key": [
+                                                {
+                                                  "Column": 1
+                                                },
+                                                {
+                                                  "Column": 0
+                                                }
+                                              ],
+                                              "aggregates": [],
+                                              "monotonic": false,
+                                              "expected_group_size": null
+                                            }
+                                          },
+                                          "body": {
+                                            "Project": {
+                                              "input": {
+                                                "Join": {
+                                                  "inputs": [
+                                                    {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Local": 4
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
                                                             {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            },
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            }
+                                                          ],
+                                                          "keys": []
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Let": {
+                                                        "id": 7,
+                                                        "value": {
+                                                          "Let": {
+                                                            "id": 6,
+                                                            "value": {
                                                               "Reduce": {
                                                                 "input": {
+                                                                  "Join": {
+                                                                    "inputs": [
+                                                                      {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Local": 5
+                                                                          },
+                                                                          "typ": {
+                                                                            "column_types": [
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              },
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              }
+                                                                            ],
+                                                                            "keys": [
+                                                                              [
+                                                                                0,
+                                                                                1
+                                                                              ]
+                                                                            ]
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "Get": {
+                                                                          "id": {
+                                                                            "Global": {
+                                                                              "User": 1
+                                                                            }
+                                                                          },
+                                                                          "typ": {
+                                                                            "column_types": [
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              },
+                                                                              {
+                                                                                "scalar_type": "Int32",
+                                                                                "nullable": true
+                                                                              }
+                                                                            ],
+                                                                            "keys": []
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    ],
+                                                                    "equivalences": [],
+                                                                    "implementation": "Unimplemented"
+                                                                  }
+                                                                },
+                                                                "group_key": [
+                                                                  {
+                                                                    "Column": 0
+                                                                  },
+                                                                  {
+                                                                    "Column": 1
+                                                                  }
+                                                                ],
+                                                                "aggregates": [
+                                                                  {
+                                                                    "func": "MaxInt32",
+                                                                    "expr": {
+                                                                      "CallBinary": {
+                                                                        "func": "MulInt32",
+                                                                        "expr1": {
+                                                                          "Column": 1
+                                                                        },
+                                                                        "expr2": {
+                                                                          "Column": 2
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "distinct": false
+                                                                  }
+                                                                ],
+                                                                "monotonic": false,
+                                                                "expected_group_size": null
+                                                              }
+                                                            },
+                                                            "body": {
+                                                              "Union": {
+                                                                "base": {
                                                                   "Get": {
                                                                     "id": {
-                                                                      "Local": 5
+                                                                      "Local": 6
                                                                     },
                                                                     "typ": {
                                                                       "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        },
                                                                         {
                                                                           "scalar_type": "Int32",
                                                                           "nullable": true
@@ -8787,353 +8758,382 @@ FROM
                                                                     }
                                                                   }
                                                                 },
-                                                                "group_key": [
+                                                                "inputs": [
                                                                   {
-                                                                    "Column": 0
-                                                                  },
-                                                                  {
-                                                                    "Column": 1
-                                                                  }
-                                                                ],
-                                                                "aggregates": [],
-                                                                "monotonic": false,
-                                                                "expected_group_size": null
-                                                              }
-                                                            }
-                                                          ]
-                                                        }
-                                                      },
-                                                      {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 5
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": [
-                                                              [
-                                                                0,
-                                                                1
-                                                              ]
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    ],
-                                                    "equivalences": [
-                                                      [
-                                                        {
-                                                          "Column": 0
-                                                        },
-                                                        {
-                                                          "Column": 2
-                                                        }
-                                                      ],
-                                                      [
-                                                        {
-                                                          "Column": 1
-                                                        },
-                                                        {
-                                                          "Column": 3
-                                                        }
-                                                      ]
-                                                    ],
-                                                    "implementation": "Unimplemented"
-                                                  }
-                                                },
-                                                "outputs": [
-                                                  0,
-                                                  1
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "Constant": {
-                                                "rows": {
-                                                  "Ok": [
-                                                    [
-                                                      {
-                                                        "data": [
-                                                          0
-                                                        ]
-                                                      },
-                                                      1
-                                                    ]
-                                                  ]
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    }
-                                                  ],
-                                                  "keys": []
-                                                }
-                                              }
-                                            }
-                                          ],
-                                          "equivalences": [],
-                                          "implementation": "Unimplemented"
-                                        }
-                                      }
-                                    ]
-                                  }
-                                },
-                                "body": {
-                                  "Filter": {
-                                    "input": {
-                                      "Project": {
-                                        "input": {
-                                          "Join": {
-                                            "inputs": [
-                                              {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 1
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      },
-                                                      {
-                                                        "scalar_type": "Int32",
-                                                        "nullable": true
-                                                      }
-                                                    ],
-                                                    "keys": []
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "Filter": {
-                                                  "input": {
-                                                    "Filter": {
-                                                      "input": {
-                                                        "Project": {
-                                                          "input": {
-                                                            "Join": {
-                                                              "inputs": [
-                                                                {
-                                                                  "Get": {
-                                                                    "id": {
-                                                                      "Local": 4
-                                                                    },
-                                                                    "typ": {
-                                                                      "column_types": [
+                                                                    "Join": {
+                                                                      "inputs": [
                                                                         {
-                                                                          "scalar_type": "Int32",
-                                                                          "nullable": true
+                                                                          "Project": {
+                                                                            "input": {
+                                                                              "Join": {
+                                                                                "inputs": [
+                                                                                  {
+                                                                                    "Union": {
+                                                                                      "base": {
+                                                                                        "Negate": {
+                                                                                          "input": {
+                                                                                            "Reduce": {
+                                                                                              "input": {
+                                                                                                "Get": {
+                                                                                                  "id": {
+                                                                                                    "Local": 6
+                                                                                                  },
+                                                                                                  "typ": {
+                                                                                                    "column_types": [
+                                                                                                      {
+                                                                                                        "scalar_type": "Int32",
+                                                                                                        "nullable": true
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "scalar_type": "Int32",
+                                                                                                        "nullable": true
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "scalar_type": "Int32",
+                                                                                                        "nullable": true
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "keys": [
+                                                                                                      [
+                                                                                                        0,
+                                                                                                        1
+                                                                                                      ]
+                                                                                                    ]
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "group_key": [
+                                                                                                {
+                                                                                                  "Column": 0
+                                                                                                },
+                                                                                                {
+                                                                                                  "Column": 1
+                                                                                                }
+                                                                                              ],
+                                                                                              "aggregates": [],
+                                                                                              "monotonic": false,
+                                                                                              "expected_group_size": null
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "inputs": [
+                                                                                        {
+                                                                                          "Reduce": {
+                                                                                            "input": {
+                                                                                              "Get": {
+                                                                                                "id": {
+                                                                                                  "Local": 5
+                                                                                                },
+                                                                                                "typ": {
+                                                                                                  "column_types": [
+                                                                                                    {
+                                                                                                      "scalar_type": "Int32",
+                                                                                                      "nullable": true
+                                                                                                    },
+                                                                                                    {
+                                                                                                      "scalar_type": "Int32",
+                                                                                                      "nullable": true
+                                                                                                    }
+                                                                                                  ],
+                                                                                                  "keys": [
+                                                                                                    [
+                                                                                                      0,
+                                                                                                      1
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "group_key": [
+                                                                                              {
+                                                                                                "Column": 0
+                                                                                              },
+                                                                                              {
+                                                                                                "Column": 1
+                                                                                              }
+                                                                                            ],
+                                                                                            "aggregates": [],
+                                                                                            "monotonic": false,
+                                                                                            "expected_group_size": null
+                                                                                          }
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "Get": {
+                                                                                      "id": {
+                                                                                        "Local": 5
+                                                                                      },
+                                                                                      "typ": {
+                                                                                        "column_types": [
+                                                                                          {
+                                                                                            "scalar_type": "Int32",
+                                                                                            "nullable": true
+                                                                                          },
+                                                                                          {
+                                                                                            "scalar_type": "Int32",
+                                                                                            "nullable": true
+                                                                                          }
+                                                                                        ],
+                                                                                        "keys": [
+                                                                                          [
+                                                                                            0,
+                                                                                            1
+                                                                                          ]
+                                                                                        ]
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                ],
+                                                                                "equivalences": [
+                                                                                  [
+                                                                                    {
+                                                                                      "Column": 0
+                                                                                    },
+                                                                                    {
+                                                                                      "Column": 2
+                                                                                    }
+                                                                                  ],
+                                                                                  [
+                                                                                    {
+                                                                                      "Column": 1
+                                                                                    },
+                                                                                    {
+                                                                                      "Column": 3
+                                                                                    }
+                                                                                  ]
+                                                                                ],
+                                                                                "implementation": "Unimplemented"
+                                                                              }
+                                                                            },
+                                                                            "outputs": [
+                                                                              0,
+                                                                              1
+                                                                            ]
+                                                                          }
                                                                         },
                                                                         {
-                                                                          "scalar_type": "Int32",
-                                                                          "nullable": true
+                                                                          "Constant": {
+                                                                            "rows": {
+                                                                              "Ok": [
+                                                                                [
+                                                                                  {
+                                                                                    "data": [
+                                                                                      0
+                                                                                    ]
+                                                                                  },
+                                                                                  1
+                                                                                ]
+                                                                              ]
+                                                                            },
+                                                                            "typ": {
+                                                                              "column_types": [
+                                                                                {
+                                                                                  "scalar_type": "Int32",
+                                                                                  "nullable": true
+                                                                                }
+                                                                              ],
+                                                                              "keys": []
+                                                                            }
+                                                                          }
                                                                         }
                                                                       ],
-                                                                      "keys": []
+                                                                      "equivalences": [],
+                                                                      "implementation": "Unimplemented"
                                                                     }
                                                                   }
+                                                                ]
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "body": {
+                                                          "Filter": {
+                                                            "input": {
+                                                              "Get": {
+                                                                "id": {
+                                                                  "Local": 7
                                                                 },
-                                                                {
-                                                                  "Filter": {
-                                                                    "input": {
-                                                                      "Get": {
-                                                                        "id": {
-                                                                          "Local": 7
+                                                                "typ": {
+                                                                  "column_types": [
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    },
+                                                                    {
+                                                                      "scalar_type": "Int32",
+                                                                      "nullable": true
+                                                                    }
+                                                                  ],
+                                                                  "keys": []
+                                                                }
+                                                              }
+                                                            },
+                                                            "predicates": [
+                                                              {
+                                                                "CallVariadic": {
+                                                                  "func": "And",
+                                                                  "exprs": [
+                                                                    {
+                                                                      "CallBinary": {
+                                                                        "func": "Eq",
+                                                                        "expr1": {
+                                                                          "Column": 1
                                                                         },
-                                                                        "typ": {
-                                                                          "column_types": [
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            },
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            },
-                                                                            {
-                                                                              "scalar_type": "Int32",
-                                                                              "nullable": true
-                                                                            }
-                                                                          ],
-                                                                          "keys": []
+                                                                        "expr2": {
+                                                                          "Column": 0
                                                                         }
                                                                       }
                                                                     },
-                                                                    "predicates": [
-                                                                      {
-                                                                        "CallVariadic": {
-                                                                          "func": "And",
-                                                                          "exprs": [
+                                                                    {
+                                                                      "CallBinary": {
+                                                                        "func": "Gt",
+                                                                        "expr1": {
+                                                                          "Column": 2
+                                                                        },
+                                                                        "expr2": {
+                                                                          "Literal": [
                                                                             {
-                                                                              "CallBinary": {
-                                                                                "func": "Eq",
-                                                                                "expr1": {
-                                                                                  "Column": 1
-                                                                                },
-                                                                                "expr2": {
-                                                                                  "Column": 0
-                                                                                }
+                                                                              "Ok": {
+                                                                                "data": [
+                                                                                  4,
+                                                                                  5,
+                                                                                  0,
+                                                                                  0,
+                                                                                  0
+                                                                                ]
                                                                               }
                                                                             },
                                                                             {
-                                                                              "CallBinary": {
-                                                                                "func": "Gt",
-                                                                                "expr1": {
-                                                                                  "Column": 2
-                                                                                },
-                                                                                "expr2": {
-                                                                                  "Literal": [
-                                                                                    {
-                                                                                      "Ok": {
-                                                                                        "data": [
-                                                                                          4,
-                                                                                          5,
-                                                                                          0,
-                                                                                          0,
-                                                                                          0
-                                                                                        ]
-                                                                                      }
-                                                                                    },
-                                                                                    {
-                                                                                      "scalar_type": "Int32",
-                                                                                      "nullable": false
-                                                                                    }
-                                                                                  ]
-                                                                                }
-                                                                              }
+                                                                              "scalar_type": "Int32",
+                                                                              "nullable": false
                                                                             }
                                                                           ]
                                                                         }
                                                                       }
-                                                                    ]
-                                                                  }
+                                                                    }
+                                                                  ]
                                                                 }
-                                                              ],
-                                                              "equivalences": [
-                                                                [
-                                                                  {
-                                                                    "Column": 1
-                                                                  },
-                                                                  {
-                                                                    "Column": 2
-                                                                  }
-                                                                ],
-                                                                [
-                                                                  {
-                                                                    "Column": 0
-                                                                  },
-                                                                  {
-                                                                    "Column": 3
-                                                                  }
-                                                                ]
-                                                              ],
-                                                              "implementation": "Unimplemented"
-                                                            }
-                                                          },
-                                                          "outputs": [
-                                                            0,
-                                                            1,
-                                                            4
-                                                          ]
-                                                        }
-                                                      },
-                                                      "predicates": [
-                                                        {
-                                                          "Literal": [
-                                                            {
-                                                              "Ok": {
-                                                                "data": [
-                                                                  2
-                                                                ]
                                                               }
-                                                            },
-                                                            {
-                                                              "scalar_type": "Bool",
-                                                              "nullable": false
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    }
-                                                  },
-                                                  "predicates": [
-                                                    {
-                                                      "CallBinary": {
-                                                        "func": "NotEq",
-                                                        "expr1": {
-                                                          "Column": 0
-                                                        },
-                                                        "expr2": {
-                                                          "Column": 0
+                                                            ]
+                                                          }
                                                         }
                                                       }
                                                     }
-                                                  ]
+                                                  ],
+                                                  "equivalences": [
+                                                    [
+                                                      {
+                                                        "Column": 1
+                                                      },
+                                                      {
+                                                        "Column": 2
+                                                      }
+                                                    ],
+                                                    [
+                                                      {
+                                                        "Column": 0
+                                                      },
+                                                      {
+                                                        "Column": 3
+                                                      }
+                                                    ]
+                                                  ],
+                                                  "implementation": "Unimplemented"
                                                 }
-                                              }
-                                            ],
-                                            "equivalences": [
-                                              [
-                                                {
-                                                  "Column": 0
-                                                },
-                                                {
-                                                  "Column": 2
-                                                }
-                                              ]
-                                            ],
-                                            "implementation": "Unimplemented"
-                                          }
-                                        },
-                                        "outputs": [
-                                          0,
-                                          1,
-                                          3,
-                                          4
-                                        ]
-                                      }
-                                    },
-                                    "predicates": [
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                2
+                                              },
+                                              "outputs": [
+                                                0,
+                                                1,
+                                                4
                                               ]
                                             }
-                                          },
-                                          {
-                                            "scalar_type": "Bool",
-                                            "nullable": false
                                           }
-                                        ]
+                                        }
+                                      },
+                                      "predicates": [
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  2
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "Bool",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "predicates": [
+                                    {
+                                      "CallBinary": {
+                                        "func": "NotEq",
+                                        "expr1": {
+                                          "Column": 0
+                                        },
+                                        "expr2": {
+                                          "Column": 0
+                                        }
                                       }
-                                    ]
-                                  }
+                                    }
+                                  ]
                                 }
                               }
                             }
                           }
-                        }
+                        ],
+                        "equivalences": [
+                          [
+                            {
+                              "Column": 0
+                            },
+                            {
+                              "Column": 2
+                            }
+                          ]
+                        ],
+                        "implementation": "Unimplemented"
                       }
-                    }
+                    },
+                    "outputs": [
+                      0,
+                      1,
+                      3,
+                      4
+                    ]
                   }
                 }
               }
-            }
+            },
+            "predicates": [
+              {
+                "Literal": [
+                  {
+                    "Ok": {
+                      "data": [
+                        2
+                      ]
+                    }
+                  },
+                  {
+                    "scalar_type": "Bool",
+                    "nullable": false
+                  }
+                ]
+              }
+            ]
           }
         }
       }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -31,544 +31,544 @@ mode cockroach
 
 # Test constant error.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT 1 / 0
 ----
-Let // { subtree_size: 9 }
-  Project (#0) // { subtree_size: 3 }
-    Map ((1 / 0)) // { subtree_size: 2 }
-      Get l1 // { subtree_size: 1 }
-  Where
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - ()
-    l0 =
-      Constant // { subtree_size: 1 }
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Constant
         - ()
+Return
+  Project (#0)
+    Map ((1 / 0))
+      Get l1
 
 EOF
 
 # Test constant with two elements.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
-Let // { subtree_size: 52 }
-  Union // { subtree_size: 11 }
-    Project (#2, #3) // { subtree_size: 5 }
-      Project (#0..=#3) // { subtree_size: 4 }
-        Map (#1) // { subtree_size: 3 }
-          Map (#0) // { subtree_size: 2 }
-            Get l5 // { subtree_size: 1 }
-    Project (#2, #3) // { subtree_size: 5 }
-      Project (#0..=#3) // { subtree_size: 4 }
-        Map (#1) // { subtree_size: 3 }
-          Map (#0) // { subtree_size: 2 }
-            Get l7 // { subtree_size: 1 }
-  Where
-    l7 =
-      Project (#0, #1) // { subtree_size: 4 }
-        Map (4) // { subtree_size: 3 }
-          Map (3) // { subtree_size: 2 }
-            Get l6 // { subtree_size: 1 }
-    l6 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - ()
-    l5 =
-      Union // { subtree_size: 11 }
-        Project (#2, #3) // { subtree_size: 5 }
-          Project (#0..=#3) // { subtree_size: 4 }
-            Map (#1) // { subtree_size: 3 }
-              Map (#0) // { subtree_size: 2 }
-                Get l2 // { subtree_size: 1 }
-        Project (#2, #3) // { subtree_size: 5 }
-          Project (#0..=#3) // { subtree_size: 4 }
-            Map (#1) // { subtree_size: 3 }
-              Map (#0) // { subtree_size: 2 }
-                Get l4 // { subtree_size: 1 }
-    l4 =
-      Project (#0, #1) // { subtree_size: 4 }
-        Map (2) // { subtree_size: 3 }
-          Map (1) // { subtree_size: 2 }
-            Get l3 // { subtree_size: 1 }
-    l3 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - ()
-    l2 =
-      Project (#0, #1) // { subtree_size: 4 }
-        Map (2) // { subtree_size: 3 }
-          Map (1) // { subtree_size: 2 }
-            Get l1 // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - ()
-    l0 =
-      Constant // { subtree_size: 1 }
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Constant
         - ()
+  cte l2 =
+    Project (#0, #1)
+      Map (2)
+        Map (1)
+          Get l1
+  cte l3 =
+    CrossJoin
+      Get l0
+      Constant
+        - ()
+  cte l4 =
+    Project (#0, #1)
+      Map (2)
+        Map (1)
+          Get l3
+  cte l5 =
+    Union
+      Project (#2, #3)
+        Project (#0..=#3)
+          Map (#1)
+            Map (#0)
+              Get l2
+      Project (#2, #3)
+        Project (#0..=#3)
+          Map (#1)
+            Map (#0)
+              Get l4
+  cte l6 =
+    CrossJoin
+      Get l0
+      Constant
+        - ()
+  cte l7 =
+    Project (#0, #1)
+      Map (4)
+        Map (3)
+          Get l6
+Return
+  Union
+    Project (#2, #3)
+      Project (#0..=#3)
+        Map (#1)
+          Map (#0)
+            Get l5
+    Project (#2, #3)
+      Project (#0..=#3)
+        Map (#1)
+          Map (#0)
+            Get l7
 
 EOF
 
 # Test basic linear chains.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
 ----
-Let // { subtree_size: 12 }
-  Project (#2, #3) // { subtree_size: 5 }
-    Project (#0..=#3) // { subtree_size: 4 }
-      Map ((#0 + #1)) // { subtree_size: 3 }
-        Map (1) // { subtree_size: 2 }
-          Get l1 // { subtree_size: 1 }
-  Where
-    l1 =
-      Filter (((#0 > 0) AND (#1 < 0)) AND ((#0 + #1) > 0)) // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.mv // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    Filter (((#0 > 0) AND (#1 < 0)) AND ((#0 + #1) > 0))
+      CrossJoin
+        Get l0
+        Get materialize.public.mv
+Return
+  Project (#2, #3)
+    Project (#0..=#3)
+      Map ((#0 + #1))
+        Map (1)
+          Get l1
 
 EOF
 
 # Test table functions in the select clause (FlatMap).
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT generate_series(a, b) from t
 ----
-Let // { subtree_size: 10 }
-  Project (#2) // { subtree_size: 4 }
-    Filter true // { subtree_size: 3 }
-      FlatMap generate_series(#0, #1, 1) // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
-  Where
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+Return
+  Project (#2)
+    Filter true
+      FlatMap generate_series(#0, #1, 1)
+        Get l1
 
 EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
-Let // { subtree_size: 25 }
-  Threshold // { subtree_size: 13 }
-    Union // { subtree_size: 12 }
-      Distinct group_by=[#0] // { subtree_size: 5 }
-        Project (#1) // { subtree_size: 4 }
-          Project (#0, #1) // { subtree_size: 3 }
-            Map (#0) // { subtree_size: 2 }
-              Get l1 // { subtree_size: 1 }
-      Negate // { subtree_size: 6 }
-        Distinct group_by=[#0] // { subtree_size: 5 }
-          Project (#1) // { subtree_size: 4 }
-            Project (#0, #1) // { subtree_size: 3 }
-              Map (#0) // { subtree_size: 2 }
-                Get l2 // { subtree_size: 1 }
-  Where
-    l2 =
-      Project (#1) // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.mv // { subtree_size: 1 }
-    l1 =
-      Project (#0) // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    Project (#0)
+      CrossJoin
+        Get l0
+        Get materialize.public.t
+  cte l2 =
+    Project (#1)
+      CrossJoin
+        Get l0
+        Get materialize.public.mv
+Return
+  Threshold
+    Union
+      Distinct group_by=[#0]
+        Project (#1)
+          Project (#0, #1)
+            Map (#0)
+              Get l1
+      Negate
+        Distinct group_by=[#0]
+          Project (#1)
+            Project (#0, #1)
+              Map (#0)
+                Get l2
 
 EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
-Let // { subtree_size: 23 }
-  Threshold // { subtree_size: 11 }
-    Union // { subtree_size: 10 }
-      Project (#1) // { subtree_size: 4 }
-        Project (#0, #1) // { subtree_size: 3 }
-          Map (#0) // { subtree_size: 2 }
-            Get l1 // { subtree_size: 1 }
-      Negate // { subtree_size: 5 }
-        Project (#1) // { subtree_size: 4 }
-          Project (#0, #1) // { subtree_size: 3 }
-            Map (#0) // { subtree_size: 2 }
-              Get l2 // { subtree_size: 1 }
-  Where
-    l2 =
-      Project (#1) // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.mv // { subtree_size: 1 }
-    l1 =
-      Project (#0) // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    Project (#0)
+      CrossJoin
+        Get l0
+        Get materialize.public.t
+  cte l2 =
+    Project (#1)
+      CrossJoin
+        Get l0
+        Get materialize.public.mv
+Return
+  Threshold
+    Union
+      Project (#1)
+        Project (#0, #1)
+          Map (#0)
+            Get l1
+      Negate
+        Project (#1)
+          Project (#0, #1)
+            Map (#0)
+              Get l2
 
 EOF
 
 # Test TopK.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 VIEW ov
 ----
-Let // { subtree_size: 7 }
-  Project (#0, #1) // { subtree_size: 5 }
-    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false // { subtree_size: 4 }
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-  Where
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+Return
+  Project (#0, #1)
+    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
+      CrossJoin
+        Get l0
+        Get materialize.public.t
 
 EOF
 
 # Test Finish.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
-  Let // { subtree_size: 5 }
-    CrossJoin // { subtree_size: 3 }
-      Get l0 // { subtree_size: 1 }
-      Get materialize.public.t // { subtree_size: 1 }
-    Where
-      l0 =
-        Constant // { subtree_size: 1 }
-          - ()
+  With
+    cte l0 =
+      Constant
+        - ()
+  Return
+    CrossJoin
+      Get l0
+      Get materialize.public.t
 
 EOF
 
 # Test Reduce (global).
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
-Let // { subtree_size: 25 }
-  Project (#2) // { subtree_size: 4 }
-    Project (#0..=#2) // { subtree_size: 3 }
-      Map (abs((#0 - #1))) // { subtree_size: 2 }
-        Get l2 // { subtree_size: 1 }
-  Where
-    l2 =
-      Union // { subtree_size: 13 }
-        Get l1 // { subtree_size: 1 }
-        CrossJoin // { subtree_size: 11 }
-          Project () // { subtree_size: 9 }
-            CrossJoin // { subtree_size: 8 }
-              Union // { subtree_size: 6 }
-                Negate // { subtree_size: 3 }
-                  Distinct // { subtree_size: 2 }
-                    Get l1 // { subtree_size: 1 }
-                Distinct // { subtree_size: 2 }
-                  Get l0 // { subtree_size: 1 }
-              Get l0 // { subtree_size: 1 }
-          Constant // { subtree_size: 1 }
-            - (null, null)
-    l1 =
-      Reduce aggregates=[min(#0), max(#0)] // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    Reduce aggregates=[min(#0), max(#0)]
+      CrossJoin
+        Get l0
+        Get materialize.public.t
+  cte l2 =
+    Union
+      Get l1
+      CrossJoin
+        Project ()
+          CrossJoin
+            Union
+              Negate
+                Distinct
+                  Get l1
+              Distinct
+                Get l0
+            Get l0
+        Constant
+          - (null, null)
+Return
+  Project (#2)
+    Project (#0..=#2)
+      Map (abs((#0 - #1)))
+        Get l2
 
 EOF
 
 # Test Reduce (local).
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
-Let // { subtree_size: 15 }
-  Project (#3) // { subtree_size: 4 }
-    Project (#0..=#3) // { subtree_size: 3 }
-      Map (abs((#1 - #2))) // { subtree_size: 2 }
-        Get l2 // { subtree_size: 1 }
-  Where
-    l2 =
-      Reduce group_by=[#2] aggregates=[min(#0), max(#0)] // { subtree_size: 4 }
-        Project (#0..=#2) // { subtree_size: 3 }
-          Map (#1) // { subtree_size: 2 }
-            Get l1 // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    Reduce group_by=[#2] aggregates=[min(#0), max(#0)]
+      Project (#0..=#2)
+        Map (#1)
+          Get l1
+Return
+  Project (#3)
+    Project (#0..=#3)
+      Map (abs((#1 - #2)))
+        Get l2
 
 EOF
 
 # Test EXISTS subqueries.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
-Let // { subtree_size: 66 }
-  Project (#0, #1) // { subtree_size: 18 }
-    Filter #2 // { subtree_size: 17 }
-      Project (#0, #1, #3) // { subtree_size: 16 }
-        Join on=(#1 = #2) // { subtree_size: 15 }
-          Get l4 // { subtree_size: 1 }
-          Union // { subtree_size: 13 }
-            Get l6 // { subtree_size: 1 }
-            CrossJoin // { subtree_size: 11 }
-              Project (#0) // { subtree_size: 9 }
-                Join on=(#0 = #1) // { subtree_size: 8 }
-                  Union // { subtree_size: 6 }
-                    Negate // { subtree_size: 3 }
-                      Distinct group_by=[#0] // { subtree_size: 2 }
-                        Get l6 // { subtree_size: 1 }
-                    Distinct group_by=[#0] // { subtree_size: 2 }
-                      Get l5 // { subtree_size: 1 }
-                  Get l5 // { subtree_size: 1 }
-              Constant // { subtree_size: 1 }
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    Filter (true AND true)
+      CrossJoin
+        Get l0
+        Get materialize.public.t
+  cte l2 =
+    Distinct group_by=[#0]
+      Get l1
+  cte l3 =
+    CrossJoin
+      Distinct group_by=[#0]
+        Filter (#0 < #1)
+          CrossJoin
+            Get l2
+            Get materialize.public.mv
+      Constant
+        - (true)
+  cte l4 =
+    Project (#0, #1)
+      Filter #2
+        Project (#0, #1, #3)
+          Join on=(#0 = #2)
+            Get l1
+            Union
+              Get l3
+              CrossJoin
+                Project (#0)
+                  Join on=(#0 = #1)
+                    Union
+                      Negate
+                        Distinct group_by=[#0]
+                          Get l3
+                      Distinct group_by=[#0]
+                        Get l2
+                    Get l2
+                Constant
+                  - (false)
+  cte l5 =
+    Distinct group_by=[#1]
+      Get l4
+  cte l6 =
+    CrossJoin
+      Distinct group_by=[#0]
+        Filter (#0 > #2)
+          CrossJoin
+            Get l5
+            Get materialize.public.mv
+      Constant
+        - (true)
+Return
+  Project (#0, #1)
+    Filter #2
+      Project (#0, #1, #3)
+        Join on=(#1 = #2)
+          Get l4
+          Union
+            Get l6
+            CrossJoin
+              Project (#0)
+                Join on=(#0 = #1)
+                  Union
+                    Negate
+                      Distinct group_by=[#0]
+                        Get l6
+                    Distinct group_by=[#0]
+                      Get l5
+                  Get l5
+              Constant
                 - (false)
-  Where
-    l6 =
-      CrossJoin // { subtree_size: 7 }
-        Distinct group_by=[#0] // { subtree_size: 5 }
-          Filter (#0 > #2) // { subtree_size: 4 }
-            CrossJoin // { subtree_size: 3 }
-              Get l5 // { subtree_size: 1 }
-              Get materialize.public.mv // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - (true)
-    l5 =
-      Distinct group_by=[#1] // { subtree_size: 2 }
-        Get l4 // { subtree_size: 1 }
-    l4 =
-      Project (#0, #1) // { subtree_size: 18 }
-        Filter #2 // { subtree_size: 17 }
-          Project (#0, #1, #3) // { subtree_size: 16 }
-            Join on=(#0 = #2) // { subtree_size: 15 }
-              Get l1 // { subtree_size: 1 }
-              Union // { subtree_size: 13 }
-                Get l3 // { subtree_size: 1 }
-                CrossJoin // { subtree_size: 11 }
-                  Project (#0) // { subtree_size: 9 }
-                    Join on=(#0 = #1) // { subtree_size: 8 }
-                      Union // { subtree_size: 6 }
-                        Negate // { subtree_size: 3 }
-                          Distinct group_by=[#0] // { subtree_size: 2 }
-                            Get l3 // { subtree_size: 1 }
-                        Distinct group_by=[#0] // { subtree_size: 2 }
-                          Get l2 // { subtree_size: 1 }
-                      Get l2 // { subtree_size: 1 }
-                  Constant // { subtree_size: 1 }
-                    - (false)
-    l3 =
-      CrossJoin // { subtree_size: 7 }
-        Distinct group_by=[#0] // { subtree_size: 5 }
-          Filter (#0 < #1) // { subtree_size: 4 }
-            CrossJoin // { subtree_size: 3 }
-              Get l2 // { subtree_size: 1 }
-              Get materialize.public.mv // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - (true)
-    l2 =
-      Distinct group_by=[#0] // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
-    l1 =
-      Filter (true AND true) // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l0 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
 
 EOF
 
 # Test SELECT subqueries.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
-Let // { subtree_size: 86 }
-  Project (#2, #3) // { subtree_size: 38 }
-    Project (#0, #1, #8, #9) // { subtree_size: 37 }
-      Map (#7) // { subtree_size: 36 }
-        Map (#4) // { subtree_size: 35 }
-          Join on=(eq(#0, #2, #5) AND eq(#1, #3, #6)) // { subtree_size: 34 }
-            Get l1 // { subtree_size: 1 }
-            Project (#0, #1, #3) // { subtree_size: 16 }
-              Join on=(#1 = #2) // { subtree_size: 15 }
-                Get l2 // { subtree_size: 1 }
-                Union // { subtree_size: 13 }
-                  Get l5 // { subtree_size: 1 }
-                  CrossJoin // { subtree_size: 11 }
-                    Project (#0) // { subtree_size: 9 }
-                      Join on=(#0 = #1) // { subtree_size: 8 }
-                        Union // { subtree_size: 6 }
-                          Negate // { subtree_size: 3 }
-                            Distinct group_by=[#0] // { subtree_size: 2 }
-                              Get l5 // { subtree_size: 1 }
-                          Distinct group_by=[#0] // { subtree_size: 2 }
-                            Get l3 // { subtree_size: 1 }
-                        Get l3 // { subtree_size: 1 }
-                    Constant // { subtree_size: 1 }
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    Distinct group_by=[#0, #1]
+      Get l1
+  cte l3 =
+    Distinct group_by=[#1]
+      Get l2
+  cte l4 =
+    Project (#0, #1)
+      TopK group_by=[#0] limit=1 monotonic=false
+        Filter (#2 = #0)
+          CrossJoin
+            Get l3
+            Get materialize.public.v
+  cte l5 =
+    Union
+      Get l4
+      Map (error("more than one record produced in subquery"))
+        Project (#0)
+          Filter (#1 > 1)
+            Reduce group_by=[#0] aggregates=[count(true)]
+              Get l4
+  cte l6 =
+    Distinct group_by=[#0, #1]
+      Get l1
+  cte l7 =
+    Distinct group_by=[#1]
+      Get l6
+  cte l8 =
+    Project (#0, #1)
+      TopK group_by=[#0] limit=1 monotonic=false
+        Filter (#2 = #0)
+          CrossJoin
+            Get l7
+            Get materialize.public.mv
+  cte l9 =
+    Union
+      Get l8
+      Map (error("more than one record produced in subquery"))
+        Project (#0)
+          Filter (#1 > 1)
+            Reduce group_by=[#0] aggregates=[count(true)]
+              Get l8
+Return
+  Project (#2, #3)
+    Project (#0, #1, #8, #9)
+      Map (#7)
+        Map (#4)
+          Join on=(eq(#0, #2, #5) AND eq(#1, #3, #6))
+            Get l1
+            Project (#0, #1, #3)
+              Join on=(#1 = #2)
+                Get l2
+                Union
+                  Get l5
+                  CrossJoin
+                    Project (#0)
+                      Join on=(#0 = #1)
+                        Union
+                          Negate
+                            Distinct group_by=[#0]
+                              Get l5
+                          Distinct group_by=[#0]
+                            Get l3
+                        Get l3
+                    Constant
                       - (null)
-            Project (#0, #1, #3) // { subtree_size: 16 }
-              Join on=(#1 = #2) // { subtree_size: 15 }
-                Get l6 // { subtree_size: 1 }
-                Union // { subtree_size: 13 }
-                  Get l9 // { subtree_size: 1 }
-                  CrossJoin // { subtree_size: 11 }
-                    Project (#0) // { subtree_size: 9 }
-                      Join on=(#0 = #1) // { subtree_size: 8 }
-                        Union // { subtree_size: 6 }
-                          Negate // { subtree_size: 3 }
-                            Distinct group_by=[#0] // { subtree_size: 2 }
-                              Get l9 // { subtree_size: 1 }
-                          Distinct group_by=[#0] // { subtree_size: 2 }
-                            Get l7 // { subtree_size: 1 }
-                        Get l7 // { subtree_size: 1 }
-                    Constant // { subtree_size: 1 }
+            Project (#0, #1, #3)
+              Join on=(#1 = #2)
+                Get l6
+                Union
+                  Get l9
+                  CrossJoin
+                    Project (#0)
+                      Join on=(#0 = #1)
+                        Union
+                          Negate
+                            Distinct group_by=[#0]
+                              Get l9
+                          Distinct group_by=[#0]
+                            Get l7
+                        Get l7
+                    Constant
                       - (null)
-  Where
-    l9 =
-      Union // { subtree_size: 7 }
-        Get l8 // { subtree_size: 1 }
-        Map (error("more than one record produced in subquery")) // { subtree_size: 5 }
-          Project (#0) // { subtree_size: 4 }
-            Filter (#1 > 1) // { subtree_size: 3 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { subtree_size: 2 }
-                Get l8 // { subtree_size: 1 }
-    l8 =
-      Project (#0, #1) // { subtree_size: 6 }
-        TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
-          Filter (#2 = #0) // { subtree_size: 4 }
-            CrossJoin // { subtree_size: 3 }
-              Get l7 // { subtree_size: 1 }
-              Get materialize.public.mv // { subtree_size: 1 }
-    l7 =
-      Distinct group_by=[#1] // { subtree_size: 2 }
-        Get l6 // { subtree_size: 1 }
-    l6 =
-      Distinct group_by=[#0, #1] // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
-    l5 =
-      Union // { subtree_size: 7 }
-        Get l4 // { subtree_size: 1 }
-        Map (error("more than one record produced in subquery")) // { subtree_size: 5 }
-          Project (#0) // { subtree_size: 4 }
-            Filter (#1 > 1) // { subtree_size: 3 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { subtree_size: 2 }
-                Get l4 // { subtree_size: 1 }
-    l4 =
-      Project (#0, #1) // { subtree_size: 6 }
-        TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
-          Filter (#2 = #0) // { subtree_size: 4 }
-            CrossJoin // { subtree_size: 3 }
-              Get l3 // { subtree_size: 1 }
-              Get materialize.public.v // { subtree_size: 1 }
-    l3 =
-      Distinct group_by=[#1] // { subtree_size: 2 }
-        Get l2 // { subtree_size: 1 }
-    l2 =
-      Distinct group_by=[#0, #1] // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
 
 EOF
 
 # Test CrossJoin derived from a comma join without a predicate.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
-Let // { subtree_size: 18 }
-  Project (#0, #2) // { subtree_size: 2 }
-    Get l3 // { subtree_size: 1 }
-  Where
-    l3 =
-      Filter true // { subtree_size: 5 }
-        Project (#0..=#3) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l1 // { subtree_size: 1 }
-            Get l2 // { subtree_size: 1 }
-    l2 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l3 =
+    Filter true
+      Project (#0..=#3)
+        CrossJoin
+          Get l1
+          Get l2
+Return
+  Project (#0, #2)
+    Get l3
 
 EOF
 
 # Test CrossJoin derived from an INNER JOIN with a trivial ON clause.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
 ----
-Let // { subtree_size: 18 }
-  Project (#0, #2) // { subtree_size: 2 }
-    Get l3 // { subtree_size: 1 }
-  Where
-    l3 =
-      Filter true // { subtree_size: 5 }
-        Project (#0..=#3) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l1 // { subtree_size: 1 }
-            Get l2 // { subtree_size: 1 }
-    l2 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l3 =
+    Filter true
+      Project (#0..=#3)
+        CrossJoin
+          Get l1
+          Get l2
+Return
+  Project (#0, #2)
+    Get l3
 
 EOF
 
 # Test InnerJoin (comma syntax).
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a
 FROM
   t as t1,
@@ -576,196 +576,196 @@ FROM
   t as t3
 WHERE t1.b = t2.b AND t2.b = t3.b
 ----
-Let // { subtree_size: 31 }
-  Project (#0, #2) // { subtree_size: 3 }
-    Filter ((#1 = #3) AND (#3 = #5)) // { subtree_size: 2 }
-      Get l6 // { subtree_size: 1 }
-  Where
-    l6 =
-      Filter true // { subtree_size: 5 }
-        Project (#0..=#5) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l4 // { subtree_size: 1 }
-            Get l5 // { subtree_size: 1 }
-    l5 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l4 =
-      Get l3 // { subtree_size: 1 }
-    l3 =
-      Filter true // { subtree_size: 5 }
-        Project (#0..=#3) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l1 // { subtree_size: 1 }
-            Get l2 // { subtree_size: 1 }
-    l2 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l3 =
+    Filter true
+      Project (#0..=#3)
+        CrossJoin
+          Get l1
+          Get l2
+  cte l4 =
+    Get l3
+  cte l5 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l6 =
+    Filter true
+      Project (#0..=#5)
+        CrossJoin
+          Get l4
+          Get l5
+Return
+  Project (#0, #2)
+    Filter ((#1 = #3) AND (#3 = #5))
+      Get l6
 
 EOF
 
 # Test InnerJoin (ON syntax).
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a
 FROM t as t1
 INNER JOIN t as t2 ON t1.b = t2.b
 INNER JOIN t as t3 ON t2.b = t3.b
 ----
-Let // { subtree_size: 30 }
-  Project (#0, #2) // { subtree_size: 2 }
-    Get l6 // { subtree_size: 1 }
-  Where
-    l6 =
-      Filter (#3 = #5) // { subtree_size: 5 }
-        Project (#0..=#5) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l4 // { subtree_size: 1 }
-            Get l5 // { subtree_size: 1 }
-    l5 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l4 =
-      Get l3 // { subtree_size: 1 }
-    l3 =
-      Filter (#1 = #3) // { subtree_size: 5 }
-        Project (#0..=#3) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l1 // { subtree_size: 1 }
-            Get l2 // { subtree_size: 1 }
-    l2 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l3 =
+    Filter (#1 = #3)
+      Project (#0..=#3)
+        CrossJoin
+          Get l1
+          Get l2
+  cte l4 =
+    Get l3
+  cte l5 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l6 =
+    Filter (#3 = #5)
+      Project (#0..=#5)
+        CrossJoin
+          Get l4
+          Get l5
+Return
+  Project (#0, #2)
+    Get l6
 
 EOF
 
 # Test InnerJoin (ON syntax).
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a
 FROM t as t1
 LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
-Let // { subtree_size: 57 }
-  Project (#0, #2) // { subtree_size: 12 }
-    Union // { subtree_size: 11 }
-      Project (#2..=#5, #0, #1) // { subtree_size: 9 }
-        Map (null, null, null, null) // { subtree_size: 8 }
-          Union // { subtree_size: 7 }
-            Negate // { subtree_size: 5 }
-              Project (#0, #1) // { subtree_size: 4 }
-                Join on=(#1 = #2) // { subtree_size: 3 }
-                  Get l6 // { subtree_size: 1 }
-                  Get l8 // { subtree_size: 1 }
-            Get l6 // { subtree_size: 1 }
-      Get l7 // { subtree_size: 1 }
-  Where
-    l8 =
-      Distinct group_by=[#0] // { subtree_size: 3 }
-        Project (#3) // { subtree_size: 2 }
-          Get l7 // { subtree_size: 1 }
-    l7 =
-      Filter (#3 = #5) // { subtree_size: 5 }
-        Project (#0..=#5) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l5 // { subtree_size: 1 }
-            Get l6 // { subtree_size: 1 }
-    l6 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l5 =
-      Union // { subtree_size: 10 }
-        Map (null, null) // { subtree_size: 8 }
-          Union // { subtree_size: 7 }
-            Negate // { subtree_size: 5 }
-              Project (#0, #1) // { subtree_size: 4 }
-                Join on=(#1 = #2) // { subtree_size: 3 }
-                  Get l1 // { subtree_size: 1 }
-                  Get l4 // { subtree_size: 1 }
-            Get l1 // { subtree_size: 1 }
-        Get l3 // { subtree_size: 1 }
-    l4 =
-      Distinct group_by=[#0] // { subtree_size: 3 }
-        Project (#1) // { subtree_size: 2 }
-          Get l3 // { subtree_size: 1 }
-    l3 =
-      Filter (#1 = #3) // { subtree_size: 5 }
-        Project (#0..=#3) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l1 // { subtree_size: 1 }
-            Get l2 // { subtree_size: 1 }
-    l2 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l3 =
+    Filter (#1 = #3)
+      Project (#0..=#3)
+        CrossJoin
+          Get l1
+          Get l2
+  cte l4 =
+    Distinct group_by=[#0]
+      Project (#1)
+        Get l3
+  cte l5 =
+    Union
+      Map (null, null)
+        Union
+          Negate
+            Project (#0, #1)
+              Join on=(#1 = #2)
+                Get l1
+                Get l4
+          Get l1
+      Get l3
+  cte l6 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l7 =
+    Filter (#3 = #5)
+      Project (#0..=#5)
+        CrossJoin
+          Get l5
+          Get l6
+  cte l8 =
+    Distinct group_by=[#0]
+      Project (#3)
+        Get l7
+Return
+  Project (#0, #2)
+    Union
+      Project (#2..=#5, #0, #1)
+        Map (null, null, null, null)
+          Union
+            Negate
+              Project (#0, #1)
+                Join on=(#1 = #2)
+                  Get l6
+                  Get l8
+            Get l6
+      Get l7
 
 EOF
 
 # Test a single CTE.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
 ----
-Let // { subtree_size: 23 }
-  Project (#2) // { subtree_size: 4 }
-    Project (#0..=#2) // { subtree_size: 3 }
-      Map ((#0 + #1)) // { subtree_size: 2 }
-        Get l4 // { subtree_size: 1 }
-  Where
-    l4 =
-      Get l3 // { subtree_size: 1 }
-    l3 =
-      Filter true // { subtree_size: 5 }
-        Project (#0, #1) // { subtree_size: 4 }
-          CrossJoin // { subtree_size: 3 }
-            Get l2 // { subtree_size: 1 }
-            Get l2 // { subtree_size: 1 }
-    l2 =
-      Project (#2) // { subtree_size: 4 }
-        Project (#0..=#2) // { subtree_size: 3 }
-          Map ((#0 * #1)) // { subtree_size: 2 }
-            Get l1 // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    Project (#2)
+      Project (#0..=#2)
+        Map ((#0 * #1))
+          Get l1
+  cte l3 =
+    Filter true
+      Project (#0, #1)
+        CrossJoin
+          Get l2
+          Get l2
+  cte l4 =
+    Get l3
+Return
+  Project (#2)
+    Project (#0..=#2)
+      Map ((#0 + #1))
+        Get l4
 
 EOF
 
 # Test multiple CTEs: a case where we cannot pull the let statement up through
 # the join because the local l0 is correlated against the lhs of the enclosing join.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT
   *
 FROM
@@ -785,74 +785,74 @@ FROM
     SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
   ) as r5;
 ----
-Let // { subtree_size: 63 }
-  Filter true // { subtree_size: 6 }
-    Project (#0..=#2, #4) // { subtree_size: 5 }
-      Join on=(#0 = #3) // { subtree_size: 4 }
-        Get l5 // { subtree_size: 1 }
-        Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL)) // { subtree_size: 2 }
-          Get l8 // { subtree_size: 1 }
-  Where
-    l8 =
-      Union // { subtree_size: 13 }
-        Get l7 // { subtree_size: 1 }
-        CrossJoin // { subtree_size: 11 }
-          Project (#0) // { subtree_size: 9 }
-            Join on=(#0 = #1) // { subtree_size: 8 }
-              Union // { subtree_size: 6 }
-                Negate // { subtree_size: 3 }
-                  Distinct group_by=[#0] // { subtree_size: 2 }
-                    Get l7 // { subtree_size: 1 }
-                Distinct group_by=[#0] // { subtree_size: 2 }
-                  Get l6 // { subtree_size: 1 }
-              Get l6 // { subtree_size: 1 }
-          Constant // { subtree_size: 1 }
-            - (null)
-    l7 =
-      Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l6 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l6 =
-      Distinct group_by=[#0] // { subtree_size: 2 }
-        Get l5 // { subtree_size: 1 }
-    l5 =
-      Filter true // { subtree_size: 6 }
-        Project (#0, #1, #3) // { subtree_size: 5 }
-          Join on=(#0 = #2) // { subtree_size: 4 }
-            Get l1 // { subtree_size: 1 }
-            Filter (#1 != #0) // { subtree_size: 2 }
-              Get l4 // { subtree_size: 1 }
-    l4 =
-      Union // { subtree_size: 13 }
-        Get l3 // { subtree_size: 1 }
-        CrossJoin // { subtree_size: 11 }
-          Project (#0) // { subtree_size: 9 }
-            Join on=(#0 = #1) // { subtree_size: 8 }
-              Union // { subtree_size: 6 }
-                Negate // { subtree_size: 3 }
-                  Distinct group_by=[#0] // { subtree_size: 2 }
-                    Get l3 // { subtree_size: 1 }
-                Distinct group_by=[#0] // { subtree_size: 2 }
-                  Get l2 // { subtree_size: 1 }
-              Get l2 // { subtree_size: 1 }
-          Constant // { subtree_size: 1 }
-            - (null)
-    l3 =
-      Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l2 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l2 =
-      Distinct group_by=[#0] // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    Distinct group_by=[#0]
+      Get l1
+  cte l3 =
+    Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+      CrossJoin
+        Get l2
+        Get materialize.public.t
+  cte l4 =
+    Union
+      Get l3
+      CrossJoin
+        Project (#0)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct group_by=[#0]
+                  Get l3
+              Distinct group_by=[#0]
+                Get l2
+            Get l2
+        Constant
+          - (null)
+  cte l5 =
+    Filter true
+      Project (#0, #1, #3)
+        Join on=(#0 = #2)
+          Get l1
+          Filter (#1 != #0)
+            Get l4
+  cte l6 =
+    Distinct group_by=[#0]
+      Get l5
+  cte l7 =
+    Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+      CrossJoin
+        Get l6
+        Get materialize.public.t
+  cte l8 =
+    Union
+      Get l7
+      CrossJoin
+        Project (#0)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct group_by=[#0]
+                  Get l7
+              Distinct group_by=[#0]
+                Get l6
+            Get l6
+        Constant
+          - (null)
+Return
+  Filter true
+    Project (#0..=#2, #4)
+      Join on=(#0 = #3)
+        Get l5
+        Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
+          Get l8
 
 EOF
 
@@ -860,7 +860,7 @@ EOF
 # through the join because the local l0 is correlated against the lhs of
 # the enclosing join.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT
   *
 FROM
@@ -883,71 +883,71 @@ FROM
     WHERE a != r1.a
   ) as r5;
 ----
-Let // { subtree_size: 61 }
-  Filter true // { subtree_size: 11 }
-    Project (#0, #1, #3, #4) // { subtree_size: 10 }
-      Join on=(#0 = #2) // { subtree_size: 9 }
-        Get l1 // { subtree_size: 1 }
-        Filter (#0 != #0) // { subtree_size: 7 }
-          Filter true // { subtree_size: 6 }
-            Project (#0, #1, #4) // { subtree_size: 5 }
-              Join on=(#1 = #2 AND #0 = #3) // { subtree_size: 4 }
-                Get l4 // { subtree_size: 1 }
-                Filter ((#1 = #0) AND (#2 > 5)) // { subtree_size: 2 }
-                  Get l7 // { subtree_size: 1 }
-  Where
-    l7 =
-      Union // { subtree_size: 13 }
-        Get l6 // { subtree_size: 1 }
-        CrossJoin // { subtree_size: 11 }
-          Project (#0, #1) // { subtree_size: 9 }
-            Join on=(#0 = #2 AND #1 = #3) // { subtree_size: 8 }
-              Union // { subtree_size: 6 }
-                Negate // { subtree_size: 3 }
-                  Distinct group_by=[#0, #1] // { subtree_size: 2 }
-                    Get l6 // { subtree_size: 1 }
-                Distinct group_by=[#0, #1] // { subtree_size: 2 }
-                  Get l5 // { subtree_size: 1 }
-              Get l5 // { subtree_size: 1 }
-          Constant // { subtree_size: 1 }
-            - (null)
-    l6 =
-      Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))] // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l5 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l5 =
-      Distinct group_by=[#1, #0] // { subtree_size: 2 }
-        Get l4 // { subtree_size: 1 }
-    l4 =
-      Union // { subtree_size: 13 }
-        Get l3 // { subtree_size: 1 }
-        CrossJoin // { subtree_size: 11 }
-          Project (#0) // { subtree_size: 9 }
-            Join on=(#0 = #1) // { subtree_size: 8 }
-              Union // { subtree_size: 6 }
-                Negate // { subtree_size: 3 }
-                  Distinct group_by=[#0] // { subtree_size: 2 }
-                    Get l3 // { subtree_size: 1 }
-                Distinct group_by=[#0] // { subtree_size: 2 }
-                  Get l2 // { subtree_size: 1 }
-              Get l2 // { subtree_size: 1 }
-          Constant // { subtree_size: 1 }
-            - (null)
-    l3 =
-      Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { subtree_size: 4 }
-        CrossJoin // { subtree_size: 3 }
-          Get l2 // { subtree_size: 1 }
-          Get materialize.public.t // { subtree_size: 1 }
-    l2 =
-      Distinct group_by=[#0] // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
-    l1 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Get materialize.public.t // { subtree_size: 1 }
-    l0 =
-      Constant // { subtree_size: 1 }
-        - ()
+With
+  cte l0 =
+    Constant
+      - ()
+  cte l1 =
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+  cte l2 =
+    Distinct group_by=[#0]
+      Get l1
+  cte l3 =
+    Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+      CrossJoin
+        Get l2
+        Get materialize.public.t
+  cte l4 =
+    Union
+      Get l3
+      CrossJoin
+        Project (#0)
+          Join on=(#0 = #1)
+            Union
+              Negate
+                Distinct group_by=[#0]
+                  Get l3
+              Distinct group_by=[#0]
+                Get l2
+            Get l2
+        Constant
+          - (null)
+  cte l5 =
+    Distinct group_by=[#1, #0]
+      Get l4
+  cte l6 =
+    Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]
+      CrossJoin
+        Get l5
+        Get materialize.public.t
+  cte l7 =
+    Union
+      Get l6
+      CrossJoin
+        Project (#0, #1)
+          Join on=(#0 = #2 AND #1 = #3)
+            Union
+              Negate
+                Distinct group_by=[#0, #1]
+                  Get l6
+              Distinct group_by=[#0, #1]
+                Get l5
+            Get l5
+        Constant
+          - (null)
+Return
+  Filter true
+    Project (#0, #1, #3, #4)
+      Join on=(#0 = #2)
+        Get l1
+        Filter (#0 != #0)
+          Filter true
+            Project (#0, #1, #4)
+              Join on=(#1 = #2 AND #0 = #3)
+                Get l4
+                Filter ((#1 = #0) AND (#2 > 5))
+                  Get l7
 
 EOF

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -47,7 +47,7 @@ mode cockroach
 
 # Test constant error.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT 1 / 0
 ----
 {
@@ -78,7 +78,7 @@ EOF
 
 # Test constant with two elements.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
 {
@@ -148,7 +148,7 @@ EOF
 
 # Test basic linear chains (fast path).
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT 1, a + b as c FROM t WHERE a > 0 and b < 0 and a + b > 0
 ----
 {
@@ -316,7 +316,7 @@ EOF
 
 # Test basic linear chains (slow path).
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
 ----
 {
@@ -596,7 +596,7 @@ EOF
 
 # Test table functions in the select clause (FlatMap).
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT generate_series(a, b) from t
 ----
 {
@@ -672,7 +672,7 @@ EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
 {
@@ -812,7 +812,7 @@ EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 {
@@ -928,7 +928,7 @@ EOF
 
 # Test TopK.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 VIEW ov
 ----
 {
@@ -985,7 +985,7 @@ EOF
 
 # Test Finish.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 {
@@ -1022,7 +1022,7 @@ EOF
 
 # Test Reduce (global).
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
 {
@@ -1244,7 +1244,7 @@ EOF
 
 # Test Reduce (local).
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
 {
@@ -1339,7 +1339,7 @@ EOF
 
 # Test EXISTS subqueries.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 {
@@ -1803,7 +1803,7 @@ EOF
 
 # Test SELECT subqueries.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
 {
@@ -2516,7 +2516,7 @@ EOF
 
 # Test outer joins (ON syntax).
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT t1.a, t2.a
 FROM t as t1
 LEFT JOIN t as t2 ON t1.b = t2.b
@@ -2980,7 +2980,7 @@ EOF
 # Test multiple CTEs: a case where we cannot pull the let statement up through
 # the join because the local l0 is correlated against the lhs of the enclosing join.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT
   *
 FROM
@@ -3513,7 +3513,7 @@ EOF
 
 # Test cross join.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
 {
@@ -3622,7 +3622,7 @@ EOF
 
 # Test cyclic join.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT t1.a, t2.a
 FROM
   t as t1,
@@ -3859,7 +3859,7 @@ CREATE INDEX v_e_idx ON V(e);
 
 # Test a differential join.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT a, b, c, d, e, f
 FROM t, u, v
 WHERE a = c and d = e and b = f
@@ -4123,7 +4123,7 @@ CREATE INDEX t_b_idx ON T(b);
 
 # Test a delta join WITH.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS JSON FOR
+EXPLAIN OPTIMIZED PLAN WITH(raw) AS JSON FOR
 SELECT a, b, c, d, e, f
 FROM t, u, v
 WHERE b = c and d = e

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -196,7 +196,12 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Reduce aggregates=[min(#0), max(#0)]
+        Project (#0)
+          Get materialize.public.t
+  Return
     Project (#2)
       Map (abs((#0 - #1)))
         Union
@@ -208,11 +213,6 @@ Explained Query:
                   Get l0
               Constant
                 - ()
-    Where
-      l0 =
-        Reduce aggregates=[min(#0), max(#0)]
-          Project (#0)
-            Get materialize.public.t
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -241,7 +241,24 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Project (#0, #1)
+        Join on=(#0 = #2) type=delta
+          ArrangeBy keys=[[#0]]
+            Get materialize.public.t
+          ArrangeBy keys=[[#0]]
+            Distinct group_by=[#0]
+              Project (#0)
+                Filter (#0 < #1)
+                  CrossJoin type=differential
+                    ArrangeBy keys=[[]]
+                      Distinct group_by=[#0]
+                        Project (#0)
+                          Get materialize.public.t
+                    Project (#0)
+                      Get materialize.public.mv
+  Return
     Project (#0, #1)
       Join on=(#1 = #2) type=differential
         Get l0
@@ -256,23 +273,6 @@ Explained Query:
                         Get l0
                   Project (#1)
                     Get materialize.public.mv
-    Where
-      l0 =
-        Project (#0, #1)
-          Join on=(#0 = #2) type=delta
-            ArrangeBy keys=[[#0]]
-              Get materialize.public.t
-            ArrangeBy keys=[[#0]]
-              Distinct group_by=[#0]
-                Project (#0)
-                  Filter (#0 < #1)
-                    CrossJoin type=differential
-                      ArrangeBy keys=[[]]
-                        Distinct group_by=[#0]
-                          Project (#0)
-                            Get materialize.public.t
-                      Project (#0)
-                        Get materialize.public.mv
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -285,7 +285,31 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Project (#1)
+        Get materialize.public.t
+    cte l1 =
+      Distinct group_by=[#0]
+        Get l0
+    cte l2 =
+      ArrangeBy keys=[[#0]]
+        Get l1
+    cte l3 =
+      TopK group_by=[#0] limit=1 monotonic=false
+        Project (#0, #1)
+          Join on=(#0 = #2) type=differential
+            Get l2
+            Filter (#1) IS NOT NULL
+              Get materialize.public.iv
+    cte l4 =
+      TopK group_by=[#0] limit=1 monotonic=false
+        Project (#0, #1)
+          Join on=(#0 = #2) type=differential
+            Get l2
+            Filter (#1) IS NOT NULL
+              Get materialize.public.mv
+  Return
     Project (#2, #4)
       Join on=(eq(#0, #1, #3)) type=differential
         Get l0
@@ -307,30 +331,6 @@ Explained Query:
                   Project (#0)
                     Get l4
                 Get l1
-    Where
-      l4 =
-        TopK group_by=[#0] limit=1 monotonic=false
-          Project (#0, #1)
-            Join on=(#0 = #2) type=differential
-              Get l2
-              Filter (#1) IS NOT NULL
-                Get materialize.public.mv
-      l3 =
-        TopK group_by=[#0] limit=1 monotonic=false
-          Project (#0, #1)
-            Join on=(#0 = #2) type=differential
-              Get l2
-              Filter (#1) IS NOT NULL
-                Get materialize.public.iv
-      l2 =
-        ArrangeBy keys=[[#0]]
-          Get l1
-      l1 =
-        Distinct group_by=[#0]
-          Get l0
-      l0 =
-        Project (#1)
-          Get materialize.public.t
 
 Source materialize.public.mv
   filter=((#1) IS NOT NULL)
@@ -350,7 +350,21 @@ LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Filter (#1) IS NOT NULL
+        Get materialize.public.t
+    cte l1 =
+      ArrangeBy keys=[[#1]]
+        Get l0
+    cte l2 =
+      Project (#0..=#2)
+        Join on=(eq(#1, #3, #4)) type=differential
+          Get l1
+          Get l1
+          Project (#1)
+            Get l0
+  Return
     Union
       Map (null, null)
         Union
@@ -367,20 +381,6 @@ Explained Query:
             Get materialize.public.t
       Project (#0, #2)
         Get l2
-    Where
-      l2 =
-        Project (#0..=#2)
-          Join on=(eq(#1, #3, #4)) type=differential
-            Get l1
-            Get l1
-            Project (#1)
-              Get l0
-      l1 =
-        ArrangeBy keys=[[#1]]
-          Get l0
-      l0 =
-        Filter (#1) IS NOT NULL
-          Get materialize.public.t
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -393,18 +393,18 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Project (#2)
+        Map ((#0 * #1))
+          Get materialize.public.t
+  Return
     Project (#2)
       Map ((#0 + #1))
         CrossJoin type=differential
           ArrangeBy keys=[[]]
             Get l0
           Get l0
-    Where
-      l0 =
-        Project (#2)
-          Map ((#0 * #1))
-            Get materialize.public.t
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -435,7 +435,24 @@ FROM
   ) as r5;
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Project (#0)
+        Get materialize.public.t
+    cte l1 =
+      Project (#0, #1, #3)
+        Filter (#0 != #3)
+          Join on=(#0 = #2) type=delta
+            ArrangeBy keys=[[#0]]
+              Get materialize.public.t
+            ArrangeBy keys=[[#0]]
+              Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Distinct group_by=[#0]
+                      Get l0
+                  Get l0
+  Return
     Project (#0..=#2, #4)
       Filter ((#0 != #4) OR ((#4) IS NOT NULL AND (#0) IS NULL))
         Join on=(#0 = #3) type=differential
@@ -448,23 +465,6 @@ Explained Query:
                     Project (#0)
                       Get l1
                 Get l0
-    Where
-      l1 =
-        Project (#0, #1, #3)
-          Filter (#0 != #3)
-            Join on=(#0 = #2) type=delta
-              ArrangeBy keys=[[#0]]
-                Get materialize.public.t
-              ArrangeBy keys=[[#0]]
-                Reduce group_by=[#0] aggregates=[max((#0 * #1))]
-                  CrossJoin type=differential
-                    ArrangeBy keys=[[]]
-                      Distinct group_by=[#0]
-                        Get l0
-                    Get l0
-      l0 =
-        Project (#0)
-          Get materialize.public.t
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -477,15 +477,15 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Project (#0)
+        Get materialize.public.t
+  Return
     CrossJoin type=differential
       ArrangeBy keys=[[]]
         Get l0
       Get l0
-    Where
-      l0 =
-        Project (#0)
-          Get materialize.public.t
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -503,20 +503,20 @@ FROM
 WHERE t1.b = t2.b AND t2.b = t3.b
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Filter (#1) IS NOT NULL
+        Get materialize.public.t
+    cte l1 =
+      ArrangeBy keys=[[#1]]
+        Get l0
+  Return
     Project (#0, #2)
       Join on=(eq(#1, #3, #4)) type=differential
         Get l1
         Get l1
         Project (#1)
           Get l0
-    Where
-      l1 =
-        ArrangeBy keys=[[#1]]
-          Get l0
-      l0 =
-        Filter (#1) IS NOT NULL
-          Get materialize.public.t
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -570,16 +570,16 @@ WHERE a = c and d = e and b = f
 Explained Query:
   Project (#0, #1, #0, #3, #3, #1)
     Filter (#0) IS NOT NULL
-      Filter #0 = #2 AND #1 = #5 AND #3 = #4
-        LinearJoin using=[#0, #1]
-          ArrangeBy keys=[[#0, #1]]
-            Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
-              Get materialize.public.v
-          LinearJoin using=[#0]
-            ArrangeBy keys=[[#0]]
-              Get materialize.public.t
-            ArrangeBy keys=[[#0]]
-              Get materialize.public.u
+      Join on=(#0 = #2 AND #1 = #5 AND #3 = #4) type=differential
+        implementation
+          %1 » %0 using [#0] » %2 using [#0, #1]
+        ArrangeBy keys=[[#0]]
+          Get materialize.public.t
+        ArrangeBy keys=[[#0]]
+          Get materialize.public.u
+        ArrangeBy keys=[[#0, #1]]
+          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+            Get materialize.public.v
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -629,32 +629,17 @@ WHERE b = c and d = e
 Explained Query:
   Project (#0, #1, #1, #3, #3, #5)
     Filter (#1) IS NOT NULL AND (#3) IS NOT NULL
-      Filter #1 = #2 AND #3 = #4
-        Union
-          HalfJoin using=[#0]
-            ArrangeBy keys=[[#0]]
-              Get materialize.public.v
-            HalfJoin using=[#0]
-              ArrangeBy keys=[[#0], [#1]]
-                Get materialize.public.u
-              ArrangeBy keys=[[#1]]
-                Get materialize.public.t
-          HalfJoin using=[#0]
-            ArrangeBy keys=[[#0]]
-              Get materialize.public.v
-            HalfJoin using=[#1]
-              ArrangeBy keys=[[#1]]
-                Get materialize.public.t
-              ArrangeBy keys=[[#0], [#1]]
-                Get materialize.public.u
-          HalfJoin using=[#1]
-            ArrangeBy keys=[[#1]]
-              Get materialize.public.t
-            HalfJoin using=[#1]
-              ArrangeBy keys=[[#0], [#1]]
-                Get materialize.public.u
-              ArrangeBy keys=[[#0]]
-                Get materialize.public.v
+      Join on=(#1 = #2 AND #3 = #4) type=delta
+        implementation
+          %0 » %1 using [#0] » %2 using [#0]
+          %1 » %0 using [#1] » %2 using [#0]
+          %2 » %1 using [#1] » %0 using [#1]
+        ArrangeBy keys=[[#1]]
+          Get materialize.public.t
+        ArrangeBy keys=[[#0], [#1]]
+          Get materialize.public.u
+        ArrangeBy keys=[[#0]]
+          Get materialize.public.v
 
 Used Indexes:
   - materialize.public.u_c_idx
@@ -704,9 +689,13 @@ GROUP BY a
 Explained Query:
   Reduce group_by=[#0] aggregates=[max(#1)]
     Project (#0, #1)
-      Lookup (#0 = 0 AND #1 = 1) OR (#0 = 3 AND #1 = 4) OR (#0 = 7 AND #1 = 8)
+      Join on=(#0 = #2 AND #1 = #3) type=indexed_filter
         ArrangeBy keys=[[#0, #1]]
           Get materialize.public.t
+        Constant
+          - (0, 1)
+          - (3, 4)
+          - (7, 8)
 
 Used Indexes:
   - materialize.public.t_a_b_idx

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -179,7 +179,22 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
 (SELECT x + 1 FROM cte UNION ALL SELECT x - 1 FROM cte)
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
+        ArrangeBy
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=() }
+          Union
+            Get::Arrangement materialize.public.t
+              project=(#0)
+              key=#0
+              raw=false
+              arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+            Negate
+              Get::Collection materialize.public.mv
+                raw=true
+  Return
     Union
       Get::Arrangement l0
         project=(#1)
@@ -193,21 +208,6 @@ Explained Query:
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-    Where
-      l0 =
-        Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
-          ArrangeBy
-            raw=false
-            arrangements[0]={ key=[#0], permutation=id, thinning=() }
-            Union
-              Get::Arrangement materialize.public.t
-                project=(#0)
-                key=#0
-                raw=false
-                arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-              Negate
-                Get::Collection materialize.public.mv
-                  raw=true
 
 Source materialize.public.mv
   project=(#1)
@@ -327,7 +327,21 @@ SELECT
 FROM t
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, sum(#0))
+        distinct_aggrs[0]=(1, 1, count(distinct #0))
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+  Return
     Union
       ArrangeBy
         input_key=[]
@@ -347,20 +361,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-    Where
-      l0 =
-        Reduce::Accumulable
-          simple_aggrs[0]=(0, 0, sum(#0))
-          distinct_aggrs[0]=(1, 1, count(distinct #0))
-          val_plan
-            project=(#0, #0)
-          key_plan
-            project=()
-          Get::Arrangement materialize.public.t
-            project=(#1)
-            key=#0
-            raw=false
-            arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -405,7 +405,22 @@ SELECT
 FROM t
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Reduce::Hierarchical
+        aggr_funcs=[min, max]
+        skips=[0, 0]
+        buckets=[0, 0]
+        val_plan
+          project=(#0, #0)
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+  Return
     Union
       ArrangeBy
         input_key=[]
@@ -425,21 +440,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-    Where
-      l0 =
-        Reduce::Hierarchical
-          aggr_funcs=[min, max]
-          skips=[0, 0]
-          buckets=[0, 0]
-          val_plan
-            project=(#0, #0)
-          key_plan
-            project=()
-          Get::Arrangement materialize.public.t
-            project=(#1)
-            key=#0
-            raw=false
-            arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -484,7 +484,22 @@ SELECT
 FROM t
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Reduce::Basic
+        aggrs[0]=(0, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
+        aggrs[1]=(1, string_agg(row(row((integer_to_text(#0) || "2"), ","))))
+        val_plan
+          project=(#2, #3)
+          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+  Return
     Union
       ArrangeBy
         input_key=[]
@@ -504,21 +519,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-    Where
-      l0 =
-        Reduce::Basic
-          aggrs[0]=(0, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
-          aggrs[1]=(1, string_agg(row(row((integer_to_text(#0) || "2"), ","))))
-          val_plan
-            project=(#2, #3)
-            map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-          key_plan
-            project=()
-          Get::Arrangement materialize.public.t
-            project=(#1)
-            key=#0
-            raw=false
-            arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -580,7 +580,31 @@ SELECT
 FROM t
 ----
 Explained Query:
-  Let
+  With
+    cte l0 =
+      Reduce::Collation
+        aggregate_types=[a, b, h, h, a, b]
+        accumulable
+          simple_aggrs[0]=(1, 4, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
+        hierarchical
+          aggr_funcs=[min, max]
+          skips=[2, 0]
+          buckets=[2, 0]
+        basic
+          aggrs[0]=(1, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
+          aggrs[1]=(5, string_agg(row(row((integer_to_text(#0) || "2"), ","))))
+        val_plan
+          project=(#0, #2, #0, #0, #0, #3)
+          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+  Return
     Union
       ArrangeBy
         input_key=[]
@@ -600,30 +624,6 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
           Constant
             - ()
-    Where
-      l0 =
-        Reduce::Collation
-          aggregate_types=[a, b, h, h, a, b]
-          accumulable
-            simple_aggrs[0]=(1, 4, sum(#0))
-            distinct_aggrs[0]=(0, 0, count(distinct #0))
-          hierarchical
-            aggr_funcs=[min, max]
-            skips=[2, 0]
-            buckets=[2, 0]
-          basic
-            aggrs[0]=(1, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
-            aggrs[1]=(5, string_agg(row(row((integer_to_text(#0) || "2"), ","))))
-          val_plan
-            project=(#0, #2, #0, #0, #0, #3)
-            map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-          key_plan
-            project=()
-          Get::Arrangement materialize.public.t
-            project=(#1)
-            key=#0
-            raw=false
-            arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -156,16 +156,16 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
-Let
+With
+  cte l2 =
+    Filter (#^1 > #1)
+      Get materialize.public.mv
+  cte l1 =
+    Filter (#^0 < #0)
+      Get materialize.public.mv
+Return
   Filter (exists(Get l1) AND exists(Get l2))
     Get materialize.public.t
-  Where
-    l1 =
-      Filter (#^0 < #0)
-        Get materialize.public.mv
-    l2 =
-      Filter (#^1 > #1)
-        Get materialize.public.mv
 
 EOF
 
@@ -175,20 +175,20 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
 Project (#2, #3)
-  Let
+  With
+    cte l2 =
+      Project (#0)
+        TopK limit=1
+          Filter (#1 = #^1)
+            Get materialize.public.mv
+    cte l1 =
+      Project (#0)
+        TopK limit=1
+          Filter (#1 = #^1)
+            Get materialize.public.v
+  Return
     Map (select(Get l1), select(Get l2))
       Get materialize.public.t
-    Where
-      l1 =
-        Project (#0)
-          TopK limit=1
-            Filter (#1 = #^1)
-              Get materialize.public.v
-      l2 =
-        Project (#0)
-          TopK limit=1
-            Filter (#1 = #^1)
-              Get materialize.public.mv
 
 EOF
 
@@ -276,14 +276,14 @@ EXPLAIN RAW PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
 ----
 Project (#1)
-  Let
+  With
+    cte l0 =
+      Project (#2)
+        Map ((#0 * #1))
+          Get materialize.public.t
+  Return
     Map ((#0 + 5))
       Get l0
-    Where
-      l0 =
-        Project (#2)
-          Map ((#0 * #1))
-            Get materialize.public.t
 
 EOF
 
@@ -292,18 +292,18 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 WITH A AS (SELECT 1 AS a), B as (SELECT a as b FROM A WHERE a > 0) SELECT * FROM A, B;
 ----
-Let
+With
+  cte l0 =
+    Map (1)
+      Constant
+        - ()
+  cte l1 =
+    Filter (#0 > 0)
+      Get l0
+Return
   CrossJoin
     Get l0
     Get l1
-  Where
-    l1 =
-      Filter (#0 > 0)
-        Get l0
-    l0 =
-      Map (1)
-        Constant
-          - ()
 
 EOF
 
@@ -333,20 +333,20 @@ FROM
 CrossJoin
   CrossJoin
     Get materialize.public.t
-    Let
-      Filter (#0 != #^0)
-        Get l0
-      Where
-        l0 =
-          Reduce aggregates=[max((#^0 * #0))]
-            Get materialize.public.t
-  Let
-    Filter ((#0 != #^0) OR ((#0) IS NOT NULL AND (#^0) IS NULL))
-      Get l0
-    Where
-      l0 =
+    With
+      cte l0 =
         Reduce aggregates=[max((#^0 * #0))]
           Get materialize.public.t
+    Return
+      Filter (#0 != #^0)
+        Get l0
+  With
+    cte l0 =
+      Reduce aggregates=[max((#^0 * #0))]
+        Get materialize.public.t
+  Return
+    Filter ((#0 != #^0) OR ((#0) IS NOT NULL AND (#^0) IS NULL))
+      Get l0
 
 EOF
 
@@ -379,20 +379,20 @@ FROM
 ----
 CrossJoin
   Get materialize.public.t
-  Let
+  With
+    cte l0 =
+      Reduce aggregates=[max((#^0 * #0))]
+        Get materialize.public.t
+  Return
     Filter (#^0 != #^0)
       CrossJoin
         Get l0
-        Let
+        With
+          cte l1 =
+            Reduce aggregates=[max((#^^0 * #0))]
+              Get materialize.public.t
+        Return
           Filter ((#^^0 = #^0) AND (#0 > 5))
             Get l1
-          Where
-            l1 =
-              Reduce aggregates=[max((#^^0 * #0))]
-                Get materialize.public.t
-    Where
-      l0 =
-        Reduce aggregates=[max((#^0 * #0))]
-          Get materialize.public.t
 
 EOF


### PR DESCRIPTION
Opening a separate PR so we can interactively address Frank's concerns regarding `EXPLAIN AS TEXT` output details. 

This is an alternative to #15119. Only one of the two should be merged.

### Motivation

  * This PR adds a known-desirable feature.

This should close #13297.

### Tips for reviewer

@frankmcsherry: since @ggevay is also using the syntax and has reviewed the previous PRs I'm mostly interested in your approval.

The changes introduced in this PR are as follows:

- [x] Old-style `join_impls`.
  - I suggest to move back to the more compact join implementation blocks for MIR plans.
  - These will be rendered if `join_impls` is requested in the `WITH` options. If this option is not present, the plan will only emit the join type `type=differential`, `type=delta` (the main reason for not having those as default is that they might look scary for regular users).
- [x] Rendering of `Let` blocks:
  - Use `With ... Return ...` as opposed to `Let ... In ...` when rendering `Let` blocks.
  - Prefix let bindings with `cte`.
  - Render let bindings before the body.
- [x] Linear chains in `EXPLAIN AS TEXT` as is available as an optional `linear_chains` toggle.
  - In this mode, new `Let` / `Get` bindings are introduced in non-trivial inputs of `Union` and `Join`, so that rendered tree fragments can only be linear chains.
  - This currently works only for MIR plans. It can also be implemented for `LIR` and `HIR`, but this needs further discussion and planning.
  - The current tree-based output is still the default.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes (the new `EXPLAIN ... AS TEXT` output format is not public yet).
