### PR TITLE
persist: filter out compactions for mostly empty batches

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -194,6 +194,8 @@ where
         // (especially in aggregate). This heuristic is something we'll need to
         // tune over time.
         let should_compact = req.inputs.len() >= self.cfg.compaction_heuristic_min_inputs
+            || req.inputs.iter().filter(|x| x.len > 0).count()
+                > self.cfg.compaction_heuristic_min_non_empty_inputs
             || req.inputs.iter().map(|x| x.len).sum::<usize>()
                 >= self.cfg.compaction_heuristic_min_updates;
         if !should_compact {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -208,8 +208,13 @@ pub struct PersistConfig {
     /// consolidation of updates, at the cost of greater memory usage.
     pub compaction_memory_bound_bytes: usize,
     /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
-    /// if the number of inputs is at least this many. Compaction is performed
-    /// if any of the heuristic criteria are met (they are OR'd).
+    /// if the number of non-empty inputs is at least this many. Compaction is
+    /// performed if any of the heuristic criteria are met (they are OR'd).
+    pub compaction_heuristic_min_non_empty_inputs: usize,
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of inputs, including empty batches, is at least this many.
+    /// Compaction is performed if any of the heuristic criteria are met (they are OR'd).
+    /// Expected to be larger than `compaction_heuristic_min_non_empty_inputs`
     pub compaction_heuristic_min_inputs: usize,
     /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
     /// if the number of updates is at least this many. Compaction is performed
@@ -281,6 +286,7 @@ impl PersistConfig {
             batch_builder_max_outstanding_parts: 2,
             compaction_enabled: !compaction_disabled,
             compaction_memory_bound_bytes: 1024 * MB,
+            compaction_heuristic_min_non_empty_inputs: 128,
             compaction_heuristic_min_inputs: 8,
             compaction_heuristic_min_updates: 1024,
             consensus_connection_pool_max_size: 50,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -208,17 +208,19 @@ pub struct PersistConfig {
     /// consolidation of updates, at the cost of greater memory usage.
     pub compaction_memory_bound_bytes: usize,
     /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
-    /// if the number of non-empty inputs is at least this many. Compaction is
-    /// performed if any of the heuristic criteria are met (they are OR'd).
-    pub compaction_heuristic_min_non_empty_inputs: usize,
-    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
     /// if the number of inputs, including empty batches, is at least this many.
     /// Compaction is performed if any of the heuristic criteria are met (they are OR'd).
-    /// Expected to be larger than `compaction_heuristic_min_non_empty_inputs`
-    pub compaction_heuristic_min_inputs: usize,
+    /// Expected to be larger than `compaction_heuristic_min_inputs_with_updates`
+    pub compaction_heuristic_min_total_inputs: usize,
     /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
-    /// if the number of updates is at least this many. Compaction is performed
-    /// if any of the heuristic criteria are met (they are OR'd).
+    /// if the number of non-empty inputs is at least this many. Compaction is
+    /// performed if any of the heuristic criteria are met (they are OR'd).
+    /// Expected to be smaller than `compaction_heuristic_min_total_inputs`
+    pub compaction_heuristic_min_inputs_with_updates: usize,
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of updates is at least this many, spread across at least two
+    /// different batches. Compaction is performed if any of the heuristic criteria
+    /// are met (they are OR'd).
     pub compaction_heuristic_min_updates: usize,
     /// The maximum size of the connection pool to Postgres/CRDB when performing
     /// consensus reads and writes.
@@ -286,8 +288,8 @@ impl PersistConfig {
             batch_builder_max_outstanding_parts: 2,
             compaction_enabled: !compaction_disabled,
             compaction_memory_bound_bytes: 1024 * MB,
-            compaction_heuristic_min_non_empty_inputs: 128,
-            compaction_heuristic_min_inputs: 8,
+            compaction_heuristic_min_total_inputs: 128,
+            compaction_heuristic_min_inputs_with_updates: 8,
             compaction_heuristic_min_updates: 1024,
             consensus_connection_pool_max_size: 50,
             writer_lease_duration: Duration::from_secs(60 * 15),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

While investigating compaction, I've noticed that we compact... a lot. It looks like we frequently get requests where most of the inputs are frontier batches. While this does force a logical compaction of any batches in the request that do contain updates, locally I frequently saw requests where only 1 of 8 inputs actually contained updates. This means for some shards we're rewriting the data every 8 or so seconds, even if no new updates have come in.

Currently we run compaction if we have >= 8 inputs, but those inputs may be empty. This PR updates our compaction heuristics to have a few separate tiers: 
* we compact if we have >= 8 inputs with updates
* we compact if we have >= 128 inputs total
* we compact if we have >= 1000 updates across the inputs, and at least 2 inputs with updates (this latter clause helps prevent a scenario in which 1 batch with >=1000 updates is compacted with many empty batches)

### Motivation

May help with https://github.com/MaterializeInc/materialize/issues/15093 and https://github.com/MaterializeInc/materialize/issues/15098

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
