### PR TITLE
doc/user: add note about changing active cluster to `CREATE CLUSTER`

### DIFF
--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -7,8 +7,15 @@ menu:
     parent: commands
 ---
 
-`CREATE CLUSTER` creates a logical [cluster](/overview/key-concepts#clusters), which
-contains indexes.
+`CREATE CLUSTER` creates a logical [cluster](/overview/key-concepts#clusters),
+which contains indexes. By default, a cluster named `default` with a single
+cluster replica will exist in every environment.
+
+To switch your active cluster, use the `SET` command:
+
+```sql
+SET cluster = other_cluster;
+```
 
 ## Conceptual framework
 


### PR DESCRIPTION
While #10218 doesn't land, add note with instructions on how to switch active cluster to the `CREATE CLUSTER` command page.