### PR TITLE
cloudtest: fix fallout from changing testdrive reset semantics

### DIFF
--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -58,6 +58,7 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
             true
             """
         ),
+        no_reset=True,
         seed=seed,
     )
 
@@ -87,6 +88,14 @@ def validate(mz: MaterializeApplication, seed: int) -> None:
             """
         ),
         no_reset=True,
+        seed=seed,
+    )
+    # resets the environment
+    mz.testdrive.run(
+        input=dedent(
+            """
+            """
+        ),
         seed=seed,
     )
 

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -51,6 +51,7 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
             true
             """
         ),
+        no_reset=True,
         seed=seed,
     )
 
@@ -76,6 +77,14 @@ def validate(mz: MaterializeApplication, seed: int) -> None:
             """
         ),
         no_reset=True,
+        seed=seed,
+    )
+    # resets the environment
+    mz.testdrive.run(
+        input=dedent(
+            """
+            """
+        ),
         seed=seed,
     )
 


### PR DESCRIPTION
[This crashed](https://buildkite.com/materialize/tests/builds/42343) due to #15078; trying to fix. If this does fix, I'll merge and file an issue to fix the hack.

### Motivation

This PR fixes a recognized bug. https://buildkite.com/materialize/tests/builds/42343

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - here are no user-facing behavior changes
