### PR TITLE
testdrive: clean up kafka state at beginning of test script

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -315,10 +315,6 @@ impl State {
     pub async fn reset_kafka(&mut self) -> Result<(), anyhow::Error> {
         let mut errors: Vec<anyhow::Error> = Vec::new();
 
-        if self.kafka_topics.is_empty() {
-            return Ok(());
-        }
-
         let metadata = self.kafka_producer.client().fetch_metadata(
             None,
             Some(std::cmp::max(Duration::from_secs(1), self.default_timeout)),

--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -58,7 +58,6 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
             true
             """
         ),
-        no_reset=True,
         seed=seed,
     )
 
@@ -88,14 +87,6 @@ def validate(mz: MaterializeApplication, seed: int) -> None:
             """
         ),
         no_reset=True,
-        seed=seed,
-    )
-    # resets the environment
-    mz.testdrive.run(
-        input=dedent(
-            """
-            """
-        ),
         seed=seed,
     )
 

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -51,7 +51,6 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
             true
             """
         ),
-        no_reset=True,
         seed=seed,
     )
 
@@ -77,14 +76,6 @@ def validate(mz: MaterializeApplication, seed: int) -> None:
             """
         ),
         no_reset=True,
-        seed=seed,
-    )
-    # resets the environment
-    mz.testdrive.run(
-        input=dedent(
-            """
-            """
-        ),
         seed=seed,
     )
 


### PR DESCRIPTION
@sploiselle I thiiiiink this fixes #15090. We'll see what CI says.

----

The testdrive philosophy is to leave around state at the end of the
execution. Instead cleanup of the *last* test script is performed at the
beginning of each test run.  This makes it easy to debug a testdrive
script, because the state is left around after testdrive exits.  It also
makes it possible to use a testdrive script in demos or development as
to set up a Materialize instance for further tinkering.

The one wrinkle with this approach is that Kafka is not always
available. So condition the cleanup of Kafka state on whether the test
script uses a Kafka-related action.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
