### PR TITLE
adapter: segment: send org_id as context.groupId

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -268,8 +268,10 @@ impl<S: Append + 'static> Coordinator<S> {
                     event_type,
                     json!({
                         "event_source": "environmentd",
-                        "organization_id": user_metadata.group_id,
                         "details": event.event_details.as_json(),
+                    }),
+                    json!({
+                        "groupId": user_metadata.group_id,
                     }),
                 );
             }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -270,9 +270,9 @@ impl<S: Append + 'static> Coordinator<S> {
                         "event_source": "environmentd",
                         "details": event.event_details.as_json(),
                     }),
-                    json!({
+                    Some(json!({
                         "groupId": user_metadata.group_id,
-                    }),
+                    })),
                 );
             }
         }

--- a/src/segment/src/lib.rs
+++ b/src/segment/src/lib.rs
@@ -62,8 +62,13 @@ impl Client {
     /// logged but not returned.
     ///
     /// [track event]: https://segment.com/docs/connections/spec/track/
-    pub fn track<S>(&self, user_id: Uuid, event: S, properties: serde_json::Value)
-    where
+    pub fn track<S>(
+        &self,
+        user_id: Uuid,
+        event: S,
+        properties: serde_json::Value,
+        context: Option<serde_json::Value>,
+    ) where
         S: Into<String>,
     {
         let message = BatchMessage::Track(Track {
@@ -72,6 +77,7 @@ impl Client {
             },
             event: event.into(),
             properties,
+            context,
             ..Default::default()
         });
         match self.tx.try_send(message) {


### PR DESCRIPTION
Segment [recommends](https://segment.com/docs/connections/spec/b2b-saas/) linking users to organizations (groups) by setting context.groupId in track calls. 
Enable the [context](https://docs.rs/segment/latest/segment/message/struct.Track.html#structfield.context) field in our segment client and set it for the audit events we send to segment.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/cloud/issues/4134

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a

