### PR TITLE
avro: prevent panic during time encoding

### DIFF
--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -313,8 +313,8 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::Date => Value::Date(datum.unwrap_date().unix_epoch_days()),
                 ScalarType::Time => Value::Long({
                     let time = datum.unwrap_time();
-                    (time.num_seconds_from_midnight() * 1_000_000) as i64
-                        + (time.nanosecond() as i64) / 1_000
+                    i64::from(time.num_seconds_from_midnight()) * 1_000_000
+                        + i64::from(time.nanosecond()) / 1_000
                 }),
                 ScalarType::Timestamp => Value::Timestamp(datum.unwrap_timestamp()),
                 ScalarType::TimestampTz => Value::Timestamp(datum.unwrap_timestamptz().naive_utc()),

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -60,7 +60,7 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messa
 {"before": null, "after": {"row": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}}
 {"before": null, "after": {"row": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}}
 
-> CREATE MATERIALIZED VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04')
+> CREATE MATERIALIZED VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04'), (TIME '00:00:00'), (TIME '23:59:59')
 
 > CREATE SINK time_data_sink FROM time_data
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-time-data-sink-${testdrive.seed}')
@@ -68,8 +68,10 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messa
   ENVELOPE DEBEZIUM
 
 $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=true
+{"before": null, "after": {"row": {"time": 0}}}
 {"before": null, "after": {"row": {"time": 3723000000}}}
 {"before": null, "after": {"row": {"time": 3724000000}}}
+{"before": null, "after": {"row": {"time": 86399000000}}}
 
 # Test jsonb
 


### PR DESCRIPTION
Convert to i64 before multiplying to avoid overflow.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a