### PR TITLE
avro: correctly describe interval schema

### DIFF
--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -318,10 +318,9 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 }),
                 ScalarType::Timestamp => Value::Timestamp(datum.unwrap_timestamp()),
                 ScalarType::TimestampTz => Value::Timestamp(datum.unwrap_timestamptz().naive_utc()),
-                // This feature isn't actually supported by the Avro Java
-                // client (https://issues.apache.org/jira/browse/AVRO-2123),
-                // so no one is likely to be using it, so we're just using
-                // our own very convenient format.
+                // SQL intervals and Avro durations differ quite a lot (signed
+                // vs unsigned, different int sizes), so SQL intervals are their
+                // own bespoke type.
                 ScalarType::Interval => Value::Fixed(16, {
                     let iv = datum.unwrap_interval();
                     let mut buf = Vec::with_capacity(16);

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -250,11 +250,19 @@ fn build_row_schema_field<F: FnMut() -> String>(
             "type": "long",
             "logicalType": "timestamp-micros"
         }),
-        ScalarType::Interval => json!({
-            "type": "fixed",
-            "size": 12,
-            "logicalType": "duration"
-        }),
+        ScalarType::Interval => {
+            let name = format!("{AVRO_NAMESPACE}.interval");
+            if names_seen.contains(&name) {
+                json!(name)
+            } else {
+                names_seen.insert(name.clone());
+                json!({
+                "type": "fixed",
+                "size": 16,
+                "name": name,
+                })
+            }
+        }
         ScalarType::Bytes => json!("bytes"),
         ScalarType::String | ScalarType::Char { .. } | ScalarType::VarChar { .. } => {
             json!("string")

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -21,6 +21,27 @@
   FOR CONFLUENT SCHEMA REGISTRY
   URL '${testdrive.schema-registry-url}';
 
+# Test interval type.
+
+> CREATE MATERIALIZED VIEW interval_data (interval) AS VALUES
+  (INTERVAL '0s'),
+  (INTERVAL '1month 1day 1us'),
+  (INTERVAL '-1month -1day -1us'),
+  (INTERVAL '-178000000 years'),
+  (INTERVAL '178000000 years')
+
+> CREATE SINK interval_data_sink FROM interval_data
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-interval-data-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ kafka-verify format=avro sink=materialize.public.interval_data_sink sort-messages=true
+{"before": null, "after": {"row": {"interval": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}}}
+{"before": null, "after": {"row": {"interval": [0, 198, 80, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}}}
+{"before": null, "after": {"row": {"interval": [0, 58, 175, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}}}
+{"before": null, "after": {"row": {"interval": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]}}}
+{"before": null, "after": {"row": {"interval": [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]}}}
+
 # See #9723
 #> CREATE MATERIALIZED VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
 #


### PR DESCRIPTION
We were announcing that we support the avro duration spec, but were pushing our own custom bytes. Fix the schema description and add some tests for the custom format.

### Motivation

  * This PR adds a known-desirable feature. #7141 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a