### PR TITLE
Add `--dev` flag to cloudtest

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -29,6 +29,7 @@ from materialize.cloudtest.wait import wait
 class Application:
     resources: List[K8sResource]
     images: List[str]
+    release_mode: bool
 
     def __init__(self) -> None:
         self.create()
@@ -39,7 +40,7 @@ class Application:
             resource.create()
 
     def acquire_images(self) -> None:
-        repo = mzbuild.Repository(ROOT)
+        repo = mzbuild.Repository(ROOT, release_mode=self.release_mode)
         for image in self.images:
             deps = repo.resolve_dependencies([repo.images[image]])
             deps.acquire()
@@ -63,9 +64,10 @@ class Application:
 
 
 class MaterializeApplication(Application):
-    def __init__(self) -> None:
+    def __init__(self, release_mode: bool) -> None:
         self.environmentd = EnvironmentdService()
         self.testdrive = Testdrive()
+        self.release_mode = release_mode
 
         self.resources = [
             *POSTGRES_RESOURCES,

--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -13,5 +13,9 @@ from materialize.cloudtest.application import MaterializeApplication
 
 
 @pytest.fixture(scope="session")
-def mz() -> MaterializeApplication:
-    return MaterializeApplication()
+def mz(pytestconfig) -> MaterializeApplication:
+    return MaterializeApplication(release_mode=(not pytestconfig.getoption("dev")))
+
+
+def pytest_addoption(parser):
+    parser.addoption("--dev", action="store_true")

--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -13,9 +13,9 @@ from materialize.cloudtest.application import MaterializeApplication
 
 
 @pytest.fixture(scope="session")
-def mz(pytestconfig) -> MaterializeApplication:
+def mz(pytestconfig: pytest.Config) -> MaterializeApplication:
     return MaterializeApplication(release_mode=(not pytestconfig.getoption("dev")))
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--dev", action="store_true")


### PR DESCRIPTION


### Motivation

  * This PR adds a feature that has not yet been specified.
  
Optionally enable dev builds to improve iteration speed when running cloudtest locally.

