### PR TITLE
sql: check all timestamps for a valid range

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -173,7 +173,7 @@ impl CatalogState {
                 Datum::UInt64(replica_id),
                 Datum::Int64(process_id),
                 Datum::String(status),
-                Datum::TimestampTz(event.time),
+                Datum::TimestampTz(event.time.try_into().expect("must fit")),
             ]),
             diff,
         }
@@ -769,7 +769,7 @@ impl CatalogState {
                     Some(user) => Datum::String(user),
                     None => Datum::Null,
                 },
-                Datum::TimestampTz(DateTime::from_utc(dt, Utc)),
+                Datum::TimestampTz(DateTime::from_utc(dt, Utc).try_into().expect("must fit")),
             ]),
             diff: 1,
         })
@@ -783,7 +783,10 @@ impl CatalogState {
     ) -> BuiltinTableUpdate {
         let ReplicaMetadata { last_heartbeat } = md;
         let table = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_HEARTBEATS);
-        let row = Row::pack_slice(&[Datum::UInt64(id), Datum::TimestampTz(last_heartbeat)]);
+        let row = Row::pack_slice(&[
+            Datum::UInt64(id),
+            Datum::TimestampTz(last_heartbeat.try_into().expect("must fit")),
+        ]);
         BuiltinTableUpdate {
             id: table,
             row,
@@ -813,7 +816,7 @@ impl CatalogState {
             Datum::UInt64(id),
             object_id_val,
             Datum::UInt64(size_bytes),
-            Datum::TimestampTz(DateTime::from_utc(dt, Utc)),
+            Datum::TimestampTz(DateTime::from_utc(dt, Utc).try_into().expect("must fit")),
         ]);
         let diff = 1;
         Ok(BuiltinTableUpdate {

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -633,7 +633,10 @@ fn eval_unmaterializable_func(
                     .collect(),
             )
         }
-        UnmaterializableFunc::CurrentTimestamp => pack(Datum::from(session.pcx().wall_time)),
+        UnmaterializableFunc::CurrentTimestamp => {
+            let t: Datum = session.pcx().wall_time.try_into()?;
+            pack(t)
+        }
         UnmaterializableFunc::CurrentUser => pack(Datum::from(&*session.user().name)),
         UnmaterializableFunc::MzEnvironmentId => pack(Datum::from(&*state.config().environment_id)),
         UnmaterializableFunc::MzNow => match logical_time {
@@ -653,7 +656,10 @@ fn eval_unmaterializable_func(
             pack(Datum::Int32(state.config().build_info.version_num()))
         }
         UnmaterializableFunc::PgBackendPid => pack(Datum::Int32(session.conn_id() as i32)),
-        UnmaterializableFunc::PgPostmasterStartTime => pack(Datum::from(state.config().start_time)),
+        UnmaterializableFunc::PgPostmasterStartTime => {
+            let t: Datum = state.config().start_time.try_into()?;
+            pack(t)
+        }
         UnmaterializableFunc::Version => {
             let build_info = state.config().build_info;
             let version = format!(

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use std::num::TryFromIntError;
 
 use dec::TryFromDecimalError;
+use mz_repr::adt::timestamp::TimestampError;
 use tokio::sync::oneshot;
 
 use mz_compute_client::controller::ComputeError;
@@ -536,6 +537,13 @@ impl From<StorageError> for AdapterError {
 impl From<ComputeError> for AdapterError {
     fn from(e: ComputeError) -> Self {
         AdapterError::Compute(e)
+    }
+}
+
+impl From<TimestampError> for AdapterError {
+    fn from(e: TimestampError) -> Self {
+        let e: EvalError = e.into();
+        e.into()
     }
 }
 

--- a/src/avro/src/error.rs
+++ b/src/avro/src/error.rs
@@ -24,6 +24,7 @@
 use crate::types::ScalarKind;
 use crate::{util::TsUnit, ParseSchemaError, SchemaResolutionError};
 
+use chrono::NaiveDateTime;
 use fmt::{Debug, Display};
 use std::fmt;
 
@@ -94,6 +95,7 @@ pub enum DecodeError {
         actual: [u8; 16],
     },
     DateOutOfRange(i32),
+    TimestampOutOfRange(NaiveDateTime),
     Custom(String),
 }
 
@@ -175,6 +177,9 @@ impl DecodeError {
                 actual, expected
             ),
             DecodeError::DateOutOfRange(inner) => write!(f, "Date out of range: {}", inner),
+            DecodeError::TimestampOutOfRange(inner) => {
+                write!(f, "Timestamp out of range: {}", inner)
+            }
         }
     }
 }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -11,12 +11,11 @@
 
 use std::fmt;
 use std::iter;
+use std::ops::Deref;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use dec::OrderedDecimal;
 use itertools::Itertools;
-use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
-use mz_repr::adt::date::Date;
 use num::{CheckedAdd, Integer, Signed};
 use ordered_float::OrderedFloat;
 use proptest::prelude::{Arbitrary, Just};
@@ -28,10 +27,14 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::ArrayDimension;
+use mz_repr::adt::date::Date;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::numeric::{self, NumericMaxScale};
 use mz_repr::adt::regex::Regex as ReprRegex;
+use mz_repr::adt::timestamp::CheckedTimestamp;
+use mz_repr::adt::timestamp::TimestampLike;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, RelationType, Row, RowArena, ScalarType};
 
 use crate::relation::{
@@ -209,7 +212,7 @@ fn max_timestamp<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    let x: Option<NaiveDateTime> = datums
+    let x: Option<CheckedTimestamp<NaiveDateTime>> = datums
         .into_iter()
         .filter(|d| !d.is_null())
         .map(|d| d.unwrap_timestamp())
@@ -221,7 +224,7 @@ fn max_timestamptz<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    let x: Option<DateTime<Utc>> = datums
+    let x: Option<CheckedTimestamp<DateTime<Utc>>> = datums
         .into_iter()
         .filter(|d| !d.is_null())
         .map(|d| d.unwrap_timestamptz())
@@ -391,7 +394,7 @@ fn min_timestamp<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    let x: Option<NaiveDateTime> = datums
+    let x: Option<CheckedTimestamp<NaiveDateTime>> = datums
         .into_iter()
         .filter(|d| !d.is_null())
         .map(|d| d.unwrap_timestamp())
@@ -403,7 +406,7 @@ fn min_timestamptz<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    let x: Option<DateTime<Utc>> = datums
+    let x: Option<CheckedTimestamp<DateTime<Utc>>> = datums
         .into_iter()
         .filter(|d| !d.is_null())
         .map(|d| d.unwrap_timestamptz())
@@ -1885,28 +1888,29 @@ where
 /// [`num::range_step_inclusive`](https://github.com/rust-num/num-iter/blob/ddb14c1e796d401014c6c7a727de61d8109ad986/src/lib.rs#L279),
 /// but for our timestamp types using [`Interval`] for `step`.xwxw
 #[derive(Clone)]
-pub struct TimestampRangeStepInclusive {
-    state: NaiveDateTime,
-    stop: NaiveDateTime,
+pub struct TimestampRangeStepInclusive<T> {
+    state: CheckedTimestamp<T>,
+    stop: CheckedTimestamp<T>,
     step: Interval,
     rev: bool,
     done: bool,
 }
 
-impl Iterator for TimestampRangeStepInclusive {
-    type Item = NaiveDateTime;
+impl<T: TimestampLike> Iterator for TimestampRangeStepInclusive<T> {
+    type Item = CheckedTimestamp<T>;
 
     #[inline]
-    fn next(&mut self) -> Option<NaiveDateTime> {
+    fn next(&mut self) -> Option<CheckedTimestamp<T>> {
         if !self.done
             && ((self.rev && self.state >= self.stop) || (!self.rev && self.state <= self.stop))
         {
             let result = self.state.clone();
-            match add_timestamp_months(self.state, self.step.months) {
+            match add_timestamp_months(self.state.deref(), self.step.months) {
                 Ok(state) => match state.checked_add_signed(self.step.duration_as_chrono()) {
-                    Some(v) => {
-                        self.state = v;
-                    }
+                    Some(v) => match CheckedTimestamp::from_timestamplike(v) {
+                        Ok(v) => self.state = v,
+                        Err(_) => self.done = true,
+                    },
                     None => self.done = true,
                 },
                 Err(..) => {
@@ -1921,11 +1925,11 @@ impl Iterator for TimestampRangeStepInclusive {
     }
 }
 
-fn generate_series_ts(
-    start: NaiveDateTime,
-    stop: NaiveDateTime,
+fn generate_series_ts<T: TimestampLike>(
+    start: CheckedTimestamp<T>,
+    stop: CheckedTimestamp<T>,
     step: Interval,
-    conv: fn(NaiveDateTime) -> Datum<'static>,
+    conv: fn(CheckedTimestamp<T>) -> Datum<'static>,
 ) -> Result<impl Iterator<Item = (Row, Diff)>, EvalError> {
     let normalized_step = step.as_microseconds();
     if normalized_step == 0 {
@@ -2294,7 +2298,7 @@ impl TableFunc {
                 Ok(Box::new(res))
             }
             TableFunc::GenerateSeriesTimestamp => {
-                fn pass_through<'a>(d: NaiveDateTime) -> Datum<'a> {
+                fn pass_through<'a>(d: CheckedTimestamp<NaiveDateTime>) -> Datum<'a> {
                     Datum::from(d)
                 }
                 let res = generate_series_ts(
@@ -2306,12 +2310,12 @@ impl TableFunc {
                 Ok(Box::new(res))
             }
             TableFunc::GenerateSeriesTimestampTz => {
-                fn gen_ts_tz<'a>(d: NaiveDateTime) -> Datum<'a> {
-                    Datum::from(DateTime::<Utc>::from_utc(d, Utc))
+                fn gen_ts_tz<'a>(d: CheckedTimestamp<DateTime<Utc>>) -> Datum<'a> {
+                    Datum::from(d)
                 }
                 let res = generate_series_ts(
-                    datums[0].unwrap_timestamptz().naive_utc(),
-                    datums[1].unwrap_timestamptz().naive_utc(),
+                    datums[0].unwrap_timestamptz(),
+                    datums[1].unwrap_timestamptz(),
                     datums[2].unwrap_interval(),
                     gen_ts_tz,
                 )?;

--- a/src/expr/src/scalar/func/format.rs
+++ b/src/expr/src/scalar/func/format.rs
@@ -873,10 +873,10 @@ impl DateTimeFormat {
     /// Renders the format string using the timestamp `ts` as the input. The
     /// placeholders in the format string will be filled in appropriately
     /// according to the value of `ts`.
-    pub fn render(&self, ts: impl TimestampLike) -> String {
+    pub fn render(&self, ts: &impl TimestampLike) -> String {
         let mut out = String::new();
         for node in &self.0 {
-            node.render(&mut out, &ts)
+            node.render(&mut out, ts)
                 .expect("rendering to string cannot fail");
         }
         out

--- a/src/expr/src/scalar/func/impls/mz_timestamp.rs
+++ b/src/expr/src/scalar/func/impls/mz_timestamp.rs
@@ -10,7 +10,10 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 
 use mz_ore::result::ResultExt;
-use mz_repr::{adt::numeric::Numeric, strconv, Timestamp};
+use mz_repr::{
+    adt::{numeric::Numeric, timestamp::CheckedTimestamp},
+    strconv, Timestamp,
+};
 
 use crate::EvalError;
 
@@ -80,7 +83,9 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_tz_to_mz_timestamp"]
-    fn cast_timestamp_tz_to_mz_timestamp(a: DateTime<Utc>) -> Result<Timestamp, EvalError> {
+    fn cast_timestamp_tz_to_mz_timestamp(
+        a: CheckedTimestamp<DateTime<Utc>>,
+    ) -> Result<Timestamp, EvalError> {
         a.timestamp_millis()
             .try_into()
             .map_err(|_| EvalError::MzTimestampOutOfRange)
@@ -89,7 +94,9 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_to_mz_timestamp"]
-    fn cast_timestamp_to_mz_timestamp(a: NaiveDateTime) -> Result<Timestamp, EvalError> {
+    fn cast_timestamp_to_mz_timestamp(
+        a: CheckedTimestamp<NaiveDateTime>,
+    ) -> Result<Timestamp, EvalError> {
         a.timestamp_millis()
             .try_into()
             .map_err(|_| EvalError::MzTimestampOutOfRange)

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -12,6 +12,7 @@ use std::fmt;
 
 use chrono::{DateTime, NaiveDateTime, NaiveTime, Utc};
 use mz_repr::adt::date::Date;
+use mz_repr::adt::timestamp::CheckedTimestamp;
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -166,14 +167,18 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_timestamp"]
-    fn cast_string_to_timestamp<'a>(a: &'a str) -> Result<NaiveDateTime, EvalError> {
+    fn cast_string_to_timestamp<'a>(
+        a: &'a str,
+    ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
         strconv::parse_timestamp(a).err_into()
     }
 );
 
 sqlfunc!(
     #[sqlname = "text_to_timestamp_with_time_zone"]
-    fn cast_string_to_timestamp_tz<'a>(a: &'a str) -> Result<DateTime<Utc>, EvalError> {
+    fn cast_string_to_timestamp_tz<'a>(
+        a: &'a str,
+    ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
         strconv::parse_timestamptz(a).err_into()
     }
 );

--- a/src/expr/src/scalar/func/impls/time.rs
+++ b/src/expr/src/scalar/func/impls/time.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 use chrono::{NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike};
 use mz_repr::adt::datetime::DateTimeField;
+use mz_repr::adt::timestamp::TimeLike;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -22,45 +23,6 @@ use mz_repr::{strconv, ColumnType, ScalarType};
 
 use crate::scalar::func::EagerUnaryFunc;
 use crate::EvalError;
-
-/// Common set of methods for time component.
-pub trait TimeLike: chrono::Timelike {
-    fn extract_epoch<T>(&self) -> T
-    where
-        T: DecimalLike,
-    {
-        T::from(self.hour() * 60 * 60 + self.minute() * 60) + self.extract_second::<T>()
-    }
-
-    fn extract_second<T>(&self) -> T
-    where
-        T: DecimalLike,
-    {
-        let s = T::from(self.second());
-        let ns = T::from(self.nanosecond()) / T::from(1e9);
-        s + ns
-    }
-
-    fn extract_millisecond<T>(&self) -> T
-    where
-        T: DecimalLike,
-    {
-        let s = T::from(self.second() * 1_000);
-        let ns = T::from(self.nanosecond()) / T::from(1e6);
-        s + ns
-    }
-
-    fn extract_microsecond<T>(&self) -> T
-    where
-        T: DecimalLike,
-    {
-        let s = T::from(self.second() * 1_000_000);
-        let ns = T::from(self.nanosecond()) / T::from(1e3);
-        s + ns
-    }
-}
-
-impl<T> TimeLike for T where T: chrono::Timelike {}
 
 sqlfunc!(
     #[sqlname = "time_to_text"]

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -47,7 +47,7 @@ macro_rules! sqlfunc {
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
-        fn $fn_name:ident<$lt:lifetime>(mut $param_name:ident: $input_ty:ty) -> $output_ty:ty
+        fn $fn_name:ident<$lt:lifetime>(mut $param_name:ident: $input_ty:ty $(,)?) -> $output_ty:ty
             $body:block
     ) => {
         sqlfunc!(
@@ -63,7 +63,7 @@ macro_rules! sqlfunc {
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
-        fn $fn_name:ident<$lt:lifetime>($param_name:ident: $input_ty:ty) -> $output_ty:ty
+        fn $fn_name:ident<$lt:lifetime>($param_name:ident: $input_ty:ty $(,)?) -> $output_ty:ty
             $body:block
     ) => {
         paste::paste! {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -9,6 +9,7 @@
 
 use itertools::Itertools;
 use mz_repr::adt::date::DateError;
+use mz_repr::adt::timestamp::TimestampError;
 use std::collections::HashSet;
 use std::fmt;
 use std::mem;
@@ -2137,6 +2138,14 @@ impl From<DateError> for EvalError {
     fn from(e: DateError) -> EvalError {
         match e {
             DateError::OutOfRange => EvalError::DateOutOfRange,
+        }
+    }
+}
+
+impl From<TimestampError> for EvalError {
+    fn from(e: TimestampError) -> EvalError {
+        match e {
+            TimestampError::OutOfRange => EvalError::TimestampOutOfRange,
         }
     }
 }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -31,6 +31,8 @@ fn is_null(schema: &SchemaPieceOrNamed) -> bool {
 mod tests {
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
     use mz_repr::adt::date::Date;
+    use mz_repr::adt::timestamp::CheckedTimestamp;
+
     use ordered_float::OrderedFloat;
 
     use mz_avro::types::{DecimalValue, Value};
@@ -115,12 +117,15 @@ mod tests {
             ),
             (
                 ScalarType::Timestamp,
-                Datum::Timestamp(date_time),
+                Datum::Timestamp(CheckedTimestamp::from_timestamplike(date_time).unwrap()),
                 Value::Timestamp(date_time),
             ),
             (
                 ScalarType::TimestampTz,
-                Datum::TimestampTz(DateTime::from_utc(date_time, Utc)),
+                Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(DateTime::from_utc(date_time, Utc))
+                        .unwrap(),
+                ),
                 Value::Timestamp(date_time),
             ),
             (

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -316,8 +316,8 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                     i64::from(time.num_seconds_from_midnight()) * 1_000_000
                         + i64::from(time.nanosecond()) / 1_000
                 }),
-                ScalarType::Timestamp => Value::Timestamp(datum.unwrap_timestamp()),
-                ScalarType::TimestampTz => Value::Timestamp(datum.unwrap_timestamptz().naive_utc()),
+                ScalarType::Timestamp => Value::Timestamp(datum.unwrap_timestamp().to_naive()),
+                ScalarType::TimestampTz => Value::Timestamp(datum.unwrap_timestamptz().to_naive()),
                 // SQL intervals and Avro durations differ quite a lot (signed
                 // vs unsigned, different int sizes), so SQL intervals are their
                 // own bespoke type.

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -135,11 +135,11 @@ impl ToJson for TypedDatum<'_> {
                 ScalarType::Time => serde_json::Value::String(format!("{:?}", datum.unwrap_time())),
                 ScalarType::Timestamp => serde_json::Value::String(format!(
                     "{:?}",
-                    datum.unwrap_timestamp().timestamp_millis()
+                    datum.unwrap_timestamp().to_naive().timestamp_millis()
                 )),
                 ScalarType::TimestampTz => serde_json::Value::String(format!(
                     "{:?}",
-                    datum.unwrap_timestamptz().timestamp_millis()
+                    datum.unwrap_timestamptz().to_naive().timestamp_millis()
                 )),
                 ScalarType::Interval => {
                     serde_json::Value::String(format!("{}", datum.unwrap_interval()))

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -12,6 +12,7 @@
 //! These test utilities are relied by crates other than `repr`.
 
 use chrono::NaiveDateTime;
+use mz_repr::adt::timestamp::CheckedTimestamp;
 use proc_macro2::TokenTree;
 
 use mz_lowertest::deserialize_optional_generic;
@@ -76,9 +77,13 @@ where
                     } else {
                         NaiveDateTime::parse_from_str(litval, "\"%Y-%m-%d %H:%M:%S\"")
                     };
-                    Ok(Datum::from(datetime.map_err(|e| {
-                        format!("Error while parsing NaiveDateTime: {}", e)
-                    })?))
+                    Ok(Datum::from(
+                        CheckedTimestamp::from_timestamplike(
+                            datetime
+                                .map_err(|e| format!("Error while parsing NaiveDateTime: {}", e))?,
+                        )
+                        .unwrap(),
+                    ))
                 }
                 _ => Err(format!("Unsupported literal type {:?}", littyp)),
             }

--- a/src/repr-test-util/tests/testdata/datum
+++ b/src/repr-test-util/tests/testdata/datum
@@ -96,12 +96,12 @@ Numeric(OrderedDecimal(5.2))
 build-datum
 "2021-01-02 00:12:59" timestamp
 ----
-Timestamp(2021-01-02T00:12:59)
+Timestamp(CheckedTimestamp { t: 2021-01-02T00:12:59 })
 
 build-datum
 "1999-12-31 23:42:23.342" timestamp
 ----
-Timestamp(1999-12-31T23:42:23.342)
+Timestamp(CheckedTimestamp { t: 1999-12-31T23:42:23.342 })
 
 build-datum
 2 (list jsonb (user 100))

--- a/src/repr-test-util/tests/testdata/row
+++ b/src/repr-test-util/tests/testdata/row
@@ -14,7 +14,7 @@ Int32(1)
 Numeric(OrderedDecimal(1))
 Float32(OrderedFloat(2.0))
 String("\"quoted\" string")
-Timestamp(2022-10-20T21:34:54)
+Timestamp(CheckedTimestamp { t: 2022-10-20T21:34:54 })
 
 build-row
 ["string" 1 2.1 true false null]

--- a/src/repr/src/adt.rs
+++ b/src/repr/src/adt.rs
@@ -26,4 +26,5 @@ pub mod jsonb;
 pub mod numeric;
 pub mod regex;
 pub mod system;
+pub mod timestamp;
 pub mod varchar;

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -1,0 +1,587 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Methods for checked timestamp operations.
+
+use std::fmt::Display;
+use std::ops::Sub;
+
+use ::chrono::{DateTime, Duration, NaiveDateTime, NaiveTime, Utc};
+use ::chrono::{Datelike, NaiveDate};
+use once_cell::sync::Lazy;
+use serde::{Serialize, Serializer};
+use thiserror::Error;
+
+use mz_proto::{RustType, TryFromProtoError};
+
+use crate::chrono::ProtoNaiveDateTime;
+use crate::Datum;
+
+use super::numeric::DecimalLike;
+
+include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.date.rs"));
+
+/// Common set of methods for time component.
+pub trait TimeLike: chrono::Timelike {
+    fn extract_epoch<T>(&self) -> T
+    where
+        T: DecimalLike,
+    {
+        T::from(self.hour() * 60 * 60 + self.minute() * 60) + self.extract_second::<T>()
+    }
+
+    fn extract_second<T>(&self) -> T
+    where
+        T: DecimalLike,
+    {
+        let s = T::from(self.second());
+        let ns = T::from(self.nanosecond()) / T::from(1e9);
+        s + ns
+    }
+
+    fn extract_millisecond<T>(&self) -> T
+    where
+        T: DecimalLike,
+    {
+        let s = T::from(self.second() * 1_000);
+        let ns = T::from(self.nanosecond()) / T::from(1e6);
+        s + ns
+    }
+
+    fn extract_microsecond<T>(&self) -> T
+    where
+        T: DecimalLike,
+    {
+        let s = T::from(self.second() * 1_000_000);
+        let ns = T::from(self.nanosecond()) / T::from(1e3);
+        s + ns
+    }
+}
+
+impl<T> TimeLike for T where T: chrono::Timelike {}
+
+/// Common set of methods for date component.
+pub trait DateLike: chrono::Datelike {
+    fn extract_epoch(&self) -> i64 {
+        let naive_date =
+            NaiveDate::from_ymd(self.year(), self.month(), self.day()).and_hms(0, 0, 0);
+        naive_date.timestamp()
+    }
+
+    fn millennium(&self) -> i32 {
+        (self.year() + if self.year() > 0 { 999 } else { -1_000 }) / 1_000
+    }
+
+    fn century(&self) -> i32 {
+        (self.year() + if self.year() > 0 { 99 } else { -100 }) / 100
+    }
+
+    fn decade(&self) -> i32 {
+        self.year().div_euclid(10)
+    }
+
+    fn quarter(&self) -> f64 {
+        (f64::from(self.month()) / 3.0).ceil()
+    }
+
+    /// Extract the iso week of the year
+    ///
+    /// Note that because isoweeks are defined in terms of January 4th, Jan 1 is only in week
+    /// 1 about half of the time
+    fn iso_week_number(&self) -> u32 {
+        self.iso_week().week()
+    }
+
+    fn day_of_week(&self) -> u32 {
+        self.weekday().num_days_from_sunday()
+    }
+
+    fn iso_day_of_week(&self) -> u32 {
+        self.weekday().number_from_monday()
+    }
+}
+
+impl<T> DateLike for T where T: chrono::Datelike {}
+
+/// A timestamp with both a date and a time component, but not necessarily a
+/// timezone component.
+pub trait TimestampLike:
+    Clone
+    + PartialOrd
+    + std::ops::Add<Duration, Output = Self>
+    + std::ops::Sub<Duration, Output = Self>
+    + std::ops::Sub<Output = Duration>
+    + for<'a> TryInto<Datum<'a>, Error = TimestampError>
+    + for<'a> TryFrom<Datum<'a>, Error = ()>
+    + TimeLike
+    + DateLike
+{
+    fn new(date: NaiveDate, time: NaiveTime) -> Self;
+
+    /// Returns the weekday as a `usize` between 0 and 6, where 0 represents
+    /// Sunday and 6 represents Saturday.
+    fn weekday0(&self) -> usize {
+        self.weekday().num_days_from_sunday() as usize
+    }
+
+    /// Like [`chrono::Datelike::year_ce`], but works on the ISO week system.
+    fn iso_year_ce(&self) -> u32 {
+        let year = self.iso_week().year();
+        if year < 1 {
+            (1 - year) as u32
+        } else {
+            year as u32
+        }
+    }
+
+    fn timestamp(&self) -> i64;
+
+    fn timestamp_subsec_micros(&self) -> u32;
+
+    fn extract_epoch<T>(&self) -> T
+    where
+        T: DecimalLike,
+    {
+        T::lossy_from(self.timestamp()) + T::from(self.timestamp_subsec_micros()) / T::from(1e6)
+    }
+
+    fn truncate_microseconds(&self) -> Self {
+        let time = NaiveTime::from_hms_micro(
+            self.hour(),
+            self.minute(),
+            self.second(),
+            self.nanosecond() / 1_000,
+        );
+
+        Self::new(self.date(), time)
+    }
+
+    fn truncate_milliseconds(&self) -> Self {
+        let time = NaiveTime::from_hms_milli(
+            self.hour(),
+            self.minute(),
+            self.second(),
+            self.nanosecond() / 1_000_000,
+        );
+
+        Self::new(self.date(), time)
+    }
+
+    fn truncate_second(&self) -> Self {
+        let time = NaiveTime::from_hms(self.hour(), self.minute(), self.second());
+
+        Self::new(self.date(), time)
+    }
+
+    fn truncate_minute(&self) -> Self {
+        Self::new(
+            self.date(),
+            NaiveTime::from_hms(self.hour(), self.minute(), 0),
+        )
+    }
+
+    fn truncate_hour(&self) -> Self {
+        Self::new(self.date(), NaiveTime::from_hms(self.hour(), 0, 0))
+    }
+
+    fn truncate_day(&self) -> Self {
+        Self::new(self.date(), NaiveTime::from_hms(0, 0, 0))
+    }
+
+    fn truncate_week(&self) -> Result<Self, TimestampError> {
+        let num_days_from_monday = self.date().weekday().num_days_from_monday() as i64;
+        let new_date = NaiveDate::from_ymd(self.year(), self.month(), self.day())
+            .checked_sub_signed(Duration::days(num_days_from_monday))
+            .ok_or(TimestampError::OutOfRange)?;
+        Ok(Self::new(new_date, NaiveTime::from_hms(0, 0, 0)))
+    }
+
+    fn truncate_month(&self) -> Self {
+        Self::new(
+            NaiveDate::from_ymd(self.year(), self.month(), 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    fn truncate_quarter(&self) -> Self {
+        let month = self.month();
+        let quarter = if month <= 3 {
+            1
+        } else if month <= 6 {
+            4
+        } else if month <= 9 {
+            7
+        } else {
+            10
+        };
+
+        Self::new(
+            NaiveDate::from_ymd(self.year(), quarter, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    fn truncate_year(&self) -> Self {
+        Self::new(
+            NaiveDate::from_ymd(self.year(), 1, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+    fn truncate_decade(&self) -> Self {
+        Self::new(
+            NaiveDate::from_ymd(self.year() - self.year().rem_euclid(10), 1, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+    fn truncate_century(&self) -> Self {
+        // Expects the first year of the century, meaning 2001 instead of 2000.
+        Self::new(
+            NaiveDate::from_ymd(
+                if self.year() > 0 {
+                    self.year() - (self.year() - 1) % 100
+                } else {
+                    self.year() - self.year() % 100 - 99
+                },
+                1,
+                1,
+            ),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+    fn truncate_millennium(&self) -> Self {
+        // Expects the first year of the millennium, meaning 2001 instead of 2000.
+        Self::new(
+            NaiveDate::from_ymd(
+                if self.year() > 0 {
+                    self.year() - (self.year() - 1) % 1000
+                } else {
+                    self.year() - self.year() % 1000 - 999
+                },
+                1,
+                1,
+            ),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    /// Return the date component of the timestamp
+    fn date(&self) -> NaiveDate;
+
+    /// Return the date and time of the timestamp
+    fn date_time(&self) -> NaiveDateTime;
+
+    /// Return the date and time of the timestamp
+    fn from_date_time(dt: NaiveDateTime) -> Self;
+
+    /// Returns a string representing the timezone's offset from UTC.
+    fn timezone_offset(&self) -> &'static str;
+
+    /// Returns a string representing the hour portion of the timezone's offset
+    /// from UTC.
+    fn timezone_hours(&self) -> &'static str;
+
+    /// Returns a string representing the minute portion of the timezone's
+    /// offset from UTC.
+    fn timezone_minutes(&self) -> &'static str;
+
+    /// Returns the abbreviated name of the timezone with the specified
+    /// capitalization.
+    fn timezone_name(&self, caps: bool) -> &'static str;
+
+    /// Adds given Duration to the current date and time.
+    fn checked_add_signed(self, rhs: Duration) -> Option<Self>;
+
+    /// Subtracts given Duration from the current date and time.
+    fn checked_sub_signed(self, rhs: Duration) -> Option<Self>;
+}
+
+impl TryFrom<Datum<'_>> for NaiveDateTime {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Timestamp(dt) => Ok(dt.t),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for DateTime<Utc> {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::TimestampTz(dt_tz) => Ok(dt_tz.t),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TimestampLike for chrono::NaiveDateTime {
+    fn new(date: NaiveDate, time: NaiveTime) -> Self {
+        NaiveDateTime::new(date, time)
+    }
+
+    fn date(&self) -> NaiveDate {
+        self.date()
+    }
+
+    fn date_time(&self) -> NaiveDateTime {
+        self.clone()
+    }
+
+    fn from_date_time(dt: NaiveDateTime) -> NaiveDateTime {
+        dt
+    }
+
+    fn timestamp(&self) -> i64 {
+        self.timestamp()
+    }
+
+    fn timestamp_subsec_micros(&self) -> u32 {
+        self.timestamp_subsec_micros()
+    }
+
+    fn timezone_offset(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_hours(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_minutes(&self) -> &'static str {
+        "00"
+    }
+
+    fn timezone_name(&self, _caps: bool) -> &'static str {
+        ""
+    }
+
+    fn checked_add_signed(self, rhs: Duration) -> Option<Self> {
+        self.checked_add_signed(rhs)
+    }
+
+    fn checked_sub_signed(self, rhs: Duration) -> Option<Self> {
+        self.checked_sub_signed(rhs)
+    }
+}
+
+impl TimestampLike for chrono::DateTime<chrono::Utc> {
+    fn new(date: NaiveDate, time: NaiveTime) -> Self {
+        Self::from_date_time(NaiveDateTime::new(date, time))
+    }
+
+    fn date(&self) -> NaiveDate {
+        self.naive_utc().date()
+    }
+
+    fn date_time(&self) -> NaiveDateTime {
+        self.naive_utc()
+    }
+
+    fn from_date_time(dt: NaiveDateTime) -> Self {
+        DateTime::<Utc>::from_utc(dt, Utc)
+    }
+
+    fn timestamp(&self) -> i64 {
+        self.timestamp()
+    }
+
+    fn timestamp_subsec_micros(&self) -> u32 {
+        self.timestamp_subsec_micros()
+    }
+
+    fn timezone_offset(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_hours(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_minutes(&self) -> &'static str {
+        "00"
+    }
+
+    fn timezone_name(&self, caps: bool) -> &'static str {
+        if caps {
+            "UTC"
+        } else {
+            "utc"
+        }
+    }
+
+    fn checked_add_signed(self, rhs: Duration) -> Option<Self> {
+        self.checked_add_signed(rhs)
+    }
+
+    fn checked_sub_signed(self, rhs: Duration) -> Option<Self> {
+        self.checked_sub_signed(rhs)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TimestampError {
+    #[error("timestamp out of range")]
+    OutOfRange,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CheckedTimestamp<T> {
+    t: T,
+}
+
+impl<T: Serialize> Serialize for CheckedTimestamp<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.t.serialize(serializer)
+    }
+}
+
+// We support intersection of the limits of Postgres, Avro, and chrono dates:
+// the set of dates that are representable in all used formats.
+//
+// - Postgres supports 4713 BC to 294276 AD (any time on those days inclusive).
+// - Avro supports i64 milliseconds since the Unix epoch: -292275055-05-16
+// 16:47:04.192 to 292278994-08-17 07:12:55.807.
+// - Avro also supports i64 microseconds since the Unix epoch: -290308-12-21
+//   19:59:05.224192 to 294247-01-10 04:00:54.775807.
+// - chrono's NaiveDate supports January 1, 262145 BCE to December 31, 262143
+//   CE.
+//
+// Thus on the low end we have 4713-12-31 BC from Postgres, and on the high end
+// 262143-12-31 from chrono.
+
+static LOW_DATE: Lazy<NaiveDate> = Lazy::new(|| NaiveDate::from_ymd(-4713, 12, 31));
+static HIGH_DATE: Lazy<NaiveDate> = Lazy::new(|| NaiveDate::from_ymd(262143, 12, 31));
+
+impl<T: TimestampLike> CheckedTimestamp<T> {
+    pub fn from_timestamplike(t: T) -> Result<Self, TimestampError> {
+        let d = t.date();
+        if d < *LOW_DATE {
+            return Err(TimestampError::OutOfRange);
+        }
+        if d > *HIGH_DATE {
+            return Err(TimestampError::OutOfRange);
+        }
+        Ok(Self { t })
+    }
+
+    pub fn checked_add_signed(self, rhs: Duration) -> Option<T> {
+        self.t.checked_add_signed(rhs)
+    }
+
+    pub fn checked_sub_signed(self, rhs: Duration) -> Option<T> {
+        self.t.checked_sub_signed(rhs)
+    }
+}
+
+impl TryFrom<NaiveDateTime> for CheckedTimestamp<NaiveDateTime> {
+    type Error = TimestampError;
+
+    fn try_from(value: NaiveDateTime) -> Result<Self, Self::Error> {
+        Self::from_timestamplike(value)
+    }
+}
+
+impl TryFrom<DateTime<Utc>> for CheckedTimestamp<DateTime<Utc>> {
+    type Error = TimestampError;
+
+    fn try_from(value: DateTime<Utc>) -> Result<Self, Self::Error> {
+        Self::from_timestamplike(value)
+    }
+}
+
+impl<T: TimestampLike> std::ops::Deref for CheckedTimestamp<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.t
+    }
+}
+
+impl From<CheckedTimestamp<NaiveDateTime>> for NaiveDateTime {
+    fn from(val: CheckedTimestamp<NaiveDateTime>) -> Self {
+        val.t
+    }
+}
+
+impl From<CheckedTimestamp<DateTime<Utc>>> for DateTime<Utc> {
+    fn from(val: CheckedTimestamp<DateTime<Utc>>) -> Self {
+        val.t
+    }
+}
+
+impl CheckedTimestamp<NaiveDateTime> {
+    pub fn to_naive(&self) -> NaiveDateTime {
+        self.t
+    }
+}
+
+impl CheckedTimestamp<DateTime<Utc>> {
+    pub fn to_naive(&self) -> NaiveDateTime {
+        self.t.date().naive_utc().and_time(self.t.time())
+    }
+}
+
+impl Display for CheckedTimestamp<NaiveDateTime> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.t.fmt(f)
+    }
+}
+
+impl Display for CheckedTimestamp<DateTime<Utc>> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.t.fmt(f)
+    }
+}
+
+impl RustType<ProtoNaiveDateTime> for CheckedTimestamp<NaiveDateTime> {
+    fn into_proto(&self) -> ProtoNaiveDateTime {
+        self.t.into_proto()
+    }
+
+    fn from_proto(proto: ProtoNaiveDateTime) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            t: NaiveDateTime::from_proto(proto)?,
+        })
+    }
+}
+
+impl RustType<ProtoNaiveDateTime> for CheckedTimestamp<DateTime<Utc>> {
+    fn into_proto(&self) -> ProtoNaiveDateTime {
+        self.t.into_proto()
+    }
+
+    fn from_proto(proto: ProtoNaiveDateTime) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            t: DateTime::<Utc>::from_proto(proto)?,
+        })
+    }
+}
+
+impl<T: Sub<Output = Duration>> Sub<CheckedTimestamp<T>> for CheckedTimestamp<T> {
+    type Output = Duration;
+
+    #[inline]
+    fn sub(self, rhs: CheckedTimestamp<T>) -> Duration {
+        self.t - rhs.t
+    }
+}
+
+impl<T: Sub<Duration, Output = T>> Sub<Duration> for CheckedTimestamp<T> {
+    type Output = T;
+
+    #[inline]
+    fn sub(self, rhs: Duration) -> T {
+        self.t - rhs
+    }
+}

--- a/src/repr/src/explain_new/mod.rs
+++ b/src/repr/src/explain_new/mod.rs
@@ -675,6 +675,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::adt::timestamp::CheckedTimestamp;
+
     use super::*;
 
     struct Environment {
@@ -858,14 +860,22 @@ mod tests {
                 r#""12:10:22""#,
             ),
             (
-                Datum::Timestamp(chrono::NaiveDateTime::from_timestamp(1023123, 234)),
+                Datum::Timestamp(
+                    CheckedTimestamp::from_timestamplike(chrono::NaiveDateTime::from_timestamp(
+                        1023123, 234,
+                    ))
+                    .unwrap(),
+                ),
                 r#""1970-01-12T20:12:03.000000234""#,
             ),
             (
-                Datum::TimestampTz(chrono::DateTime::from_utc(
-                    chrono::NaiveDateTime::from_timestamp(90234242, 234),
-                    chrono::Utc,
-                )),
+                Datum::TimestampTz(
+                    CheckedTimestamp::from_timestamplike(chrono::DateTime::from_utc(
+                        chrono::NaiveDateTime::from_timestamp(90234242, 234),
+                        chrono::Utc,
+                    ))
+                    .unwrap(),
+                ),
                 r#""1972-11-10T09:04:02.000000234Z""#,
             ),
             (

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -37,6 +37,7 @@ use crate::adt::date::Date;
 use crate::adt::interval::Interval;
 use crate::adt::numeric;
 use crate::adt::numeric::Numeric;
+use crate::adt::timestamp::CheckedTimestamp;
 use crate::scalar::arb_datum;
 use crate::{Datum, Timestamp};
 
@@ -442,12 +443,18 @@ unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
         Tag::Timestamp => {
             let date = read_naive_date(data, offset);
             let time = read_time(data, offset);
-            Datum::Timestamp(date.and_time(time))
+            Datum::Timestamp(
+                CheckedTimestamp::from_timestamplike(date.and_time(time))
+                    .expect("unexpected timestamp"),
+            )
         }
         Tag::TimestampTz => {
             let date = read_naive_date(data, offset);
             let time = read_time(data, offset);
-            Datum::TimestampTz(DateTime::from_utc(date.and_time(time), Utc))
+            Datum::TimestampTz(
+                CheckedTimestamp::from_timestamplike(DateTime::from_utc(date.and_time(time), Utc))
+                    .expect("unexpected timestamptz"),
+            )
         }
         Tag::Interval => {
             let months = i32::from_le_bytes(read_byte_array(data, offset));
@@ -634,13 +641,15 @@ where
         }
         Datum::Timestamp(t) => {
             data.push(Tag::Timestamp.into());
-            push_naive_date(data, t.date());
-            push_time(data, t.time());
+            let datetime = t.to_naive();
+            push_naive_date(data, datetime.date());
+            push_time(data, datetime.time());
         }
         Datum::TimestampTz(t) => {
             data.push(Tag::TimestampTz.into());
-            push_naive_date(data, t.date().naive_utc());
-            push_time(data, t.time());
+            let datetime = t.to_naive();
+            push_naive_date(data, datetime.date());
+            push_time(data, datetime.time());
         }
         Datum::Interval(i) => {
             data.push(Tag::Interval.into());
@@ -1591,12 +1600,18 @@ mod tests {
             Datum::Float64(OrderedFloat::from(-2_147_483_648.0 - 42.12)),
             Datum::Date(Date::from_pg_epoch(365 * 45 + 21).unwrap()),
             Datum::Timestamp(
-                NaiveDate::from_isoywd(2019, 30, chrono::Weekday::Wed).and_hms(14, 32, 11),
+                CheckedTimestamp::from_timestamplike(
+                    NaiveDate::from_isoywd(2019, 30, chrono::Weekday::Wed).and_hms(14, 32, 11),
+                )
+                .unwrap(),
             ),
-            Datum::TimestampTz(DateTime::<Utc>::from_utc(
-                NaiveDateTime::from_timestamp(61, 0),
-                Utc,
-            )),
+            Datum::TimestampTz(
+                CheckedTimestamp::from_timestamplike(DateTime::<Utc>::from_utc(
+                    NaiveDateTime::from_timestamp(61, 0),
+                    Utc,
+                ))
+                .unwrap(),
+            ),
             Datum::Interval(Interval {
                 months: 312,
                 ..Default::default()
@@ -1808,8 +1823,16 @@ mod tests {
             Datum::from(numeric::Numeric::from(1000)),
             Datum::from(numeric::Numeric::from(9999)),
             Datum::Date(NaiveDate::from_ymd(1, 1, 1).try_into().unwrap()),
-            Datum::Timestamp(NaiveDateTime::from_timestamp(0, 0)),
-            Datum::TimestampTz(DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc)),
+            Datum::Timestamp(
+                CheckedTimestamp::from_timestamplike(NaiveDateTime::from_timestamp(0, 0)).unwrap(),
+            ),
+            Datum::TimestampTz(
+                CheckedTimestamp::from_timestamplike(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp(0, 0),
+                    Utc,
+                ))
+                .unwrap(),
+            ),
             Datum::Interval(Interval::default()),
             Datum::Bytes(&[]),
             Datum::String(""),

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -298,6 +298,7 @@ mod tests {
     use crate::adt::array::ArrayDimension;
     use crate::adt::interval::Interval;
     use crate::adt::numeric::Numeric;
+    use crate::adt::timestamp::CheckedTimestamp;
     use crate::{Datum, Row};
 
     // TODO: datadriven golden tests for various interesting Datums and Rows to
@@ -318,12 +319,18 @@ mod tests {
             Datum::Date(NaiveDate::from_ymd(6, 7, 8).try_into().unwrap()),
             Datum::Time(NaiveTime::from_hms(9, 10, 11)),
             Datum::Timestamp(
-                NaiveDate::from_ymd(12, 13 % 12, 14).and_time(NaiveTime::from_hms(15, 16, 17)),
+                CheckedTimestamp::from_timestamplike(
+                    NaiveDate::from_ymd(12, 13 % 12, 14).and_time(NaiveTime::from_hms(15, 16, 17)),
+                )
+                .unwrap(),
             ),
-            Datum::TimestampTz(DateTime::from_utc(
-                NaiveDate::from_ymd(18, 19 % 12, 20).and_time(NaiveTime::from_hms(21, 22, 23)),
-                Utc,
-            )),
+            Datum::TimestampTz(
+                CheckedTimestamp::from_timestamplike(DateTime::from_utc(
+                    NaiveDate::from_ymd(18, 19 % 12, 20).and_time(NaiveTime::from_hms(21, 22, 23)),
+                    Utc,
+                ))
+                .unwrap(),
+            ),
             Datum::Interval(Interval {
                 months: 24,
                 days: 42,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -36,6 +36,7 @@ use crate::adt::interval::Interval;
 use crate::adt::jsonb::{Jsonb, JsonbRef};
 use crate::adt::numeric::{Numeric, NumericMaxScale};
 use crate::adt::system::{Oid, PgLegacyChar, RegClass, RegProc, RegType};
+use crate::adt::timestamp::{CheckedTimestamp, TimestampError};
 use crate::adt::varchar::{VarChar, VarCharMaxLength};
 use crate::GlobalId;
 use crate::{ColumnName, ColumnType, DatumList, DatumMap};
@@ -77,9 +78,9 @@ pub enum Datum<'a> {
     /// A time.
     Time(NaiveTime),
     /// A date and time, without a timezone.
-    Timestamp(NaiveDateTime),
+    Timestamp(CheckedTimestamp<NaiveDateTime>),
     /// A date and time, with a timezone.
-    TimestampTz(DateTime<Utc>),
+    TimestampTz(CheckedTimestamp<DateTime<Utc>>),
     /// A span of time.
     Interval(Interval),
     /// A sequence of untyped bytes.
@@ -366,7 +367,7 @@ impl TryFrom<Datum<'_>> for Option<u64> {
     }
 }
 
-impl TryFrom<Datum<'_>> for NaiveDateTime {
+impl TryFrom<Datum<'_>> for CheckedTimestamp<NaiveDateTime> {
     type Error = ();
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
@@ -376,7 +377,7 @@ impl TryFrom<Datum<'_>> for NaiveDateTime {
     }
 }
 
-impl TryFrom<Datum<'_>> for DateTime<Utc> {
+impl TryFrom<Datum<'_>> for CheckedTimestamp<DateTime<Utc>> {
     type Error = ();
     fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
         match from {
@@ -571,7 +572,7 @@ impl<'a> Datum<'a> {
     ///
     /// Panics if the datum is not [`Datum::Timestamp`].
     #[track_caller]
-    pub fn unwrap_timestamp(&self) -> chrono::NaiveDateTime {
+    pub fn unwrap_timestamp(&self) -> CheckedTimestamp<chrono::NaiveDateTime> {
         match self {
             Datum::Timestamp(ts) => *ts,
             _ => panic!("Datum::unwrap_timestamp called on {:?}", self),
@@ -584,7 +585,7 @@ impl<'a> Datum<'a> {
     ///
     /// Panics if the datum is not [`Datum::TimestampTz`].
     #[track_caller]
-    pub fn unwrap_timestamptz(&self) -> chrono::DateTime<Utc> {
+    pub fn unwrap_timestamptz(&self) -> CheckedTimestamp<chrono::DateTime<Utc>> {
         match self {
             Datum::TimestampTz(ts) => *ts,
             _ => panic!("Datum::unwrap_timestamptz called on {:?}", self),
@@ -945,15 +946,33 @@ impl<'a> From<NaiveTime> for Datum<'a> {
     }
 }
 
-impl<'a> From<NaiveDateTime> for Datum<'a> {
-    fn from(dt: NaiveDateTime) -> Datum<'a> {
+impl<'a> From<CheckedTimestamp<NaiveDateTime>> for Datum<'a> {
+    fn from(dt: CheckedTimestamp<NaiveDateTime>) -> Datum<'a> {
         Datum::Timestamp(dt)
     }
 }
 
-impl<'a> From<DateTime<Utc>> for Datum<'a> {
-    fn from(dt: DateTime<Utc>) -> Datum<'a> {
+impl<'a> From<CheckedTimestamp<DateTime<Utc>>> for Datum<'a> {
+    fn from(dt: CheckedTimestamp<DateTime<Utc>>) -> Datum<'a> {
         Datum::TimestampTz(dt)
+    }
+}
+
+impl<'a> TryInto<Datum<'a>> for NaiveDateTime {
+    type Error = TimestampError;
+
+    fn try_into(self) -> Result<Datum<'a>, Self::Error> {
+        let t = CheckedTimestamp::from_timestamplike(self)?;
+        Ok(t.into())
+    }
+}
+
+impl<'a> TryInto<Datum<'a>> for DateTime<Utc> {
+    type Error = TimestampError;
+
+    fn try_into(self) -> Result<Datum<'a>, Self::Error> {
+        let t = CheckedTimestamp::from_timestamplike(self)?;
+        Ok(t.into())
     }
 }
 
@@ -1511,8 +1530,8 @@ impl_datum_type_copy!(u64, UInt64);
 impl_datum_type_copy!(Interval, Interval);
 impl_datum_type_copy!(Date, Date);
 impl_datum_type_copy!(NaiveTime, Time);
-impl_datum_type_copy!(NaiveDateTime, Timestamp);
-impl_datum_type_copy!(DateTime<Utc>, TimestampTz);
+impl_datum_type_copy!(CheckedTimestamp<NaiveDateTime>, Timestamp);
+impl_datum_type_copy!(CheckedTimestamp<DateTime<Utc>>, TimestampTz);
 impl_datum_type_copy!(Uuid, Uuid);
 impl_datum_type_copy!('a, &'a str, String);
 impl_datum_type_copy!('a, &'a [u8], Bytes);
@@ -2346,8 +2365,8 @@ pub enum PropDatum {
 
     Date(Date),
     Time(chrono::NaiveTime),
-    Timestamp(chrono::NaiveDateTime),
-    TimestampTz(chrono::DateTime<chrono::Utc>),
+    Timestamp(CheckedTimestamp<chrono::NaiveDateTime>),
+    TimestampTz(CheckedTimestamp<chrono::DateTime<chrono::Utc>>),
 
     Interval(Interval),
     Numeric(Numeric),
@@ -2380,8 +2399,9 @@ pub fn arb_datum() -> BoxedStrategy<PropDatum> {
         arb_date().prop_map(PropDatum::Date),
         add_arb_duration(chrono::NaiveTime::from_hms(0, 0, 0)).prop_map(PropDatum::Time),
         add_arb_duration(chrono::NaiveDateTime::from_timestamp(0, 0))
-            .prop_map(PropDatum::Timestamp),
-        add_arb_duration(chrono::Utc.timestamp(0, 0)).prop_map(PropDatum::TimestampTz),
+            .prop_map(|t| PropDatum::Timestamp(CheckedTimestamp::from_timestamplike(t).unwrap())),
+        add_arb_duration(chrono::Utc.timestamp(0, 0))
+            .prop_map(|t| PropDatum::TimestampTz(CheckedTimestamp::from_timestamplike(t).unwrap())),
         arb_interval().prop_map(PropDatum::Interval),
         arb_numeric().prop_map(PropDatum::Numeric),
         prop::collection::vec(any::<u8>(), 1024).prop_map(PropDatum::Bytes),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -351,8 +351,12 @@ impl<'a> FromSql<'a> for Slt {
                 Self(Value::Text(types::text_from_sql(raw)?.to_string()))
             }
             PgType::TIME => Self(Value::Time(NaiveTime::from_sql(ty, raw)?)),
-            PgType::TIMESTAMP => Self(Value::Timestamp(NaiveDateTime::from_sql(ty, raw)?)),
-            PgType::TIMESTAMPTZ => Self(Value::TimestampTz(DateTime::<Utc>::from_sql(ty, raw)?)),
+            PgType::TIMESTAMP => Self(Value::Timestamp(
+                NaiveDateTime::from_sql(ty, raw)?.try_into()?,
+            )),
+            PgType::TIMESTAMPTZ => Self(Value::TimestampTz(
+                DateTime::<Utc>::from_sql(ty, raw)?.try_into()?,
+            )),
             PgType::UUID => Self(Value::Uuid(Uuid::from_sql(ty, raw)?)),
             PgType::RECORD => {
                 let num_fields = read_be_i32(&mut raw)?;

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -183,7 +183,9 @@ impl Generator for Auction {
                         Datum::String(&rng.gen_range(1..=CELEBRETIES.len()).to_string()), // seller
                         Datum::String(AUCTIONS.choose(&mut rng).unwrap()), // item
                         Datum::String(&cast_timestamp_tz_to_string(
-                            now + chrono::Duration::seconds(10),
+                            (now + chrono::Duration::seconds(10))
+                                .try_into()
+                                .expect("timestamp must fit"),
                         )), // end time
                     ]);
                     pending.push_back(vec![auction]);
@@ -201,7 +203,9 @@ impl Generator for Auction {
                                 Datum::String(&counter.to_string()), // auction id
                                 Datum::String(&rng.gen_range(1..100).to_string()), // amount
                                 Datum::String(&cast_timestamp_tz_to_string(
-                                    now + chrono::Duration::seconds(i),
+                                    (now + chrono::Duration::seconds(i))
+                                        .try_into()
+                                        .expect("timestamp must fit"),
                                 )), // bid time
                             ]);
                             bid

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -259,7 +259,8 @@ impl Healthchecker {
                 .try_into()
                 .expect("timestamp millis does not fit into a u32"),
         )
-        .into();
+        .try_into()
+        .expect("timestamp does not fit");
         let source_id = self.source_id.to_string();
         let source_name = Datum::String(&self.source_name);
         let source_id = Datum::String(&source_id);

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -53,14 +53,14 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, anyhow::
             let ts = n.as_i64().unwrap();
             Ok(Value::Timestamp(chrono::NaiveDateTime::from_timestamp(
                 ts / 1_000,
-                ((ts % 1_000) * 1_000_000) as u32,
+                ((ts % 1_000).abs() * 1_000_000) as u32,
             )))
         }
         (JsonValue::Number(ref n), SchemaPiece::TimestampMicro) => {
             let ts = n.as_i64().unwrap();
             Ok(Value::Timestamp(chrono::NaiveDateTime::from_timestamp(
                 ts / 1_000_000,
-                ((ts % 1_000_000) * 1_000) as u32,
+                ((ts % 1_000_000).abs() * 1_000) as u32,
             )))
         }
         (JsonValue::Array(items), SchemaPiece::Array(inner)) => Ok(Value::Array(

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1323,25 +1323,32 @@ select '0001-02-24 03:04:05.6789 +00:00'::timestamptz - interval '-2147483648 MO
 query error invalid input syntax for type date
 select 'infinity'::date
 
-# We don't support BC parsing or 6 digit dates, so do some jank.
+# We don't support BC parsing or 6 digit dates, so do some jank. Additionally,
+# we don't yet support the `date - int` operation and have to use `date -
+# interval` instead, which produces a `timestamp`, and thus we aren't able to even
+# express the full range of date values.
+
+# Lowest date we could support, but timestamps don't.
+# select ('0001-01-01'::date - '4713years 1months 7days')::date
 
 query T
-select ('0001-01-01'::date - '4713years 1months 7days')::date
+select ('0001-01-01'::date - '1721389days'::interval)::date
 ----
-4714-11-24 BC
+4714-12-31 BC
 
 query T
-select ('0001-01-01'::date + '262142years 11months 30days')::date
+select ('0001-01-01'::date + '262142years 11months 30days'::interval)::date
 ----
 262143-12-31
 
-query error date out of range
+# Out of range for both dates and timestamps, but timestamp triggers first.
+query error timestamp out of range
 select ('0001-01-01'::date - '4713years 1months 8days')::date
 
 query error timestamp out of range
 select ('0001-01-01'::date + '262142years 11months 30days')::date + '1day'
 
 query II
-select ('0001-01-01'::date - '4713years 1months 7days')::date - ('0001-01-01'::date + '262142years 11months 30days')::date, ('0001-01-01'::date + '262142years 11months 30days')::date - ('0001-01-01'::date - '4713years 1months 7days')::date
+select ('0001-01-01'::date - '1721389days'::interval)::date - ('0001-01-01'::date + '262142years 11months 30days'::interval)::date, ('0001-01-01'::date + '262142years 11months 30days'::interval)::date - ('0001-01-01'::date - '1721389days'::interval)::date
 ----
--97467189 97467189
+-97467152 97467152

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -70,7 +70,9 @@ $ kafka-verify format=avro sink=materialize.public.interval_data_sink sort-messa
 
 > CREATE MATERIALIZED VIEW datetime_data (date, ts, ts_tz) AS VALUES
   (DATE '2000-01-01', TIMESTAMP '2000-01-01 10:10:10.111', TIMESTAMPTZ '2000-01-01 10:10:10.111+02'),
-  (DATE '2000-02-01', TIMESTAMP '2000-02-01 10:10:10.111', TIMESTAMPTZ '2000-02-01 10:10:10.111+02')
+  (DATE '2000-02-01', TIMESTAMP '2000-02-01 10:10:10.111', TIMESTAMPTZ '2000-02-01 10:10:10.111+02'),
+  (('0001-01-01'::DATE - '1721389days'::INTERVAL)::DATE, ('0001-01-01'::DATE - '1721389days'::INTERVAL)::TIMESTAMP, ('0001-01-01'::DATE - '1721389days'::INTERVAL)::TIMESTAMPTZ),
+  (('0001-01-01'::DATE + '262142years 11months 30days'::INTERVAL)::DATE, ('0001-01-01'::DATE + '262142years 11months 30days'::INTERVAL)::TIMESTAMP, ('0001-01-01'::DATE + '262142years 11months 30days'::INTERVAL)::TIMESTAMPTZ)
 
 > CREATE SINK datetime_data_sink FROM datetime_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-datetime-data-sink-${testdrive.seed}')
@@ -78,8 +80,10 @@ $ kafka-verify format=avro sink=materialize.public.interval_data_sink sort-messa
   ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messages=true
+{"before": null, "after": {"row": {"date": -2440551, "ts": -210863606400000000, "ts_tz": -210863606400000000}}}
 {"before": null, "after": {"row": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}}
 {"before": null, "after": {"row": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}}
+{"before": null, "after": {"row": {"date": 95026601, "ts": 8210298326400000000, "ts_tz": 8210298326400000000}}}
 
 > CREATE MATERIALIZED VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04'), (TIME '00:00:00'), (TIME '23:59:59')
 


### PR DESCRIPTION
Previously we would allow any timestamp supported by chrono, even if they weren't representable in pgwire/postgres or avro. Instead, wrap all timestamps in a struct that verifies they are valid or returns an error. Valid here means the smallest set of dates that are representable in postgres, avro, and chrono.

This unfortunately hits a huge amount of code because many things require infalliable casts from a rust type into a datum, but all of the datetime logic works on chrono objects.

### Motivation

  * This PR adds a known-desirable feature. #7141

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Timestamp types now have a reduced range now within the postgres spec.