### PR TITLE
Rename "compute instance replica" to "compute replica"

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -30,8 +30,8 @@ use mz_audit_log::{
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_compute_client::command::{ProcessId, ReplicaId};
 use mz_compute_client::controller::{
-    ComputeInstanceEvent, ComputeInstanceId, ComputeInstanceReplicaAllocation,
-    ComputeInstanceReplicaConfig, ComputeInstanceReplicaLocation, ComputeInstanceReplicaLogging,
+    ComputeInstanceEvent, ComputeInstanceId, ComputeReplicaAllocation, ComputeReplicaConfig,
+    ComputeReplicaLocation, ComputeReplicaLogging,
 };
 use mz_compute_client::logging::{LogVariant, LogView, DEFAULT_LOG_VARIANTS, DEFAULT_LOG_VIEWS};
 use mz_expr::{MirScalarExpr, OptimizedMirRelationExpr};
@@ -390,7 +390,7 @@ impl CatalogState {
     /// Create and insert the per replica log sources and log views.
     fn insert_replica_introspection_items(
         &mut self,
-        logging: &ComputeInstanceReplicaLogging,
+        logging: &ComputeReplicaLogging,
         replica_id: u64,
     ) {
         for (variant, source_id) in &logging.sources {
@@ -709,15 +709,15 @@ impl CatalogState {
         assert!(self.compute_instances_by_name.insert(name, id).is_none());
     }
 
-    fn insert_compute_instance_replica(
+    fn insert_compute_replica(
         &mut self,
         on_instance: ComputeInstanceId,
         replica_name: String,
         replica_id: ReplicaId,
-        config: ComputeInstanceReplicaConfig,
+        config: ComputeReplicaConfig,
     ) {
         self.insert_replica_introspection_items(&config.logging, replica_id);
-        let replica = ComputeInstanceReplica {
+        let replica = ComputeReplica {
             config,
             process_status: HashMap::new(),
         };
@@ -754,7 +754,7 @@ impl CatalogState {
     ///
     /// This method returns `None` if no status was found for the given
     /// compute instance process because:
-    ///   * The given compute instance replica is not found. This can occur
+    ///   * The given compute replica is not found. This can occur
     ///     if we already dropped the replica from the catalog, but we still
     ///     receive status updates.
     ///   * The given replica process is not found. This is the case when we
@@ -1309,12 +1309,12 @@ pub struct ComputeInstance {
     /// Does not include introspection source indexes.
     pub exports: HashSet<GlobalId>,
     pub replica_id_by_name: HashMap<String, ReplicaId>,
-    pub replicas_by_id: HashMap<ReplicaId, ComputeInstanceReplica>,
+    pub replicas_by_id: HashMap<ReplicaId, ComputeReplica>,
 }
 
 #[derive(Debug, Serialize, Clone)]
-pub struct ComputeInstanceReplica {
-    pub config: ComputeInstanceReplicaConfig,
+pub struct ComputeReplica {
+    pub config: ComputeReplicaConfig,
     pub process_status: HashMap<ProcessId, ComputeInstanceEvent>,
 }
 
@@ -2156,11 +2156,7 @@ impl<S: Append> Catalog<S> {
             catalog.state.insert_compute_instance(id, name, all_indexes);
         }
 
-        let replicas = catalog
-            .storage()
-            .await
-            .load_compute_instance_replicas()
-            .await?;
+        let replicas = catalog.storage().await.load_compute_replicas().await?;
         for (instance_id, replica_id, name, serialized_config) in replicas {
             let log_sources = match serialized_config.logging.sources {
                 Some(sources) => sources,
@@ -2171,13 +2167,13 @@ impl<S: Append> Catalog<S> {
                 None => catalog.allocate_persisted_introspection_views().await,
             };
 
-            let logging = ComputeInstanceReplicaLogging {
+            let logging = ComputeReplicaLogging {
                 log_logging: serialized_config.logging.log_logging,
                 interval: serialized_config.logging.interval,
                 sources: log_sources,
                 views: log_views,
             };
-            let config = ComputeInstanceReplicaConfig {
+            let config = ComputeReplicaConfig {
                 location: catalog.concretize_replica_location(serialized_config.location)?,
                 logging,
             };
@@ -2191,7 +2187,7 @@ impl<S: Append> Catalog<S> {
 
             catalog
                 .state
-                .insert_compute_instance_replica(instance_id, name, replica_id, config);
+                .insert_compute_replica(instance_id, name, replica_id, config);
         }
 
         let system_config = catalog.storage().await.load_system_configuration().await?;
@@ -2284,7 +2280,7 @@ impl<S: Append> Catalog<S> {
             builtin_table_updates.push(catalog.state.pack_compute_instance_update(name, 1));
             let instance = &catalog.state.compute_instances_by_id[id];
             for (replica_name, _replica_id) in &instance.replica_id_by_name {
-                builtin_table_updates.push(catalog.state.pack_compute_instance_replica_update(
+                builtin_table_updates.push(catalog.state.pack_compute_replica_update(
                     *id,
                     replica_name,
                     1,
@@ -3190,20 +3186,20 @@ impl<S: Append> Catalog<S> {
 
     pub fn concretize_replica_location(
         &self,
-        location: SerializedComputeInstanceReplicaLocation,
-    ) -> Result<ComputeInstanceReplicaLocation, AdapterError> {
+        location: SerializedComputeReplicaLocation,
+    ) -> Result<ComputeReplicaLocation, AdapterError> {
         let cluster_replica_sizes = &self.state.cluster_replica_sizes;
         let location = match location {
-            SerializedComputeInstanceReplicaLocation::Remote {
+            SerializedComputeReplicaLocation::Remote {
                 addrs,
                 compute_addrs,
                 workers,
-            } => ComputeInstanceReplicaLocation::Remote {
+            } => ComputeReplicaLocation::Remote {
                 addrs,
                 compute_addrs,
                 workers,
             },
-            SerializedComputeInstanceReplicaLocation::Managed {
+            SerializedComputeReplicaLocation::Managed {
                 size,
                 availability_zone,
                 az_user_specified,
@@ -3213,7 +3209,7 @@ impl<S: Append> Catalog<S> {
                     entries.sort_by_key(
                         |(
                             _name,
-                            ComputeInstanceReplicaAllocation {
+                            ComputeReplicaAllocation {
                                 scale, cpu_limit, ..
                             },
                         )| (scale, cpu_limit),
@@ -3224,7 +3220,7 @@ impl<S: Append> Catalog<S> {
                         expected,
                     }
                 })?;
-                ComputeInstanceReplicaLocation::Managed {
+                ComputeReplicaLocation::Managed {
                     allocation: allocation.clone(),
                     availability_zone,
                     size,
@@ -3340,11 +3336,11 @@ impl<S: Append> Catalog<S> {
                 // These are the legacy, active logs of this compute instance
                 arranged_introspection_sources: Vec<(&'static BuiltinLog, GlobalId)>,
             },
-            CreateComputeInstanceReplica {
+            CreateComputeReplica {
                 id: ReplicaId,
                 name: String,
                 on_cluster_name: String,
-                config: ComputeInstanceReplicaConfig,
+                config: ComputeReplicaConfig,
             },
             CreateItem {
                 id: GlobalId,
@@ -3367,7 +3363,7 @@ impl<S: Append> Catalog<S> {
                 name: String,
                 introspection_source_index_ids: Vec<GlobalId>,
             },
-            DropComputeInstanceReplica {
+            DropComputeReplica {
                 name: String,
                 compute_id: ComputeInstanceId,
             },
@@ -3604,7 +3600,7 @@ impl<S: Append> Catalog<S> {
                         },
                     )?;
                 }
-                Op::CreateComputeInstanceReplica {
+                Op::CreateComputeReplica {
                     name,
                     on_cluster_name,
                     config,
@@ -3614,14 +3610,11 @@ impl<S: Append> Catalog<S> {
                             ErrorKind::ReservedReplicaName(name),
                         )));
                     }
-                    let id = tx.insert_compute_instance_replica(
-                        &on_cluster_name,
-                        &name,
-                        &config.clone().into(),
-                    )?;
-                    if let ComputeInstanceReplicaLocation::Managed { size, .. } = &config.location {
-                        let details = EventDetails::CreateComputeInstanceReplicaV1(
-                            mz_audit_log::CreateComputeInstanceReplicaV1 {
+                    let id =
+                        tx.insert_compute_replica(&on_cluster_name, &name, &config.clone().into())?;
+                    if let ComputeReplicaLocation::Managed { size, .. } = &config.location {
+                        let details = EventDetails::CreateComputeReplicaV1(
+                            mz_audit_log::CreateComputeReplicaV1 {
                                 cluster_id: id,
                                 cluster_name: on_cluster_name.clone(),
                                 replica_name: name.clone(),
@@ -3641,7 +3634,7 @@ impl<S: Append> Catalog<S> {
                     catalog_action(
                         state,
                         builtin_table_updates,
-                        Action::CreateComputeInstanceReplica {
+                        Action::CreateComputeReplica {
                             id,
                             name,
                             on_cluster_name,
@@ -3781,9 +3774,9 @@ impl<S: Append> Catalog<S> {
                         },
                     )?;
                 }
-                Op::DropComputeInstanceReplica { name, compute_name } => {
+                Op::DropComputeReplica { name, compute_name } => {
                     let instance = state.resolve_compute_instance(&compute_name)?;
-                    tx.remove_compute_instance_replica(&name, instance.id)?;
+                    tx.remove_compute_replica(&name, instance.id)?;
 
                     let replica_id = instance.replica_id_by_name[&name];
                     let replica = &instance.replicas_by_id[&replica_id];
@@ -3797,19 +3790,18 @@ impl<S: Append> Catalog<S> {
                         builtin_table_updates.push(update);
                     }
 
-                    builtin_table_updates.push(state.pack_compute_instance_replica_update(
+                    builtin_table_updates.push(state.pack_compute_replica_update(
                         instance.id,
                         &name,
                         -1,
                     ));
 
-                    let details = EventDetails::DropComputeInstanceReplicaV1(
-                        mz_audit_log::DropComputeInstanceReplicaV1 {
+                    let details =
+                        EventDetails::DropComputeReplicaV1(mz_audit_log::DropComputeReplicaV1 {
                             cluster_id: instance.id,
                             cluster_name: instance.name.clone(),
                             replica_name: name.clone(),
-                        },
-                    );
+                        });
                     state.add_to_audit_log(
                         session,
                         tx,
@@ -3824,7 +3816,7 @@ impl<S: Append> Catalog<S> {
                     catalog_action(
                         state,
                         builtin_table_updates,
-                        Action::DropComputeInstanceReplica { name, compute_id },
+                        Action::DropComputeReplica { name, compute_id },
                     )?;
                 }
                 Op::DropItem(id) => {
@@ -4156,7 +4148,7 @@ impl<S: Append> Catalog<S> {
                     }
                 }
 
-                Action::CreateComputeInstanceReplica {
+                Action::CreateComputeReplica {
                     id,
                     name,
                     on_cluster_name,
@@ -4164,16 +4156,11 @@ impl<S: Append> Catalog<S> {
                 } => {
                     let compute_instance_id = state.compute_instances_by_name[&on_cluster_name];
                     let introspection_ids: Vec<_> = config.logging.source_and_view_ids().collect();
-                    state.insert_compute_instance_replica(
-                        compute_instance_id,
-                        name.clone(),
-                        id,
-                        config,
-                    );
+                    state.insert_compute_replica(compute_instance_id, name.clone(), id, config);
                     for id in introspection_ids {
                         builtin_table_updates.extend(state.pack_item_update(id, 1));
                     }
-                    builtin_table_updates.push(state.pack_compute_instance_replica_update(
+                    builtin_table_updates.push(state.pack_compute_replica_update(
                         compute_instance_id,
                         &name,
                         1,
@@ -4236,7 +4223,7 @@ impl<S: Append> Catalog<S> {
                     );
                 }
 
-                Action::DropComputeInstanceReplica { name, compute_id } => {
+                Action::DropComputeReplica { name, compute_id } => {
                     let instance = state
                         .compute_instances_by_id
                         .get_mut(&compute_id)
@@ -4654,10 +4641,10 @@ pub enum Op {
         name: String,
         arranged_introspection_sources: Vec<(&'static BuiltinLog, GlobalId)>,
     },
-    CreateComputeInstanceReplica {
+    CreateComputeReplica {
         name: String,
         on_cluster_name: String,
-        config: ComputeInstanceReplicaConfig,
+        config: ComputeReplicaConfig,
     },
     CreateItem {
         id: GlobalId,
@@ -4678,7 +4665,7 @@ pub enum Op {
     DropComputeInstance {
         name: String,
     },
-    DropComputeInstanceReplica {
+    DropComputeReplica {
         name: String,
         compute_name: String,
     },
@@ -4725,28 +4712,28 @@ pub enum SerializedCatalogItem {
 }
 
 /// Serialized (stored alongside the replica) logging configuration of
-/// a replica. Serialized variant of `ComputeInstanceReplicaLogging`.
+/// a replica. Serialized variant of `ComputeReplicaLogging`.
 ///
 /// A `None` value for `sources` or `views` indicates that we did not yet create them in the
 /// catalog. This is only used for initializing the default replica of the default compute
 /// instance.
 /// To indicate the absence of sources/views, use `Some(Vec::new())`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SerializedComputeInstanceReplicaLogging {
+pub struct SerializedComputeReplicaLogging {
     log_logging: bool,
     interval: Option<Duration>,
     sources: Option<Vec<(LogVariant, GlobalId)>>,
     views: Option<Vec<(LogView, GlobalId)>>,
 }
 
-impl From<ComputeInstanceReplicaLogging> for SerializedComputeInstanceReplicaLogging {
+impl From<ComputeReplicaLogging> for SerializedComputeReplicaLogging {
     fn from(
-        ComputeInstanceReplicaLogging {
+        ComputeReplicaLogging {
             log_logging,
             interval,
             sources,
             views,
-        }: ComputeInstanceReplicaLogging,
+        }: ComputeReplicaLogging,
     ) -> Self {
         Self {
             log_logging,
@@ -4757,20 +4744,18 @@ impl From<ComputeInstanceReplicaLogging> for SerializedComputeInstanceReplicaLog
     }
 }
 
-/// A [`mz_compute_client::controller::ComputeInstanceReplicaConfig`] that is serialized as JSON
+/// A [`mz_compute_client::controller::ComputeReplicaConfig`] that is serialized as JSON
 /// and persisted to the catalog stash. This is a separate type to allow us to evolve the on-disk
 /// format independently from the SQL layer.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
-pub struct SerializedComputeInstanceReplicaConfig {
-    pub location: SerializedComputeInstanceReplicaLocation,
-    pub logging: SerializedComputeInstanceReplicaLogging,
+pub struct SerializedComputeReplicaConfig {
+    pub location: SerializedComputeReplicaLocation,
+    pub logging: SerializedComputeReplicaLogging,
 }
 
-impl From<ComputeInstanceReplicaConfig> for SerializedComputeInstanceReplicaConfig {
-    fn from(
-        ComputeInstanceReplicaConfig { location, logging }: ComputeInstanceReplicaConfig,
-    ) -> Self {
-        SerializedComputeInstanceReplicaConfig {
+impl From<ComputeReplicaConfig> for SerializedComputeReplicaConfig {
+    fn from(ComputeReplicaConfig { location, logging }: ComputeReplicaConfig) -> Self {
+        SerializedComputeReplicaConfig {
             location: location.into(),
             logging: logging.into(),
         }
@@ -4778,7 +4763,7 @@ impl From<ComputeInstanceReplicaConfig> for SerializedComputeInstanceReplicaConf
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SerializedComputeInstanceReplicaLocation {
+pub enum SerializedComputeReplicaLocation {
     Remote {
         addrs: BTreeSet<String>,
         compute_addrs: BTreeSet<String>,
@@ -4793,10 +4778,10 @@ pub enum SerializedComputeInstanceReplicaLocation {
     },
 }
 
-impl From<ComputeInstanceReplicaLocation> for SerializedComputeInstanceReplicaLocation {
-    fn from(loc: ComputeInstanceReplicaLocation) -> Self {
+impl From<ComputeReplicaLocation> for SerializedComputeReplicaLocation {
+    fn from(loc: ComputeReplicaLocation) -> Self {
         match loc {
-            ComputeInstanceReplicaLocation::Remote {
+            ComputeReplicaLocation::Remote {
                 addrs,
                 compute_addrs,
                 workers,
@@ -4805,7 +4790,7 @@ impl From<ComputeInstanceReplicaLocation> for SerializedComputeInstanceReplicaLo
                 compute_addrs,
                 workers,
             },
-            ComputeInstanceReplicaLocation::Managed {
+            ComputeReplicaLocation::Managed {
                 allocation: _,
                 size,
                 availability_zone,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
 use mz_compute_client::command::{ProcessId, ReplicaId};
 use mz_compute_client::controller::{
-    ComputeInstanceId, ComputeInstanceReplicaLocation, ComputeInstanceStatus,
+    ComputeInstanceId, ComputeInstanceStatus, ComputeReplicaLocation,
 };
 use mz_expr::MirScalarExpr;
 use mz_ore::cast::CastFrom;
@@ -118,7 +118,7 @@ impl CatalogState {
         }
     }
 
-    pub(super) fn pack_compute_instance_replica_update(
+    pub(super) fn pack_compute_replica_update(
         &self,
         compute_instance_id: ComputeInstanceId,
         name: &str,
@@ -129,13 +129,13 @@ impl CatalogState {
         let replica = &instance.replicas_by_id[&id];
 
         let (size, az) = match &replica.config.location {
-            ComputeInstanceReplicaLocation::Managed {
+            ComputeReplicaLocation::Managed {
                 size,
                 availability_zone,
                 az_user_specified: _,
                 allocation: _,
             } => (Some(&**size), Some(availability_zone.as_str())),
-            ComputeInstanceReplicaLocation::Remote { .. } => (None, None),
+            ComputeReplicaLocation::Remote { .. } => (None, None),
         };
 
         BuiltinTableUpdate {

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use mz_build_info::BuildInfo;
-use mz_compute_client::controller::ComputeInstanceReplicaAllocation;
+use mz_compute_client::controller::ComputeReplicaAllocation;
 use mz_ore::metrics::MetricsRegistry;
 use mz_secrets::SecretsReader;
 use mz_storage::types::hosts::StorageHostResourceAllocation;
@@ -51,7 +51,7 @@ pub struct Config<'a, S> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct ClusterReplicaSizeMap(pub HashMap<String, ComputeInstanceReplicaAllocation>);
+pub struct ClusterReplicaSizeMap(pub HashMap<String, ComputeReplicaAllocation>);
 
 impl Default for ClusterReplicaSizeMap {
     fn default() -> Self {
@@ -75,7 +75,7 @@ impl Default for ClusterReplicaSizeMap {
                 let workers = 1 << i;
                 (
                     workers.to_string(),
-                    ComputeInstanceReplicaAllocation {
+                    ComputeReplicaAllocation {
                         memory_limit: None,
                         cpu_limit: None,
                         scale: NonZeroUsize::new(1).unwrap(),
@@ -89,7 +89,7 @@ impl Default for ClusterReplicaSizeMap {
             let scale = 1 << i;
             inner.insert(
                 format!("{scale}-1"),
-                ComputeInstanceReplicaAllocation {
+                ComputeReplicaAllocation {
                     memory_limit: None,
                     cpu_limit: None,
                     scale: NonZeroUsize::new(scale).unwrap(),
@@ -100,7 +100,7 @@ impl Default for ClusterReplicaSizeMap {
 
         inner.insert(
             "2-2".to_string(),
-            ComputeInstanceReplicaAllocation {
+            ComputeReplicaAllocation {
                 memory_limit: None,
                 cpu_limit: None,
                 scale: NonZeroUsize::new(2).unwrap(),
@@ -109,7 +109,7 @@ impl Default for ClusterReplicaSizeMap {
         );
         inner.insert(
             "2-4".to_string(),
-            ComputeInstanceReplicaAllocation {
+            ComputeReplicaAllocation {
                 memory_limit: None,
                 cpu_limit: None,
                 scale: NonZeroUsize::new(2).unwrap(),

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -20,7 +20,7 @@ use timely::progress::Timestamp;
 
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
 use mz_compute_client::command::ReplicaId;
-use mz_compute_client::controller::{ComputeInstanceId, ComputeInstanceReplicaConfig};
+use mz_compute_client::controller::{ComputeInstanceId, ComputeReplicaConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::GlobalId;
@@ -35,12 +35,11 @@ use mz_storage::types::sources::Timeline;
 use crate::catalog;
 use crate::catalog::builtin::{BuiltinLog, BUILTIN_ROLES};
 use crate::catalog::error::{Error, ErrorKind};
-use crate::catalog::SerializedComputeInstanceReplicaConfig;
+use crate::catalog::SerializedComputeReplicaConfig;
 use crate::catalog::SystemObjectMapping;
 
 use super::{
-    SerializedCatalogItem, SerializedComputeInstanceReplicaLocation,
-    SerializedComputeInstanceReplicaLogging,
+    SerializedCatalogItem, SerializedComputeReplicaLocation, SerializedComputeReplicaLogging,
 };
 
 const USER_VERSION: &str = "user_version";
@@ -217,16 +216,16 @@ async fn migrate<S: Append>(
             let default_instance = ComputeInstanceValue {
                 name: "default".into(),
             };
-            let default_replica = ComputeInstanceReplicaValue {
+            let default_replica = ComputeReplicaValue {
                 compute_instance_id: DEFAULT_COMPUTE_INSTANCE_ID,
                 name: "default_replica".into(),
-                config: SerializedComputeInstanceReplicaConfig {
-                    location: SerializedComputeInstanceReplicaLocation::Managed {
+                config: SerializedComputeReplicaConfig {
+                    location: SerializedComputeReplicaLocation::Managed {
                         size: bootstrap_args.default_cluster_replica_size.clone(),
                         availability_zone: bootstrap_args.default_availability_zone.clone(),
                         az_user_specified: false,
                     },
-                    logging: SerializedComputeInstanceReplicaLogging {
+                    logging: SerializedComputeReplicaLogging {
                         log_logging: false,
                         interval: Some(Duration::from_secs(1)),
                         sources: None,
@@ -240,8 +239,8 @@ async fn migrate<S: Append>(
                 },
                 default_instance.clone(),
             )?;
-            txn.compute_instance_replicas.insert(
-                ComputeInstanceReplicaKey {
+            txn.compute_replicas.insert(
+                ComputeReplicaKey {
                     id: DEFAULT_REPLICA_ID,
                 },
                 default_replica.clone(),
@@ -271,8 +270,8 @@ async fn migrate<S: Append>(
                         id,
                         EventType::Create,
                         ObjectType::ClusterReplica,
-                        EventDetails::CreateComputeInstanceReplicaV1(
-                            mz_audit_log::CreateComputeInstanceReplicaV1 {
+                        EventDetails::CreateComputeReplicaV1(
+                            mz_audit_log::CreateComputeReplicaV1 {
                                 cluster_id: DEFAULT_COMPUTE_INSTANCE_ID,
                                 cluster_name: default_instance.name,
                                 replica_name: default_replica.name,
@@ -485,18 +484,18 @@ impl<S: Append> Connection<S> {
             .collect())
     }
 
-    pub async fn load_compute_instance_replicas(
+    pub async fn load_compute_replicas(
         &mut self,
     ) -> Result<
         Vec<(
             ComputeInstanceId,
             ReplicaId,
             String,
-            SerializedComputeInstanceReplicaConfig,
+            SerializedComputeReplicaConfig,
         )>,
         Error,
     > {
-        Ok(COLLECTION_COMPUTE_INSTANCE_REPLICAS
+        Ok(COLLECTION_COMPUTE_REPLICAS
             .peek_one(&mut self.stash)
             .await?
             .into_iter()
@@ -643,15 +642,15 @@ impl<S: Append> Connection<S> {
         replica_id: ReplicaId,
         compute_instance_id: ComputeInstanceId,
         name: String,
-        config: &ComputeInstanceReplicaConfig,
+        config: &ComputeReplicaConfig,
     ) -> Result<(), Error> {
-        let key = ComputeInstanceReplicaKey { id: replica_id };
-        let val = ComputeInstanceReplicaValue {
+        let key = ComputeReplicaKey { id: replica_id };
+        let val = ComputeReplicaValue {
             compute_instance_id,
             name,
             config: config.clone().into(),
         };
-        COLLECTION_COMPUTE_INSTANCE_REPLICAS
+        COLLECTION_COMPUTE_REPLICAS
             .upsert_key(&mut self.stash, &key, &val)
             .await?;
         Ok(())
@@ -754,7 +753,7 @@ pub async fn transaction<'a, S: Append>(stash: &'a mut S) -> Result<Transaction<
     let roles = COLLECTION_ROLE.peek_one(stash).await?;
     let items = COLLECTION_ITEM.peek_one(stash).await?;
     let compute_instances = COLLECTION_COMPUTE_INSTANCES.peek_one(stash).await?;
-    let compute_instance_replicas = COLLECTION_COMPUTE_INSTANCE_REPLICAS.peek_one(stash).await?;
+    let compute_replicas = COLLECTION_COMPUTE_REPLICAS.peek_one(stash).await?;
     let introspection_sources = COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX
         .peek_one(stash)
         .await?;
@@ -774,7 +773,7 @@ pub async fn transaction<'a, S: Append>(stash: &'a mut S) -> Result<Transaction<
         items: TableTransaction::new(items, |a, b| a.schema_id == b.schema_id && a.name == b.name),
         roles: TableTransaction::new(roles, |a, b| a.name == b.name),
         compute_instances: TableTransaction::new(compute_instances, |a, b| a.name == b.name),
-        compute_instance_replicas: TableTransaction::new(compute_instance_replicas, |a, b| {
+        compute_replicas: TableTransaction::new(compute_replicas, |a, b| {
             a.compute_instance_id == b.compute_instance_id && a.name == b.name
         }),
         introspection_sources: TableTransaction::new(introspection_sources, |_a, _b| false),
@@ -796,8 +795,7 @@ pub struct Transaction<'a, S> {
     items: TableTransaction<ItemKey, ItemValue>,
     roles: TableTransaction<RoleKey, RoleValue>,
     compute_instances: TableTransaction<ComputeInstanceKey, ComputeInstanceValue>,
-    compute_instance_replicas:
-        TableTransaction<ComputeInstanceReplicaKey, ComputeInstanceReplicaValue>,
+    compute_replicas: TableTransaction<ComputeReplicaKey, ComputeReplicaValue>,
     introspection_sources:
         TableTransaction<ComputeIntrospectionSourceIndexKey, ComputeIntrospectionSourceIndexValue>,
     id_allocator: TableTransaction<IdAllocKey, IdAllocValue>,
@@ -960,11 +958,11 @@ impl<'a, S: Append> Transaction<'a, S> {
         Ok(id)
     }
 
-    pub fn insert_compute_instance_replica(
+    pub fn insert_compute_replica(
         &mut self,
         compute_name: &str,
         replica_name: &str,
-        config: &SerializedComputeInstanceReplicaConfig,
+        config: &SerializedComputeReplicaConfig,
     ) -> Result<ReplicaId, Error> {
         let id = self.get_and_increment_id(REPLICA_ID_ALLOC_KEY.to_string())?;
         let mut compute_instance_id = None;
@@ -976,9 +974,9 @@ impl<'a, S: Append> Transaction<'a, S> {
                 break;
             }
         }
-        if let Err(_) = self.compute_instance_replicas.insert(
-            ComputeInstanceReplicaKey { id },
-            ComputeInstanceReplicaValue {
+        if let Err(_) = self.compute_replicas.insert(
+            ComputeReplicaKey { id },
+            ComputeReplicaValue {
                 compute_instance_id: compute_instance_id.unwrap(),
                 name: replica_name.into(),
                 config: config.clone(),
@@ -1077,7 +1075,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             assert_eq!(deleted.len(), 1);
             // Cascade delete introsepction sources and cluster replicas.
             let id = deleted.into_element().0.id;
-            self.compute_instance_replicas
+            self.compute_replicas
                 .delete(|_k, v| v.compute_instance_id == id);
             let introspection_source_indexes = self
                 .introspection_sources
@@ -1092,19 +1090,19 @@ impl<'a, S: Append> Transaction<'a, S> {
         }
     }
 
-    pub fn remove_compute_instance_replica(
+    pub fn remove_compute_replica(
         &mut self,
         name: &str,
         compute_id: ComputeInstanceId,
     ) -> Result<(), Error> {
         let deleted = self
-            .compute_instance_replicas
+            .compute_replicas
             .delete(|_k, v| v.compute_instance_id == compute_id && v.name == name);
         if deleted.len() == 1 {
             Ok(())
         } else {
             assert!(deleted.is_empty());
-            Err(SqlCatalogError::UnknownComputeInstanceReplica(name.to_owned()).into())
+            Err(SqlCatalogError::UnknownComputeReplica(name.to_owned()).into())
         }
     }
 
@@ -1293,8 +1291,8 @@ impl<'a, S: Append> Transaction<'a, S> {
         add_batch(
             self.stash,
             &mut batches,
-            &COLLECTION_COMPUTE_INSTANCE_REPLICAS,
-            self.compute_instance_replicas.pending(),
+            &COLLECTION_COMPUTE_REPLICAS,
+            self.compute_replicas.pending(),
         )
         .await?;
         add_batch(
@@ -1419,7 +1417,7 @@ pub async fn initialize_stash<S: Append>(stash: &mut S) -> Result<(), Error> {
         &COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX,
     )
     .await?;
-    add_batch(stash, &mut batches, &COLLECTION_COMPUTE_INSTANCE_REPLICAS).await?;
+    add_batch(stash, &mut batches, &COLLECTION_COMPUTE_REPLICAS).await?;
     add_batch(stash, &mut batches, &COLLECTION_DATABASE).await?;
     add_batch(stash, &mut batches, &COLLECTION_SCHEMA).await?;
     add_batch(stash, &mut batches, &COLLECTION_ITEM).await?;
@@ -1491,15 +1489,15 @@ struct DatabaseKey {
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
-struct ComputeInstanceReplicaKey {
+struct ComputeReplicaKey {
     id: ReplicaId,
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Eq, Ord)]
-struct ComputeInstanceReplicaValue {
+struct ComputeReplicaValue {
     compute_instance_id: ComputeInstanceId,
     name: String,
-    config: SerializedComputeInstanceReplicaConfig,
+    config: SerializedComputeReplicaConfig,
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialOrd, PartialEq, Eq, Ord)]
@@ -1588,10 +1586,8 @@ static COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX: TypedCollection<
     ComputeIntrospectionSourceIndexKey,
     ComputeIntrospectionSourceIndexValue,
 > = TypedCollection::new("compute_introspection_source_index");
-static COLLECTION_COMPUTE_INSTANCE_REPLICAS: TypedCollection<
-    ComputeInstanceReplicaKey,
-    ComputeInstanceReplicaValue,
-> = TypedCollection::new("compute_instance_replicas");
+static COLLECTION_COMPUTE_REPLICAS: TypedCollection<ComputeReplicaKey, ComputeReplicaValue> =
+    TypedCollection::new("compute_replicas");
 static COLLECTION_DATABASE: TypedCollection<DatabaseKey, DatabaseValue> =
     TypedCollection::new("database");
 static COLLECTION_SCHEMA: TypedCollection<SchemaKey, SchemaValue> = TypedCollection::new("schema");

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -227,8 +227,8 @@ pub enum ExecuteResponse {
     CreatedComputeInstance {
         existed: bool,
     },
-    /// The requested compute instance replica was created.
-    CreatedComputeInstanceReplica {
+    /// The requested compute replica was created.
+    CreatedComputeReplica {
         existed: bool,
     },
     /// The requested index was created.
@@ -283,8 +283,8 @@ pub enum ExecuteResponse {
     DroppedConnection,
     /// The requested compute instance was dropped.
     DroppedComputeInstance,
-    /// The requested compute instance replicas were dropped.
-    DroppedComputeInstanceReplicas,
+    /// The requested compute replica was dropped.
+    DroppedComputeReplica,
     /// The requested database was dropped.
     DroppedDatabase,
     /// The requested role was dropped.
@@ -384,7 +384,7 @@ impl ExecuteResponse {
             CreatedSchema { .. } => created!("schema"),
             CreatedRole => created!("role"),
             CreatedComputeInstance { .. } => created!("cluster"),
-            CreatedComputeInstanceReplica { .. } => created!("cluster replica"),
+            CreatedComputeReplica { .. } => created!("cluster replica"),
             CreatedIndex { .. } => created!("index"),
             CreatedSecret { .. } => created!("secret"),
             CreatedSink { .. } => created!("sink"),
@@ -402,7 +402,7 @@ impl ExecuteResponse {
             DiscardedAll => Some("DISCARD ALL".into()),
             DroppedConnection => dropped!("connection"),
             DroppedComputeInstance => dropped!("cluster"),
-            DroppedComputeInstanceReplicas => dropped!("cluster replica"),
+            DroppedComputeReplica => dropped!("cluster replica"),
             DroppedDatabase => dropped!("database"),
             DroppedRole => dropped!("role"),
             DroppedSchema => dropped!("schema"),
@@ -475,7 +475,7 @@ impl ExecuteResponse {
             CreatedComputeInstance { existed } => {
                 existed!(*existed, SqlState::DUPLICATE_OBJECT, "cluster")
             }
-            CreatedComputeInstanceReplica { existed } => {
+            CreatedComputeReplica { existed } => {
                 existed!(*existed, SqlState::DUPLICATE_OBJECT, "cluster replica")
             }
             CreatedTable { existed } => {
@@ -574,7 +574,7 @@ impl ExecuteResponse {
             | DiscardedAll
             | DroppedConnection
             | DroppedComputeInstance
-            | DroppedComputeInstanceReplicas
+            | DroppedComputeReplica
             | DroppedDatabase
             | DroppedRole
             | DroppedSchema
@@ -634,7 +634,7 @@ impl ExecuteResponse {
             CreateSchema => vec![CreatedSchema],
             CreateRole => vec![CreatedRole],
             CreateComputeInstance => vec![CreatedComputeInstance],
-            CreateComputeInstanceReplica => vec![CreatedComputeInstanceReplica],
+            CreateComputeReplica => vec![CreatedComputeReplica],
             CreateSource => vec![CreatedSource, CreatedSources],
             CreateSecret => vec![CreatedSecret],
             CreateSink => vec![CreatedSink],
@@ -652,7 +652,7 @@ impl ExecuteResponse {
             DropSchema => vec![DroppedSchema],
             DropRoles => vec![DroppedRole],
             DropComputeInstances => vec![DroppedComputeInstance],
-            DropComputeInstanceReplica => vec![DroppedComputeInstanceReplicas],
+            DropComputeReplicas => vec![DroppedComputeReplica],
             DropItems => vec![
                 DroppedConnection,
                 DroppedSource,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -847,7 +847,7 @@ pub async fn serve<S: Append + 'static>(
         availability_zones.push(DUMMY_AVAILABILITY_ZONE.into());
     }
     // Shuffle availability zones for unbiased selection in
-    // Coordinator::sequence_create_compute_instance_replica.
+    // Coordinator::sequence_create_compute_replica.
     availability_zones.shuffle(&mut rand::thread_rng());
 
     let (mut catalog, builtin_migration_metadata, builtin_table_updates) =

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -147,7 +147,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
                 // Drop timelines
                 timelines_to_drop.extend(self.remove_compute_instance_from_timeline(id));
-            } else if let catalog::Op::DropComputeInstanceReplica { name, compute_name } = op {
+            } else if let catalog::Op::DropComputeReplica { name, compute_name } = op {
                 let compute_instance = self.catalog.resolve_compute_instance(compute_name)?;
                 let replica_id = &compute_instance.replica_id_by_name[name];
                 let replica = &compute_instance.replicas_by_id[replica_id];
@@ -527,7 +527,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 Op::CreateComputeInstance { .. } => {
                     new_clusters += 1;
                 }
-                Op::CreateComputeInstanceReplica {
+                Op::CreateComputeReplica {
                     on_cluster_name, ..
                 } => {
                     *new_replicas_per_cluster.entry(on_cluster_name).or_insert(0) += 1;
@@ -574,7 +574,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 Op::DropComputeInstance { .. } => {
                     new_clusters -= 1;
                 }
-                Op::DropComputeInstanceReplica { compute_name, .. } => {
+                Op::DropComputeReplica { compute_name, .. } => {
                     *new_replicas_per_cluster.entry(compute_name).or_insert(0) -= 1;
                 }
                 Op::DropItem(id) => {

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -134,8 +134,8 @@ serde_plain::derive_display_from_serialize!(ObjectType);
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub enum EventDetails {
-    CreateComputeInstanceReplicaV1(CreateComputeInstanceReplicaV1),
-    DropComputeInstanceReplicaV1(DropComputeInstanceReplicaV1),
+    CreateComputeReplicaV1(CreateComputeReplicaV1),
+    DropComputeReplicaV1(DropComputeReplicaV1),
     FullNameV1(FullNameV1),
     NameV1(NameV1),
     RenameItemV1(RenameItemV1),
@@ -167,14 +167,14 @@ pub struct RenameItemV1 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
-pub struct DropComputeInstanceReplicaV1 {
+pub struct DropComputeReplicaV1 {
     pub cluster_id: u64,
     pub cluster_name: String,
     pub replica_name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
-pub struct CreateComputeInstanceReplicaV1 {
+pub struct CreateComputeReplicaV1 {
     pub cluster_id: u64,
     pub cluster_name: String,
     pub replica_name: String,
@@ -184,10 +184,10 @@ pub struct CreateComputeInstanceReplicaV1 {
 impl EventDetails {
     pub fn as_json(&self) -> serde_json::Value {
         match self {
-            EventDetails::CreateComputeInstanceReplicaV1(v) => {
+            EventDetails::CreateComputeReplicaV1(v) => {
                 serde_json::to_value(v).expect("must serialize")
             }
-            EventDetails::DropComputeInstanceReplicaV1(v) => {
+            EventDetails::DropComputeReplicaV1(v) => {
                 serde_json::to_value(v).expect("must serialize")
             }
             EventDetails::RenameItemV1(v) => serde_json::to_value(v).expect("must serialize"),

--- a/src/compute-client/src/controller/orchestrator.rs
+++ b/src/compute-client/src/controller/orchestrator.rs
@@ -23,7 +23,7 @@ use mz_orchestrator::{
 
 use crate::command::ReplicaId;
 
-use super::{ComputeInstanceEvent, ComputeInstanceId, ComputeInstanceReplicaAllocation};
+use super::{ComputeInstanceEvent, ComputeInstanceId, ComputeReplicaAllocation};
 
 pub(super) struct ComputeOrchestrator {
     inner: Arc<dyn NamespacedOrchestrator>,
@@ -42,7 +42,7 @@ impl ComputeOrchestrator {
         &self,
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
-        allocation: ComputeInstanceReplicaAllocation,
+        allocation: ComputeReplicaAllocation,
         availability_zone: String,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let service_name = generate_replica_service_name(instance_id, replica_id);

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -321,7 +321,7 @@ async fn execute_stmt(
         | ExecuteResponse::CreatedSchema { .. }
         | ExecuteResponse::CreatedRole
         | ExecuteResponse::CreatedComputeInstance { .. }
-        | ExecuteResponse::CreatedComputeInstanceReplica { .. }
+        | ExecuteResponse::CreatedComputeReplica { .. }
         | ExecuteResponse::CreatedTable { .. }
         | ExecuteResponse::CreatedIndex { .. }
         | ExecuteResponse::CreatedSecret { .. }
@@ -339,7 +339,7 @@ async fn execute_stmt(
         | ExecuteResponse::DroppedSchema
         | ExecuteResponse::DroppedRole
         | ExecuteResponse::DroppedComputeInstance
-        | ExecuteResponse::DroppedComputeInstanceReplicas
+        | ExecuteResponse::DroppedComputeReplica
         | ExecuteResponse::DroppedSource
         | ExecuteResponse::DroppedIndex
         | ExecuteResponse::DroppedSink

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1243,7 +1243,7 @@ where
             | ExecuteResponse::AlteredObject(..)
             | ExecuteResponse::AlteredSystemConfiguraion
             | ExecuteResponse::CreatedComputeInstance { .. }
-            | ExecuteResponse::CreatedComputeInstanceReplica { .. }
+            | ExecuteResponse::CreatedComputeReplica { .. }
             | ExecuteResponse::CreatedConnection { .. }
             | ExecuteResponse::CreatedDatabase { .. }
             | ExecuteResponse::CreatedIndex { .. }
@@ -1263,7 +1263,7 @@ where
             | ExecuteResponse::DiscardedAll
             | ExecuteResponse::DiscardedTemp
             | ExecuteResponse::DroppedComputeInstance
-            | ExecuteResponse::DroppedComputeInstanceReplicas
+            | ExecuteResponse::DroppedComputeReplica
             | ExecuteResponse::DroppedConnection
             | ExecuteResponse::DroppedDatabase
             | ExecuteResponse::DroppedIndex

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -550,8 +550,8 @@ pub enum CatalogError {
     UnknownRole(String),
     /// Unknown compute instance.
     UnknownComputeInstance(String),
-    /// Unknown compute instance replica.
-    UnknownComputeInstanceReplica(String),
+    /// Unknown compute replica.
+    UnknownComputeReplica(String),
     /// Unknown item.
     UnknownItem(String),
     /// Unknown function.
@@ -578,7 +578,7 @@ impl fmt::Display for CatalogError {
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),
             Self::UnknownComputeInstance(name) => write!(f, "unknown cluster '{}'", name),
-            Self::UnknownComputeInstanceReplica(name) => {
+            Self::UnknownComputeReplica(name) => {
                 write!(f, "unknown cluster replica '{}'", name)
             }
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -90,7 +90,7 @@ pub enum Plan {
     CreateSchema(CreateSchemaPlan),
     CreateRole(CreateRolePlan),
     CreateComputeInstance(CreateComputeInstancePlan),
-    CreateComputeInstanceReplica(CreateComputeInstanceReplicaPlan),
+    CreateComputeReplica(CreateComputeReplicaPlan),
     CreateSource(CreateSourcePlan),
     CreateSecret(CreateSecretPlan),
     CreateSink(CreateSinkPlan),
@@ -106,7 +106,7 @@ pub enum Plan {
     DropSchema(DropSchemaPlan),
     DropRoles(DropRolesPlan),
     DropComputeInstances(DropComputeInstancesPlan),
-    DropComputeInstanceReplica(DropComputeInstanceReplicaPlan),
+    DropComputeReplicas(DropComputeReplicasPlan),
     DropItems(DropItemsPlan),
     EmptyQuery,
     ShowAllVariables,
@@ -175,7 +175,7 @@ impl Plan {
                 PlanKind::Subscribe,
             ],
             StatementKind::CreateCluster => vec![PlanKind::CreateComputeInstance],
-            StatementKind::CreateClusterReplica => vec![PlanKind::CreateComputeInstanceReplica],
+            StatementKind::CreateClusterReplica => vec![PlanKind::CreateComputeReplica],
             StatementKind::CreateConnection => vec![PlanKind::CreateConnection],
             StatementKind::CreateDatabase => vec![PlanKind::CreateDatabase],
             StatementKind::CreateIndex => vec![PlanKind::CreateIndex],
@@ -193,7 +193,7 @@ impl Plan {
             StatementKind::Declare => vec![PlanKind::Declare],
             StatementKind::Delete => vec![PlanKind::ReadThenWrite],
             StatementKind::Discard => vec![PlanKind::DiscardAll, PlanKind::DiscardTemp],
-            StatementKind::DropClusterReplicas => vec![PlanKind::DropComputeInstanceReplica],
+            StatementKind::DropClusterReplicas => vec![PlanKind::DropComputeReplicas],
             StatementKind::DropClusters => vec![PlanKind::DropComputeInstances],
             StatementKind::DropDatabase => vec![PlanKind::DropDatabase],
             StatementKind::DropObjects => vec![PlanKind::DropItems],
@@ -250,19 +250,19 @@ pub struct CreateRolePlan {
 #[derive(Debug)]
 pub struct CreateComputeInstancePlan {
     pub name: String,
-    pub replicas: Vec<(String, ComputeInstanceReplicaConfig)>,
+    pub replicas: Vec<(String, ComputeReplicaConfig)>,
 }
 
 #[derive(Debug)]
-pub struct CreateComputeInstanceReplicaPlan {
+pub struct CreateComputeReplicaPlan {
     pub name: String,
     pub of_cluster: String,
-    pub config: ComputeInstanceReplicaConfig,
+    pub config: ComputeReplicaConfig,
 }
 
-/// Configuration of introspection for a compute instance replica.
+/// Configuration of introspection for a compute replica.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
-pub struct ComputeInstanceReplicaIntrospectionConfig {
+pub struct ComputeReplicaIntrospectionConfig {
     /// Whether to introspect the introspection.
     pub debugging: bool,
     /// The interval at which to introspect.
@@ -270,30 +270,30 @@ pub struct ComputeInstanceReplicaIntrospectionConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ComputeInstanceReplicaConfig {
+pub enum ComputeReplicaConfig {
     Remote {
         addrs: BTreeSet<String>,
         compute_addrs: BTreeSet<String>,
         workers: NonZeroUsize,
-        introspection: Option<ComputeInstanceReplicaIntrospectionConfig>,
+        introspection: Option<ComputeReplicaIntrospectionConfig>,
     },
     Managed {
         size: String,
         availability_zone: Option<String>,
-        introspection: Option<ComputeInstanceReplicaIntrospectionConfig>,
+        introspection: Option<ComputeReplicaIntrospectionConfig>,
     },
 }
 
-impl ComputeInstanceReplicaConfig {
+impl ComputeReplicaConfig {
     pub fn get_az(&self) -> Option<&str> {
         match self {
-            ComputeInstanceReplicaConfig::Remote {
+            ComputeReplicaConfig::Remote {
                 addrs: _,
                 compute_addrs: _,
                 workers: _,
                 introspection: _,
             } => None,
-            ComputeInstanceReplicaConfig::Managed {
+            ComputeReplicaConfig::Managed {
                 size: _,
                 availability_zone,
                 introspection: _,
@@ -314,7 +314,7 @@ pub struct CreateSourcePlan {
 /// Settings related to storage hosts
 ///
 /// This represents how resources for a storage instance are going to be
-/// provisioned, based on the SQL logic. Storage equivalent of ComputeInstanceReplicaConfig
+/// provisioned, based on the SQL logic. Storage equivalent of ComputeReplicaConfig.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum StorageHostConfig {
     /// Remote unmanaged storage
@@ -420,7 +420,7 @@ pub struct DropComputeInstancesPlan {
 }
 
 #[derive(Debug)]
-pub struct DropComputeInstanceReplicaPlan {
+pub struct DropComputeReplicasPlan {
     pub names: Vec<(String, String)>,
 }
 

--- a/src/storage/src/types/hosts.rs
+++ b/src/storage/src/types/hosts.rs
@@ -18,7 +18,7 @@ use mz_orchestrator::{CpuLimit, MemoryLimit};
 
 /// Resource allocations for a storage host.
 ///
-/// Has some overlap with mz_controller::ComputeInstanceReplicaAllocation,
+/// Has some overlap with mz_compute_client::controller::ComputeReplicaAllocation,
 /// but keeping it separate for now due slightly different semantics.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct StorageHostResourceAllocation {


### PR DESCRIPTION
This removes a significant amount of verboseness without losing expressivity.

There are no user-facing changes, because we always refer to "cluster replicas" in the UI. But there are still breaking changes wrt persistent storage:
* The `compute_instance_replicas` stash collection is renamed to `compute_replicas`.
* `EventDetails::{Create,Drop}ComputeInstanceReplicaV1` have been renamed to `EventDetails::{Create,Drop}ComputeReplicaV1`. It seems for these events, we store the type name durably, so this is a breaking change.

Because of the breaking changes, this PR must be merged before the next release on Tuesday.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
