### PR TITLE
compute-client,adapter: remove `Concrete` prefixes

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
 use mz_compute_client::command::{ProcessId, ReplicaId};
 use mz_compute_client::controller::{
-    ComputeInstanceId, ComputeInstanceStatus, ConcreteComputeInstanceReplicaLocation,
+    ComputeInstanceId, ComputeInstanceReplicaLocation, ComputeInstanceStatus,
 };
 use mz_expr::MirScalarExpr;
 use mz_ore::cast::CastFrom;
@@ -128,13 +128,13 @@ impl CatalogState {
         let replica = &instance.replicas_by_id[&id];
 
         let (size, az) = match &replica.config.location {
-            ConcreteComputeInstanceReplicaLocation::Managed {
+            ComputeInstanceReplicaLocation::Managed {
                 size,
                 availability_zone,
                 az_user_specified: _,
                 allocation: _,
             } => (Some(&**size), Some(availability_zone.as_str())),
-            ConcreteComputeInstanceReplicaLocation::Remote { .. } => (None, None),
+            ComputeInstanceReplicaLocation::Remote { .. } => (None, None),
         };
 
         BuiltinTableUpdate {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -20,7 +20,7 @@ use timely::progress::Timestamp;
 
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
 use mz_compute_client::command::ReplicaId;
-use mz_compute_client::controller::{ComputeInstanceId, ConcreteComputeInstanceReplicaConfig};
+use mz_compute_client::controller::{ComputeInstanceId, ComputeInstanceReplicaConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::GlobalId;
@@ -650,7 +650,7 @@ impl<S: Append> Connection<S> {
         replica_id: ReplicaId,
         compute_instance_id: ComputeInstanceId,
         name: String,
-        config: &ConcreteComputeInstanceReplicaConfig,
+        config: &ComputeInstanceReplicaConfig,
     ) -> Result<(), Error> {
         let key = ComputeInstanceReplicaKey { id: replica_id };
         let val = ComputeInstanceReplicaValue {

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -170,14 +170,14 @@ impl From<anyhow::Error> for ComputeError {
 
 /// Replica configuration
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ConcreteComputeInstanceReplicaConfig {
-    pub location: ConcreteComputeInstanceReplicaLocation,
-    pub persisted_logs: ConcreteComputeInstanceReplicaLogging,
+pub struct ComputeInstanceReplicaConfig {
+    pub location: ComputeInstanceReplicaLocation,
+    pub persisted_logs: ComputeInstanceReplicaLogging,
 }
 
 /// Size or location of a replica
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ConcreteComputeInstanceReplicaLocation {
+pub enum ComputeInstanceReplicaLocation {
     /// Out-of-process replica
     Remote {
         /// The network addresses of the processes in the replica.
@@ -202,11 +202,11 @@ pub enum ConcreteComputeInstanceReplicaLocation {
     },
 }
 
-impl ConcreteComputeInstanceReplicaLocation {
+impl ComputeInstanceReplicaLocation {
     pub fn get_az(&self) -> Option<&str> {
         match self {
-            ConcreteComputeInstanceReplicaLocation::Remote { .. } => None,
-            ConcreteComputeInstanceReplicaLocation::Managed {
+            ComputeInstanceReplicaLocation::Remote { .. } => None,
+            ComputeInstanceReplicaLocation::Managed {
                 availability_zone, ..
             } => Some(availability_zone),
         }
@@ -235,7 +235,7 @@ impl ComputeInstanceReplicaAllocation {
 /// Logging configuration of a replica.
 /// Changing this type requires a catalog storage migration!
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum ConcreteComputeInstanceReplicaLogging {
+pub enum ComputeInstanceReplicaLogging {
     /// Instantiate default logging configuration upon system start.
     /// To configure a replica without logging, ConcreteViews(vec![],vec![]) should be used.
     Default,
@@ -243,20 +243,20 @@ pub enum ConcreteComputeInstanceReplicaLogging {
     ConcreteViews(Vec<(LogVariant, GlobalId)>, Vec<(LogView, GlobalId)>),
 }
 
-impl ConcreteComputeInstanceReplicaLogging {
+impl ComputeInstanceReplicaLogging {
     /// Return all persisted introspection sources contained.
     pub fn get_sources(&self) -> &[(LogVariant, GlobalId)] {
         match self {
-            ConcreteComputeInstanceReplicaLogging::Default => &[],
-            ConcreteComputeInstanceReplicaLogging::ConcreteViews(logs, _) => logs,
+            ComputeInstanceReplicaLogging::Default => &[],
+            ComputeInstanceReplicaLogging::ConcreteViews(logs, _) => logs,
         }
     }
 
     /// Return all persisted introspection views contained.
     pub fn get_views(&self) -> &[(LogView, GlobalId)] {
         match self {
-            ConcreteComputeInstanceReplicaLogging::Default => &[],
-            ConcreteComputeInstanceReplicaLogging::ConcreteViews(_, views) => views,
+            ComputeInstanceReplicaLogging::Default => &[],
+            ComputeInstanceReplicaLogging::ConcreteViews(_, views) => views,
         }
     }
 
@@ -480,7 +480,7 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
-        config: ConcreteComputeInstanceReplicaConfig,
+        config: ComputeInstanceReplicaConfig,
     ) -> Result<(), ComputeError> {
         let persisted_logs = config
             .persisted_logs
@@ -491,7 +491,7 @@ where
 
         // Add replicas backing that instance.
         match config.location {
-            ConcreteComputeInstanceReplicaLocation::Remote {
+            ComputeInstanceReplicaLocation::Remote {
                 addrs,
                 compute_addrs,
                 workers,
@@ -507,7 +507,7 @@ where
                     },
                 );
             }
-            ConcreteComputeInstanceReplicaLocation::Managed {
+            ComputeInstanceReplicaLocation::Managed {
                 allocation,
                 availability_zone,
                 ..
@@ -539,9 +539,9 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
-        config: ConcreteComputeInstanceReplicaConfig,
+        config: ComputeInstanceReplicaConfig,
     ) -> Result<(), ComputeError> {
-        if let ConcreteComputeInstanceReplicaLocation::Managed { .. } = config.location {
+        if let ComputeInstanceReplicaLocation::Managed { .. } = config.location {
             self.compute
                 .orchestrator
                 .drop_replica(instance_id, replica_id)


### PR DESCRIPTION
`mz_compute_client` defines the `ConcreteComputeInstanceReplicaConfig` type. This type, as well as its subtypes, have a `Concrete` prefix solely because of a naming conflict with `mz_sql::plan::ComputeInstanceReplicaConfig`. It is not great that the compute client needs to concern itself with the type definitions in an otherwise unrelated crate.

This PR removes the `Concrete` prefixes and instead solves the naming conflict by prefixing the `mz_sql` type with its module name in the only module where both are used.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
