### PR TITLE
doc/user: remove operations docs from main menu

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -25,11 +25,6 @@ name = "Reference"
 weight= 15
 
 [[menu.main]]
-identifier = "ops"
-name = "Operating Materialize"
-weight= 20
-
-[[menu.main]]
 identifier = "integrations"
 name = "Tools and integrations"
 weight= 25


### PR DESCRIPTION
Temporarily hide operations and troubleshooting docs until we get the chance to put together updated guides. These are still accessible, just not part of the main menu.