### PR TITLE
persist: fix handling of empty batches in compaction

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -435,7 +435,6 @@ where
             batch_runs.retain_mut(|(_, iter)| iter.inner.peek().is_some());
         }
 
-        assert_eq!(total_number_of_runs, ordered_runs.len());
         ordered_runs
     }
 
@@ -746,6 +745,10 @@ impl<'a, T> Iterator for HollowBatchRunIter<'a, T> {
     type Item = &'a [HollowBatchPart];
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.batch.parts.is_empty() {
+            return None;
+        }
+
         if !self.emitted_implicit {
             self.emitted_implicit = true;
             return Some(match self.inner.peek() {

--- a/src/persist-client/tests/machine/compaction_bounded
+++ b/src/persist-client/tests/machine/compaction_bounded
@@ -282,3 +282,69 @@ f 8 1
 <run 0>
 part 0
 part 1
+
+
+# try compacting two batches with many empty (frontier update) batches in-between. we want to
+# ensure we don't count the empty batches against the memory limit when calculating which chunks
+# of runs to compact together.
+
+write-batch output=e1 lower=3 upper=4
+----
+parts=0 len=0
+
+write-batch output=e2 lower=4 upper=5
+----
+parts=0 len=0
+
+write-batch output=e3 lower=5 upper=6
+----
+parts=0 len=0
+
+write-batch output=e4 lower=6 upper=7
+----
+parts=0 len=0
+
+write-batch output=e5 lower=7 upper=8
+----
+parts=0 len=0
+
+write-batch output=e6 lower=8 upper=9
+----
+parts=0 len=0
+
+write-batch output=e7 lower=9 upper=10
+----
+parts=0 len=0
+
+write-batch output=e8 lower=10 upper=11
+----
+parts=0 len=0
+
+write-batch output=e9 lower=11 upper=12
+----
+parts=0 len=0
+
+write-batch output=e10 lower=12 upper=13
+----
+parts=0 len=0
+
+write-batch output=b1 lower=13 upper=15 target_size=0 parts_size_override=25
+a 13 1
+b 13 1
+d 13 1
+----
+parts=3 len=3
+
+compact output=b0_1 inputs=(b0,e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,b1) lower=0 upper=15 since=14 target_size=200 memory_bound=800
+----
+parts=1 len=4
+
+fetch-batch input=b0_1
+----
+<part 0>
+a 14 2
+b 14 2
+c 14 1
+d 14 1
+<run 0>
+part 0


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Philip has discovered some... suspicious behavior (🤨) with persist in https://github.com/MaterializeInc/materialize/issues/15093 and https://github.com/MaterializeInc/materialize/issues/15098

After digging into real life compaction, we're generating some very poor run chunking due to mishandling of empty batches. When a compaction request comes in, it typically contains many empty batches representing frontier updates. Those empty batches are each considered to contain a run, and because they're empty and don't have an `encoded_size`, their runs are assigned a default size of `blob_target_size`, or 128MiB. 

Because our memory limit for a given shard's compaction is only 1GiB, this means the frontier updates can rapidly consume the whole memory budget, forcing batches that have physical updates to be compacted separately, and therefore preventing the chance for their updates to consolidate.

This PR fixes this behavior by considering empty batches to... *dun dun dun* not contain a run.

### Motivation

  * This PR fixes a recognized bug.

I can't say this will wholly fix 15093 and 15098, but I think it's an important factor

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
