### PR TITLE
[sinks] Rename some lingering consistency refernces to progress

### DIFF
--- a/src/adapter/src/sink_connection.rs
+++ b/src/adapter/src/sink_connection.rs
@@ -17,7 +17,7 @@ use mz_ore::collections::CollectionExt;
 use mz_storage::types::connections::{ConnectionContext, PopulateClientConfig};
 use mz_storage::types::sinks::{
     KafkaConsistencyConfig, KafkaSinkConnection, KafkaSinkConnectionBuilder,
-    KafkaSinkConnectionRetention, KafkaSinkConsistencyConnection, PublishedSchemaInfo,
+    KafkaSinkConnectionRetention, KafkaSinkProgressConnection, PublishedSchemaInfo,
     StorageSinkConnection, StorageSinkConnectionBuilder,
 };
 
@@ -237,7 +237,7 @@ async fn build_kafka(
         mz_storage::types::sinks::KafkaSinkFormat::Json => None,
     };
 
-    let consistency = match builder.consistency_config {
+    let progress = match builder.consistency_config {
         KafkaConsistencyConfig::Progress { topic } => {
             ensure_kafka_topic(
                 &client,
@@ -249,7 +249,7 @@ async fn build_kafka(
             .await
             .context("error registering kafka consistency topic for sink")?;
 
-            KafkaSinkConsistencyConnection { topic }
+            KafkaSinkProgressConnection { topic }
         }
     };
 
@@ -261,7 +261,7 @@ async fn build_kafka(
         key_desc_and_indices: builder.key_desc_and_indices,
         value_desc: builder.value_desc,
         published_schema_info,
-        consistency,
+        progress,
         exactly_once: true,
         fuel: builder.fuel,
     }))

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -458,7 +458,7 @@ impl KafkaSinkState {
         };
 
         let sink_state = KafkaSinkStateEnum::Init(Some(ProgressInitState {
-            topic: connection.consistency.topic,
+            topic: connection.progress.topic,
             key: format!("mz-sink-{sink_id}"),
             progress_client_config,
         }));
@@ -738,7 +738,7 @@ impl KafkaSinkState {
 
             if partitions.len() != 1 {
                 bail!(
-                    "Consistency topic {} should contain a single partition, but instead contains {} partitions",
+                    "Progress topic {} should contain a single partition, but instead contains {} partitions",
                     progress_topic, partitions.len(),
                 );
             }

--- a/src/storage/src/types/sinks.proto
+++ b/src/storage/src/types/sinks.proto
@@ -41,7 +41,7 @@ message ProtoStorageSinkConnection {
     }
 }
 
-message ProtoKafkaSinkConsistencyConnection {
+message ProtoKafkaSinkProgressConnection {
     string topic = 1;
     // int32 schema_id = 2;
     reserved 2;
@@ -74,7 +74,7 @@ message ProtoKafkaSinkConnection {
     optional ProtoRelationKeyIndicesVec relation_key_indices = 5;
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
     optional ProtoPublishedSchemaInfo published_schema_info = 7;
-    ProtoKafkaSinkConsistencyConnection consistency = 8;
+    ProtoKafkaSinkProgressConnection progress = 8;
     bool exactly_once = 9;
     uint64 fuel = 11;
     map<string, mz_storage.types.connections.ProtoStringOrSecret> options = 12;

--- a/src/storage/src/types/sinks.rs
+++ b/src/storage/src/types/sinks.rs
@@ -210,19 +210,19 @@ impl RustType<ProtoStorageSinkConnection> for StorageSinkConnection {
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConsistencyConnection {
+pub struct KafkaSinkProgressConnection {
     pub topic: String,
 }
 
-impl RustType<ProtoKafkaSinkConsistencyConnection> for KafkaSinkConsistencyConnection {
-    fn into_proto(&self) -> ProtoKafkaSinkConsistencyConnection {
-        ProtoKafkaSinkConsistencyConnection {
+impl RustType<ProtoKafkaSinkProgressConnection> for KafkaSinkProgressConnection {
+    fn into_proto(&self) -> ProtoKafkaSinkProgressConnection {
+        ProtoKafkaSinkProgressConnection {
             topic: self.topic.clone(),
         }
     }
 
-    fn from_proto(proto: ProtoKafkaSinkConsistencyConnection) -> Result<Self, TryFromProtoError> {
-        Ok(KafkaSinkConsistencyConnection { topic: proto.topic })
+    fn from_proto(proto: ProtoKafkaSinkProgressConnection) -> Result<Self, TryFromProtoError> {
+        Ok(KafkaSinkProgressConnection { topic: proto.topic })
     }
 }
 
@@ -235,7 +235,7 @@ pub struct KafkaSinkConnection {
     pub relation_key_indices: Option<Vec<usize>>,
     pub value_desc: RelationDesc,
     pub published_schema_info: Option<PublishedSchemaInfo>,
-    pub consistency: KafkaSinkConsistencyConnection,
+    pub progress: KafkaSinkProgressConnection,
     pub exactly_once: bool,
     // Maximum number of records the sink will attempt to send each time it is
     // invoked
@@ -263,7 +263,7 @@ proptest::prop_compose! {
         relation_key_indices in any::<Option<Vec<usize>>>(),
         value_desc in any::<RelationDesc>(),
         published_schema_info in any::<Option<PublishedSchemaInfo>>(),
-        consistency in any::<KafkaSinkConsistencyConnection>(),
+        progress in any::<KafkaSinkProgressConnection>(),
         exactly_once in any::<bool>(),
         fuel in any::<usize>(),
     ) -> KafkaSinkConnection {
@@ -275,7 +275,7 @@ proptest::prop_compose! {
             relation_key_indices,
             value_desc,
             published_schema_info,
-            consistency,
+            progress,
             exactly_once,
             fuel,
         }
@@ -339,7 +339,7 @@ impl RustType<ProtoKafkaSinkConnection> for KafkaSinkConnection {
             relation_key_indices: self.relation_key_indices.into_proto(),
             value_desc: Some(self.value_desc.into_proto()),
             published_schema_info: self.published_schema_info.into_proto(),
-            consistency: Some(self.consistency.into_proto()),
+            progress: Some(self.progress.into_proto()),
             exactly_once: self.exactly_once,
             fuel: self.fuel.into_proto(),
         }
@@ -364,9 +364,9 @@ impl RustType<ProtoKafkaSinkConnection> for KafkaSinkConnection {
                 .value_desc
                 .into_rust_if_some("ProtoKafkaSinkConnection::addrs")?,
             published_schema_info: proto.published_schema_info.into_rust()?,
-            consistency: proto
-                .consistency
-                .into_rust_if_some("ProtoKafkaSinkConnection::topic")?,
+            progress: proto
+                .progress
+                .into_rust_if_some("ProtoKafkaSinkConnection::progress")?,
             exactly_once: proto.exactly_once,
             fuel: proto.fuel.into_rust()?,
         })


### PR DESCRIPTION
Not exactly everything because we have `KafkaConsistencyConfig` enum that contains a `Progress` variant -- so there are places where a generic consistency field does make sense.  For things that only hold the topic, though, I've changed to progress since those are locked in to the progress brand of consistency.

### Motivation
cleanup

### Tips for reviewer

Doesn't actually change the substance of any protos.  Just renaming -- which won't affect wire format

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
