### PR TITLE
[sink] Log specific sink that causes primary key error

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -160,11 +160,11 @@ pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
     }
 }
 
-pub fn upsert_format(dps: Vec<DiffPair<Row>>) -> Option<Row> {
-    let dp = dps.expect_element(
-        "primary key error: expected at most one update \
-          per key and timestamp. This can happen when the configured sink key is \
-          not a primary key of the sinked relation.",
-    );
+pub fn upsert_format(dps: Vec<DiffPair<Row>>, sink_id: GlobalId, from: GlobalId) -> Option<Row> {
+    let dp = dps.expect_element(format!(
+        "primary key error: expected at most one update per key and timestamp \
+          This can happen when the configured sink key is not a primary key of \
+          the sinked relation: sink {sink_id} created from {from}."
+    ));
     dp.after
 }


### PR DESCRIPTION
Do the title

### Motivation
Fixes #12669

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
