### PR TITLE
adapter: collect storage usage by shard

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -248,6 +248,7 @@ Field            | Type       | Meaning
 `type`           | [`text`]   | The type of the source: `kafka` or `postgres`.
 `connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
 
+{{< comment >}}
 ### `mz_storage_usage`
 
 The `mz_storage_usage` table contains a row for each daily storage utilization
@@ -258,6 +259,7 @@ snapshot collected by the system.
 | `object_id`            | [`text`]                     | Materialize's unique ID for the storage object.       |
 | `size_bytes`           | [`bigint`]                   | The size in bytes of the storage object.              |
 | `collection_timestamp` | [`timestamp with time zone`] | The time at which the storage snapshot was collected. |
+{{< /comment >}}
 
 ### `mz_tables`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -15,6 +15,10 @@ The objects in the `mz_internal` schema are not part of Materialize's stable int
 Backwards-incompatible changes to these tables may be made at any time.
 {{< /warning >}}
 
+{{< warning >}}
+Not all objects in the `mz_internal` schema are documented.
+{{< /warning >}}
+
 ### `mz_arrangement_sharing`
 
 The `mz_arrangement_sharing` source describes how many times each [arrangement]

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1198,14 +1198,14 @@ impl CatalogState {
         &self,
         tx: &mut storage::Transaction<S>,
         builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
-        object_id: Option<String>,
+        shard_id: Option<String>,
         size_bytes: u64,
     ) -> Result<(), Error> {
         let collection_timestamp = (self.config.now)();
         let id = tx.get_and_increment_id(storage::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
 
         let event_details =
-            VersionedStorageUsage::new(id, object_id, size_bytes, collection_timestamp);
+            VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
         builtin_table_updates.push(self.pack_storage_usage_update(&event_details)?);
         tx.insert_storage_usage_event(event_details);
         Ok(())
@@ -4034,10 +4034,10 @@ impl<S: Append> Catalog<S> {
                     )?;
                 }
                 Op::UpdateStorageUsage {
-                    object_id,
+                    shard_id,
                     size_bytes,
                 } => {
-                    state.add_to_storage_usage(tx, builtin_table_updates, object_id, size_bytes)?;
+                    state.add_to_storage_usage(tx, builtin_table_updates, shard_id, size_bytes)?;
                 }
                 Op::UpdateSystemConfiguration { name, value } => {
                     tx.upsert_system_config(&name, &value)?;
@@ -4750,7 +4750,7 @@ pub enum Op {
         to_item: CatalogItem,
     },
     UpdateStorageUsage {
-        object_id: Option<String>,
+        shard_id: Option<String>,
         size_bytes: u64,
     },
     UpdateSystemConfiguration {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1364,12 +1364,12 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinStorageCollection> =
             .with_column("error", ScalarType::String.nullable(true))
             .with_column("metadata", ScalarType::Jsonb.nullable(true)),
     });
-pub static MZ_STORAGE_USAGE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_storage_usage",
-    schema: MZ_CATALOG_SCHEMA,
+pub static MZ_STORAGE_USAGE_BY_SHARD: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_storage_usage_by_shard",
+    schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::UInt64.nullable(false))
-        .with_column("object_id", ScalarType::String.nullable(true))
+        .with_column("shard_id", ScalarType::String.nullable(true))
         .with_column("size_bytes", ScalarType::UInt64.nullable(false))
         .with_column(
             "collection_timestamp",
@@ -2340,7 +2340,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_CLUSTER_REPLICA_STATUSES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
         Builtin::Table(&MZ_AUDIT_EVENTS),
-        Builtin::Table(&MZ_STORAGE_USAGE),
+        Builtin::Table(&MZ_STORAGE_USAGE_BY_SHARD),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_ARRANGEMENT_SHARING),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1068,7 +1068,7 @@ pub const MZ_ARRANGEMENT_RECORDS_INTERNAL: BuiltinLog = BuiltinLog {
 
 pub static MZ_VIEW_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_view_keys",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
         .with_column("column", ScalarType::UInt64.nullable(false))
@@ -1077,7 +1077,7 @@ pub static MZ_VIEW_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
     BuiltinTable {
         name: "mz_view_foreign_keys",
-        schema: MZ_CATALOG_SCHEMA,
+        schema: MZ_INTERNAL_SCHEMA,
         desc: RelationDesc::empty()
             .with_column("child_id", ScalarType::String.nullable(false))
             .with_column("child_column", ScalarType::UInt64.nullable(false))

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -32,8 +32,8 @@ use crate::catalog::builtin::{
     MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS,
     MZ_DATABASES, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS,
     MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS,
-    MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE, MZ_TABLES,
-    MZ_TYPES, MZ_VIEWS,
+    MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD,
+    MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
     CatalogItem, CatalogState, Connection, Error, ErrorKind, Func, Index, MaterializedView, Sink,
@@ -779,33 +779,15 @@ impl CatalogState {
 
     pub fn pack_storage_usage_update(
         &self,
-        event: &VersionedStorageUsage,
+        VersionedStorageUsage::V1(event): &VersionedStorageUsage,
     ) -> Result<BuiltinTableUpdate, Error> {
-        let (id, object_id, size_bytes, collection_timestamp): (u64, &Option<String>, u64, u64) =
-            match event {
-                VersionedStorageUsage::V1(ev) => {
-                    (ev.id, &ev.object_id, ev.size_bytes, ev.collection_timestamp)
-                }
-            };
-
-        let table = self.resolve_builtin_table(&MZ_STORAGE_USAGE);
-        let object_id_val = match object_id {
-            Some(s) => Datum::String(s),
-            None => Datum::Null,
-        };
-        let dt = mz_ore::now::to_datetime(collection_timestamp).naive_utc();
-
+        let id = self.resolve_builtin_table(&MZ_STORAGE_USAGE_BY_SHARD);
         let row = Row::pack_slice(&[
-            Datum::UInt64(id),
-            object_id_val,
-            Datum::UInt64(size_bytes),
-            Datum::TimestampTz(DateTime::from_utc(dt, Utc)),
+            Datum::UInt64(event.id),
+            Datum::from(event.shard_id.as_deref()),
+            Datum::UInt64(event.size_bytes),
+            Datum::TimestampTz(mz_ore::now::to_datetime(event.collection_timestamp)),
         ]);
-        let diff = 1;
-        Ok(BuiltinTableUpdate {
-            id: table,
-            row,
-            diff,
-        })
+        Ok(BuiltinTableUpdate { id, row, diff: 1 })
     }
 }

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -289,7 +289,7 @@ pub enum VersionedStorageUsage {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct StorageUsageV1 {
     pub id: u64,
-    pub object_id: Option<String>,
+    pub shard_id: Option<String>,
     pub size_bytes: u64,
     pub collection_timestamp: EpochMillis,
 }
@@ -303,7 +303,7 @@ impl StorageUsageV1 {
     ) -> StorageUsageV1 {
         StorageUsageV1 {
             id,
-            object_id,
+            shard_id: object_id,
             size_bytes,
             collection_timestamp,
         }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -658,7 +658,10 @@ fn test_storage_usage_collection_interval() -> Result<(), Box<dyn Error>> {
     // Retry because it may take some time for the initial snapshot to be taken.
     let initial_storage: i64 = Retry::default().retry(|_| {
         client
-            .query_one("SELECT SUM(size_bytes)::int8 FROM mz_storage_usage;", &[])
+            .query_one(
+                "SELECT SUM(size_bytes)::int8 FROM mz_internal.mz_storage_usage_by_shard;",
+                &[],
+            )
             .map_err(|e| e.to_string())?
             .try_get::<_, i64>(0)
             .map_err(|e| e.to_string())
@@ -670,7 +673,7 @@ fn test_storage_usage_collection_interval() -> Result<(), Box<dyn Error>> {
     // Retry until storage usage is updated.
     Retry::default().max_duration(Duration::from_secs(5)).retry(|_| {
         let updated_storage = client
-            .query_one("SELECT SUM(size_bytes)::int8 FROM mz_storage_usage;", &[])
+            .query_one("SELECT SUM(size_bytes)::int8 FROM mz_internal.mz_storage_usage_by_shard;", &[])
             .map_err(|e| e.to_string())?
             .try_get::<_, i64>(0)
             .map_err(|e| e.to_string())?;
@@ -703,7 +706,7 @@ fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
             client
                     .query_one(
-                        "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_storage_usage;",
+                        "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_internal.mz_storage_usage_by_shard;",
                         &[],
                     )
                     .map_err(|e| e.to_string())?
@@ -722,7 +725,7 @@ fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
         // Retry until storage usage is updated.
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
             let updated_timestamp = client
-                .query_one("SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_storage_usage;", &[])
+                .query_one("SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_internal.mz_storage_usage_by_shard;", &[])
                 .map_err(|e| e.to_string())?
                 .try_get::<_, f64>(0)
                 .map_err(|e| e.to_string())?;
@@ -756,7 +759,7 @@ fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Err
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
             client
                     .query_one(
-                        "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_storage_usage;",
+                        "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_internal.mz_storage_usage_by_shard;",
                         &[],
                     )
                     .map_err(|e| e.to_string())?
@@ -774,7 +777,7 @@ fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Err
 
         let updated_timestamp = client
             .query_one(
-                "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_storage_usage;",
+                "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_internal.mz_storage_usage_by_shard;",
                 &[],
             )?.get::<_, f64>(0);
 

--- a/test/sqllogictest/unstable.slt
+++ b/test/sqllogictest/unstable.slt
@@ -36,10 +36,10 @@ CREATE DEFAULT INDEX ON mz_internal.mz_scheduling_elapsed_1
 # mz_view_keys and mz_view_foreign_keys are unstable.
 
 statement error cannot create view with unstable dependencies
-CREATE VIEW v AS SELECT * FROM mz_view_keys
+CREATE VIEW v AS SELECT * FROM mz_internal.mz_view_keys
 
 statement error cannot create index with unstable dependencies
-CREATE DEFAULT INDEX ON mz_view_foreign_keys
+CREATE DEFAULT INDEX ON mz_internal.mz_view_foreign_keys
 
 # Other system tables are stable.
 
@@ -55,4 +55,4 @@ statement ok
 SELECT * FROM mz_internal.mz_peek_active_1
 
 statement ok
-SELECT * FROM mz_view_keys
+SELECT * FROM mz_internal.mz_view_keys

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -483,8 +483,6 @@ mz_ssh_tunnel_connections
 mz_storage_usage
 mz_tables
 mz_types
-mz_view_foreign_keys
-mz_view_keys
 mz_views
 
 > SHOW VIEWS FROM mz_catalog

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -480,7 +480,6 @@ mz_secrets
 mz_sinks
 mz_sources
 mz_ssh_tunnel_connections
-mz_storage_usage
 mz_tables
 mz_types
 mz_views
@@ -543,6 +542,9 @@ mz_worker_compute_import_frontiers_1            log
 > SHOW TABLES FROM mz_internal
 name
 ----
+mz_storage_usage_by_shard
+mz_view_foreign_keys
+mz_view_keys
 
 > SHOW VIEWS FROM mz_internal
 name

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -330,7 +330,7 @@ contains:column "a" specified more than once
 # Test pg_table_is_visible.
 > CREATE SCHEMA non_default
 > CREATE TABLE non_default.hidden (dummy int)
-> SELECT name, pg_table_is_visible(oid) AS visible FROM mz_tables WHERE schema_id != 1
+> SELECT name, pg_table_is_visible(oid) AS visible FROM mz_tables WHERE schema_id != 1 AND id LIKE 'u%'
 name    visible
 ---------------
 hidden  false


### PR DESCRIPTION
Move the `mz_catalog.mz_storage_usage` table to
`mz_internal.mz_storage_usage_by_shard`, and include storage usage by
shard ID.

A future commit will add back `mz_catalog.mz_storage_usage` as a view
that joins `mz_storage_usage_by_shard` with the forthcoming table that
maps shard IDs and object IDs together (https://github.com/MaterializeInc/materialize/pull/15052).

Touches https://github.com/MaterializeInc/cloud/issues/3726.

### Motivation

  * This PR makes progress on a known-desirable feature.

### Tips for reviewer

@teskje—can you review the first commit, which changes the logic for determining whether a relation is unstable?

@sploiselle or @jpepin—can you review the second commit?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
