### PR TITLE
persist: fix `persistcli inspect` post incremental state

### DIFF
--- a/src/persist-client/examples/inspect.rs
+++ b/src/persist-client/examples/inspect.rs
@@ -27,6 +27,9 @@ pub(crate) enum Command {
     /// Prints latest consensus state as JSON
     State(StateArgs),
 
+    /// Prints latest consensus rollup state as JSON
+    StateRollup(StateArgs),
+
     /// Prints each consensus state change as JSON. Output includes the full consensus state
     /// before and after each state transitions:
     ///
@@ -71,25 +74,52 @@ pub struct StateArgs {
     ///
     #[clap(long, verbatim_doc_comment)]
     consensus_uri: String,
+
+    /// Blob to use
+    ///
+    /// When connecting to a deployed environment's blob, the necessary connection glue must be in
+    /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
+    /// URI scoped to the environment's bucket prefix.
+    #[clap(long)]
+    blob_uri: String,
 }
 
 pub async fn run(command: InspectArgs) -> Result<(), anyhow::Error> {
     match command.command {
         Command::State(args) => {
             let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
-            let state =
-                mz_persist_client::inspect::fetch_current_state(shard_id, &args.consensus_uri)
-                    .await?;
+            let state = mz_persist_client::inspect::fetch_latest_state(
+                shard_id,
+                &args.consensus_uri,
+                &args.blob_uri,
+            )
+            .await?;
             println!(
                 "{}",
                 serde_json::to_string_pretty(&state).expect("unserializable state")
             );
         }
+        Command::StateRollup(args) => {
+            let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
+            let state_rollup = mz_persist_client::inspect::fetch_latest_state_rollup(
+                shard_id,
+                &args.consensus_uri,
+                &args.blob_uri,
+            )
+            .await?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&state_rollup).expect("unserializable state")
+            );
+        }
         Command::StateDiff(args) => {
             let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
-            let states =
-                mz_persist_client::inspect::fetch_state_diffs(shard_id, &args.consensus_uri)
-                    .await?;
+            let states = mz_persist_client::inspect::fetch_state_diffs(
+                shard_id,
+                &args.consensus_uri,
+                &args.blob_uri,
+            )
+            .await?;
             for window in states.windows(2) {
                 println!(
                     "{}",

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -9,28 +9,91 @@
 
 //! CLI introspection tools for persist
 
-use crate::internal::state::ProtoStateRollup;
-use crate::{Metrics, PersistConfig, ShardId};
+use std::sync::{Arc, Mutex};
+
 use anyhow::anyhow;
-use mz_build_info::DUMMY_BUILD_INFO;
-use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::SYSTEM_TIME;
-use mz_persist::cfg::ConsensusConfig;
-use mz_persist::location::SeqNo;
+use bytes::BufMut;
+use differential_dataflow::difference::Semigroup;
 use prost::Message;
 
+use mz_build_info::BuildInfo;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
+use mz_persist::cfg::{BlobConfig, ConsensusConfig};
+use mz_persist_types::{Codec, Codec64};
+use mz_proto::RustType;
+
+use crate::internal::paths::PartialRollupKey;
+use crate::internal::state::{ProtoStateDiff, ProtoStateRollup};
+use crate::{Metrics, PersistConfig, ShardId, StateVersions};
+
+const READ_ALL_BUILD_INFO: BuildInfo = BuildInfo {
+    version: "10000000.0.0+test",
+    sha: "0000000000000000000000000000000000000000",
+    time: "",
+};
+
 /// Fetches the current state of a given shard
-pub async fn fetch_current_state(
+pub async fn fetch_latest_state(
     shard_id: ShardId,
     consensus_uri: &str,
+    blob_uri: &str,
 ) -> Result<impl serde::Serialize, anyhow::Error> {
-    let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
-    let metrics = Metrics::new(&cfg, &MetricsRegistry::new());
-    let consensus = ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus)?;
+    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
+    let consensus =
+        ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus.clone())?;
     let consensus = consensus.clone().open().await?;
+    let blob = BlobConfig::try_from(&blob_uri).await?;
+    let blob = blob.clone().open().await?;
 
-    if let Some(data) = consensus.head(&shard_id.to_string()).await? {
-        let proto = ProtoStateRollup::decode(data.data).expect("invalid encoded state");
+    let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
+    let versions = state_versions.fetch_live_diffs(&shard_id).await;
+
+    let state = match state_versions
+        .fetch_current_state::<K, V, u64, D>(&shard_id, versions.clone())
+        .await
+    {
+        Ok(s) => s.into_proto(),
+        Err(codec) => {
+            {
+                let mut kvtd = KVTD_CODECS.lock().expect("lockable");
+                *kvtd = codec.actual;
+            }
+            state_versions
+                .fetch_current_state::<K, V, u64, D>(&shard_id, versions)
+                .await
+                .expect("codecs match")
+                .into_proto()
+        }
+    };
+
+    Ok(state)
+}
+
+/// Fetches the current state rollup of a given shard
+pub async fn fetch_latest_state_rollup(
+    shard_id: ShardId,
+    consensus_uri: &str,
+    blob_uri: &str,
+) -> Result<impl serde::Serialize, anyhow::Error> {
+    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
+    let consensus =
+        ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus.clone())?;
+    let consensus = consensus.clone().open().await?;
+    let blob = BlobConfig::try_from(&blob_uri).await?;
+    let blob = blob.clone().open().await?;
+
+    if let Some(diff_buf) = consensus.head(&shard_id.to_string()).await? {
+        let diff = ProtoStateDiff::decode(diff_buf.data).expect("invalid encoded diff");
+        let rollup_key = PartialRollupKey(diff.latest_rollup_key);
+        let rollup_buf = blob
+            .get(&rollup_key.complete(&shard_id))
+            .await
+            .unwrap()
+            .unwrap();
+        let proto = ProtoStateRollup::decode(rollup_buf.as_slice()).expect("invalid encoded state");
         return Ok(proto);
     }
 
@@ -41,19 +104,144 @@ pub async fn fetch_current_state(
 pub async fn fetch_state_diffs(
     shard_id: ShardId,
     consensus_uri: &str,
+    blob_uri: &str,
 ) -> Result<Vec<impl serde::Serialize>, anyhow::Error> {
-    let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
-    let metrics = Metrics::new(&cfg, &MetricsRegistry::new());
-    let consensus = ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus)?;
+    let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+    let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
+    let consensus =
+        ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus.clone())?;
     let consensus = consensus.clone().open().await?;
+    let blob = BlobConfig::try_from(&blob_uri).await?;
+    let blob = blob.clone().open().await?;
 
-    let mut states = vec![];
-    for state in consensus
-        .scan(&shard_id.to_string(), SeqNo::minimum())
-        .await?
+    let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
+
+    let mut live_states = vec![];
+    let mut state_iter = match state_versions
+        .fetch_live_states::<K, V, u64, D>(&shard_id)
+        .await
     {
-        states.push(ProtoStateRollup::decode(state.data).expect("invalid encoded state"));
+        Ok(state_iter) => state_iter,
+        Err(codec) => {
+            {
+                let mut kvtd = KVTD_CODECS.lock().expect("lockable");
+                *kvtd = codec.actual;
+            }
+            state_versions
+                .fetch_live_states::<K, V, u64, D>(&shard_id)
+                .await?
+        }
+    };
+
+    while let Some(v) = state_iter.next() {
+        live_states.push(v.into_proto());
     }
 
-    Ok(states)
+    Ok(live_states)
+}
+
+/// The following is a very terrible hack that no one should draw inspiration from. Currently State
+/// is generic over <K, V, T, D>, with KVD being represented as phantom data for type safety and to
+/// detect persisted codec mismatches. However, reading persisted States does not require actually
+/// decoding KVD, so we only need their codec _names_ to match, not the full types. For the purposes
+/// of `persistcli inspect`, which only wants to read the persistent data, we create new types that
+/// return static Codec names, and rebind the names if/when we get a CodecMismatch, so we can convince
+/// the type system and our safety checks that we really can read the data.
+
+#[derive(Debug)]
+struct K;
+#[derive(Debug)]
+struct V;
+#[derive(Debug)]
+struct T;
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+struct D(i64);
+
+static KVTD_CODECS: Mutex<(String, String, String, String)> =
+    Mutex::new((String::new(), String::new(), String::new(), String::new()));
+
+impl Codec for K {
+    fn codec_name() -> String {
+        KVTD_CODECS.lock().expect("lockable").0.clone()
+    }
+
+    fn encode<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+
+    fn decode(_buf: &[u8]) -> Result<Self, String> {
+        Ok(Self)
+    }
+}
+
+impl Codec for V {
+    fn codec_name() -> String {
+        KVTD_CODECS.lock().expect("lockable").1.clone()
+    }
+
+    fn encode<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+
+    fn decode(_buf: &[u8]) -> Result<Self, String> {
+        Ok(Self)
+    }
+}
+
+impl Codec for T {
+    fn codec_name() -> String {
+        KVTD_CODECS.lock().expect("lockable").2.clone()
+    }
+
+    fn encode<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+
+    fn decode(_buf: &[u8]) -> Result<Self, String> {
+        Ok(Self)
+    }
+}
+
+impl Codec64 for D {
+    fn codec_name() -> String {
+        KVTD_CODECS.lock().expect("lockable").3.clone()
+    }
+
+    fn encode(&self) -> [u8; 8] {
+        todo!()
+    }
+
+    fn decode(_buf: [u8; 8]) -> Self {
+        Self(0)
+    }
+}
+
+impl Codec for D {
+    fn codec_name() -> String {
+        KVTD_CODECS.lock().expect("lockable").3.clone()
+    }
+
+    fn encode<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+
+    fn decode(_buf: &[u8]) -> Result<Self, String> {
+        Ok(Self(0))
+    }
+}
+
+impl Semigroup for D {
+    fn plus_equals(&mut self, _rhs: &Self) {}
+
+    fn is_zero(&self) -> bool {
+        false
+    }
 }

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -214,27 +214,11 @@ impl Codec64 for D {
     }
 
     fn encode(&self) -> [u8; 8] {
-        todo!()
+        [0; 8]
     }
 
     fn decode(_buf: [u8; 8]) -> Self {
         Self(0)
-    }
-}
-
-impl Codec for D {
-    fn codec_name() -> String {
-        KVTD_CODECS.lock().expect("lockable").3.clone()
-    }
-
-    fn encode<B>(&self, _buf: &mut B)
-    where
-        B: BufMut,
-    {
-    }
-
-    fn decode(_buf: &[u8]) -> Result<Self, String> {
-        Ok(Self(0))
     }
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Updates `persistcli inspect` to work after the incremental state rewrite + adds a new command for fetching the latest rollup state specifically (without having applied any subsequent diffs in consensus). This gives us three commands now, to pull down the latest state, the latest rollup state, and the diffs of all live states.

This PR gets around the KVTD generics/codec requirements with one of the biggest hacks yet added to the Mz codebase, where we create new types that pretend to have the same codec names as what was persisted. It's gross, but for an unstable tool like `persistcli inspect`, I don't think it's unmergeably terrible? 😅 

### Motivation

  * This PR fixes a recognized bug.

One small piece on the M2 persist priorities

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
