### PR TITLE
docs: remove vestiges of `DEBEZIUM UPSERT` from docs

### DIFF
--- a/doc/user/content/integrations/cdc-mysql.md
+++ b/doc/user/content/integrations/cdc-mysql.md
@@ -113,8 +113,6 @@ CREATE SOURCE kafka_repl
     ENVELOPE DEBEZIUM;
 ```
 
-If log compaction is enabled for your Debezium topic, you must use `ENVELOPE DEBEZIUM UPSERT`. This will require **more memory** in Materialize, as it needs to track state proportional to the number of unique primary keys in the changing data.
-
 #### Transaction support
 
 Debezium provides [transaction metadata](https://debezium.io/documentation/reference/connectors/mysql.html#mysql-transaction-metadata) that can be used to preserve transactional boundaries downstream. We are working on using this topic to support transaction-aware processing in Materialize ([#7537](https://github.com/MaterializeInc/materialize/issues/7537))!

--- a/doc/user/content/integrations/cdc-postgres.md
+++ b/doc/user/content/integrations/cdc-postgres.md
@@ -228,21 +228,10 @@ Debezium emits change events using an envelope that contains detailed informatio
 CREATE SOURCE kafka_repl
     FROM KAFKA CONNECTION kafka_connection (TOPIC 'pg_repl.public.table1')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
-    ENVELOPE DEBEZIUM UPSERT;
-```
-
-Enabling `UPSERT` allows you to replicate tables with `REPLICA IDENTITY DEFAULT` or `INDEX`. Although this approach is less resource-intensive for the upstream database, it will require **more memory** in Materialize, as it needs to track state proportional to the number of unique primary keys in the changing data.
-
-If the original Postgres table uses `REPLICA IDENTITY FULL`:
-
-```sql
-CREATE SOURCE kafka_repl
-    FROM KAFKA CONNECTION kafka_connection (TOPIC 'pg_repl.public.table1')
-    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
     ENVELOPE DEBEZIUM;
 ```
 
-When should you use what? `UPSERT` works best when there is a small number of quickly changing rows and is required if log compaction is enabled for your Debezium topic; setting `REPLICA IDENTITY FULL` in the original tables and using the regular Debezium envelope works best for pretty much everything else.
+This allows you to replicate tables with `REPLICA IDENTITY DEFAULT`, `INDEX`, or `FULL`.
 
 #### Transaction support
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -122,10 +122,6 @@ CREATE SOURCE kafka_repl
   ENVELOPE DEBEZIUM;
 ```
 
-Note that:
-
-- If log compaction is enabled for your Debezium topic, you must use `ENVELOPE DEBEZIUM UPSERT`.
-
 Any materialized view defined on top of this source will be incrementally updated as new change events stream in through Kafka, as a result of `INSERT`, `UPDATE` and `DELETE` operations in the original database.
 
 For more details and a step-by-step guide on using Kafka+Debezium for Change Data Capture (CDC), check out [Using Debezium](/integrations/debezium/).
@@ -228,10 +224,6 @@ offset
 13
 ```
 
-Note that:
-
-- Using the `INCLUDE OFFSET` option with Debezium requires `UPSERT` semantics.
-
 ### Setting start offsets
 
 To start consuming a Kafka stream from a specific offset, you can use the `start_offset` option.
@@ -249,7 +241,6 @@ Note that:
 
 - If fewer offsets than partitions are provided, the remaining partitions will start at offset 0. This is true if you provide `start_offset=1` or `start_offset=[1, ...]`.
 - If more offsets than partitions are provided, then any partitions added later will incorrectly be read from that offset. So, if you have a single partition, but you provide `start_offset=[1,2]`, when you add the second partition you will miss the first 2 records of data.
-- Using an offset with a source envelope that can supply updates or deletes requires that Materialize handle possibly nonsensical events (e.g. an update for a row that was never inserted). For that reason, starting at an offset requires either a `NONE` envelope or a `(DEBEZIUM) UPSERT` envelope.
 
 #### Time-based offsets
 

--- a/doc/user/layouts/partials/create-source/envelope/debezium/syntax.html
+++ b/doc/user/layouts/partials/create-source/envelope/debezium/syntax.html
@@ -1,2 +1,1 @@
 **ENVELOPE DEBEZIUM** | Use the Debezium envelope, which uses a diff envelope to handle CRUD operations. For more information, see [Using Debezium](/sql/create-source/kafka#using-debezium).
-**ENVELOPE DEBEZIUM UPSERT** | Use the Debezium envelope with `UPSERT` enabled. This is required for Kafka sources with log compaction, but increases memory consumption.

--- a/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="1103">
+<svg xmlns="http://www.w3.org/2000/svg" width="601" height="1071">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -188,94 +188,86 @@
    <rect x="438" y="565" width="56" height="32"/>
    <rect x="436" y="563" width="56" height="32" class="nonterminal"/>
    <text class="nonterminal" x="446" y="583">name</text>
-   <rect x="111" y="823" width="94" height="32" rx="10"/>
-   <rect x="109"
+   <rect x="179" y="823" width="94" height="32" rx="10"/>
+   <rect x="177"
          y="821"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="119" y="841">ENVELOPE</text>
-   <rect x="245" y="823" width="60" height="32" rx="10"/>
-   <rect x="243"
+   <text class="terminal" x="187" y="841">ENVELOPE</text>
+   <rect x="313" y="823" width="60" height="32" rx="10"/>
+   <rect x="311"
          y="821"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="253" y="841">NONE</text>
-   <rect x="245" y="867" width="92" height="32" rx="10"/>
-   <rect x="243"
+   <text class="terminal" x="321" y="841">NONE</text>
+   <rect x="313" y="867" width="92" height="32" rx="10"/>
+   <rect x="311"
          y="865"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="253" y="885">DEBEZIUM</text>
-   <rect x="377" y="899" width="76" height="32" rx="10"/>
-   <rect x="375"
-         y="897"
+   <text class="terminal" x="321" y="885">DEBEZIUM</text>
+   <rect x="313" y="911" width="76" height="32" rx="10"/>
+   <rect x="311"
+         y="909"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="385" y="917">UPSERT</text>
-   <rect x="245" y="943" width="76" height="32" rx="10"/>
-   <rect x="243"
-         y="941"
-         width="76"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="253" y="961">UPSERT</text>
-   <rect x="189" y="1053" width="58" height="32" rx="10"/>
+   <text class="terminal" x="321" y="929">UPSERT</text>
+   <rect x="189" y="1021" width="58" height="32" rx="10"/>
    <rect x="187"
-         y="1051"
+         y="1019"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="197" y="1071">WITH</text>
-   <rect x="267" y="1053" width="26" height="32" rx="10"/>
+   <text class="terminal" x="197" y="1039">WITH</text>
+   <rect x="267" y="1021" width="26" height="32" rx="10"/>
    <rect x="265"
-         y="1051"
+         y="1019"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="275" y="1071">(</text>
-   <rect x="333" y="1053" width="48" height="32"/>
-   <rect x="331" y="1051" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="341" y="1071">field</text>
-   <rect x="401" y="1053" width="28" height="32" rx="10"/>
+   <text class="terminal" x="275" y="1039">(</text>
+   <rect x="333" y="1021" width="48" height="32"/>
+   <rect x="331" y="1019" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="341" y="1039">field</text>
+   <rect x="401" y="1021" width="28" height="32" rx="10"/>
    <rect x="399"
-         y="1051"
+         y="1019"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="409" y="1071">=</text>
-   <rect x="449" y="1053" width="38" height="32"/>
-   <rect x="447" y="1051" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="457" y="1071">val</text>
-   <rect x="333" y="1009" width="24" height="32" rx="10"/>
+   <text class="terminal" x="409" y="1039">=</text>
+   <rect x="449" y="1021" width="38" height="32"/>
+   <rect x="447" y="1019" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="457" y="1039">val</text>
+   <rect x="333" y="977" width="24" height="32" rx="10"/>
    <rect x="331"
-         y="1007"
+         y="975"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="1027">,</text>
-   <rect x="527" y="1053" width="26" height="32" rx="10"/>
+   <text class="terminal" x="341" y="995">,</text>
+   <rect x="527" y="1021" width="26" height="32" rx="10"/>
    <rect x="525"
-         y="1051"
+         y="1019"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="535" y="1071">)</text>
+   <text class="terminal" x="535" y="1039">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-579 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-390 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-527 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h392 m-422 0 h20 m402 0 h20 m-442 0 q10 0 10 10 m422 0 q0 -10 10 -10 m-432 10 v12 m422 0 v-12 m-422 12 q0 10 10 10 m402 0 q10 0 10 -10 m-412 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h168 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v24 m268 0 v-24 m-268 24 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m92 0 h10 m20 0 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m-238 -42 v20 m268 0 v-20 m-268 20 v56 m268 0 v-56 m-268 56 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m76 0 h10 m0 0 h152 m42 -152 l2 0 m2 0 l2 0 m2 0 l2 0 m-388 262 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="591 1067 599 1063 599 1071"/>
-   <polygon points="591 1067 583 1063 583 1071"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-579 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-373 50 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-390 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-459 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m42 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-320 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="591 1035 599 1031 599 1039"/>
+   <polygon points="591 1035 583 1031 583 1039"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -80,7 +80,7 @@ create_source_kafka ::=
   ('INCLUDE'
     ( ('KEY' | 'PARTITION' | 'OFFSET' | 'TIMESTAMP' | 'HEADERS' ) ('AS' name)? )*
   )?
-  ('ENVELOPE' ('NONE' | 'DEBEZIUM' ('UPSERT')? | 'UPSERT'))?
+  ('ENVELOPE' ('NONE' | 'DEBEZIUM' | 'UPSERT'))?
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_source_kinesis ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name


### PR DESCRIPTION
We might have to re-add some of the removed paragraphs if we re-introduce a distinction between upsert-flavoured DEBEZIUM and "memory-efficient" debezium in the future.

## Motivation

Closes #15036.