### PR TITLE
mzcompose: Add support for Minio S3-compatible object storage

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -41,6 +41,7 @@ class Materialized(Service):
         ports: Optional[List[str]] = None,
         extra_ports: List[int] = [],
         memory: Optional[str] = None,
+        persist_blob_url: Optional[str] = None,
         data_directory: str = "/mzdata",
         workers: Optional[int] = None,
         options: Optional[Union[str, List[str]]] = "",
@@ -52,12 +53,15 @@ class Materialized(Service):
         depends_on: Optional[List[str]] = None,
         allow_host_ports: bool = False,
     ) -> None:
+        if persist_blob_url is None:
+            persist_blob_url = f"file://{data_directory}/persist/blob"
+
         if environment is None:
             environment = [
                 "MZ_SOFT_ASSERTIONS=1",
                 "MZ_UNSAFE_MODE=1",
                 "MZ_EXPERIMENTAL=1",
-                f"MZ_PERSIST_BLOB_URL=file://{data_directory}/persist/blob",
+                f"MZ_PERSIST_BLOB_URL={persist_blob_url}",
                 f"MZ_ORCHESTRATOR_PROCESSDATA_DIRECTORY={data_directory}",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
@@ -576,6 +580,34 @@ class Localstack(Service):
                 "environment": environment,
                 "volumes": volumes,
             },
+        )
+
+
+class Minio(Service):
+    def __init__(
+        self,
+        name: str = "minio",
+        image: str = f"minio/minio:RELEASE.2022-09-25T15-44-53Z.fips",
+    ) -> None:
+        super().__init__(
+            name=name,
+            config={
+                "command": "minio server /data --console-address :9001",
+                "image": image,
+                "ports": [9000, 9001],
+            },
+        )
+
+
+class MinioMc(Service):
+    def __init__(
+        self,
+        name: str = "minio_mc",
+        image: str = f"minio/mc:RELEASE.2022-09-16T09-16-47Z",
+    ) -> None:
+        super().__init__(
+            name=name,
+            config={"image": image},
         )
 
 

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -11,6 +11,8 @@ from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Kafka,
     Materialized,
+    Minio,
+    MinioMc,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -31,6 +33,8 @@ mz_with_options = [
 ]
 
 SERVICES = [
+    Minio(),
+    MinioMc(),
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
@@ -74,3 +78,27 @@ def workflow_mz_with_options(c: Composition) -> None:
     c.up("mz_4_workers")
     c.wait_for_materialized("mz_4_workers")
     c.kill("mz_4_workers")
+
+
+def workflow_minio(c: Composition) -> None:
+    mz = Materialized(
+        persist_blob_url="s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
+    )
+
+    with c.override(mz):
+        c.start_and_wait_for_tcp(services=["minio"])
+        c.up("minio_mc", persistent=True)
+        c.exec(
+            "minio_mc",
+            "mc",
+            "config",
+            "host",
+            "add",
+            "myminio",
+            "http://minio:9000",
+            "minioadmin",
+            "minioadmin",
+        )
+        c.exec("minio_mc", "mc", "mb", "myminio/persist"),
+        c.start_and_wait_for_tcp(services=["materialized"])
+        c.wait_for_materialized()


### PR DESCRIPTION
- Allow Materialize() instances to specify the blob URL directly
- Add Minio and MinioMc services, the latter being the management client
- add an example in mzcompose_examples on how to start up Mz with Minio as blob storage

### Motivation
* This PR adds a feature that has not yet been specified.
For testing purposes, we need to use an s3 back-end. Localstack, being Python software, appears to be on the slower side, so add support for Minio