### PR TITLE
Using schema file cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,6 +4305,7 @@ dependencies = [
  "flate2",
  "futures",
  "globset",
+ "hex",
  "http",
  "itertools",
  "junit-report",

--- a/misc/python/materialize/checks/kafka_formats.py
+++ b/misc/python/materialize/checks/kafka_formats.py
@@ -27,7 +27,7 @@ PROTOBUF = dedent(
         string value2 = 2;
     }
 
-    $ protobuf-compile-descriptors inputs=test.proto output=test.proto
+    $ protobuf-compile-descriptors inputs=test.proto output=test.proto set-var=test-schema
     """
 )
 
@@ -78,8 +78,8 @@ class KafkaFormats(Check):
 
                 > CREATE SOURCE format_protobuf1
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-protobuf-${testdrive.seed}')
-                  KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
-                  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
+                  KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
+                  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
                   INCLUDE KEY
             """
             )
@@ -116,8 +116,8 @@ class KafkaFormats(Check):
 
                 > CREATE SOURCE format_protobuf2
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-protobuf-${testdrive.seed}')
-                  KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
-                  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
+                  KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
+                  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
                   INCLUDE KEY
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-bytes

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -22,33 +22,20 @@
 //! (commonly referred to as Data Definition Language, or DDL)
 
 use std::fmt;
-use std::path::PathBuf;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{AstInfo, Expr, Ident, UnresolvedObjectName, WithOptionValue};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Schema {
-    File(PathBuf),
-    Inline(String),
+pub struct Schema {
+    pub schema: String,
 }
 
 impl AstDisplay for Schema {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            Self::File(path) => {
-                f.write_str("SCHEMA FILE '");
-                f.write_node(&display::escape_single_quote_string(
-                    &path.display().to_string(),
-                ));
-                f.write_str("'");
-            }
-            Self::Inline(inner) => {
-                f.write_str("SCHEMA '");
-                f.write_node(&display::escape_single_quote_string(inner));
-                f.write_str("'");
-            }
-        }
+        f.write_str("SCHEMA '");
+        f.write_node(&display::escape_single_quote_string(&self.schema));
+        f.write_str("'");
     }
 }
 impl_display!(Schema);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -123,7 +123,6 @@ Factor
 False
 Fetch
 Fields
-File
 Filter
 First
 Float

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1704,7 +1704,10 @@ impl<'a> Parser<'a> {
             AvroSchema::Csr { csr_connection }
         } else if self.parse_keyword(SCHEMA) {
             self.prev_token();
-            let schema = self.parse_schema()?;
+            self.expect_keyword(SCHEMA)?;
+            let schema = Schema {
+                schema: self.parse_literal_string()?,
+            };
             let with_options = if self.consume_token(&Token::LParen) {
                 let with_options = self.parse_comma_separated(Parser::parse_avro_schema_option)?;
                 self.expect_token(&Token::RParen)?;
@@ -1742,7 +1745,10 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(MESSAGE) {
             let message_name = self.parse_literal_string()?;
             self.expect_keyword(USING)?;
-            let schema = self.parse_schema()?;
+            self.expect_keyword(SCHEMA)?;
+            let schema = Schema {
+                schema: self.parse_literal_string()?,
+            };
             Ok(ProtobufSchema::InlineSchema {
                 message_name,
                 schema,
@@ -1881,16 +1887,6 @@ impl<'a> Parser<'a> {
         };
 
         Ok(CsrConnectionProtobuf { connection, seed })
-    }
-
-    fn parse_schema(&mut self) -> Result<Schema, ParserError> {
-        self.expect_keyword(SCHEMA)?;
-        let schema = if self.parse_keyword(FILE) {
-            Schema::File(self.parse_literal_string()?.into())
-        } else {
-            Schema::Inline(self.parse_literal_string()?)
-        };
-        Ok(schema)
     }
 
     fn parse_envelope(&mut self) -> Result<Envelope, ParserError> {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -887,7 +887,7 @@ fn get_encoding_inner(
                 // TODO(jldlaughlin): we need a way to pass in primary key information
                 // when building a source from a string or file.
                 AvroSchema::InlineSchema {
-                    schema: mz_sql_parser::ast::Schema::Inline(schema),
+                    schema: mz_sql_parser::ast::Schema { schema },
                     with_options,
                 } => {
                     let AvroSchemaOptionExtracted {
@@ -901,12 +901,6 @@ fn get_encoding_inner(
                         csr_connection: None,
                         confluent_wire_format,
                     }
-                }
-                AvroSchema::InlineSchema {
-                    schema: mz_sql_parser::ast::Schema::File(_),
-                    ..
-                } => {
-                    unreachable!("File schema should already have been inlined")
                 }
                 AvroSchema::Csr {
                     csr_connection:
@@ -1006,14 +1000,9 @@ fn get_encoding_inner(
             }
             ProtobufSchema::InlineSchema {
                 message_name,
-                schema,
+                schema: mz_sql_parser::ast::Schema { schema },
             } => {
-                let descriptors = match schema {
-                    mz_sql_parser::ast::Schema::Inline(bytes) => strconv::parse_bytes(bytes)?,
-                    mz_sql_parser::ast::Schema::File(_) => {
-                        unreachable!("File schema should already have been inlined")
-                    }
-                };
+                let descriptors = strconv::parse_bytes(schema)?;
 
                 DataEncodingInner::Protobuf(ProtobufEncoding {
                     descriptors,

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "3.2.20", features = ["derive"] }
 flate2 = "1.0.24"
 futures = "0.3.24"
 globset = "0.4.9"
+hex = "0.4.3"
 http = "0.2.8"
 itertools = "0.10.4"
 junit-report = "0.7.1"

--- a/test/kafka-matrix/kafka-matrix.td
+++ b/test/kafka-matrix/kafka-matrix.td
@@ -37,13 +37,13 @@ message Input {
     string field = 1;
 }
 
-$ protobuf-compile-descriptors inputs=input.proto output=input.pb
+$ protobuf-compile-descriptors inputs=input.proto output=input.pb set-var=input-schema
 
 $ kafka-create-topic topic=input_proto
 
 > CREATE SOURCE input_proto
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input_proto-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Input' USING SCHEMA FILE '${testdrive.temp-dir}/input.pb'
+  FORMAT PROTOBUF MESSAGE '.Input' USING SCHEMA '${input-schema}'
 
 $ kafka-ingest format=protobuf topic=input_proto message=Input descriptor-file=input.pb timestamp=1
 {"field": "a"}

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -220,7 +220,7 @@ $ file-append path=importee.proto
 $ file-append path=importer.proto
 \${importer-schema}
 
-$ protobuf-compile-descriptors inputs=empty.proto,importee.proto,importer.proto output=import.pb
+$ protobuf-compile-descriptors inputs=empty.proto,importee.proto,importer.proto output=import.pb set-var=import-schema
 
 $ kafka-create-topic topic=import-csr partitions=1
 

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -262,7 +262,7 @@ message Value {
     int32 measurement = 1;
 }
 
-$ protobuf-compile-descriptors inputs=test.proto output=test.proto
+$ protobuf-compile-descriptors inputs=test.proto output=test.proto set-var=test-schema
 
 $ kafka-create-topic topic=proto partitions=1
 
@@ -276,8 +276,8 @@ $ kafka-ingest topic=proto format=protobuf descriptor-file=test.proto message=Va
 
 > CREATE SOURCE input_proto
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-proto-${testdrive.seed}')
-  KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
-  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
+  KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
+  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
   INCLUDE KEY
 
 > SELECT * FROM input_proto
@@ -295,8 +295,8 @@ $ kafka-ingest topic=proto-structured
 
 > CREATE SOURCE input_proto_structured
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-proto-structured-${testdrive.seed}')
-  KEY FORMAT PROTOBUF MESSAGE '.KeyComplex' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
-  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
+  KEY FORMAT PROTOBUF MESSAGE '.KeyComplex' USING SCHEMA '${test-schema}'
+  VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
   INCLUDE KEY AS key
 
 > SELECT key::text, (key).id1, (key).id2, measurement FROM input_proto_structured

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -181,20 +181,20 @@ message Test {
     string f = 1;
 }
 
-$ protobuf-compile-descriptors inputs=test.proto output=test.pb
+$ protobuf-compile-descriptors inputs=test.proto output=test.pb set-var=test-schema
 
 $ kafka-create-topic topic=textproto partitions=1
 
 > CREATE SOURCE textproto
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textproto-${testdrive.seed}')
   KEY FORMAT TEXT
-  VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA FILE '${testdrive.temp-dir}/test.pb'
+  VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA '${test-schema}'
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytesproto
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textproto-${testdrive.seed}')
   KEY FORMAT BYTES
-  VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA FILE '${testdrive.temp-dir}/test.pb'
+  VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA '${test-schema}'
   ENVELOPE UPSERT
 
 $ kafka-ingest topic=textproto

--- a/test/testdrive/protobuf-basic.td
+++ b/test/testdrive/protobuf-basic.td
@@ -56,7 +56,7 @@ message Basic {
     Nested message = 17;
 }
 
-$ protobuf-compile-descriptors inputs=basic.proto output=basic.pb
+$ protobuf-compile-descriptors inputs=basic.proto output=basic.pb set-var=basic-schema
 
 $ kafka-create-topic topic=basic partitions=1
 
@@ -72,7 +72,7 @@ $ kafka-ingest topic=basic format=protobuf descriptor-file=basic.pb message=Basi
 
 > CREATE SOURCE basic FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-basic-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Basic' USING SCHEMA FILE '${testdrive.temp-dir}/basic.pb'
+  FORMAT PROTOBUF MESSAGE '.Basic' USING SCHEMA '${basic-schema}'
 
 > SHOW COLUMNS FROM basic
 name       nullable  type

--- a/test/testdrive/protobuf-corrupted.td
+++ b/test/testdrive/protobuf-corrupted.td
@@ -20,7 +20,7 @@ message OneString {
     string f = 1;
 }
 
-$ protobuf-compile-descriptors inputs=simple.proto output=simple.pb
+$ protobuf-compile-descriptors inputs=simple.proto output=simple.pb set-var=simple-schema
 
 $ kafka-create-topic topic=total-garbage
 
@@ -32,7 +32,7 @@ garbage
 
 > CREATE SOURCE total_garbage FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-total-garbage-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.OneInt' USING SCHEMA FILE '${testdrive.temp-dir}/simple.pb'
+  FORMAT PROTOBUF MESSAGE '.OneInt' USING SCHEMA '${simple-schema}'
 
 ! SELECT * FROM total_garbage
 contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type value: 7
@@ -44,7 +44,7 @@ $ kafka-ingest topic=wrong-message format=protobuf descriptor-file=simple.pb mes
 
 > CREATE SOURCE wrong_message FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-wrong-message-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.OneString' USING SCHEMA FILE '${testdrive.temp-dir}/simple.pb'
+  FORMAT PROTOBUF MESSAGE '.OneString' USING SCHEMA '${simple-schema}'
 
 ! SELECT * FROM wrong_message
 contains:Decode error: Text: protobuf deserialization error: failed to decode Protobuf message: invalid wire type: Varint (expected LengthDelimited)

--- a/test/testdrive/protobuf-defaults.td
+++ b/test/testdrive/protobuf-defaults.td
@@ -28,7 +28,7 @@ message Defaults {
     optional Enum enum = 8 [default = ENUM1];
 }
 
-$ protobuf-compile-descriptors inputs=defaults.proto output=defaults.pb
+$ protobuf-compile-descriptors inputs=defaults.proto output=defaults.pb set-var=defaults-schema
 
 $ kafka-create-topic topic=defaults partitions=1
 
@@ -40,7 +40,7 @@ $ kafka-ingest topic=defaults format=protobuf descriptor-file=defaults.pb messag
 
 > CREATE SOURCE defaults FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-defaults-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Defaults' USING SCHEMA FILE '${testdrive.temp-dir}/defaults.pb'
+  FORMAT PROTOBUF MESSAGE '.Defaults' USING SCHEMA '${defaults-schema}'
 
 > SELECT * FROM defaults
 bool  int32  int64  float  double  bytes  string enum

--- a/test/testdrive/protobuf-evolution.td
+++ b/test/testdrive/protobuf-evolution.td
@@ -21,7 +21,7 @@ message Message {
 $ file-append path=evolution.proto
 \${schema}
 
-$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb
+$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb set-var=evolution-schema
 
 $ schema-registry-publish subject=testdrive-evolution-${testdrive.seed}-value schema-type=protobuf
 \${schema}
@@ -62,7 +62,7 @@ $ file-delete path=evolution.proto
 $ file-append path=evolution.proto
 \${schema}
 
-$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb
+$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb set-var=evolution-schema
 
 $ schema-registry-publish subject=testdrive-evolution-${testdrive.seed}-value schema-type=protobuf
 \${schema}
@@ -90,7 +90,7 @@ $ file-delete path=evolution.proto
 $ file-append path=evolution.proto
 \${schema}
 
-$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb
+$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb set-var=evolution-schema
 
 $ schema-registry-publish subject=testdrive-evolution-${testdrive.seed}-value schema-type=protobuf
 \${schema}
@@ -123,7 +123,7 @@ $ file-delete path=evolution.proto
 $ file-append path=evolution.proto
 \${schema}
 
-$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb
+$ protobuf-compile-descriptors inputs=evolution.proto output=evolution.pb set-var=evolution-schema
 
 $ schema-registry-publish subject=testdrive-evolution-${testdrive.seed}-value schema-type=protobuf
 \${schema}

--- a/test/testdrive/protobuf-import.td
+++ b/test/testdrive/protobuf-import.td
@@ -49,7 +49,7 @@ $ file-append path=importee.proto
 $ file-append path=importer.proto
 \${importer-schema}
 
-$ protobuf-compile-descriptors inputs=empty.proto,importee.proto,importer.proto output=import.pb
+$ protobuf-compile-descriptors inputs=empty.proto,importee.proto,importer.proto output=import.pb set-var=import-schema
 
 $ kafka-create-topic topic=import partitions=1
 
@@ -61,7 +61,7 @@ $ kafka-ingest topic=import format=protobuf descriptor-file=import.pb message=Im
 
 > CREATE SOURCE import FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-import-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Importer' USING SCHEMA FILE '${testdrive.temp-dir}/import.pb'
+  FORMAT PROTOBUF MESSAGE '.Importer' USING SCHEMA '${import-schema}'
 
 > SELECT importee1::text, importee2::text FROM import
 importee1  importee2

--- a/test/testdrive/protobuf-map.td
+++ b/test/testdrive/protobuf-map.td
@@ -19,12 +19,12 @@ message Maps {
   map<string, google.protobuf.Int64Value> message_map = 2;
 }
 
-$ protobuf-compile-descriptors inputs=maps.proto output=maps.pb
+$ protobuf-compile-descriptors inputs=maps.proto output=maps.pb set-var=maps-schema
 
 > CREATE CONNECTION kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 ! CREATE SOURCE maps FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-maps-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Maps' USING SCHEMA FILE '${testdrive.temp-dir}/maps.pb'
+  FORMAT PROTOBUF MESSAGE '.Maps' USING SCHEMA '${maps-schema}'
 contains:Protobuf map fields are not supported

--- a/test/testdrive/protobuf-name.td
+++ b/test/testdrive/protobuf-name.td
@@ -18,7 +18,7 @@ message Name {
     int32 i = 1;
 }
 
-$ protobuf-compile-descriptors inputs=name.proto output=name.pb
+$ protobuf-compile-descriptors inputs=name.proto output=name.pb set-var=name-schema
 
 $ kafka-create-topic topic=name partitions=1
 
@@ -31,7 +31,7 @@ $ kafka-ingest topic=name format=protobuf descriptor-file=name.pb message=some.w
 # Ingesting with the fully-qualified absolute path should work.
 > CREATE SOURCE qualified_absolute_path FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-name-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.some.where.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+  FORMAT PROTOBUF MESSAGE '.some.where.Name' USING SCHEMA '${name-schema}'
 > SELECT i FROM qualified_absolute_path
 i
 ---
@@ -40,7 +40,7 @@ i
 # Ingesting with the absolute path should work without the leading dot.
 > CREATE SOURCE absolute_path FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-name-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE 'some.where.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+  FORMAT PROTOBUF MESSAGE 'some.where.Name' USING SCHEMA '${name-schema}'
 > SELECT i FROM absolute_path
 i
 ---
@@ -49,9 +49,9 @@ i
 # Ingesting without the package prefix should fail.
 ! CREATE SOURCE absolute_path FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-name-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE 'Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+  FORMAT PROTOBUF MESSAGE 'Name' USING SCHEMA '${name-schema}'
 contains:protobuf message "Name" not found in file descriptor set
 ! CREATE SOURCE absolute_path FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-name-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
+  FORMAT PROTOBUF MESSAGE '.Name' USING SCHEMA '${name-schema}'
 contains:protobuf message ".Name" not found in file descriptor set

--- a/test/testdrive/protobuf-recursive.td
+++ b/test/testdrive/protobuf-recursive.td
@@ -28,15 +28,15 @@ message Mutual3 {
     Mutual1 m = 1;
 }
 
-$ protobuf-compile-descriptors inputs=recursive.proto output=recursive.pb
+$ protobuf-compile-descriptors inputs=recursive.proto output=recursive.pb set-var=recursive-schema
 
 > CREATE CONNECTION kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 ! CREATE SOURCE recursive FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-recursive-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Self' USING SCHEMA FILE '${testdrive.temp-dir}/recursive.pb'
+  FORMAT PROTOBUF MESSAGE '.Self' USING SCHEMA '${recursive-schema}'
 contains:Recursive types are not supported: Self
 
 ! CREATE SOURCE recursive FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-recursive-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Mutual1' USING SCHEMA FILE '${testdrive.temp-dir}/recursive.pb'
+  FORMAT PROTOBUF MESSAGE '.Mutual1' USING SCHEMA '${recursive-schema}'
 contains:Recursive types are not supported: Mutual1

--- a/test/testdrive/protobuf-repeated.td
+++ b/test/testdrive/protobuf-repeated.td
@@ -34,7 +34,7 @@ message Repeated {
     repeated Message message = 9;
 }
 
-$ protobuf-compile-descriptors inputs=repeated.proto output=repeated.pb
+$ protobuf-compile-descriptors inputs=repeated.proto output=repeated.pb set-var=repeated-schema
 
 $ kafka-create-topic topic=repeated partitions=1
 
@@ -47,7 +47,7 @@ $ kafka-ingest topic=repeated format=protobuf descriptor-file=repeated.pb messag
 
 > CREATE SOURCE repeated FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-repeated-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Repeated' USING SCHEMA FILE '${testdrive.temp-dir}/repeated.pb'
+  FORMAT PROTOBUF MESSAGE '.Repeated' USING SCHEMA '${repeated-schema}'
 
 > SHOW COLUMNS FROM repeated
 name       nullable  type

--- a/test/testdrive/protobuf-required.td
+++ b/test/testdrive/protobuf-required.td
@@ -16,7 +16,7 @@ message Required {
   required int32 f = 1;
 }
 
-$ protobuf-compile-descriptors inputs=required.proto output=required.pb
+$ protobuf-compile-descriptors inputs=required.proto output=required.pb set-var=required-schema
 
 $ kafka-create-topic topic=required partitions=1
 
@@ -27,7 +27,7 @@ $ kafka-ingest topic=required format=protobuf descriptor-file=required.pb messag
 
 > CREATE SOURCE required FROM
   KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-required-${testdrive.seed}')
-  FORMAT PROTOBUF MESSAGE '.Required' USING SCHEMA FILE '${testdrive.temp-dir}/required.pb'
+  FORMAT PROTOBUF MESSAGE '.Required' USING SCHEMA '${required-schema}'
 
 > SELECT * FROM required
 f

--- a/test/upgrade/create-in-current_source-compile-proto-sources.td
+++ b/test/upgrade/create-in-current_source-compile-proto-sources.td
@@ -17,7 +17,7 @@ message Message {
 $ file-append path=message.proto
 \${schema}
 
-$ protobuf-compile-descriptors inputs=message.proto output=message.pb
+$ protobuf-compile-descriptors inputs=message.proto output=message.pb set-var=message-schema
 
 $ kafka-create-topic topic=upgrade-proto-source-${arg.upgrade-from-version}
 


### PR DESCRIPTION
@benesch There's an alternative design that aims to more generally set vars from files; lmk if you prefer that

### Motivation

This PR adds a known-desirable feature. Closes #14911

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
