### PR TITLE
sql: remove the last of the legacy with option handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4058,6 +4058,7 @@ dependencies = [
  "enum-kinds",
  "globset",
  "hex",
+ "http",
  "itertools",
  "mz-build-info",
  "mz-ccsr",

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -67,7 +67,7 @@ of queries that obey the spacing rules
 ```sql
 CREATE TABLE t (a varchar(40));
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'localhost:9092';
-CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn (TOPIC 'top') LEGACYWITH (config_param = 'yes') FORMAT BYTES;
+CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn (TOPIC 'top') WITH (config_param = 'yes') FORMAT BYTES;
 SELECT coalesce(1, NULL, 2);
 SELECT CAST (1 AS text); -- note the space after CAST
 SELECT (1 + 2) - (7 * 4);
@@ -78,7 +78,7 @@ and several queries that don't:
 ```sql
 CREATE TABLE t (a varchar (40));
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'localhost:9092';
-CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn )TOPIC 'top') LEGACYWITH(tail=true);
+CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn )TOPIC 'top') WITH (tail=true);
 SELECT coalesce (1, NULL,2);
 SELECT CAST(1 AS text);
 SELECT 1+2;

--- a/doc/user/content/overview/timelines.md
+++ b/doc/user/content/overview/timelines.md
@@ -40,13 +40,13 @@ CREATE SOURCE source_1
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'topic-1')
   FORMAT AVRO USING SCHEMA 'schema-1'
   ENVELOPE MATERIALIZE
-  LEGACYWITH (TIMELINE 'my_user_timeline');
+  WITH (TIMELINE 'my_user_timeline');
 
 CREATE SOURCE source_2
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'topic-2')
   FORMAT AVRO USING SCHEMA 'schema-2'
   ENVELOPE MATERIALIZE
-  LEGACYWITH (TIMELINE 'my_user_timeline');
+  WITH (TIMELINE 'my_user_timeline');
 ```
 
 ## CDC Sources
@@ -63,7 +63,7 @@ CREATE SOURCE source_3
   FROM KAFKA CONDITION kafka_conn (TOPIC 'topic-3')
   FORMAT AVRO USING SCHEMA 'schema'
   ENVELOPE MATERIALIZE
-  LEGACYWITH (TIMELINE 'mz_epoch_ms')
+  WITH (TIMELINE 'mz_epoch_ms')
 ```
 
 [cdc-sources]: /connect/materialize-cdc

--- a/doc/user/content/sql/create-type.md
+++ b/doc/user/content/sql/create-type.md
@@ -43,14 +43,14 @@ _field_type_        | The data type of a field indicated by _field_name_.
 
 Field | Use
 -----|-----
-`element_type` | Creates a custom [`list`](../types/list) whose elements are of `element_type`.
+`ELEMENT TYPE` | Creates a custom [`list`](../types/list) whose elements are of `ELEMENT TYPE`.
 
 ### `map` properties
 
 Field | Use
 -----|-----
-`key_type` | Creates a custom [`map`](../types/map) whose keys are of `key_type`. `key_type` must resolve to [`text`](../types/text).
-`value_type` | Creates a custom [`map`](../types/map) whose values are of `value_type`.
+`KEY TYPE` | Creates a custom [`map`](../types/map) whose keys are of `KEY TYPE`. `KEY TYPE` must resolve to [`text`](../types/text).
+`VALUE TYPE` | Creates a custom [`map`](../types/map) whose values are of `VALUE TYPE`.
 
 ## Details
 
@@ -71,7 +71,7 @@ custom type's properties.
 ### Custom `list`
 
 ```sql
-CREATE TYPE int4_list AS LIST (element_type = int4);
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
 SELECT '{1,2}'::int4_list::text AS custom_list;
 ```
@@ -84,7 +84,7 @@ SELECT '{1,2}'::int4_list::text AS custom_list;
 ### Nested custom `list`
 
 ```sql
-CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
 SELECT '{{1,2}}'::int4_list_list::text AS custom_nested_list;
 ```
@@ -97,7 +97,7 @@ SELECT '{{1,2}}'::int4_list_list::text AS custom_nested_list;
 ### Custom `map`
 
 ```sql
-CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 SELECT '{a=>1}'::int4_map::text AS custom_map;
 ```
@@ -110,7 +110,7 @@ SELECT '{a=>1}'::int4_map::text AS custom_map;
 ### Nested custom `map`
 
 ```sql
-CREATE TYPE int4_map_map AS MAP (key_type=text, value_type=int4_map);
+CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
 SELECT '{a=>{a=>1}}'::int4_map_map::text AS custom_nested_map;
 ```

--- a/doc/user/content/sql/drop-type.md
+++ b/doc/user/content/sql/drop-type.md
@@ -23,7 +23,7 @@ _data_type_name_ | The name of the type to remove.
 
 ### Remove a type with no dependent objects
 ```sql
-CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 SHOW TYPES;
 ```
@@ -52,9 +52,9 @@ By default, `DROP TYPE` will not remove a type with dependent objects. The **CAS
 In the example below, the **CASCADE** switch removes `int4_list`, `int4_list_list` (which depends on `int4_list`), and the table *t*, which has a column of data type `int4_list`.
 
 ```sql
-CREATE TYPE int4_list AS LIST (element_type = int4);
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
-CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
 CREATE TABLE t (a int4_list);
 

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -107,7 +107,7 @@ The following query hints are valid within the `OPTION` clause.
 
 Hint | Value type | Description
 ------|------------|------------
-`expected_group_size` | `int` | How many rows will have the same group key. Materialize can render `min` and `max` expressions more efficiently with this information.
+`EXPECTED GROUP SIZE` | `int` | How many rows will have the same group key. Materialize can render `min` and `max` expressions more efficiently with this information.
 
 For an example, see [Using query hints](#using-query-hints).
 
@@ -216,7 +216,7 @@ SELECT a,
        min(b) AS min
 FROM example
 GROUP BY a
-OPTION (expected_group_size = 100)
+OPTIONS (EXPECTED GROUP SIZE = 100)
 ```
 
 Here the hint indicates that there may be up to a hundred distinct `(a, b)` pairs

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -30,7 +30,7 @@ _target&lowbar;elem_ | Return identified columns or functions.
 _join&lowbar;expr_ | A join expression; for more details, see the [`JOIN` documentation](../join).
 **WHERE** _expression_ | Filter tuples by _expression_.
 **GROUP BY** _col&lowbar;ref_ | Group aggregations by _col&lowbar;ref_.
-**OPTION (** _hint&lowbar;list_ **)** | Specify one or more [query hints](#query-hints).
+**OPTIONS (** _hint&lowbar;list_ **)** | Specify one or more [query hints](#query-hints).
 **HAVING** _expression_ | Filter aggregations by _expression_.
 **ORDER BY** _col&lowbar;ref_... | Sort results in either **ASC** or **DESC** order (_default: **ASC**_).<br/><br/>Use the **NULLS FIRST** and **NULLS LAST** options to determine whether nulls appear before or after non-null values in the sort ordering _(default: **NULLS LAST** for **ASC**, **NULLS FIRST** for **DESC**)_.<br/><br>
 **LIMIT** | Limit the number of returned results to _integer_.

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -290,7 +290,7 @@ select_stmt ::=
   join_expr?
   ( 'WHERE' expr )?
   ( 'GROUP' 'BY' col_ref ( ',' col_ref )* )?
-  ( 'OPTION' '(' ( option '=' val ) ( ( ',' option '=' val ) )* ')' )?
+  ( 'OPTIONS' '(' ( option '=' val ) ( ( ',' option '=' val ) )* ')' )?
   ( 'HAVING' expr )?
   ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )?
   ( 'LIMIT' integer )?

--- a/misc/python/materialize/checks/nested_types.py
+++ b/misc/python/materialize/checks/nested_types.py
@@ -19,10 +19,10 @@ class NestedTypes(Check):
             dedent(
                 """
             > CREATE TYPE record_type AS (f1 INT, f2 STRING);
-            > CREATE TYPE map_type AS MAP (key_type=text, value_type=integer);
+            > CREATE TYPE map_type AS MAP (KEY TYPE = text, VALUE TYPE = integer);
 
-            > CREATE TYPE int4_list AS LIST (element_type = int4);
-            > CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+            > CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
+            > CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
             > CREATE TABLE nested_types_table(map_col map_type, list_col int4_list_list, record_col record_type, array_col STRING);
 

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -688,6 +688,9 @@ impl_display_t!(PostgresConnectionOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AwsConnectionOptionName {
     AccessKeyId,
+    Endpoint,
+    Region,
+    RoleArn,
     SecretAccessKey,
     Token,
 }
@@ -696,6 +699,9 @@ impl AstDisplay for AwsConnectionOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             AwsConnectionOptionName::AccessKeyId => "ACCESS KEY ID",
+            AwsConnectionOptionName::Endpoint => "ENDPOINT",
+            AwsConnectionOptionName::Region => "REGION",
+            AwsConnectionOptionName::RoleArn => "ROLE ARN",
             AwsConnectionOptionName::SecretAccessKey => "SECRET ACCESS KEY",
             AwsConnectionOptionName::Token => "TOKEN",
         })

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -265,7 +265,7 @@ impl<T: AstInfo> AstDisplay for Select<T> {
             f.write_node(having);
         }
         if !self.options.is_empty() {
-            f.write_str(" OPTION (");
+            f.write_str(" OPTIONS (");
             f.write_node(&display::comma_separated(&self.options));
             f.write_str(")");
         }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -739,7 +739,6 @@ pub struct CreateTableStatement<T: AstInfo> {
     /// Optional schema
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
-    pub with_options: Vec<WithOption<T>>,
     pub if_not_exists: bool,
     pub temporary: bool,
 }
@@ -762,12 +761,6 @@ impl<T: AstInfo> AstDisplay for CreateTableStatement<T> {
             f.write_node(&display::comma_separated(&self.constraints));
         }
         f.write_str(")");
-
-        if !self.with_options.is_empty() {
-            f.write_str(" WITH (");
-            f.write_node(&display::comma_separated(&self.with_options));
-            f.write_str(")");
-        }
     }
 }
 impl_display_t!(CreateTableStatement);
@@ -944,11 +937,19 @@ impl<T: AstInfo> AstDisplay for CreateTypeStatement<T> {
         f.write_node(&self.name);
         f.write_str(" AS ");
         match &self.as_type {
-            CreateTypeAs::List { with_options } | CreateTypeAs::Map { with_options } => {
+            CreateTypeAs::List { options } => {
                 f.write_str(&self.as_type);
                 f.write_str("( ");
-                if !with_options.is_empty() {
-                    f.write_node(&display::comma_separated(with_options));
+                if !options.is_empty() {
+                    f.write_node(&display::comma_separated(options));
+                }
+                f.write_str(" )");
+            }
+            CreateTypeAs::Map { options } => {
+                f.write_str(&self.as_type);
+                f.write_str("( ");
+                if !options.is_empty() {
+                    f.write_node(&display::comma_separated(options));
                 }
                 f.write_str(" )");
             }
@@ -1097,9 +1098,15 @@ impl<T: AstInfo> AstDisplay for ReplicaOption<T> {
 /// `CREATE TYPE .. AS <TYPE>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateTypeAs<T: AstInfo> {
-    List { with_options: Vec<WithOption<T>> },
-    Map { with_options: Vec<WithOption<T>> },
-    Record { column_defs: Vec<ColumnDef<T>> },
+    List {
+        options: Vec<CreateTypeListOption<T>>,
+    },
+    Map {
+        options: Vec<CreateTypeMapOption<T>>,
+    },
+    Record {
+        column_defs: Vec<ColumnDef<T>>,
+    },
 }
 
 impl<T: AstInfo> AstDisplay for CreateTypeAs<T> {
@@ -1112,6 +1119,66 @@ impl<T: AstInfo> AstDisplay for CreateTypeAs<T> {
     }
 }
 impl_display_t!(CreateTypeAs);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CreateTypeListOptionName {
+    ElementType,
+}
+
+impl AstDisplay for CreateTypeListOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            CreateTypeListOptionName::ElementType => "ELEMENT TYPE",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateTypeListOption<T: AstInfo> {
+    pub name: CreateTypeListOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for CreateTypeListOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CreateTypeMapOptionName {
+    KeyType,
+    ValueType,
+}
+
+impl AstDisplay for CreateTypeMapOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            CreateTypeMapOptionName::KeyType => "KEY TYPE",
+            CreateTypeMapOptionName::ValueType => "VALUE TYPE",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateTypeMapOption<T: AstInfo> {
+    pub name: CreateTypeMapOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for CreateTypeMapOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
 
 /// `ALTER <OBJECT> ... RENAME TO`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2029,29 +2096,10 @@ impl<T: AstInfo> AstDisplay for ShowStatementFilter<T> {
 impl_display_t!(ShowStatementFilter);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct WithOption<T: AstInfo> {
-    pub key: Ident,
-    pub value: Option<WithOptionValue<T>>,
-}
-
-impl<T: AstInfo> AstDisplay for WithOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_node(&self.key);
-        if let Some(opt) = &self.value {
-            f.write_str(" = ");
-            f.write_node(opt);
-        }
-    }
-}
-impl_display_t!(WithOption);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
     Ident(Ident),
     DataType(T::DataType),
-    // Temporary variant until we have support for connections, which will use
-    // explicit fields for each secret reference.
     Secret(T::ObjectName),
     Object(T::ObjectName),
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -454,7 +454,6 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
     pub connection: CreateSourceConnection<T>,
-    pub legacy_with_options: Vec<WithOption<T>>,
     pub include_metadata: Vec<SourceIncludeMetadata>,
     pub format: CreateSourceFormat<T>,
     pub envelope: Option<Envelope>,
@@ -486,11 +485,6 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
         }
         f.write_str("FROM ");
         f.write_node(&self.connection);
-        if !self.legacy_with_options.is_empty() {
-            f.write_str(" LEGACYWITH (");
-            f.write_node(&display::comma_separated(&self.legacy_with_options));
-            f.write_str(")");
-        }
         f.write_node(&self.format);
         if !self.include_metadata.is_empty() {
             f.write_str(" INCLUDE ");

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -71,7 +71,7 @@ impl Keyword {
         matches!(
             self,
             // Keywords that can appear at the top-level of a SELECT statement.
-            WITH | SELECT | FROM | WHERE | GROUP | HAVING | ORDER | LIMIT | OFFSET | FETCH | OPTION |
+            WITH | SELECT | FROM | WHERE | GROUP | HAVING | ORDER | LIMIT | OFFSET | FETCH | OPTIONS |
             // Set operations.
             UNION | EXCEPT | INTERSECT
         )

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -108,6 +108,7 @@ Distinct
 Dot
 Double
 Drop
+Element
 Else
 Enable
 End
@@ -118,6 +119,7 @@ Escape
 Except
 Execute
 Exists
+Expected
 Explain
 Extract
 Factor
@@ -226,7 +228,7 @@ Only
 Operator
 Optimized
 Optimizer
-Option
+Options
 Or
 Order
 Ordinality

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -111,6 +111,7 @@ Drop
 Else
 Enable
 End
+Endpoint
 Enforced
 Envelope
 Escape
@@ -181,7 +182,6 @@ Latest
 Leading
 Least
 Left
-Legacywith
 Level
 Like
 Limit
@@ -258,6 +258,7 @@ Real
 References
 Refresh
 Regex
+Region
 Registry
 Remote
 Rename

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -241,7 +241,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         CREATE TABLE e01 (
             e02 INT PRIMARY KEY DEFAULT e03 CHECK (e04),
             CHECK (e05)
-        ) WITH (e06 = 1);
+        );
         CREATE VIEW f01 (f02) AS SELECT * FROM f03;
         DROP TABLE j01;
         DROP VIEW k01;
@@ -265,7 +265,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         "b01", "b02", "b03", "b04",
         "c01", "c02", "c03", "c04", "c05",
         "d01", "d02",
-        "e01", "e02", "int4", "e03", "e04", "e05", "e06",
+        "e01", "e02", "int4", "e03", "e04", "e05",
         "f01", "f02", "f03",
         "j01",
         "k01",

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -46,21 +46,21 @@ COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Object(Name(UnresolvedObjectName([Ident("text")])))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|')
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|')
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Object(Name(UnresolvedObjectName([Ident("csv")])))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Object(Name(UnresolvedObjectName([Ident("text")])))) }] })
 
 parse-statement
 COPY t TO STDOUT ()

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -14,88 +14,88 @@
 # limitations under the License.
 
 parse-statement
-CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
+CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 ----
-CREATE TYPE custom AS MAP ( key_type = text, value_type = bool )
+CREATE TYPE custom AS MAP ( KEY TYPE   = text, VALUE TYPE   = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS MAP (KEY_TYPE=text, VaLuE_tYpE=custom_type)
+CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = custom_type)
 ----
-CREATE TYPE custom AS MAP ( key_type = text, value_type = custom_type )
+CREATE TYPE custom AS MAP ( KEY TYPE   = text, VALUE TYPE   = custom_type )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS MAP (key_type=text)
+CREATE TYPE custom AS MAP (KEY TYPE = text)
 ----
-CREATE TYPE custom AS MAP ( key_type = text )
+CREATE TYPE custom AS MAP ( KEY TYPE   = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS MAP (value_type=bool)
+CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 ----
-CREATE TYPE custom AS MAP ( value_type = bool )
+CREATE TYPE custom AS MAP ( VALUE TYPE   = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS MAP (key_type=text, value_type=bool, random_type=int)
+CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, random_type=int)
 ----
-CREATE TYPE custom AS MAP ( key_type = text, value_type = bool, random_type = int4 )
+CREATE TYPE custom AS MAP ( KEY TYPE   = text, VALUE TYPE   = bool, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS MAP (key_type=text, random_type=int)
+CREATE TYPE custom AS MAP (KEY TYPE = text, random_type=int)
 ----
-CREATE TYPE custom AS MAP ( key_type = text, random_type = int4 )
+CREATE TYPE custom AS MAP ( KEY TYPE   = text, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS LIST (element_type=text)
+CREATE TYPE custom AS LIST (ELEMENT TYPE=text)
 ----
-CREATE TYPE custom AS LIST ( element_type = text )
+CREATE TYPE custom AS LIST ( ELEMENT TYPE = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS LIST (element_type=x)
+CREATE TYPE custom AS LIST (ELEMENT TYPE=x)
 ----
-CREATE TYPE custom AS LIST ( element_type = x )
+CREATE TYPE custom AS LIST ( ELEMENT TYPE = x )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE custom AS LIST (element_type=_text)
+CREATE TYPE custom AS LIST (ELEMENT TYPE=_text)
 ----
-CREATE TYPE custom AS LIST ( element_type = _text )
+CREATE TYPE custom AS LIST ( ELEMENT TYPE = _text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE schema.t2 AS LIST (element_type=schema.t1)
+CREATE TYPE schema.t2 AS LIST (ELEMENT TYPE=schema.t1)
 ----
-CREATE TYPE schema.t2 AS LIST ( element_type = schema.t1 )
+CREATE TYPE schema.t2 AS LIST ( ELEMENT TYPE = schema.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE db2.schema2.t2 AS LIST (element_type=db1.schema1.t1)
+CREATE TYPE db2.schema2.t2 AS LIST (ELEMENT TYPE=db1.schema1.t1)
 ----
-CREATE TYPE db2.schema2.t2 AS LIST ( element_type = db1.schema1.t1 )
+CREATE TYPE db2.schema2.t2 AS LIST ( ELEMENT TYPE = db1.schema1.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
-CREATE TYPE numeric_list AS LIST (element_type=numeric(100,100,100))
+CREATE TYPE numeric_list AS LIST (ELEMENT TYPE=numeric(100,100,100))
 ----
-CREATE TYPE numeric_list AS LIST ( element_type = numeric(100, 100, 100) )
+CREATE TYPE numeric_list AS LIST ( ELEMENT TYPE = numeric(100, 100, 100) )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
 
 parse-statement
 CREATE TYPE named_composite AS (a int, b text, c float8);

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -16,86 +16,86 @@
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 ----
-CREATE TYPE custom AS MAP ( KEY TYPE   = text, VALUE TYPE   = bool )
+CREATE TYPE custom AS MAP ( KEY TYPE = text, VALUE TYPE = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = custom_type)
 ----
-CREATE TYPE custom AS MAP ( KEY TYPE   = text, VALUE TYPE   = custom_type )
+CREATE TYPE custom AS MAP ( KEY TYPE = text, VALUE TYPE = custom_type )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text)
 ----
-CREATE TYPE custom AS MAP ( KEY TYPE   = text )
+CREATE TYPE custom AS MAP ( KEY TYPE = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: KeyType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 ----
-CREATE TYPE custom AS MAP ( VALUE TYPE   = bool )
+CREATE TYPE custom AS MAP ( VALUE TYPE = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { options: [CreateTypeMapOption { name: ValueType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, random_type=int)
 ----
-CREATE TYPE custom AS MAP ( KEY TYPE   = text, VALUE TYPE   = bool, random_type = int4 )
-=>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("VALUE TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
+error: Expected one of KEY or VALUE, found identifier "random_type"
+CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, random_type=int)
+                                                               ^
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY TYPE = text, random_type=int)
 ----
-CREATE TYPE custom AS MAP ( KEY TYPE   = text, random_type = int4 )
-=>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("KEY TYPE " ), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
+error: Expected one of KEY or VALUE, found identifier "random_type"
+CREATE TYPE custom AS MAP (KEY TYPE = text, random_type=int)
+                                            ^
 
 parse-statement
 CREATE TYPE custom AS LIST (ELEMENT TYPE=text)
 ----
 CREATE TYPE custom AS LIST ( ELEMENT TYPE = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (ELEMENT TYPE=x)
 ----
 CREATE TYPE custom AS LIST ( ELEMENT TYPE = x )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (ELEMENT TYPE=_text)
 ----
 CREATE TYPE custom AS LIST ( ELEMENT TYPE = _text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE schema.t2 AS LIST (ELEMENT TYPE=schema.t1)
 ----
 CREATE TYPE schema.t2 AS LIST ( ELEMENT TYPE = schema.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE db2.schema2.t2 AS LIST (ELEMENT TYPE=db1.schema1.t1)
 ----
 CREATE TYPE db2.schema2.t2 AS LIST ( ELEMENT TYPE = db1.schema1.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE numeric_list AS LIST (ELEMENT TYPE=numeric(100,100,100))
 ----
 CREATE TYPE numeric_list AS LIST ( ELEMENT TYPE = numeric(100, 100, 100) )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { with_options: [WithOption { key: Ident("ELEMENT TYPE"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { options: [CreateTypeListOption { name: ElementType, value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
 
 parse-statement
 CREATE TYPE named_composite AS (a int, b text, c float8);
@@ -193,14 +193,14 @@ CREATE TABLE "table_name" (col_name int)
 ----
 CREATE TABLE table_name (col_name int4)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE schema_name.table_name (col_name int)
 ----
 CREATE TABLE schema_name.table_name (col_name int4)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("schema_name"), Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("schema_name"), Ident("table_name")]), columns: [ColumnDef { name: Ident("col_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE "" (col_name int)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -29,7 +29,7 @@ CREATE TABLE uk_cities (
 ----
 CREATE TABLE uk_cities (name varchar(100) NOT NULL, lat float8 NULL, lng float8, constrained int4 NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), ref int4 REFERENCES othertable (a, b))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: UnresolvedObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: UnresolvedObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
@@ -41,16 +41,16 @@ CREATE TABLE t (a int NOT NULL GARBAGE)
 parse-statement
 CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
-CREATE TABLE t (c int4) WITH (foo = 'bar', a = 123)
-=>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [WithOption { key: Ident("foo"), value: Some(Value(String("bar"))) }, WithOption { key: Ident("a"), value: Some(Value(Number("123"))) }], if_not_exists: false, temporary: false })
+error: Expected end of statement, found WITH
+CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
+                       ^
 
 parse-statement
 CREATE TABLE types_table (char_col char, bpchar_col bpchar, text_col text, bool_col boolean, date_col date, time_col time, timestamp_col timestamp, uuid_col uuid, double_col double precision);
 ----
 CREATE TABLE types_table (char_col bpchar, bpchar_col bpchar, text_col text, bool_col bool, date_col date, time_col time, timestamp_col timestamp, uuid_col uuid, double_col float8)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("types_table")]), columns: [ColumnDef { name: Ident("char_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bpchar_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("text_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bool_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("date_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("time_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("timestamp_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("uuid_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("uuid")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("double_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("types_table")]), columns: [ColumnDef { name: Ident("char_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bpchar_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bpchar")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("text_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("bool_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("date_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("time_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("timestamp_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("uuid_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("uuid")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("double_col"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t
@@ -64,14 +64,14 @@ CREATE TABLE t ()
 ----
 CREATE TABLE t ()
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t ()
 ----
 CREATE TEMPORARY TABLE t ()
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [], constraints: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (bar int,)
@@ -85,14 +85,14 @@ CREATE TABLE foo (bar int list)
 ----
 CREATE TABLE foo (bar int4 list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (bar int list list)
 ----
 CREATE TABLE foo (bar int4 list list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE tab (foo int,
@@ -106,105 +106,105 @@ CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: Name(UnresolvedObjectName([Ident("public"), Ident("address")])), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: Name(UnresolvedObjectName([Ident("public"), Ident("address")])), referred_columns: [Ident("address_id")] }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMPORARY TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 ----
 CREATE TEMPORARY TABLE foo (id int4, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: Op { namespace: [], op: "<>" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("rtrim")]), args: Args { args: [Function(Function { name: UnresolvedObjectName([Ident("ltrim")]), args: Args { args: [Identifier([Ident("ref_code")])], order_by: [] }, filter: None, over: None, distinct: false })], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: Op { namespace: [], op: "<>" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("rtrim")]), args: Args { args: [Function(Function { name: UnresolvedObjectName([Ident("ltrim")]), args: Args { args: [Identifier([Ident("ref_code")])], order_by: [] }, filter: None, over: None, distinct: false })], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 ----
 CREATE TABLE foo (id int4, PRIMARY KEY (foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, UNIQUE (id))
 ----
 CREATE TABLE foo (id int4, UNIQUE (id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 ----
 CREATE TABLE foo (id int4, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: Name(UnresolvedObjectName([Ident("anothertable")])), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: Name(UnresolvedObjectName([Ident("anothertable")])), referred_columns: [Ident("foo"), Ident("bar")] }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
 ----
 CREATE TABLE foo (id int4, CHECK (end_date > start_date OR end_date IS NULL))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Null, negated: false } } }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Null, negated: false } } }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS UNKNOWN))
 ----
 CREATE TABLE foo (id int4, CHECK (end_date > start_date OR end_date IS UNKNOWN))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Unknown, negated: false } } }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: Op { namespace: [], op: ">" }, expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsExpr { expr: Identifier([Ident("end_date")]), construct: Unknown, negated: false } } }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (start_date IS TRUE))
 ----
 CREATE TABLE foo (id int4, CHECK (start_date IS TRUE))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: IsExpr { expr: Identifier([Ident("start_date")]), construct: True, negated: false } }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: IsExpr { expr: Identifier([Ident("start_date")]), construct: True, negated: false } }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t (c schema.type)
 ----
 CREATE TEMPORARY TABLE t (c schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c db.schema.type)
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "db"."schema"."type")
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c something.db.schema.type)
 ----
 CREATE TABLE t (c something.db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t (c db.schema.type(0,1,100))
 ----
 CREATE TEMPORARY TABLE t (c db.schema.type(0, 1, 100))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c time with time zone (0,1,100))
@@ -232,14 +232,14 @@ CREATE TABLE t (c "type"(1))
 ----
 CREATE TABLE t (c type(1))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] }, collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "type"(1) list list)
 ----
 CREATE TABLE t (c type(1) list list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] })), collation: None, options: [] }], constraints: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo
@@ -407,14 +407,14 @@ CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHO
 ----
 CREATE CONNECTION pgconn FOR POSTGRES HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Object(Name(UnresolvedObjectName([Ident("tun")])))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Object(Name(UnresolvedObjectName([Ident("foo")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Object(Name(UnresolvedObjectName([Ident("tun")])))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000, TOPIC 'topic') FORMAT BYTES
@@ -760,9 +760,9 @@ CREATE TABLE public.customer (
         active integer NOT NULL
 ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 ----
-CREATE TABLE public.customer (customer_id int4 DEFAULT nextval(public.customer_customer_id_seq), store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) COLLATE "es_ES" NOT NULL, email varchar(50), address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamptz, active int4 NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
-=>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("nextval")]), args: Args { args: [Identifier([Ident("public"), Ident("customer_customer_id_seq")])], order_by: [] }, filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: Some(UnresolvedObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [WithOption { key: Ident("fillfactor"), value: Some(Value(Number("20"))) }, WithOption { key: Ident("user_catalog_table"), value: Some(Value(Boolean(true))) }, WithOption { key: Ident("autovacuum_vacuum_threshold"), value: Some(Value(Number("100"))) }], if_not_exists: false, temporary: false })
+error: Expected end of statement, found WITH
+) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
+  ^
 
 parse-statement roundtrip
 CREATE TABLE public.customer (
@@ -857,7 +857,7 @@ ALTER SOURCE name SET (SIZE LARGE)
 ----
 ALTER SOURCE name SET (SIZE = large)
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
+AlterSource(AlterSourceStatement { source_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSourceOption { name: Size, value: Some(Object(Name(UnresolvedObjectName([Ident("large")])))) }]) })
 
 parse-statement
 ALTER SOURCE name RESET (SIZE)
@@ -1171,9 +1171,9 @@ DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, na
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT BYTES
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), legacy_with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word'
@@ -1187,7 +1187,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING C
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [] })
 
 
 parse-statement
@@ -1195,7 +1195,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USI
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, seed: None } })), envelope: Some(Debezium(Plain)), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
@@ -1246,14 +1246,14 @@ CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s')
 ----
 CREATE SOURCE lg FROM LOAD GENERATOR COUNTER (TICK INTERVAL = '1s')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }] }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 # Ensure that we can parse REMOTE with pg
 parse-statement
@@ -1261,15 +1261,15 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') with (
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH (REMOTE = 'johto:42')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
 # Ensure that we can parse options
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') with (REMOTE 'johto:42');
 ----
-CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') LEGACYWITH (a = 'hmm') WITH (REMOTE = 'johto:42')
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH (REMOTE = 'johto:42')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, legacy_with_options: [WithOption { key: Ident("a"), value: Some(Value(String("hmm"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
 parse-statement
 ALTER SYSTEM SET wal_level TO logical

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1169,7 +1169,7 @@ DROP CONNECTION conn1
 DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT BYTES
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
 =>
@@ -1263,9 +1263,9 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
-# Ensure that we can parse legacy and non-legacy options
+# Ensure that we can parse options
 parse-statement
-CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') legacywith (a = 'hmm') with (REMOTE 'johto:42');
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') with (REMOTE 'johto:42');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') LEGACYWITH (a = 'hmm') WITH (REMOTE = 'johto:42')
 =>

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1130,37 +1130,37 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT * FROM foo OPTIONS (bar = 7)
 ----
+error: Expected EXPECTED, found identifier "bar"
 SELECT * FROM foo OPTIONS (bar = 7)
-=>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
+                           ^
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 7)
 ----
+error: Expected EXPECTED, found identifier "bar"
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 7)
-=>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
+                                                    ^
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 'baz')
 ----
+error: Expected EXPECTED, found identifier "bar"
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 'baz')
-=>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(String("baz"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
+                                                    ^
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar)
 ----
+error: Expected EXPECTED, found identifier "bar"
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar)
-=>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: None }] }), order_by: [], limit: None, offset: None }, as_of: None })
+                                                    ^
 
 parse-statement
 SELECT a, b, min(c) FROM ( SELECT a, b, min(d) as c GROUP BY a, b OPTIONS (bar = 7)) as agg GROUP BY a, b
 ----
-SELECT a, b, min(c) FROM (SELECT a, b, min(d) AS c GROUP BY a, b OPTIONS (bar = 7)) AS agg GROUP BY a, b
-=>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: Some(Ident("c")) }], from: [], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, alias: Some(TableAlias { name: Ident("agg"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+error: Expected joined table, found comma
+SELECT a, b, min(c) FROM ( SELECT a, b, min(d) as c GROUP BY a, b OPTIONS (bar = 7)) as agg GROUP BY a, b
+                                   ^
 
 # List subqueries
 parse-statement

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1128,37 +1128,37 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 
 # Query hints
 parse-statement
-SELECT * FROM foo OPTION (bar = 7)
+SELECT * FROM foo OPTIONS (bar = 7)
 ----
-SELECT * FROM foo OPTION (bar = 7)
+SELECT * FROM foo OPTIONS (bar = 7)
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
-SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 7)
+SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 7)
 ----
-SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 7)
+SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 7)
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
-SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 'baz')
+SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 'baz')
 ----
-SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 'baz')
+SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 'baz')
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(String("baz"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
-SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar)
+SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar)
 ----
-SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar)
+SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar)
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: None }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
-SELECT a, b, min(c) FROM ( SELECT a, b, min(d) as c GROUP BY a, b OPTION (bar = 7)) as agg GROUP BY a, b
+SELECT a, b, min(c) FROM ( SELECT a, b, min(d) as c GROUP BY a, b OPTIONS (bar = 7)) as agg GROUP BY a, b
 ----
-SELECT a, b, min(c) FROM (SELECT a, b, min(d) AS c GROUP BY a, b OPTION (bar = 7)) AS agg GROUP BY a, b
+SELECT a, b, min(c) FROM (SELECT a, b, min(d) AS c GROUP BY a, b OPTIONS (bar = 7)) AS agg GROUP BY a, b
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: Some(Ident("c")) }], from: [], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, alias: Some(TableAlias { name: Ident("agg"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4.22", default-features = false, features = ["clock", "s
 enum-kinds = "0.5.1"
 globset = "0.4.9"
 hex = "0.4.3"
+http = "0.2.8"
 itertools = "0.10.4"
 once_cell = "1.14.0"
 mz-build-info = { path = "../build-info" }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -577,29 +577,6 @@ impl fmt::Display for ResolvedDataType {
     }
 }
 
-impl ResolvedDataType {
-    pub(crate) fn get_ids(&self) -> Vec<GlobalId> {
-        let mut ids = Vec::new();
-        match self {
-            ResolvedDataType::AnonymousList(typ) => {
-                ids.extend(typ.get_ids());
-            }
-            ResolvedDataType::AnonymousMap {
-                key_type,
-                value_type,
-            } => {
-                ids.extend(key_type.get_ids());
-                ids.extend(value_type.get_ids());
-            }
-            ResolvedDataType::Named { id, .. } => {
-                ids.push(id.clone());
-            }
-            ResolvedDataType::Error => {}
-        };
-        ids
-    }
-}
-
 impl AstInfo for Aug {
     type NestedStatement = Statement<Raw>;
     type ObjectName = ResolvedObjectName;

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -14,7 +14,6 @@
 //!
 //! [`ast`]: crate::ast
 
-use std::collections::BTreeMap;
 use std::fmt;
 
 use itertools::Itertools;
@@ -25,14 +24,13 @@ use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
     CreateConnectionStatement, CreateIndexStatement, CreateMaterializedViewStatement,
     CreateSecretStatement, CreateSinkStatement, CreateSourceStatement, CreateTableStatement,
-    CreateTypeAs, CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident,
-    IfExistsBehavior, Op, Query, Statement, TableFactor, TableFunction, UnresolvedObjectName,
-    UnresolvedSchemaName, Value, ViewDefinition, WithOption, WithOptionValue,
+    CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op,
+    Query, Statement, TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName,
+    Value, ViewDefinition,
 };
 
 use crate::names::{
     Aug, FullObjectName, PartialObjectName, PartialSchemaName, RawDatabaseSpecifier,
-    ResolvedObjectName,
 };
 use crate::plan::error::PlanError;
 use crate::plan::statement::StatementContext;
@@ -129,70 +127,6 @@ impl From<SqlValueOrSecret> for Option<Value> {
             SqlValueOrSecret::Secret(_id) => None,
         }
     }
-}
-
-/// Normalizes a list of `WITH` options.
-///
-/// # Errors
-/// - If any `WithOption`'s `value` is `None`. You can prevent generating these
-///   values during parsing.
-/// - If any `WithOption` has a value of type `WithOptionValue::Secret`.
-pub fn options(
-    options: &[WithOption<Aug>],
-) -> Result<BTreeMap<String, SqlValueOrSecret>, PlanError> {
-    let mut out = BTreeMap::new();
-    for option in options {
-        let value = match &option.value {
-            Some(WithOptionValue::Value(value)) => SqlValueOrSecret::Value(value.clone()),
-            Some(WithOptionValue::Ident(id)) => {
-                SqlValueOrSecret::Value(Value::String(ident(id.clone())))
-            }
-            Some(WithOptionValue::DataType(data_type)) => {
-                SqlValueOrSecret::Value(Value::String(data_type.to_ast_string()))
-            }
-            Some(WithOptionValue::Secret(ResolvedObjectName::Object { id, .. })) => {
-                SqlValueOrSecret::Secret(*id)
-            }
-            Some(WithOptionValue::Secret(_)) => {
-                panic!("SECRET option {} must be Object", option.key)
-            }
-            Some(WithOptionValue::Object(ResolvedObjectName::Object { id, .. })) => {
-                SqlValueOrSecret::Secret(*id)
-            }
-            Some(WithOptionValue::Object(_)) => {
-                panic!("Object option {} must be Object", option.key)
-            }
-            None => {
-                sql_bail!("option {} requires a value", option.key);
-            }
-        };
-        out.insert(option.key.to_string(), value);
-    }
-    Ok(out)
-}
-
-/// Normalizes `WITH` option keys without normalizing their corresponding
-/// values.
-///
-/// # Panics
-/// - If any `WithOption`'s `value` is `None`. You can prevent generating these
-///   values during parsing.
-pub fn option_objects(options: &[WithOption<Aug>]) -> BTreeMap<String, WithOptionValue<Aug>> {
-    options
-        .iter()
-        .map(|o| {
-            (
-                ident(o.key.clone()),
-                o.value
-                    .as_ref()
-                    .clone()
-                    // The only places that generate options that do not require
-                    // keys and values do not currently use this code path.
-                    .expect("check that all entries have values before calling `option_objects`")
-                    .clone(),
-            )
-        })
-        .collect()
 }
 
 /// Unnormalizes an object name.
@@ -371,7 +305,6 @@ pub fn create_statement(
             name,
             columns,
             constraints: _,
-            with_options: _,
             if_not_exists,
             temporary,
         }) => {
@@ -465,32 +398,14 @@ pub fn create_statement(
             *if_not_exists = false;
         }
 
-        Statement::CreateType(CreateTypeStatement { name, as_type, .. }) => match as_type {
-            CreateTypeAs::List { with_options } | CreateTypeAs::Map { with_options } => {
-                *name = allocate_name(name)?;
-                let mut normalizer = QueryNormalizer::new(scx);
-                for option in with_options {
-                    match &mut option.value {
-                        Some(WithOptionValue::DataType(ref mut data_type)) => {
-                            normalizer.visit_data_type_mut(data_type);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                if let Some(err) = normalizer.err {
-                    return Err(err);
-                }
+        Statement::CreateType(CreateTypeStatement { name, as_type }) => {
+            *name = allocate_name(name)?;
+            let mut normalizer = QueryNormalizer::new(scx);
+            normalizer.visit_create_type_as_mut(as_type);
+            if let Some(err) = normalizer.err {
+                return Err(err);
             }
-            CreateTypeAs::Record { column_defs } => {
-                let mut normalizer = QueryNormalizer::new(scx);
-                for c in column_defs {
-                    normalizer.visit_column_def_mut(c);
-                }
-                if let Some(err) = normalizer.err {
-                    return Err(err);
-                }
-            }
-        },
+        }
         Statement::CreateSecret(CreateSecretStatement {
             name,
             if_not_exists,

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -28,9 +28,7 @@ use mz_repr::url::any_url;
 use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 
-use crate::types::connections::aws::AwsExternalIdPrefix;
-
-use self::aws::AwsCredentials;
+use crate::types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
 
 pub mod aws;
 
@@ -148,7 +146,7 @@ pub enum Connection {
     Csr(CsrConnection),
     Postgres(PostgresConnection),
     Ssh(SshConnection),
-    Aws(AwsCredentials),
+    Aws(AwsConfig),
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/src/storage/src/types/connections/aws.rs
+++ b/src/storage/src/types/connections/aws.rs
@@ -79,7 +79,7 @@ pub struct AwsExternalIdPrefix(pub(super) String);
 ///
 /// This is a distinct type from any of the configuration types built into the
 /// AWS SDK so that we can implement `Serialize` and `Deserialize`.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct AwsConfig {
     /// AWS Credentials, or where to find them
     pub credentials: AwsCredentials,
@@ -146,7 +146,7 @@ impl RustType<ProtoAwsCredentials> for AwsCredentials {
 }
 
 /// A role for Materialize to assume when performing AWS API calls.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct AwsAssumeRole {
     /// The Amazon Resource Name of the role to assume.
     pub arn: String,

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -66,15 +66,6 @@ $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
 {"before": null, "after": {"row": {"a": 1}}}
 {"before": null, "after": {"row": {"a": 2}}}
 
-# Old with options do not work
-! CREATE SOURCE connector_source
-  FROM KAFKA CONNECTION kafka_sasl (TOPIC 'testdrive-data-${testdrive.seed}')
-  LEGACYWITH (
-    security_protocol = 'sasl_ssl'
-  )
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
-contains:unexpected parameters for CREATE SOURCE: security_protocol
-
 # Ensure that connectors do not require the certificate authority
 > CREATE CONNECTION kafka_sasl_no_ca
   FOR KAFKA

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -40,4 +40,3 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     SASL USERNAME = 'materialize',
     SSL CERTIFICATE AUTHORITY = '${arg.ca}';
 contains:invalid CONNECTION: under-specified security configuration
-

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -41,20 +41,3 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     SSL CERTIFICATE AUTHORITY = '${arg.ca}';
 contains:invalid CONNECTION: under-specified security configuration
 
-# > CREATE CONNECTION kafka_conn
-#  FOR KAFKA BROKER '${testdrive.kafka-addr}';
-#
-# ! CREATE SOURCE data
-#   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
-#   LEGACYWITH (
-#       security_protocol = 'SASL_SSL',
-#       sasl_mechanisms = 'PLAIN',
-#       sasl_username = 'materialize',
-#       sasl_password_env = 'SASL_PASSWORD',
-#       ssl_ca_location = '/share/secrets/ca.crt'
-#   )
-#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#   WITH (
-#       ssl_ca_location = '/share/secrets/ca.crt'
-#   )
-#   ENVELOPE DEBEZIUM

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -129,9 +129,6 @@ a
 # Old with_options do not work
 ! CREATE SOURCE IF NOT EXISTS duplicate_option_specified
   FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
-  LEGACYWITH (
-    security_protocol = 'ssl'
-  )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
 contains:unexpected parameters for CREATE SOURCE: security_protocol
 

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -126,12 +126,6 @@ a
 1
 2
 
-# Old with_options do not work
-! CREATE SOURCE IF NOT EXISTS duplicate_option_specified
-  FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
-contains:unexpected parameters for CREATE SOURCE: security_protocol
-
 # Ensure that connectors do not require the certificate authority
 
 > CREATE CONNECTION kafka_sasl_no_ca

--- a/test/perf-kinesis/src/bin/perf-kinesis/mz.rs
+++ b/test/perf-kinesis/src/bin/perf-kinesis/mz.rs
@@ -38,18 +38,17 @@ pub async fn create_source_and_views(
     let aws_connection = format!(
         "CREATE CONNECTION kinesis_conn FOR AWS
             ACCESS KEY ID = '{}',
-            SECRET ACCESS KEY = SECRET aws_secret_access_key
+            SECRET ACCESS KEY = SECRET aws_secret_access_key {}
             {};",
         credentials.access_key_id(),
-        if let Some(token) = credentials.session_token() {
-            format!(
-                ",
-                TOKEN = '{}'",
-                token
-            )
-        } else {
-            "".to_string()
-        }
+        match credentials.session_token() {
+            Some(token) => format!(", TOKEN = '{}'", token),
+            None => "".to_string(),
+        },
+        match config.region() {
+            Some(region) => format!(", REGION = '{}'", region),
+            None => "".to_string(),
+        },
     );
     info!("creating connection=> {}", aws_connection);
     client

--- a/test/persistence/user-tables/table-persistence-before-basic.td
+++ b/test/persistence/user-tables/table-persistence-before-basic.td
@@ -23,13 +23,13 @@
 # Exotic types
 #
 
-> CREATE TYPE int4_list AS LIST (element_type = int4);
+> CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
-> CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+> CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
-> CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+> CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
-> CREATE TYPE int4_map_map AS MAP (key_type=text, value_type=int4_map);
+> CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
 > CREATE TABLE exotic_types (int4_list int4_list, int4_list_list int4_list_list, int4_map int4_map, int4_map_map int4_map_map);
 

--- a/test/s3-resumption/configure-materialize.td
+++ b/test/s3-resumption/configure-materialize.td
@@ -12,16 +12,14 @@
 > CREATE CONNECTION IF NOT EXISTS s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE s3_text
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 's3/*.text'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > CREATE SOURCE s3_gzip
@@ -29,8 +27,4 @@
   DISCOVER OBJECTS MATCHING 's3/*.gzip'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
   COMPRESSION GZIP
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -110,10 +110,10 @@ SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE 100)
 
 # unless hint is bad
 query error expected_group_size must be a number
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTION (EXPECTED GROUP SIZE = 'foo')
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE = 'foo')
 
 query error
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTION (EXPECTED GROUP SIZE = 0.1)
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE = 0.1)
 
 # Test that an ordinal in a GROUP BY that refers to a column that is an
 # expression, rather than a simple column reference, works.

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -102,7 +102,7 @@ SELECT a, count(b), min(b), sum(b), max(b) FROM t GROUP BY a
 
 # Test that hinting the group size works
 query II rowsort
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTION(expected_group_size = 100)
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE 100)
 ----
 1 3
 2 3
@@ -110,10 +110,10 @@ SELECT a, sum(b) AS a FROM t GROUP BY a OPTION(expected_group_size = 100)
 
 # unless hint is bad
 query error expected_group_size must be a number
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTION(expected_group_size = 'foo')
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTION (EXPECTED GROUP SIZE = 'foo')
 
 query error
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTION(expected_group_size = 0.1)
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTION (EXPECTED GROUP SIZE = 0.1)
 
 # Test that an ordinal in a GROUP BY that refers to a column that is an
 # expression, rather than a simple column reference, works.

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -109,7 +109,7 @@ SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE 100)
 3 1
 
 # unless hint is bad
-query error expected_group_size must be a number
+query error invalid EXPECTED GROUP SIZE: cannot use value as number
 SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE = 'foo')
 
 query error

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -71,16 +71,16 @@ SELECT 1.5::float::bigint
 # TODO(sploiselle): fix return type to indicate custom type
 
 statement ok
-CREATE TYPE int4_list AS LIST (element_type=int4)
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4)
 
 statement ok
-CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
+CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list)
 
 statement ok
-CREATE TYPE int4_list_too AS LIST (element_type=int4)
+CREATE TYPE int4_list_too AS LIST (ELEMENT TYPE = int4)
 
 statement ok
-CREATE TYPE int4_list_list_too AS LIST (element_type=int4_list_too)
+CREATE TYPE int4_list_list_too AS LIST (ELEMENT TYPE = int4_list_too)
 
 query T
 SELECT pg_typeof('{1}'::int4 list::int4_list)

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1967,17 +1967,17 @@ SELECT '{1}'::float4 list = '{2}'::float8 list
 
 # 🔬 CREATE TYPE .. AS LIST
 
-query error element_type must be of class type, but received pg_catalog.pg_enum which is of class view
-CREATE TYPE tbl_list AS LIST (element_type=pg_enum)
+query error ELEMENT TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
+CREATE TYPE tbl_list AS LIST (ELEMENT TYPE=pg_enum)
 
-query error CREATE TYPE ... AS LIST option "element_type" cannot accept type modifier on numeric, you must use the default type
-CREATE TYPE typ_mod_list AS LIST (element_type=numeric(38,0))
+query error CREATE TYPE ... AS LIST option "ELEMENT TYPE" cannot accept type modifier on numeric, you must use the default type
+CREATE TYPE typ_mod_list AS LIST (ELEMENT TYPE=numeric(38,0))
 
-query error CREATE TYPE ... AS LIST option "element_type" can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
-CREATE TYPE unnamed_element_list AS LIST (element_type=int4 list)
+query error CREATE TYPE ... AS LIST option "ELEMENT TYPE" can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
+CREATE TYPE unnamed_element_list AS LIST (ELEMENT TYPE=int4 list)
 
 statement ok
-CREATE TYPE int4_list_c AS LIST (element_type = int4);
+CREATE TYPE int4_list_c AS LIST (ELEMENT TYPE = int4);
 
 query T
 SELECT '{1,2}'::int4_list_c::text;
@@ -2000,7 +2000,7 @@ SELECT pg_typeof(NULL::int4_list_c);
 int4_list_c
 
 statement ok
-CREATE TYPE int4_list_list_c AS LIST (element_type = int4_list_c);
+CREATE TYPE int4_list_list_c AS LIST (ELEMENT TYPE = int4_list_c);
 
 query T
 SELECT '{{1,2}}'::int4_list_list_c::text;
@@ -2008,15 +2008,15 @@ SELECT '{{1,2}}'::int4_list_list_c::text;
 {{1,2}}
 
 query error unknown catalog item bool list
-CREATE TYPE nested_list AS LIST (element_type = "bool list")
+CREATE TYPE nested_list AS LIST (ELEMENT TYPE = "bool list")
 
 query error unknown catalog item list
-CREATE TYPE nested_list AS LIST (element_type = list)
+CREATE TYPE nested_list AS LIST (ELEMENT TYPE = list)
 
 # 🔬🔬 Check each valid non-array element type
 
 statement ok
-CREATE TYPE bool_list_c AS LIST (element_type=bool);
+CREATE TYPE bool_list_c AS LIST (ELEMENT TYPE=bool);
 
 query T
 SELECT '{true}'::bool_list_c::text
@@ -2024,7 +2024,7 @@ SELECT '{true}'::bool_list_c::text
 {t}
 
 statement ok
-CREATE TYPE int8_list_c AS LIST (element_type=int8);
+CREATE TYPE int8_list_c AS LIST (ELEMENT TYPE=int8);
 
 query T
 SELECT '{1,2}'::int8_list_c::text
@@ -2037,7 +2037,7 @@ SELECT '{1,2}'::int4_list_c::text
 {1,2}
 
 statement ok
-CREATE TYPE text_list_c AS LIST (element_type=text);
+CREATE TYPE text_list_c AS LIST (ELEMENT TYPE=text);
 
 query T
 SELECT '{a,b}'::text_list_c::text
@@ -2045,7 +2045,7 @@ SELECT '{a,b}'::text_list_c::text
 {a,b}
 
 statement ok
-CREATE TYPE float4_list_c AS LIST (element_type=float4);
+CREATE TYPE float4_list_c AS LIST (ELEMENT TYPE=float4);
 
 query T
 SELECT '{1.2,2.3}'::float4_list_c::text
@@ -2053,7 +2053,7 @@ SELECT '{1.2,2.3}'::float4_list_c::text
 {1.2,2.3}
 
 statement ok
-CREATE TYPE float8_list_c AS LIST (element_type=float8);
+CREATE TYPE float8_list_c AS LIST (ELEMENT TYPE=float8);
 
 query T
 SELECT '{1.2,2.3}'::float8_list_c::text
@@ -2061,7 +2061,7 @@ SELECT '{1.2,2.3}'::float8_list_c::text
 {1.2,2.3}
 
 statement ok
-CREATE TYPE date_list_c AS LIST (element_type=date);
+CREATE TYPE date_list_c AS LIST (ELEMENT TYPE=date);
 
 query T
 SELECT '{2001-01-01}'::date_list_c::text
@@ -2069,7 +2069,7 @@ SELECT '{2001-01-01}'::date_list_c::text
 {2001-01-01}
 
 statement ok
-CREATE TYPE time_list_c AS LIST (element_type=time);
+CREATE TYPE time_list_c AS LIST (ELEMENT TYPE=time);
 
 query T
 SELECT '{12:34:56}'::time_list_c::text
@@ -2077,7 +2077,7 @@ SELECT '{12:34:56}'::time_list_c::text
 {12:34:56}
 
 statement ok
-CREATE TYPE timestamp_list_c AS LIST (element_type=timestamp);
+CREATE TYPE timestamp_list_c AS LIST (ELEMENT TYPE=timestamp);
 
 query T
 SELECT '{2001-01-01 12:34:56}'::timestamp_list_c::text
@@ -2085,7 +2085,7 @@ SELECT '{2001-01-01 12:34:56}'::timestamp_list_c::text
 {"2001-01-01 12:34:56"}
 
 statement ok
-CREATE TYPE timestamptz_list_c AS LIST (element_type=timestamptz);
+CREATE TYPE timestamptz_list_c AS LIST (ELEMENT TYPE=timestamptz);
 
 query T
 SELECT '{2001-01-01 12:34:56}'::timestamptz_list_c::text
@@ -2093,7 +2093,7 @@ SELECT '{2001-01-01 12:34:56}'::timestamptz_list_c::text
 {"2001-01-01 12:34:56+00"}
 
 statement ok
-CREATE TYPE interval_list_c AS LIST (element_type=interval);
+CREATE TYPE interval_list_c AS LIST (ELEMENT TYPE=interval);
 
 query T
 SELECT '{1y 2d 3h 4m}'::interval_list_c::text
@@ -2101,7 +2101,7 @@ SELECT '{1y 2d 3h 4m}'::interval_list_c::text
 {"1 year 2 days 03:04:00"}
 
 statement ok
-CREATE TYPE numeric_list_c AS LIST (element_type=numeric);
+CREATE TYPE numeric_list_c AS LIST (ELEMENT TYPE=numeric);
 
 query T
 SELECT '{1.23,2.34}'::numeric_list_c::text
@@ -2109,7 +2109,7 @@ SELECT '{1.23,2.34}'::numeric_list_c::text
 {1.23,2.34}
 
 statement ok
-CREATE TYPE jsonb_list_c AS LIST (element_type=jsonb);
+CREATE TYPE jsonb_list_c AS LIST (ELEMENT TYPE=jsonb);
 
 query T
 SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
@@ -2119,7 +2119,7 @@ SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
 # 🔬🔬 Check custom type name resolution
 
 statement ok
-CREATE TYPE bool AS LIST (element_type=int4)
+CREATE TYPE bool AS LIST (ELEMENT TYPE=int4)
 
 query error invalid input syntax for type boolean: "\{1,2\}"
 SELECT '{1,2}'::bool;
@@ -2133,14 +2133,14 @@ SELECT '{1,2}'::public.bool::text;
 
 # Supports qualified subtypes
 statement ok
-CREATE TYPE qualified_int4_list AS LIST (element_type=pg_catalog.int4)
+CREATE TYPE qualified_int4_list AS LIST (ELEMENT TYPE=pg_catalog.int4)
 
 statement ok
-CREATE TYPE qualified_qualified_int4_list AS LIST (element_type=public.qualified_int4_list)
+CREATE TYPE qualified_qualified_int4_list AS LIST (ELEMENT TYPE=public.qualified_int4_list)
 
 # Supports type aliases
 statement ok
-CREATE TYPE int_list AS MAP (key_type=pg_catalog.text, value_type=int)
+CREATE TYPE int_list AS MAP (KEY TYPE = pg_catalog.text, VALUE TYPE = int)
 
 # 🔬🔬 Built-in operations
 
@@ -2176,10 +2176,10 @@ SELECT ('{1.2,2.3}'::numeric(38,5) list::numeric_list_c)::text;
 # 🔬🔬 1-D casts
 
 statement ok
-CREATE TYPE int4_list AS LIST (element_type = int4)
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4)
 
 statement ok
-CREATE TYPE int4_list_too AS LIST (element_type = int4)
+CREATE TYPE int4_list_too AS LIST (ELEMENT TYPE = int4)
 
 query T
 SELECT ('{1}'::int4_list || '{2}'::int list)::text;
@@ -2212,10 +2212,10 @@ SELECT ('{1}'::int4_list || 2)::text;
 # 🔬🔬 2-D casts
 
 statement ok
-CREATE TYPE int4_list_list AS LIST (element_type = int4_list)
+CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list)
 
 statement ok
-CREATE TYPE int4_list_list_too AS LIST (element_type = int4_list_too)
+CREATE TYPE int4_list_list_too AS LIST (ELEMENT TYPE = int4_list_too)
 
 # Custom type interoperable with anonymous type
 query T

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -18,29 +18,29 @@ mode cockroach
 # we just convert everything to `text`.
 
 # Test basic string to map casts.
-query error value_type parameter required
-CREATE TYPE custom AS MAP (key_type=text)
+query error VALUE TYPE   parameter required
+CREATE TYPE custom AS MAP (KEY TYPE = text)
 
-query error key_type parameter required
-CREATE TYPE custom AS MAP (value_type=bool)
+query error KEY TYPE parameter required
+CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 
 query error unknown catalog item 'customthing'
-CREATE TYPE custom AS MAP (key_type=text, value_type=bool, extra_type=customthing)
+CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, extra_type=customthing)
 
-query error key_type must be of class type, but received pg_catalog.pg_enum which is of class view
-CREATE TYPE tbl_map AS MAP (key_type=pg_enum, value_type=text)
+query error KEY TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
+CREATE TYPE tbl_map AS MAP (KEY TYPE = pg_enum, VALUE TYPE = text)
 
-query error value_type must be of class type, but received pg_catalog.pg_enum which is of class view
-CREATE TYPE tbl_map AS MAP (key_type=text, value_type=pg_enum)
+query error VALUE TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
+CREATE TYPE tbl_map AS MAP (KEY TYPE = text, VALUE TYPE = pg_enum)
 
-query error CREATE TYPE ... AS MAP option "value_type" cannot accept type modifier on numeric, you must use the default type
-CREATE TYPE typ_mod_map AS MAP (key_type=text, value_type=numeric(38,0))
+query error CREATE TYPE ... AS MAP option "VALUE TYPE "  cannot accept type modifier on numeric, you must use the default type
+CREATE TYPE typ_mod_map AS MAP (KEY TYPE = text, VALUE TYPE = numeric(38,0))
 
-query error CREATE TYPE ... AS LIST option "value_type" can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
-CREATE TYPE unnamed_element_map AS MAP (key_type=text, value_type=int4 list)
+query error CREATE TYPE ... AS LIST option "VALUE TYPE "  can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
+CREATE TYPE unnamed_element_map AS MAP (KEY TYPE = text, VALUE TYPE = int4 list)
 
 query error CREATE TYPE not yet supported
-CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
+CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 
 query error expected '\{', found a: "a=>1"
 SELECT ('a=>1'::map[text=>int])::text
@@ -473,7 +473,7 @@ SELECT NULL -> '{a}'::text[]
 # 🔬 CREATE TYPE .. AS MAP
 
 statement ok
-CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 query T
 SELECT '{a=>1,b=>2}'::int4_map::text;
@@ -488,7 +488,7 @@ int4_map
 # 🔬🔬 Check each valid value type
 
 statement ok
-CREATE TYPE bool_map_c AS MAP (key_type=text, value_type=bool);
+CREATE TYPE bool_map_c AS MAP (KEY TYPE = text, VALUE TYPE = bool);
 
 query T
 SELECT '{a=>true}'::bool_map_c::text
@@ -496,7 +496,7 @@ SELECT '{a=>true}'::bool_map_c::text
 {a=>t}
 
 statement ok
-CREATE TYPE int8_map_c AS MAP (key_type=text, value_type=int8);
+CREATE TYPE int8_map_c AS MAP (KEY TYPE = text, VALUE TYPE = int8);
 
 query T
 SELECT '{a=>1}'::int8_map_c::text
@@ -504,7 +504,7 @@ SELECT '{a=>1}'::int8_map_c::text
 {a=>1}
 
 statement ok
-CREATE TYPE int4_map_c AS MAP (key_type=text, value_type=int4);
+CREATE TYPE int4_map_c AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 query T
 SELECT '{a=>1}'::int4_map_c::text
@@ -512,7 +512,7 @@ SELECT '{a=>1}'::int4_map_c::text
 {a=>1}
 
 statement ok
-CREATE TYPE text_map_c AS MAP (key_type=text, value_type=text);
+CREATE TYPE text_map_c AS MAP (KEY TYPE = text, VALUE TYPE = text);
 
 query T
 SELECT '{a=>a}'::text_map_c::text
@@ -520,7 +520,7 @@ SELECT '{a=>a}'::text_map_c::text
 {a=>a}
 
 statement ok
-CREATE TYPE float4_map_c AS MAP (key_type=text, value_type=float4);
+CREATE TYPE float4_map_c AS MAP (KEY TYPE = text, VALUE TYPE = float4);
 
 query T
 SELECT '{a=>1.2}'::float4_map_c::text
@@ -528,7 +528,7 @@ SELECT '{a=>1.2}'::float4_map_c::text
 {a=>1.2}
 
 statement ok
-CREATE TYPE float8_map_c AS MAP (key_type=text, value_type=float8);
+CREATE TYPE float8_map_c AS MAP (KEY TYPE = text, VALUE TYPE = float8);
 
 query T
 SELECT '{a=>1.2}'::float8_map_c::text
@@ -536,7 +536,7 @@ SELECT '{a=>1.2}'::float8_map_c::text
 {a=>1.2}
 
 statement ok
-CREATE TYPE date_map_c AS MAP (key_type=text, value_type=date);
+CREATE TYPE date_map_c AS MAP (KEY TYPE = text, VALUE TYPE = date);
 
 query T
 SELECT '{a=>2001-01-01}'::date_map_c::text
@@ -544,7 +544,7 @@ SELECT '{a=>2001-01-01}'::date_map_c::text
 {a=>2001-01-01}
 
 statement ok
-CREATE TYPE time_map_c AS MAP (key_type=text, value_type=time);
+CREATE TYPE time_map_c AS MAP (KEY TYPE = text, VALUE TYPE = time);
 
 query T
 SELECT '{a=>12:34:56}'::time_map_c::text
@@ -552,7 +552,7 @@ SELECT '{a=>12:34:56}'::time_map_c::text
 {a=>12:34:56}
 
 statement ok
-CREATE TYPE timestamp_map_c AS MAP (key_type=text, value_type=timestamp);
+CREATE TYPE timestamp_map_c AS MAP (KEY TYPE = text, VALUE TYPE = timestamp);
 
 query T
 SELECT '{a=>2001-01-01 12:34:56}'::timestamp_map_c::text
@@ -560,7 +560,7 @@ SELECT '{a=>2001-01-01 12:34:56}'::timestamp_map_c::text
 {a=>"2001-01-01 12:34:56"}
 
 statement ok
-CREATE TYPE timestamptz_map_c AS MAP (key_type=text, value_type=timestamptz);
+CREATE TYPE timestamptz_map_c AS MAP (KEY TYPE = text, VALUE TYPE = timestamptz);
 
 query T
 SELECT '{a=>2001-01-01 12:34:56}'::timestamptz_map_c::text
@@ -568,7 +568,7 @@ SELECT '{a=>2001-01-01 12:34:56}'::timestamptz_map_c::text
 {a=>"2001-01-01 12:34:56+00"}
 
 statement ok
-CREATE TYPE interval_map_c AS MAP (key_type=text, value_type=interval);
+CREATE TYPE interval_map_c AS MAP (KEY TYPE = text, VALUE TYPE = interval);
 
 query T
 SELECT '{a=>1y 2d 3h 4m}'::interval_map_c::text
@@ -576,7 +576,7 @@ SELECT '{a=>1y 2d 3h 4m}'::interval_map_c::text
 {a=>"1 year 2 days 03:04:00"}
 
 statement ok
-CREATE TYPE numeric_map_c AS MAP (key_type=text, value_type=numeric);
+CREATE TYPE numeric_map_c AS MAP (KEY TYPE = text, VALUE TYPE = numeric);
 
 query T
 SELECT '{a=>1.23}'::numeric_map_c::text
@@ -584,7 +584,7 @@ SELECT '{a=>1.23}'::numeric_map_c::text
 {a=>1.23}
 
 statement ok
-CREATE TYPE jsonb_map_c AS MAP (key_type=text, value_type=jsonb);
+CREATE TYPE jsonb_map_c AS MAP (KEY TYPE = text, VALUE TYPE = jsonb);
 
 query T
 SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
@@ -594,7 +594,7 @@ SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
 # 🔬🔬 Check custom type name resolution
 
 statement ok
-CREATE TYPE bool AS MAP (key_type=text, value_type=int4)
+CREATE TYPE bool AS MAP (KEY TYPE = text, VALUE TYPE = int4)
 
 query error invalid input syntax for type boolean: "\{a=>1\}"
 SELECT '{a=>1}'::bool;
@@ -608,14 +608,14 @@ SELECT '{a=>1}'::public.bool::text;
 
 # Supports qualified subtypes
 statement ok
-CREATE TYPE qualified_int4_map AS MAP (key_type=pg_catalog.text, value_type=pg_catalog.int4)
+CREATE TYPE qualified_int4_map AS MAP (KEY TYPE = pg_catalog.text, VALUE TYPE = pg_catalog.int4)
 
 statement ok
-CREATE TYPE qualified_qualified_int4_map AS MAP (key_type=pg_catalog.text, value_type=public.qualified_int4_map)
+CREATE TYPE qualified_qualified_int4_map AS MAP (KEY TYPE = pg_catalog.text, VALUE TYPE = public.qualified_int4_map)
 
 # Supports type aliases
 statement ok
-CREATE TYPE int_map AS MAP (key_type=pg_catalog.text, value_type=int)
+CREATE TYPE int_map AS MAP (KEY TYPE = pg_catalog.text, VALUE TYPE = int)
 
 # `map_length`
 query T

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -24,7 +24,7 @@ CREATE TYPE custom AS MAP (KEY TYPE = text)
 query error KEY TYPE parameter required
 CREATE TYPE custom AS MAP (VALUE TYPE = bool)
 
-query error unknown catalog item 'customthing'
+query error Expected one of KEY or VALUE, found identifier "extra_type"
 CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool, extra_type=customthing)
 
 query error KEY TYPE must be of class type, but received pg_catalog.pg_enum which is of class view

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -26,4 +26,3 @@ CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker';
 
 statement error materialize.public.not_a_secret is not a secret
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker', SASL PASSWORD = SECRET not_a_secret;
-

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -25,4 +25,5 @@ statement ok
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker';
 
 statement error materialize.public.not_a_secret is not a secret
-CREATE SOURCE source FROM KAFKA CONNECTION kafka_conn (TOPIC 'topic') LEGACYWITH (secret = SECRET not_a_secret);
+CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker', SASL PASSWORD = SECRET not_a_secret;
+

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -26,3 +26,31 @@ CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker';
 
 statement error materialize.public.not_a_secret is not a secret
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker', SASL PASSWORD = SECRET not_a_secret;
+
+statement error unknown catalog item 'not_an_object_at_all'
+CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker', SASL PASSWORD = SECRET not_an_object_at_all;
+
+statement ok
+CREATE SECRET pgpass AS 'postgres'
+
+# SSH TUNNELs are required to be objects, but we'll interpret it as a string
+statement error invalid SSH TUNNEL: must provide an object
+CREATE CONNECTION pg FOR POSTGRES
+  HOST postgres,
+  DATABASE postgres,
+  USER postgres,
+  PASSWORD SECRET pgpass,
+  SSL MODE require,
+  SSH TUNNEL not_an_object_at_all
+
+statement ok
+CREATE TABLE object_reference (a int);
+
+statement error invalid HOST: incompatible value types
+CREATE CONNECTION pg FOR POSTGRES
+  HOST object_reference,
+  DATABASE postgres,
+  USER postgres,
+  PASSWORD SECRET pgpass,
+  SSL MODE require,
+  SSH TUNNEL not_an_object_at_all

--- a/test/sqllogictest/postgres/rowtypes.slt
+++ b/test/sqllogictest/postgres/rowtypes.slt
@@ -38,10 +38,10 @@ create type quad as (c1 complex, c2 complex);
 
 # and with various container types as fields
 statement ok
-CREATE TYPE int4_list AS LIST (element_type = int4);
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
 statement ok
-CREATE TYPE int4_map AS MAP (key_type = text, value_type = int4);
+CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 statement ok
 CREATE TYPE melange AS (a int[][], b text[], c int4_list, d int4_map);

--- a/test/sqllogictest/typeof.slt
+++ b/test/sqllogictest/typeof.slt
@@ -40,10 +40,10 @@ numeric
 # Custom types
 
 statement ok
-CREATE TYPE int4_list AS LIST (element_type=int4)
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4)
 
 statement ok
-CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
+CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list)
 
 statement ok
 CREATE TYPE composite AS (a int, b text, c float8);

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -79,7 +79,7 @@ name     pkey1 pkey2
   DATABASE 'source',
   USER 'yshtola',
   SSH TUNNEL johto;
-contains: unknown catalog item 'johto'
+contains: invalid SSH TUNNEL: must provide an object
 
 ! CREATE CONNECTION papalymo
   FOR POSTGRES HOST 'gridania.example.com',

--- a/test/testdrive/array.td
+++ b/test/testdrive/array.td
@@ -26,13 +26,13 @@ contains:type "int4 list[]" does not exist
 ! SELECT ARRAY[LIST[1]];
 contains:integer list[] not yet supported
 
-> CREATE TYPE bigint_list AS LIST (element_type=bigint);
+> CREATE TYPE bigint_list AS LIST (ELEMENT TYPE = bigint);
 ! CREATE TABLE bigint_list_arr (f1 bigint_list[]);
 contains:type "bigint_list[]" does not exist
 
 ! SELECT ARRAY['{a => 1}'::map[text=>int]];
 contains:map[text=>integer][] not yet supported
 
-> CREATE TYPE bigint_map AS MAP (key_type=text, value_type=bigint);
+> CREATE TYPE bigint_map AS MAP (KEY TYPE = text, VALUE TYPE = bigint);
 ! CREATE TABLE bigint_map_map_array_table (f1 bigint_map[]);
 contains:type "bigint_map[]" does not exist

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -223,23 +223,23 @@ v2      view
 
 # Test minimizing name qualification
 
-> CREATE TYPE int_list AS list (element_type=int4)
+> CREATE TYPE int_list AS list (ELEMENT TYPE = int4)
 
 > SELECT pg_typeof('{1}'::d.public.int_list)
 int_list
 
 > CREATE SCHEMA other
-> CREATE TYPE other.int_list AS list (element_type=int4)
+> CREATE TYPE other.int_list AS list (ELEMENT TYPE = int4)
 > SELECT pg_typeof('{1}'::d.other.int_list)
 other.int_list
 
 > CREATE DATABASE foo
 > CREATE SCHEMA foo.other
-> CREATE TYPE foo.other.int_list AS LIST (element_type=int4)
+> CREATE TYPE foo.other.int_list AS LIST (ELEMENT TYPE = int4)
 > SELECT pg_typeof('{1}'::foo.other.int_list)
 foo.other.int_list
 
-> CREATE TYPE bool AS LIST (element_type=int4)
+> CREATE TYPE bool AS LIST (ELEMENT TYPE = int4)
 ! SELECT '{1}'::bool
 contains:invalid input syntax for type boolean: "{1}"
 

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -21,27 +21,13 @@ place""",CA,92679
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
-
-# We should refuse to create a source with invalid LEGACYWITH options
-! CREATE SOURCE invalid_with_option
-  FROM S3 CONNECTION s3_conn
-  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    badoption = true
-  )
-  FORMAT CSV WITH 3 COLUMNS
-contains:unexpected parameters for CREATE SOURCE: badoption
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE mismatched_column_count
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH 2 COLUMNS
 ! SELECT * FROM mismatched_column_count
 contains:CSV error at record number 1: expected 2 columns, got 3.
@@ -49,10 +35,6 @@ contains:CSV error at record number 1: expected 2 columns, got 3.
 > CREATE SOURCE matching_column_names
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names where zip = '14618'
@@ -63,10 +45,6 @@ Rochester NY 14618
 > CREATE SOURCE matching_column_names_alias (a, b, c)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names_alias where c = '14618'
@@ -77,10 +55,6 @@ Rochester NY 14618
 > CREATE SOURCE mismatched_column_names
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (cities, country, zip)
 ! SELECT * FROM mismatched_column_names
 contains:first mismatched column at index 1 expected=cities actual="city"
@@ -88,10 +62,6 @@ contains:first mismatched column at index 1 expected=cities actual="city"
 > CREATE SOURCE mismatched_column_names_count
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (cities, state)
 ! SELECT * FROM mismatched_column_names_count
 contains:CSV error at record number 1: expected 2 columns, got 3
@@ -100,10 +70,6 @@ contains:CSV error at record number 1: expected 2 columns, got 3
 > CREATE SOURCE static_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH 3 COLUMNS
 
 > SELECT * FROM static_csv
@@ -117,10 +83,6 @@ Rochester      NY        14618
 ! CREATE SOURCE static_csv_nothing_demanded_src
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER
 contains:Expected a list of columns in parentheses, found EOF
 
@@ -134,10 +96,6 @@ $ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM static_csv_manual_header
@@ -188,10 +146,6 @@ badint,
 > CREATE SOURCE malformed_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'malformed.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM malformed_csv
@@ -205,10 +159,6 @@ dollars,category
 > CREATE SOURCE bad_text_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'bad-text.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM bad_text_csv
@@ -221,10 +171,6 @@ $ kafka-create-topic topic=static-csv-pkne-sink partitions=1
 > CREATE SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -378,7 +378,7 @@ contains:cannot drop materialize.public.int4_list: still depended upon by catalo
 
 > DROP TABLE t1
 
-> CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_ list)
+> CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list)
 
 ! DROP TYPE int4_list
 contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.int4_list_list'

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -312,7 +312,7 @@ contains:unknown catalog item 'j2'
 > DROP SOURCE s5;
 
 # https://github.com/MaterializeInc/materialize/issues/5577
-> CREATE TYPE int4_list AS LIST (element_type=int4)
+> CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4)
 
 > CREATE VIEW v1 AS SELECT CAST('{2}' AS int4_list)
 
@@ -378,7 +378,7 @@ contains:cannot drop materialize.public.int4_list: still depended upon by catalo
 
 > DROP TABLE t1
 
-> CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
+> CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_ list)
 
 ! DROP TYPE int4_list
 contains:cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.int4_list_list'

--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -18,15 +18,13 @@ bar
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE posix
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT BYTES;
 
 > SELECT data FROM posix
@@ -40,10 +38,6 @@ bar
 > CREATE SOURCE non_posix
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'non-posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT BYTES;
 
 > SELECT data FROM non_posix

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -116,15 +116,6 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 > CREATE CONNECTION kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
-# We should refuse to create a source with invalid WITH options
-! CREATE SOURCE invalid_with_option
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
-  LEGACYWITH (badoption = true)
-  KEY FORMAT AVRO USING SCHEMA '${key-schema}'
-  VALUE FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
-contains:unexpected parameters for CREATE SOURCE: badoption
-
 > SHOW SOURCES
 name    type   size
 -------------------

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -61,15 +61,13 @@ $ s3-put-object bucket=test key=static.csv
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 ! CREATE SOURCE headers_src
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
   INCLUDE HEADERS
 contains:INCLUDE HEADERS with non-Kafka sources not supported

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -96,13 +96,13 @@ contains:column "a" specified more than once
 
 # Complex types
 
-> CREATE TYPE int4_list AS LIST (element_type = int4);
+> CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
-> CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+> CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
-> CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+> CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
-> CREATE TYPE int4_map_map AS MAP (key_type=text, value_type=int4_map);
+> CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
 > CREATE MATERIALIZED VIEW complex_type_view AS SELECT '{{1,2},{3,4}}'::int4_list_list c1, '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map c2;
 

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -198,15 +198,6 @@ id creature
 -----------
 3  triceratops
 
-# Test that it doesn't work with full deduplication
-! CREATE SOURCE upsert_full_dedupe
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
-  LEGACYWITH (deduplication = 'full')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
-contains:unexpected parameters for CREATE SOURCE: deduplication
-
-
 # test include metadata
 > CREATE SOURCE upsert_metadata
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -33,14 +33,15 @@ here is a second test string
   FROM KINESIS CONNECTION kinesis_bad_conn
   ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
   FORMAT BYTES;
-contains:dns error: failed to lookup address information: Name or service not known
+contains:Unable to validate AWS credentials
 
 > CREATE SECRET kinesis_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
 
 > CREATE CONNECTION kinesis_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET kinesis_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}';
 
 > CREATE SOURCE f
   FROM KINESIS CONNECTION kinesis_conn

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -26,7 +26,8 @@ here is a second test string
 
 > CREATE CONNECTION kinesis_bad_conn FOR AWS
   ACCESS KEY ID = 'fake_access_key_id',
-  SECRET ACCESS KEY = SECRET kinesis_bad_conn_secret;
+  SECRET ACCESS KEY = SECRET kinesis_bad_conn_secret,
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 ! CREATE SOURCE custom_source
   FROM KINESIS CONNECTION kinesis_bad_conn
@@ -44,7 +45,6 @@ contains:dns error: failed to lookup address information: Name or service not kn
 > CREATE SOURCE f
   FROM KINESIS CONNECTION kinesis_conn
   ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
-  LEGACYWITH (endpoint = '${testdrive.aws-endpoint}')
   FORMAT BYTES;
 
 > CREATE MATERIALIZED VIEW f_view

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -11,9 +11,9 @@
 
 > SHOW TYPES
 
-> CREATE TYPE bool AS LIST (element_type=int4)
+> CREATE TYPE bool AS LIST (ELEMENT TYPE = int4)
 
-> CREATE TYPE custom AS LIST (element_type=bool)
+> CREATE TYPE custom AS LIST (ELEMENT TYPE = bool)
 
 $ set-regex match=^s\d*$ replacement=<GID>
 # Without qualifiers, should default to builtin bool.
@@ -22,7 +22,7 @@ $ set-regex match=^s\d*$ replacement=<GID>
   WHERE name = 'custom'
 <GID>
 
-> CREATE TYPE another_custom AS LIST (element_type=public.bool)
+> CREATE TYPE another_custom AS LIST (ELEMENT TYPE = public.bool)
 
 $ set-regex match=^u\d*$ replacement=<GID>
 # Qualified name should point to user-defined bool.
@@ -33,7 +33,7 @@ $ set-regex match=^u\d*$ replacement=<GID>
 
 > CREATE SCHEMA test_schema
 
-> CREATE TYPE test_schema.bool AS LIST (element_type=float4)
+> CREATE TYPE test_schema.bool AS LIST (ELEMENT TYPE = float4)
 
 > SHOW TYPES
 name
@@ -60,5 +60,5 @@ contains:cannot drop materialize.public.bool: still depended upon by catalog ite
 ! CREATE TABLE f1 (a char list);
 contains:char list not yet supported
 
-! CREATE TYPE test_schema.bool AS LIST (element_type=char)
+! CREATE TYPE test_schema.bool AS LIST (ELEMENT TYPE = char)
 contains:char list not yet supported

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -61,4 +61,4 @@ contains:cannot drop materialize.public.bool: still depended upon by catalog ite
 contains:char list not yet supported
 
 ! CREATE TYPE test_schema.bool AS LIST (ELEMENT TYPE = char)
-contains:char list not yet supported
+contains:embedding char type in a list or map not yet supported

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -11,9 +11,9 @@
 
 > SHOW TYPES
 
-> CREATE TYPE bool AS MAP (key_type=text, value_type=int4)
+> CREATE TYPE bool AS MAP (KEY TYPE = text, VALUE TYPE = int4)
 
-> CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
+> CREATE TYPE custom AS MAP (KEY TYPE = text, VALUE TYPE = bool)
 
 $ set-regex match=^s\d*$ replacement=<GID>
 # Without qualifiers, should default to builtin bool.
@@ -22,7 +22,7 @@ $ set-regex match=^s\d*$ replacement=<GID>
   WHERE name = 'custom'
 <GID>
 
-> CREATE TYPE another_custom AS MAP (key_type=text, value_type=public.bool)
+> CREATE TYPE another_custom AS MAP (KEY TYPE = text, VALUE TYPE = public.bool)
 
 $ set-regex match=^u\d*$ replacement=<GID>
 # Qualified name should point to user-defined bool.
@@ -33,7 +33,7 @@ $ set-regex match=^u\d*$ replacement=<GID>
 
 > CREATE SCHEMA test_schema
 
-> CREATE TYPE test_schema.bool AS MAP (key_type=text, value_type=float4)
+> CREATE TYPE test_schema.bool AS MAP (KEY TYPE = text, VALUE TYPE = float4)
 
 > SHOW TYPES
 name

--- a/test/testdrive/s3-gzip.td
+++ b/test/testdrive/s3-gzip.td
@@ -26,16 +26,14 @@ b3
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE s3_all_none
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-no-compression-${testdrive.seed}'
   COMPRESSION NONE
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_all_none
@@ -67,10 +65,6 @@ b3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-gzip-compression-${testdrive.seed}'
   COMPRESSION GZIP
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_all_gzip

--- a/test/testdrive/s3.td
+++ b/test/testdrive/s3.td
@@ -24,15 +24,13 @@ b3
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE s3_all
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_all
@@ -46,10 +44,6 @@ b3
 > CREATE SOURCE s3_glob_a
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING '**/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_glob_a
@@ -60,10 +54,6 @@ a3
 > CREATE SOURCE s3_just_a
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'short/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_just_a
@@ -79,10 +69,6 @@ c,9
 > CREATE SOURCE csv_example (name, counts)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING '*.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH 2 COLUMNS;
 
 > SELECT * FROM csv_example
@@ -118,10 +104,6 @@ $ s3-put-object bucket=test key=logs/2021/01/01/frontend.log
 > CREATE SOURCE frontend_logs
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'logs/**/*.log' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT REGEX '(?P<ip>[^ ]+) - - \[(?P<dt>[^]]+)\] "(?P<method>\w+) (?P<path>[^ ]+)[^"]+" (?P<status>\d+) (?P<content_length>\d+) "-" "(?P<user_agent>[^"]+)"';
 
 > SELECT dt, ip, user_agent FROM frontend_logs WHERE path = '/updates' ORDER BY dt
@@ -144,10 +126,6 @@ c3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'short/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}', BUCKET SCAN 'testdrive-other-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT text FROM s3_multi ORDER BY text;
@@ -182,10 +160,6 @@ id,value
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'csv/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (id, value);
 
 > SELECT id, value FROM s3_csv_headers

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -286,7 +286,7 @@ true
 
 # Ensure we don't allow unknown options
 ! CREATE TYPE whatever AS LIST (ELEMENT TYPE = int4, gus=int4);
-contains:unexpected parameters for CREATE TYPE: gus
+contains:Expected ELEMENT, found identifier
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET ALL

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -150,12 +150,12 @@ ALTER SYSTEM SET max_tables = 10000
 
 # User-defined types
 
-> CREATE TYPE int_list_c AS LIST (element_type=int4);
-> CREATE TYPE int_map_c AS MAP (key_type=text, value_type=int4);
+> CREATE TYPE int_list_c AS LIST (ELEMENT TYPE = int4);
+> CREATE TYPE int_map_c AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 > CREATE TYPE int_record_c AS (i1 int, i2 int, i3 int);
 
 # User-defined types can use other user-defined types
-> CREATE TYPE int_list_list_c AS LIST (element_type=int_list_c);
+> CREATE TYPE int_list_list_c AS LIST (ELEMENT TYPE = int_list_c);
 > CREATE TYPE int_record_record_c AS (j1 int, j2 int_record_c);
 
 > SHOW TYPES
@@ -172,7 +172,7 @@ int_record_record_c
 
 > INSERT INTO custom_types VALUES (LIST[1], '{a=>1}'::int_map_c);
 
-> CREATE TYPE int_array_list AS LIST (element_type=_int4);
+> CREATE TYPE int_array_list AS LIST (ELEMENT TYPE = _int4);
 
 > CREATE TABLE custom_types_2 (a int_array_list);
 
@@ -185,8 +185,8 @@ int_record_record_c
 # Custom types are namespaced objects
 > CREATE SCHEMA other;
 
-> CREATE TYPE other.other_int_list_c AS LIST (element_type=int4);
-> CREATE TYPE other.other_int_map_c AS MAP (key_type=text, value_type=int4);
+> CREATE TYPE other.other_int_list_c AS LIST (ELEMENT TYPE = int4);
+> CREATE TYPE other.other_int_map_c AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 > CREATE TYPE other.other_record_c AS (a int, b text);
 
 > SHOW TYPES FROM other;
@@ -198,68 +198,68 @@ other_record_c
 
 > CREATE TABLE custom_types_4 (a other.other_int_list_c, b other.other_int_map_c);
 
-> CREATE TYPE int_list_map AS MAP (key_type=text, value_type=other.other_int_list_c)
+> CREATE TYPE int_list_map AS MAP (KEY TYPE = text, VALUE TYPE = other.other_int_list_c)
 
 # Array element types
 
-> CREATE TYPE bool_array_list_c AS LIST (element_type=_bool);
+> CREATE TYPE bool_array_list_c AS LIST (ELEMENT TYPE = _bool);
 > CREATE TABLE bool_array_list_t (a bool_array_list_c);
 > INSERT INTO bool_array_list_t VALUES (LIST[ARRAY[true]]);
 
-> CREATE TYPE int8_array_list_c AS LIST (element_type=_int8);
+> CREATE TYPE int8_array_list_c AS LIST (ELEMENT TYPE = _int8);
 > CREATE TABLE int8_array_list_t (a int8_array_list_c);
 > INSERT INTO int8_array_list_t VALUES (LIST[ARRAY[1::int8,2::int8]]);
 
-> CREATE TYPE int4_array_list_c AS LIST (element_type=_int4);
+> CREATE TYPE int4_array_list_c AS LIST (ELEMENT TYPE = _int4);
 > CREATE TABLE int4_array_list_t (a int4_array_list_c);
 > INSERT INTO int4_array_list_t VALUES (LIST[ARRAY[1,2]]);
 
-> CREATE TYPE text_array_list_c AS LIST (element_type=_text);
+> CREATE TYPE text_array_list_c AS LIST (ELEMENT TYPE = _text);
 > CREATE TABLE text_array_list_t (a text_array_list_c);
 > INSERT INTO text_array_list_t VALUES (LIST[ARRAY['a','b']]);
 
-> CREATE TYPE varchar_array_list_c AS LIST (element_type=_varchar);
+> CREATE TYPE varchar_array_list_c AS LIST (ELEMENT TYPE = _varchar);
 > CREATE TABLE varchar_array_list_t (a varchar_array_list_c);
 > INSERT INTO varchar_array_list_t VALUES (LIST[ARRAY['a'::varchar,'b'::varchar]]);
 
 # Enable this when closing #7613
-# > CREATE TYPE char_array_list_c AS LIST (element_type=_char);
+# > CREATE TYPE char_array_list_c AS LIST (ELEMENT TYPE = _char);
 # > CREATE TABLE char_array_list_t (a char_array_list_c);
 # > INSERT INTO char_array_list_t VALUES (LIST[ARRAY['a'::char,'b'::char]]);
 
-> CREATE TYPE float4_array_list_c AS LIST (element_type=_float4);
+> CREATE TYPE float4_array_list_c AS LIST (ELEMENT TYPE = _float4);
 > CREATE TABLE float4_array_list_t (a float4_array_list_c);
 > INSERT INTO float4_array_list_t VALUES (LIST[ARRAY[1.2::float4,2.3::float4]]);
 
-> CREATE TYPE float8_array_list_c AS LIST (element_type=_float8);
+> CREATE TYPE float8_array_list_c AS LIST (ELEMENT TYPE = _float8);
 > CREATE TABLE float8_array_list_t (a float8_array_list_c);
 > INSERT INTO float8_array_list_t VALUES (LIST[ARRAY[1.2::float8,2.3::float8]]);
 
-> CREATE TYPE date_array_list_c AS LIST (element_type=_date);
+> CREATE TYPE date_array_list_c AS LIST (ELEMENT TYPE = _date);
 > CREATE TABLE date_array_list_t (a date_array_list_c);
 > INSERT INTO date_array_list_t VALUES (LIST[ARRAY['2001-01-01'::date]]);
 
-> CREATE TYPE time_array_list_c AS LIST (element_type=_time);
+> CREATE TYPE time_array_list_c AS LIST (ELEMENT TYPE = _time);
 > CREATE TABLE time_array_list_t (a time_array_list_c);
 > INSERT INTO time_array_list_t VALUES (LIST[ARRAY['12:34:56'::time]]);
 
-> CREATE TYPE timestamp_array_list_c AS LIST (element_type=_timestamp);
+> CREATE TYPE timestamp_array_list_c AS LIST (ELEMENT TYPE = _timestamp);
 > CREATE TABLE timestamp_array_list_t (a timestamp_array_list_c);
 > INSERT INTO timestamp_array_list_t VALUES (LIST[ARRAY['2001-01-01 12:34:56'::timestamp]]);
 
-> CREATE TYPE timestamptz_array_list_c AS LIST (element_type=_timestamptz);
+> CREATE TYPE timestamptz_array_list_c AS LIST (ELEMENT TYPE = _timestamptz);
 > CREATE TABLE timestamptz_array_list_t (a timestamptz_array_list_c);
 > INSERT INTO timestamptz_array_list_t VALUES (LIST[ARRAY['2001-01-01 12:34:56'::timestamptz]]);
 
-> CREATE TYPE interval_array_list_c AS LIST (element_type=_interval);
+> CREATE TYPE interval_array_list_c AS LIST (ELEMENT TYPE = _interval);
 > CREATE TABLE interval_array_list_t (a interval_array_list_c);
 > INSERT INTO interval_array_list_t VALUES (LIST[ARRAY['1y 2d 3h 4m'::interval]]);
 
-# > CREATE TYPE numeric_array_list_c AS LIST (element_type=_numeric);
+# > CREATE TYPE numeric_array_list_c AS LIST (ELEMENT TYPE = _numeric);
 # > CREATE TABLE numeric_array_list_t (a numeric_array_list_c);
 # > INSERT INTO numeric_array_list_t VALUES (LIST[ARRAY[1.23, 2.34]]);
 
-> CREATE TYPE jsonb_array_list_c AS LIST (element_type=_jsonb);
+> CREATE TYPE jsonb_array_list_c AS LIST (ELEMENT TYPE = _jsonb);
 > CREATE TABLE jsonb_array_list_t (a jsonb_array_list_c);
 > INSERT INTO jsonb_array_list_t VALUES (LIST[ARRAY['{"1":2}'::jsonb]]);
 
@@ -271,8 +271,8 @@ pg_type_is_visible
 true
 
 > CREATE SCHEMA hidden_schema;
-> CREATE TYPE hidden_schema.my_hidden_type AS LIST (element_type = int4);
-> CREATE TYPE my_type AS LIST (element_type = int4);
+> CREATE TYPE hidden_schema.my_hidden_type AS LIST (ELEMENT TYPE = int4);
+> CREATE TYPE my_type AS LIST (ELEMENT TYPE = int4);
 
 > SELECT PG_TYPE_IS_VISIBLE(oid::REGTYPE) FROM mz_catalog.mz_types WHERE name='my_hidden_type';
 pg_type_is_visible
@@ -285,7 +285,7 @@ pg_type_is_visible
 true
 
 # Ensure we don't allow unknown options
-! CREATE TYPE whatever AS LIST (element_type=int4, gus=int4);
+! CREATE TYPE whatever AS LIST (ELEMENT TYPE = int4, gus=int4);
 contains:unexpected parameters for CREATE TYPE: gus
 
 $ postgres-execute connection=mz_system

--- a/test/upgrade/create-in-current_source-custom-types.td
+++ b/test/upgrade/create-in-current_source-custom-types.td
@@ -15,11 +15,11 @@
 
 > DROP TYPE IF EXISTS int4_list;
 
-> CREATE TYPE int4_list AS LIST (element_type = int4);
+> CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 
 > CREATE MATERIALIZED VIEW int4_list_view AS SELECT '{1,2}'::int4_list AS custom_list;
 
-> CREATE TYPE int4_list_list AS LIST (element_type = int4_list);
+> CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list);
 
 > CREATE MATERIALIZED VIEW int4_list_list_view AS SELECT '{{1,2}}'::int4_list_list AS custom_nested_list;
 
@@ -27,10 +27,10 @@
 
 > DROP TYPE IF EXISTS int4_map;
 
-> CREATE TYPE int4_map AS MAP (key_type=text, value_type=int4);
+> CREATE TYPE int4_map AS MAP (KEY TYPE = text, VALUE TYPE = int4);
 
 > CREATE MATERIALIZED VIEW int4_map_view AS SELECT '{a=>1}'::int4_map AS custom_map;
 
-> CREATE TYPE int4_map_map AS MAP (key_type=text, value_type=int4_map);
+> CREATE TYPE int4_map_map AS MAP (KEY TYPE = text, VALUE TYPE = int4_map);
 
 > CREATE MATERIALIZED VIEW int4_map_map_view AS SELECT '{a=>{"a a"=>1}}'::int4_map_map AS custom_nested_map;


### PR DESCRIPTION
I'm sure I haven't tracked down all the test failures yet, but the code should be complete.

----

This commit removes the last few code paths that were not using
@sploiselle's new generic option handling macro.

There are a few minor breaking syntax changes as a result:

  * CREATE TYPE ... AS LIST (element_type = ...)
    =>
    CREATE TYPE ... AS LIST (ELEMENT TYPE = ...)

  * CREATE TYPE ... AS MAP (key_type = ..., value_type = ...)
    =>
    CREATE TYPE ... AS LIST (KEY TYPE = ..., VALUE TYPE = ...)

  * SELECT ... OPTION (expected_group_size = ...)
    =>
    SELECT ... OPTIONS (EXPECTED GROUP SIZE = ...)

Documentation has been updated accordingly.

Fix https://github.com/MaterializeInc/materialize/issues/5390.
Fix https://github.com/MaterializeInc/materialize/issues/6186.
Fix https://github.com/MaterializeInc/materialize/issues/14341.

I'm calling https://github.com/MaterializeInc/materialize/issues/6186 fixed too because it's impossible to use the new
option handling code without rejecting invalid options.

### Motivation

   * This PR refactors existing code.
   * This PR fixes several recognized bugs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
