### PR TITLE
[kafka resumption test] Re-enable timeout hold failure mode

### DIFF
--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -43,8 +43,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "toxiproxy-close-connection.td",
             "toxiproxy-limit-connection.td",
             "toxiproxy-timeout.td",
-            # TODO: Enable https://github.com/MaterializeInc/materialize/issues/11085
-            # "toxiproxy-timeout-hold.td",
+            "toxiproxy-timeout-hold.td",
         ]
     ):
         c.start_and_wait_for_tcp(["toxiproxy"])


### PR DESCRIPTION
As title

### Motivation
Fix #11085

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
