### PR TITLE
ci: Increase timeout of testdrive jobs to 10 hours

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -128,7 +128,7 @@ steps:
 
   - id: redpanda-testdrive
     label: ":panda_face: :racing_car: testdrive"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
     plugins:
@@ -139,7 +139,7 @@ steps:
 
   - id: redpanda-testdrive-aarch64
     label: ":panda_face: :racing_car: testdrive aarch64"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 600
     agents:
       queue: linux-aarch64
     plugins:
@@ -188,7 +188,7 @@ steps:
 
   - id: testdrive-workers-1
     label: ":racing_car: testdrive with --workers 1"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
     plugins:
@@ -202,7 +202,7 @@ steps:
   # - id: testdrive-workers-32
   #   label: ":racing_car: testdrive with --workers 32"
   #   depends_on: build-x86_64
-  #   timeout_in_minutes: 180
+  #   timeout_in_minutes: 600
   #   plugins:
   #     - ./ci/plugins/scratch-aws-access: ~
   #     - ./ci/plugins/mzcompose:
@@ -213,7 +213,7 @@ steps:
 
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
     plugins:
@@ -224,7 +224,7 @@ steps:
 
   - id: testdrive-replicas-4
     label: ":racing_car: testdrive 4 replicas"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
     plugins:
@@ -235,7 +235,7 @@ steps:
 
   - id: testdrive-replica-size-4
     label: ":racing_car: testdrive replica SIZE 4"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
     plugins:


### PR DESCRIPTION
As apparently 3 hours are not enough

### Motivation

  * This PR fixes a previously unreported bug.

Nightly CI is timing out.