### PR TITLE
Introspection configuration per replica

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -226,11 +226,16 @@ async fn migrate<S: Append>(
                 compute_instance_id: DEFAULT_COMPUTE_INSTANCE_ID,
                 name: "default_replica".into(),
                 config: SerializedComputeInstanceReplicaConfig {
-                    persisted_logs: SerializedComputeInstanceReplicaLogging::Default,
                     location: SerializedComputeInstanceReplicaLocation::Managed {
                         size: bootstrap_args.default_cluster_replica_size.clone(),
                         availability_zone: bootstrap_args.default_availability_zone.clone(),
                         az_user_specified: false,
+                    },
+                    logging: SerializedComputeInstanceReplicaLogging {
+                        log_logging: false,
+                        interval: Duration::from_secs(1),
+                        sources: None,
+                        views: None,
                     },
                 },
             };

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -29,7 +29,6 @@ use mz_sql::names::{
     DatabaseId, ObjectQualifiers, QualifiedObjectName, ResolvedDatabaseSpecifier, RoleId, SchemaId,
     SchemaSpecifier,
 };
-use mz_sql::plan::ComputeInstanceIntrospectionConfig;
 use mz_stash::{Append, AppendBatch, Stash, StashError, TableTransaction, TypedCollection};
 use mz_storage::types::sources::Timeline;
 
@@ -217,10 +216,6 @@ async fn migrate<S: Append>(
             )?;
             let default_instance = ComputeInstanceValue {
                 name: "default".into(),
-                config: Some(ComputeInstanceIntrospectionConfig {
-                    debugging: false,
-                    interval: Duration::from_secs(1),
-                }),
             };
             let default_replica = ComputeInstanceReplicaValue {
                 compute_instance_id: DEFAULT_COMPUTE_INSTANCE_ID,
@@ -233,7 +228,7 @@ async fn migrate<S: Append>(
                     },
                     logging: SerializedComputeInstanceReplicaLogging {
                         log_logging: false,
-                        interval: Duration::from_secs(1),
+                        interval: Some(Duration::from_secs(1)),
                         sources: None,
                         views: None,
                     },
@@ -481,19 +476,12 @@ impl<S: Append> Connection<S> {
 
     pub async fn load_compute_instances(
         &mut self,
-    ) -> Result<
-        Vec<(
-            ComputeInstanceId,
-            String,
-            Option<ComputeInstanceIntrospectionConfig>,
-        )>,
-        Error,
-    > {
+    ) -> Result<Vec<(ComputeInstanceId, String)>, Error> {
         Ok(COLLECTION_COMPUTE_INSTANCES
             .peek_one(&mut self.stash)
             .await?
             .into_iter()
-            .map(|(k, v)| (k.id, v.name, v.config))
+            .map(|(k, v)| (k.id, v.name))
             .collect())
     }
 
@@ -938,7 +926,6 @@ impl<'a, S: Append> Transaction<'a, S> {
     pub fn insert_compute_instance(
         &mut self,
         cluster_name: &str,
-        config: &Option<ComputeInstanceIntrospectionConfig>,
         introspection_source_indexes: &Vec<(&'static BuiltinLog, GlobalId)>,
     ) -> Result<ComputeInstanceId, Error> {
         let id = self.get_and_increment_id(COMPUTE_ID_ALLOC_KEY.to_string())?;
@@ -946,7 +933,6 @@ impl<'a, S: Append> Transaction<'a, S> {
             ComputeInstanceKey { id },
             ComputeInstanceValue {
                 name: cluster_name.to_string(),
-                config: config.clone(),
             },
         ) {
             return Err(Error::new(ErrorKind::ClusterAlreadyExists(
@@ -982,13 +968,8 @@ impl<'a, S: Append> Transaction<'a, S> {
     ) -> Result<ReplicaId, Error> {
         let id = self.get_and_increment_id(REPLICA_ID_ALLOC_KEY.to_string())?;
         let mut compute_instance_id = None;
-        for (
-            ComputeInstanceKey { id },
-            ComputeInstanceValue {
-                name,
-                config: _config,
-            },
-        ) in self.compute_instances.items()
+        for (ComputeInstanceKey { id }, ComputeInstanceValue { name }) in
+            self.compute_instances.items()
         {
             if &name == compute_name {
                 compute_instance_id = Some(id);
@@ -1491,7 +1472,6 @@ struct ComputeInstanceKey {
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Eq, Ord)]
 struct ComputeInstanceValue {
     name: String,
-    config: Option<ComputeInstanceIntrospectionConfig>,
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Eq, Ord, Hash)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -377,7 +377,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for instance in self.catalog.compute_instances() {
             self.controller.compute.create_instance(
                 instance.id,
-                None,
+                instance.log_indexes.clone(),
                 self.catalog.system_config().max_result_size(),
             )?;
             for (replica_id, replica) in instance.replicas_by_id.clone() {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -377,7 +377,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for instance in self.catalog.compute_instances() {
             self.controller.compute.create_instance(
                 instance.id,
-                instance.logging.clone(),
+                None,
                 self.catalog.system_config().max_result_size(),
             )?;
             for (replica_id, replica) in instance.replicas_by_id.clone() {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -383,8 +383,8 @@ impl<S: Append + 'static> Coordinator<S> {
             for (replica_id, replica) in instance.replicas_by_id.clone() {
                 let introspection_collections = replica
                     .config
-                    .persisted_logs
-                    .get_sources()
+                    .logging
+                    .sources
                     .iter()
                     .map(|(variant, id)| (*id, variant.desc().into()))
                     .collect();
@@ -397,7 +397,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
 
-                persisted_source_ids.extend(replica.config.persisted_logs.get_source_ids());
+                persisted_source_ids.extend(replica.config.logging.source_ids());
 
                 self.controller
                     .active_compute()

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -142,7 +142,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
                 // Drop the introspection sources
                 for replica in instance.replicas_by_id.values() {
-                    sources_to_drop.extend(replica.config.persisted_logs.get_source_ids());
+                    sources_to_drop.extend(replica.config.logging.source_ids());
                 }
 
                 // Drop timelines
@@ -153,7 +153,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 let replica = &compute_instance.replicas_by_id[replica_id];
 
                 // Drop the introspection sources
-                sources_to_drop.extend(replica.config.persisted_logs.get_source_ids());
+                sources_to_drop.extend(replica.config.logging.source_ids());
             }
         }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -699,6 +699,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     addrs,
                     compute_addrs,
                     workers,
+                    introspection: _,
                 } => SerializedComputeInstanceReplicaLocation::Remote {
                     addrs,
                     compute_addrs,
@@ -707,6 +708,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 mz_sql::plan::ComputeInstanceReplicaConfig::Managed {
                     size,
                     availability_zone,
+                    introspection: _,
                 } => {
                     let (availability_zone, user_specified) =
                         availability_zone.map(|az| (az, true)).unwrap_or_else(|| {
@@ -828,6 +830,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 addrs,
                 compute_addrs,
                 workers,
+                introspection: _,
             } => SerializedComputeInstanceReplicaLocation::Remote {
                 addrs,
                 compute_addrs,
@@ -836,6 +839,7 @@ impl<S: Append + 'static> Coordinator<S> {
             mz_sql::plan::ComputeInstanceReplicaConfig::Managed {
                 size,
                 availability_zone,
+                introspection: _,
             } => {
                 let (availability_zone, user_specified) = match availability_zone {
                     Some(az) => {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -665,7 +665,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .collect();
         let mut ops = vec![catalog::Op::CreateComputeInstance {
             name: name.clone(),
-            arranged_introspection_sources,
+            arranged_introspection_sources: arranged_introspection_sources.clone(),
         }];
 
         let azs = self.catalog.state().availability_zones();
@@ -778,9 +778,13 @@ impl<S: Append + 'static> Coordinator<S> {
             .catalog
             .resolve_compute_instance(&name)
             .expect("compute instance must exist after creation");
+        let arranged_logs = arranged_introspection_sources
+            .into_iter()
+            .map(|(log, id)| (log.variant.clone(), id))
+            .collect();
         self.controller.compute.create_instance(
             instance.id,
-            None,
+            arranged_logs,
             self.catalog.system_config().max_result_size(),
         )?;
         for (replica_id, replica) in instance.replicas_by_id.clone() {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -53,7 +53,7 @@ pub enum AdapterError {
     IdExhaustionError,
     /// Unexpected internal state was encountered.
     Internal(String),
-    /// Attempted to read from log sources on a cluster with disabled introspection.
+    /// Attempted to read from log sources of a replica with disabled introspection.
     IntrospectionDisabled {
         log_names: Vec<String>,
     },
@@ -307,7 +307,7 @@ impl fmt::Display for AdapterError {
             AdapterError::Internal(e) => write!(f, "internal error: {}", e),
             AdapterError::IntrospectionDisabled { .. } => write!(
                 f,
-                "cannot read log sources on cluster with disabled introspection"
+                "cannot read log sources of replica with disabled introspection"
             ),
             AdapterError::InvalidLogDependency { object_type, .. } => {
                 write!(f, "{object_type} objects cannot depend on log sources")

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -29,7 +29,7 @@
 //! from compacting beyond the allowed compaction of each of its outputs, ensuring that we can
 //! recover each dataflow to its current state in case of failure or other reconfiguration.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 use std::num::NonZeroUsize;
@@ -356,15 +356,17 @@ where
     pub fn create_instance(
         &mut self,
         id: ComputeInstanceId,
-        logging: Option<LoggingConfig>,
+        arranged_logs: BTreeMap<LogVariant, GlobalId>,
         max_result_size: u32,
     ) -> Result<(), ComputeError> {
         if self.instances.contains_key(&id) {
             return Err(ComputeError::InstanceExists(id));
         }
 
-        self.instances
-            .insert(id, Instance::new(self.build_info, logging, max_result_size));
+        self.instances.insert(
+            id,
+            Instance::new(self.build_info, arranged_logs, max_result_size),
+        );
 
         if self.initialized {
             self.instances
@@ -476,25 +478,19 @@ where
         replica_id: ReplicaId,
         config: ComputeInstanceReplicaConfig,
     ) -> Result<(), ComputeError> {
-        let persisted_logs = config.logging.sources.iter().cloned().collect();
-
-        // Add replicas backing that instance.
-        match config.location {
+        let (addrs, communication_config) = match config.location {
             ComputeInstanceReplicaLocation::Remote {
                 addrs,
                 compute_addrs,
                 workers,
             } => {
-                self.instance(instance_id)?.add_replica(
-                    replica_id,
-                    addrs.into_iter().collect(),
-                    persisted_logs,
-                    CommunicationConfig {
-                        workers: workers.get(),
-                        process: 0,
-                        addresses: compute_addrs.into_iter().collect(),
-                    },
-                );
+                let addrs = addrs.into_iter().collect();
+                let comm = CommunicationConfig {
+                    workers: workers.get(),
+                    process: 0,
+                    addresses: compute_addrs.into_iter().collect(),
+                };
+                (addrs, comm)
             }
             ComputeInstanceReplicaLocation::Managed {
                 allocation,
@@ -507,20 +503,22 @@ where
                     .ensure_replica(instance_id, replica_id, allocation, availability_zone)
                     .await?;
 
-                self.instance(instance_id)?.add_replica(
-                    replica_id,
-                    service.addresses("controller"),
-                    persisted_logs,
-                    CommunicationConfig {
-                        workers: allocation.workers.get(),
-                        process: 0,
-                        addresses: service.addresses("compute"),
-                    },
-                );
+                let addrs = service.addresses("controller");
+                let comm = CommunicationConfig {
+                    workers: allocation.workers.get(),
+                    process: 0,
+                    addresses: service.addresses("compute"),
+                };
+                (addrs, comm)
             }
-        }
+        };
 
-        Ok(())
+        self.instance(instance_id)?.add_replica(
+            replica_id,
+            addrs,
+            config.logging,
+            communication_config,
+        )
     }
 
     /// Removes a replica from an instance, including its service in the orchestrator.
@@ -698,6 +696,8 @@ struct Instance<T> {
     replicas: ActiveReplication<T>,
     /// Tracks expressed `since` and received `upper` frontiers for indexes and sinks.
     collections: BTreeMap<GlobalId, CollectionState<T>>,
+    /// IDs of arranged log sources maintained by this compute instance.
+    arranged_logs: BTreeMap<LogVariant, GlobalId>,
     /// Currently outstanding peeks: identifiers and timestamps.
     peeks: BTreeMap<Uuid, (GlobalId, T)>,
 }
@@ -736,34 +736,34 @@ where
 {
     fn new(
         build_info: &'static BuildInfo,
-        logging: Option<LoggingConfig>,
+        arranged_logs: BTreeMap<LogVariant, GlobalId>,
         max_result_size: u32,
     ) -> Self {
-        let mut collections = BTreeMap::default();
-        if let Some(logging_config) = logging.as_ref() {
-            for id in logging_config.log_identifiers() {
-                collections.insert(
-                    id,
-                    CollectionState::new(
-                        Antichain::from_elem(T::minimum()),
-                        Vec::new(),
-                        Vec::new(),
-                    ),
+        let collections = arranged_logs
+            .iter()
+            .map(|(_, id)| {
+                let state = CollectionState::new(
+                    Antichain::from_elem(T::minimum()),
+                    Vec::new(),
+                    Vec::new(),
                 );
-            }
-        }
+                (*id, state)
+            })
+            .collect();
+
         let mut replicas = ActiveReplication::new(build_info);
         // These commands will be modified by ActiveReplication
         replicas.send(ComputeCommand::CreateTimely(Default::default()));
         replicas.send(ComputeCommand::CreateInstance(InstanceConfig {
             replica_id: Default::default(),
-            logging,
+            logging: None,
             max_result_size,
         }));
 
         Self {
             replicas,
             collections,
+            arranged_logs,
             peeks: Default::default(),
         }
     }
@@ -805,35 +805,48 @@ where
         &mut self,
         id: ReplicaId,
         addrs: Vec<String>,
-        persisted_logs: HashMap<LogVariant, GlobalId>,
+        logging: ComputeInstanceReplicaLogging,
         communication_config: CommunicationConfig,
-    ) {
-        // Create ComputeState entries in Instance
-        for id in persisted_logs.values() {
-            self.compute.collections.insert(
-                *id,
-                CollectionState::new(Antichain::from_elem(T::minimum()), Vec::new(), Vec::new()),
-            );
-        }
+    ) -> Result<(), ComputeError> {
+        let logging_config = if let Some(interval) = logging.interval {
+            // Initialize state for per-replica log sources.
+            let mut sink_logs = BTreeMap::new();
+            for (variant, id) in logging.sources {
+                self.compute.collections.insert(
+                    id,
+                    CollectionState::new(
+                        Antichain::from_elem(T::minimum()),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                );
 
-        // Enrich log collections with metadata such that they can be sent over to computed
-        let persisted_logs = persisted_logs
-            .into_iter()
-            .map(|(variant, id)| {
-                let meta = self
+                let storage_meta = self
                     .storage_controller
-                    .collection(id)
-                    .expect("cannot get collection metadata")
+                    .collection(id)?
                     .collection_metadata
                     .clone();
-                (variant, (id, meta))
+                sink_logs.insert(variant, (id, storage_meta));
+            }
+
+            Some(LoggingConfig {
+                interval_ns: interval.as_nanos(),
+                active_logs: self.compute.arranged_logs.clone(),
+                log_logging: logging.log_logging,
+                sink_logs,
             })
-            .collect();
+        } else {
+            None
+        };
+
+        // Initialize collection state for per-replica log collections.
 
         // Add the replica
         self.compute
             .replicas
-            .add_replica(id, addrs, persisted_logs, communication_config);
+            .add_replica(id, addrs, logging_config, communication_config);
+
+        Ok(())
     }
 
     /// Remove an existing instance replica, by ID.

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -239,7 +239,9 @@ pub struct ComputeInstanceReplicaLogging {
     /// Whether to enable logging for the logging dataflows.
     pub log_logging: bool,
     /// The interval at which to log.
-    pub interval: Duration,
+    ///
+    /// A `None` value indicates that logging is disabled.
+    pub interval: Option<Duration>,
     /// Log sources of this replica.
     pub sources: Vec<(LogVariant, GlobalId)>,
     /// Log views of this replica.
@@ -247,6 +249,11 @@ pub struct ComputeInstanceReplicaLogging {
 }
 
 impl ComputeInstanceReplicaLogging {
+    /// Return whether logging is enabled.
+    pub fn enabled(&self) -> bool {
+        self.interval.is_some()
+    }
+
     /// Return all ids of the persisted introspection views contained.
     pub fn view_ids(&self) -> impl Iterator<Item = GlobalId> + '_ {
         self.views.iter().map(|(_, id)| *id)

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -994,10 +994,6 @@ impl_display_t!(CreateClusterStatement);
 /// An option in a `CREATE CLUSTER` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ClusterOption<T: AstInfo> {
-    /// The `INTROSPECTION INTERVAL [[=] <interval>] option.
-    IntrospectionInterval(WithOptionValue<T>),
-    /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
-    IntrospectionDebugging(WithOptionValue<T>),
     /// The `REPLICAS` option.
     Replicas(Vec<ReplicaDefinition<T>>),
 }
@@ -1005,14 +1001,6 @@ pub enum ClusterOption<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for ClusterOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            ClusterOption::IntrospectionInterval(interval) => {
-                f.write_str("INTROSPECTION INTERVAL ");
-                f.write_node(interval);
-            }
-            ClusterOption::IntrospectionDebugging(debugging) => {
-                f.write_str("INTROSPECTION DEBUGGING ");
-                f.write_node(debugging);
-            }
             ClusterOption::Replicas(replicas) => {
                 f.write_str("REPLICAS (");
                 f.write_node(&display::comma_separated(replicas));
@@ -1075,6 +1063,10 @@ pub enum ReplicaOptionName {
     Workers,
     /// The `COMPUTE [<host> [, <host> ...]]` option.
     Compute,
+    /// The `INTROSPECTION INTERVAL [[=] <interval>] option.
+    IntrospectionInterval,
+    /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
+    IntrospectionDebugging,
 }
 
 impl AstDisplay for ReplicaOptionName {
@@ -1085,6 +1077,8 @@ impl AstDisplay for ReplicaOptionName {
             ReplicaOptionName::AvailabilityZone => f.write_str("AVAILABILITY ZONE"),
             ReplicaOptionName::Workers => f.write_str("WORKERS"),
             ReplicaOptionName::Compute => f.write_str("COMPUTE"),
+            ReplicaOptionName::IntrospectionInterval => f.write_str("INTROSPECTION INTERVAL"),
+            ReplicaOptionName::IntrospectionDebugging => f.write_str("INTROSPECTION DEBUGGING"),
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -931,53 +931,18 @@ CREATE CLUSTER cluster REPLICAS ()
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([])] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER cluster WITH REPLICAS ()
 ----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL '1s'
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(String("1s")))] })
-
-parse-statement
-CREATE CLUSTER cluster INTROSPECTION INTERVAL '1s', REPLICAS ()
-----
-CREATE CLUSTER cluster INTROSPECTION INTERVAL '1s', REPLICAS ()
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionInterval(Value(String("1s"))), Replicas([])] })
-
-parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL = '1s'
-----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL '1s'
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(String("1s")))] })
-
-parse-statement
-CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION INTERVAL = '1s'
-----
-error: Expected one of REPLICAS or INTROSPECTION, found WITH
-CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION INTERVAL = '1s'
+error: Expected end of statement, found WITH
+CREATE CLUSTER cluster WITH REPLICAS ()
                        ^
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL = 0
-----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL 0
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(Number("0")))] })
-
-parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL = NULL
-----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL NULL
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(Null))] })
-
-parse-statement
 CREATE CLUSTER cluster REPLICAS (), BADOPT
 ----
-error: Expected one of REPLICAS or INTROSPECTION, found identifier "badopt"
+error: Expected end of statement, found comma
 CREATE CLUSTER cluster REPLICAS (), BADOPT
-                                    ^
+                                  ^
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
@@ -987,11 +952,18 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']))
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }])] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1'))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']), b (SIZE = '1')), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']), b (SIZE = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }]), IntrospectionInterval(Value(String("1s")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
+
+parse-statement
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING true), b (SIZE '1', INTROSPECTION INTERVAL 0))
+----
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1'], INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = '1', INTROSPECTION INTERVAL = 0))
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
@@ -1055,6 +1027,27 @@ CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 CREATE CLUSTER REPLICA default.replica REMOTE = ['host1'], AVAILABILITY ZONE = 'a'
 =>
 CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica SIZE 'small', INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING = false
+----
+CREATE CLUSTER REPLICA default.replica SIZE = 'small', INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = false
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(false))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica INTROSPECTION INTERVAL = 0, SIZE 'small'
+----
+CREATE CLUSTER REPLICA default.replica INTROSPECTION INTERVAL = 0, SIZE = 'small'
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }, ReplicaOption { name: Size, value: Some(Value(String("small"))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], INTROSPECTION INTERVAL NULL
+----
+CREATE CLUSTER REPLICA default.replica REMOTE = ['host1'], INTROSPECTION INTERVAL = NULL
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] } })
 
 parse-statement
 DROP CLUSTER cluster

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -250,7 +250,6 @@ pub struct CreateRolePlan {
 #[derive(Debug)]
 pub struct CreateComputeInstancePlan {
     pub name: String,
-    pub config: Option<ComputeInstanceIntrospectionConfig>,
     pub replicas: Vec<(String, ComputeInstanceReplicaConfig)>,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -260,9 +260,9 @@ pub struct CreateComputeInstanceReplicaPlan {
     pub config: ComputeInstanceReplicaConfig,
 }
 
-/// Configuration of introspection for a compute instance.
+/// Configuration of introspection for a compute instance replica.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
-pub struct ComputeInstanceIntrospectionConfig {
+pub struct ComputeInstanceReplicaIntrospectionConfig {
     /// Whether to introspect the introspection.
     pub debugging: bool,
     /// The interval at which to introspect.
@@ -275,12 +275,12 @@ pub enum ComputeInstanceReplicaConfig {
         addrs: BTreeSet<String>,
         compute_addrs: BTreeSet<String>,
         workers: NonZeroUsize,
-        introspection: Option<ComputeInstanceIntrospectionConfig>,
+        introspection: Option<ComputeInstanceReplicaIntrospectionConfig>,
     },
     Managed {
         size: String,
         availability_zone: Option<String>,
-        introspection: Option<ComputeInstanceIntrospectionConfig>,
+        introspection: Option<ComputeInstanceReplicaIntrospectionConfig>,
     },
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -276,10 +276,12 @@ pub enum ComputeInstanceReplicaConfig {
         addrs: BTreeSet<String>,
         compute_addrs: BTreeSet<String>,
         workers: NonZeroUsize,
+        introspection: Option<ComputeInstanceIntrospectionConfig>,
     },
     Managed {
         size: String,
         availability_zone: Option<String>,
+        introspection: Option<ComputeInstanceIntrospectionConfig>,
     },
 }
 
@@ -290,10 +292,12 @@ impl ComputeInstanceReplicaConfig {
                 addrs: _,
                 compute_addrs: _,
                 workers: _,
+                introspection: _,
             } => None,
             ComputeInstanceReplicaConfig::Managed {
                 size: _,
                 availability_zone,
+                introspection: _,
             } => availability_zone.as_deref(),
         }
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -100,11 +100,11 @@ use crate::plan::with_options::{self, OptionalInterval, TryFromValue};
 use crate::plan::{
     plan_utils, query, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan, AlterItemRenamePlan,
     AlterNoopPlan, AlterSecretPlan, AlterSourceItem, AlterSourcePlan, AlterSystemResetAllPlan,
-    AlterSystemResetPlan, AlterSystemSetPlan, ComputeInstanceIntrospectionConfig,
-    ComputeInstanceReplicaConfig, CreateComputeInstancePlan, CreateComputeInstanceReplicaPlan,
-    CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan, CreateMaterializedViewPlan,
-    CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
-    CreateTablePlan, CreateTypePlan, CreateViewPlan, CreateViewsPlan,
+    AlterSystemResetPlan, AlterSystemSetPlan, ComputeInstanceReplicaConfig,
+    ComputeInstanceReplicaIntrospectionConfig, CreateComputeInstancePlan,
+    CreateComputeInstanceReplicaPlan, CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan,
+    CreateMaterializedViewPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan,
+    CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, CreateViewsPlan,
     DropComputeInstanceReplicaPlan, DropComputeInstancesPlan, DropDatabasePlan, DropItemsPlan,
     DropRolesPlan, DropSchemaPlan, Index, MaterializedView, Params, Plan, RotateKeysPlan, Secret,
     Sink, Source, StorageHostConfig, Table, Type, View,
@@ -2256,7 +2256,7 @@ fn plan_replica_config(
         .map(|OptionalInterval(i)| i)
         .unwrap_or(Some(DEFAULT_INTROSPECTION_INTERVAL));
     let introspection = match introspection_interval {
-        Some(interval) => Some(ComputeInstanceIntrospectionConfig {
+        Some(interval) => Some(ComputeInstanceReplicaIntrospectionConfig {
             interval: interval.duration()?,
             debugging: introspection_debugging.unwrap_or(false),
         }),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2206,7 +2206,6 @@ pub fn plan_create_cluster(
 
     Ok(Plan::CreateComputeInstance(CreateComputeInstancePlan {
         name: normalize::ident(name),
-        config: None,
         replicas,
     }))
 }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -20,7 +20,7 @@ CREATE CLUSTER foo REPLICAS ()
 statement ok
 DROP CLUSTER foo
 
-statement error REPLICAS specified more than once
+statement error Expected end of statement, found comma
 CREATE CLUSTER foo REPLICAS (), REPLICAS()
 
 # Creating cluster w/ remote replica works.
@@ -301,13 +301,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], INTROSPECTION INTERVAL '1s'))
 
 statement ok
 DROP CLUSTER foo CASCADE
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], INTROSPECTION INTERVAL '1s'))
 
 statement ok
 DROP CLUSTER foo CASCADE

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -80,17 +80,30 @@ DROP CLUSTER REPLICA test.replica_b;
 statement ok
 SELECT * FROM mz_internal.mz_compute_exports
 
-# Verify that querying introspection data is disallowed on clusters with
-# introspection disabled.
+# Verify that querying introspection data is disallowed on replicas with
+# introspection disabled, but allowed on introspection-enabled replicas
+# in the same cluster.
 
 statement ok
 DROP CLUSTER test CASCADE
 
 statement ok
 CREATE CLUSTER test
-  REPLICAS (replica_a (SIZE '1', INTROSPECTION INTERVAL 0))
+  REPLICAS (
+    replica_a (SIZE '1', INTROSPECTION INTERVAL 0),
+    replica_b (SIZE '1', INTROSPECTION INTERVAL 1)
+  )
 
-query error cannot read log sources on cluster with disabled introspection
+statement ok
+SET cluster_replica = replica_a
+
+query error cannot read log sources of replica with disabled introspection
+SELECT * FROM mz_internal.mz_compute_exports
+
+statement ok
+SET cluster_replica = replica_b
+
+statement ok
 SELECT * FROM mz_internal.mz_compute_exports
 
 # Clean up.

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -18,10 +18,9 @@ INSERT INTO test VALUES('a', 'b')
 statement ok
 CREATE CLUSTER test
   REPLICAS (
-    replica_a (SIZE '1'),
-    replica_b (SIZE '2')
-  ),
-  INTROSPECTION INTERVAL '50 milliseconds'
+    replica_a (SIZE '1', INTROSPECTION INTERVAL '50 milliseconds'),
+    replica_b (SIZE '2', INTROSPECTION INTERVAL '50 milliseconds')
+  )
 
 statement ok
 SET cluster = test
@@ -89,8 +88,7 @@ DROP CLUSTER test CASCADE
 
 statement ok
 CREATE CLUSTER test
-  REPLICAS (replica_a (SIZE '1')),
-  INTROSPECTION INTERVAL 0
+  REPLICAS (replica_a (SIZE '1', INTROSPECTION INTERVAL 0))
 
 query error cannot read log sources on cluster with disabled introspection
 SELECT * FROM mz_internal.mz_compute_exports


### PR DESCRIPTION
This PR moves the configuration for compute introspection from the cluster-level to the replica-level. In the future we may want to include some kind of configuration inheritance, with default settings for the cluster that can get overwritten per replica. We are punting on this now because of how close we are to EA. Adding back cluster-level introspection configuration can be done later without breaking backwards-compatibility.

The one thing that is a bit messy now is that the old arranged introspection sources share their catalog items (indexes) between all replicas of a cluster. We need to create those when we create the cluster, even though not all replicas may have introspection enabled, and therefore may not maintain arrangements backing the catalog indexes. So the adapter needs to check before serving a peek that targets arranged introspection sources, whether the targeted replica actually has introspection enabled. Once we manage to make the persisted introspection sources ergonomic, we plan to remove the arranged ones, so this ugliness will go away eventually.

Also note that this PR changes the format of the cluster and replica configs we store in stash. This would need a migration, but writing one seems hard. So I'd rather wait until next Wednesday and then merge this PR in time for the next release that allows breaking changes.

### Motivation

  * This PR adds a known-desirable feature.

Closes #12660.

### Tips for reviewer

I tried to split this into several more digestible commits, but I'm not sure if I succeeded. I'd suggest you try looking at the commits separately and see if that helps.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Move configuration of introspection from the cluster-level to the replica-level.
