### PR TITLE
pgwire: force internal SQL connections to use user mz_system

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1429,6 +1429,11 @@ fn test_system_user() -> Result<(), Box<dyn Error>> {
         .user(&SYSTEM_USER.name)
         .connect(postgres::NoTls)
         .is_ok());
+    assert!(server
+        .pg_config_internal()
+        .user("mz_something_else")
+        .connect(postgres::NoTls)
+        .is_err());
 
     Ok(())
 }


### PR DESCRIPTION
So that the internal SQL port can't be used to impersonate a non-system user. Best to have any DDL run by the system user recorded as such, for example.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported issue.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a