### PR TITLE
testdrive: improve avro debugging and redo

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -169,6 +169,7 @@ impl Action for SqlAction {
             | CreateSchema(_)
             | CreateSource(_)
             | CreateSink(_)
+            | CreateMaterializedView(_)
             | CreateView(_)
             | CreateViews(_)
             | CreateTable(_)


### PR DESCRIPTION
Teach testdrive how to print specialized debug output for values to make it much easier to write correct testdrive files.

Teach testdrive to not retry `CREATE MATERIALIZED VIEW` statements, which was missed during the recent refactor.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a