### PR TITLE
doc/user: indicate that debezium-enveloped sources may need larger sizes

### DIFF
--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -189,9 +189,6 @@ The upsert envelope treats all records as having a **key** and a **value**, and 
 
 - If the key matches a preexisting record and the value is _null_, Materialize deletes the record.
 
-The upsert envelope has slower data ingestion and is **more memory intensive** than other envelopes. In most cases, Materialize must maintain state proportional to the number of
-unique rows in the source, and perform extra work to handle retractions based on that state.
-
 ### Debezium envelope
 
 <p style="font-size:14px"><b>Syntax:</b> <code>ENVELOPE DEBEZIUM</code></p>
@@ -232,10 +229,11 @@ By default, Materialize provisions sources using the smallest size (`3xsmall`). 
     faster, as there is more CPU available to read and decode data from the
     upstream external system.
 
-  * You are using the [upsert envelope](#upsert-envelope), and your source
-    contains **many unique keys**. This envelope must keep in-memory state
-    proportional to the number of unique keys in the upstream external system.
-    Larger sizes can store more unique keys.
+  * You are using the [upsert envelope](#upsert-envelope) or [debezium
+    envelope](#debezium-envelope), and your source contains **many unique
+    keys**. These envelopes must keep in-memory state proportional to the number
+    of unique keys in the upstream external system. Larger sizes can store more
+    unique keys.
 
 ## Related pages
 


### PR DESCRIPTION
Addresses a thought from #15043 [[0]].

[0]: https://github.com/MaterializeInc/materialize/pull/15043#discussion_r982625079

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR addresses a lingering thought from @morsapaes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
