### PR TITLE
adapter,pgwire,environmentd: generalize notice handling

### DIFF
--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -119,13 +119,21 @@ an array of the following:
 
 Result | JSON value
 ---------------------|------------
-Rows | `{"rows": <2D array of JSON-ified results>, "col_names": <array of text>}`
-Error | `{"error": <Error string from execution>}`
-Ok | `{ "ok": <tag>}`
+Rows | `{"rows": <2D array of JSON-ified results>, "col_names": <array of text>, "notices": <array of notices>}`
+Error | `{"error": <Error string from execution>, "notices": <array of notices>}`
+Ok | `{"ok": <tag>, "notices": <array of notices>}`
 
 Each committed statement returns exactly one of these values; e.g. in the case
 of "complex responses", such as `INSERT INTO...RETURNING`, the presence of a
 `"rows"` object implies `"ok"`.
+
+The `"notices"` array is present in all types of results and contains any
+diagnostic messages that were generated during execution of the query. It has
+the following structure:
+
+```
+{"severity": <"warning"|"notice"|"debug"|"info"|"log">, "message": <informational message>}
+```
 
 Note that the returned values include the results of statements which were
 ultimately rolled back because of an error in a later part of the transaction.
@@ -154,14 +162,14 @@ curl https://<MZ host address>/api/sql \
 ```json
 {
   "results": [
-    {"ok": "CREATE TABLE"},
-    {"ok": "CREATE TABLE"},
-    {"ok": "BEGIN"},
-    {"ok": "INSERT 0 2"},
-    {"ok": "COMMIT"},
-    {"ok": "BEGIN"},
-    {"ok": "INSERT 0 2"},
-    {"ok": "COMMIT"}
+    {"ok": "CREATE TABLE", "notices": []},
+    {"ok": "CREATE TABLE", "notices": []},
+    {"ok": "BEGIN", "notices": []},
+    {"ok": "INSERT 0 2", "notices": []},
+    {"ok": "COMMIT", "notices": []},
+    {"ok": "BEGIN", "notices": []},
+    {"ok": "INSERT 0 2", "notices": []},
+    {"ok": "COMMIT", "notices": []}
   ]
 }
 ```
@@ -178,12 +186,14 @@ curl https://<MZ host address>/api/sql \
 {
   "results": [
     {
-      "rows": [[null],[null],[109],[209]],
-      "col_names": ["cross_add"]
+        "rows": [[null],[null],[109],[209]],
+        "col_names": ["cross_add"],
+        "notices": []
     },
     {
         "rows":[[100],[200]],
-        "col_names":["a"]
+        "col_names":["a"],
+        "notices": []
     }
   ]
 }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -19,21 +19,18 @@ use std::sync::Arc;
 use derivative::Derivative;
 use enum_kinds::EnumKind;
 use mz_sql::plan::PlanKind;
-use serde::Serialize;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
-use tokio_postgres::error::SqlState;
 
 use mz_ore::str::StrExt;
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::{GlobalId, Row, ScalarType};
-use mz_sql::ast::{FetchDirection, NoticeSeverity, ObjectType, Raw, Statement};
+use mz_sql::ast::{FetchDirection, ObjectType, Raw, Statement};
 use mz_sql::plan::ExecuteTimeout;
 
 use crate::client::ConnectionId;
 use crate::coord::peek::PeekResponseUnary;
 use crate::error::AdapterError;
-use crate::session::ClientSeverity;
 use crate::session::{EndTransactionAction, RowBatchStream, Session};
 use crate::util::Transmittable;
 
@@ -172,31 +169,18 @@ impl fmt::Display for StartupMessage {
     }
 }
 
-#[derive(Debug, Serialize)]
-pub struct ExecuteResponsePartialError {
-    pub severity: ClientSeverity,
-    #[serde(skip)]
-    pub code: SqlState,
-    pub message: String,
-}
-
 /// The response to [`SessionClient::execute`](crate::SessionClient::execute).
 #[derive(EnumKind, Derivative)]
 #[derivative(Debug)]
 #[enum_kind(ExecuteResponseKind)]
 pub enum ExecuteResponse {
-    /// The active transaction was exited.
-    TransactionExited {
-        was_implicit: bool,
-        tag: &'static str,
-    },
-    // The requested object was altered.
+    /// The requested object was altered.
     AlteredObject(ObjectType),
-    // The index was altered.
+    /// The index was altered.
     AlteredIndexLogicalCompaction,
-    // The system configuration was altered.
+    /// The system configuration was altered.
     AlteredSystemConfiguraion,
-    // The query was canceled.
+    /// The query was canceled.
     Canceled,
     /// The requested cursor was closed.
     ClosedCursor,
@@ -210,67 +194,39 @@ pub enum ExecuteResponse {
         params: CopyFormatParams<'static>,
     },
     /// The requested connection was created.
-    CreatedConnection {
-        existed: bool,
-    },
+    CreatedConnection,
     /// The requested database was created.
-    CreatedDatabase {
-        existed: bool,
-    },
+    CreatedDatabase,
     /// The requested schema was created.
-    CreatedSchema {
-        existed: bool,
-    },
+    CreatedSchema,
     /// The requested role was created.
     CreatedRole,
     /// The requested compute instance was created.
-    CreatedComputeInstance {
-        existed: bool,
-    },
+    CreatedComputeInstance,
     /// The requested compute replica was created.
-    CreatedComputeReplica {
-        existed: bool,
-    },
+    CreatedComputeReplica,
     /// The requested index was created.
-    CreatedIndex {
-        existed: bool,
-    },
+    CreatedIndex,
     /// The requested secret was created.
-    CreatedSecret {
-        existed: bool,
-    },
+    CreatedSecret,
     /// The requested sink was created.
-    CreatedSink {
-        existed: bool,
-    },
+    CreatedSink,
     /// The requested source was created.
-    CreatedSource {
-        existed: bool,
-    },
+    CreatedSource,
     /// The requested sources were created.
     CreatedSources,
     /// The requested table was created.
-    CreatedTable {
-        existed: bool,
-    },
+    CreatedTable,
     /// The requested view was created.
-    CreatedView {
-        existed: bool,
-    },
+    CreatedView,
     /// The requested views were created.
-    CreatedViews {
-        existed: bool,
-    },
+    CreatedViews,
     /// The requested materialized view was created.
-    CreatedMaterializedView {
-        existed: bool,
-    },
+    CreatedMaterializedView,
     /// The requested type was created.
     CreatedType,
     /// The requested prepared statement was removed.
-    Deallocate {
-        all: bool,
-    },
+    Deallocate { all: bool },
     /// The requested cursor was declared.
     DeclaredCursor,
     /// The specified number of rows were deleted from the requested table.
@@ -322,6 +278,8 @@ pub enum ExecuteResponse {
     Inserted(usize),
     /// The specified prepared statement was created.
     Prepare,
+    /// A user-requested warning was raised.
+    Raised,
     /// Rows will be delivered via the specified future.
     SendingRows {
         #[derivative(Debug = "ignore")]
@@ -332,46 +290,26 @@ pub enum ExecuteResponse {
     /// The specified variable was set to a new value.
     SetVariable {
         name: String,
-        tag: &'static str,
+        /// Whether the operation was a `RESET` rather than a set.
+        reset: bool,
     },
     /// A new transaction was started.
-    StartedTransaction {
-        duplicated: bool, // true if a transaction is in progress
-    },
+    StartedTransaction,
     /// Updates to the requested source or view will be streamed to the
     /// contained receiver.
-    Subscribing {
-        rx: RowBatchStream,
-    },
+    Subscribing { rx: RowBatchStream },
+    /// The active transaction committed.
+    TransactionCommitted,
+    /// The active transaction rolled back.
+    TransactionRolledBack,
     /// The specified number of rows were updated in the requested table.
     Updated(usize),
-    /// Raise a warning.
-    Raise {
-        severity: NoticeSeverity,
-    },
 }
 
 impl ExecuteResponse {
     pub fn tag(&self) -> Option<String> {
         use ExecuteResponse::*;
-        macro_rules! generic_concat {
-            ($lede:expr, $type:expr) => {{
-                Some(format!("{} {}", $lede, $type.to_uppercase()))
-            }};
-        }
-        macro_rules! created {
-            ($type:expr) => {{
-                generic_concat!("CREATE", $type)
-            }};
-        }
-        macro_rules! dropped {
-            ($type:expr) => {{
-                generic_concat!("DROP", $type)
-            }};
-        }
-
         match self {
-            TransactionExited { tag, .. } => Some(tag.to_string()),
             AlteredObject(o) => Some(format!("ALTER {}", o)),
             AlteredIndexLogicalCompaction => Some("ALTER INDEX".into()),
             AlteredSystemConfiguraion => Some("ALTER SYSTEM".into()),
@@ -379,41 +317,41 @@ impl ExecuteResponse {
             ClosedCursor => Some("CLOSE CURSOR".into()),
             CopyTo { .. } => None,
             CopyFrom { .. } => None,
-            CreatedConnection { .. } => created!("connection"),
-            CreatedDatabase { .. } => created!("database"),
-            CreatedSchema { .. } => created!("schema"),
-            CreatedRole => created!("role"),
-            CreatedComputeInstance { .. } => created!("cluster"),
-            CreatedComputeReplica { .. } => created!("cluster replica"),
-            CreatedIndex { .. } => created!("index"),
-            CreatedSecret { .. } => created!("secret"),
-            CreatedSink { .. } => created!("sink"),
-            CreatedSource { .. } => created!("source"),
-            CreatedSources => created!("sources"),
-            CreatedTable { .. } => created!("table"),
-            CreatedView { .. } => created!("view"),
-            CreatedViews { .. } => created!("views"),
-            CreatedMaterializedView { .. } => created!("materialized view"),
-            CreatedType => created!("type"),
+            CreatedConnection { .. } => Some("CREATE CONNECTION".into()),
+            CreatedDatabase { .. } => Some("CREATE DATABASE".into()),
+            CreatedSchema { .. } => Some("CREATE SCHEMA".into()),
+            CreatedRole => Some("CREATE ROLE".into()),
+            CreatedComputeInstance { .. } => Some("CREATE CLUSTER".into()),
+            CreatedComputeReplica { .. } => Some("CREATE CLUSTER REPLICA".into()),
+            CreatedIndex { .. } => Some("CREATE INDEX".into()),
+            CreatedSecret { .. } => Some("CREATE SECRET".into()),
+            CreatedSink { .. } => Some("CREATE SINK".into()),
+            CreatedSource { .. } => Some("CREATE SOURCE".into()),
+            CreatedSources => Some("CREATE SOURCES".into()),
+            CreatedTable { .. } => Some("CREATE TABLE".into()),
+            CreatedView { .. } => Some("CREATE VIEW".into()),
+            CreatedViews { .. } => Some("CREATE VIEWS".into()),
+            CreatedMaterializedView { .. } => Some("CREATE MATERIALIZED VIEW".into()),
+            CreatedType => Some("CREATE TYPE".into()),
             Deallocate { all } => Some(format!("DEALLOCATE{}", if *all { " ALL" } else { "" })),
             DeclaredCursor => Some("DECLARE CURSOR".into()),
             Deleted(n) => Some(format!("DELETE {}", n)),
             DiscardedTemp => Some("DISCARD TEMP".into()),
             DiscardedAll => Some("DISCARD ALL".into()),
-            DroppedConnection => dropped!("connection"),
-            DroppedComputeInstance => dropped!("cluster"),
-            DroppedComputeReplica => dropped!("cluster replica"),
-            DroppedDatabase => dropped!("database"),
-            DroppedRole => dropped!("role"),
-            DroppedSchema => dropped!("schema"),
-            DroppedSource => dropped!("source"),
-            DroppedTable => dropped!("table"),
-            DroppedView => dropped!("view"),
-            DroppedMaterializedView => dropped!("materialized view"),
-            DroppedIndex => dropped!("index"),
-            DroppedSink => dropped!("sink"),
-            DroppedType => dropped!("type"),
-            DroppedSecret => dropped!("secret"),
+            DroppedConnection => Some("DROP CONNECTION".into()),
+            DroppedComputeInstance => Some("DROP CLUSTER".into()),
+            DroppedComputeReplica => Some("DROP CLUSTER REPLICA".into()),
+            DroppedDatabase => Some("DROP DATABASE".into()),
+            DroppedRole => Some("DROP ROLE".into()),
+            DroppedSchema => Some("DROP SCHEMA".into()),
+            DroppedSource => Some("DROP SOURCE".into()),
+            DroppedTable => Some("DROP TABLE".into()),
+            DroppedView => Some("DROP VIEW".into()),
+            DroppedMaterializedView => Some("DROP MATERIALIZED view".into()),
+            DroppedIndex => Some("DROP INDEX".into()),
+            DroppedSink => Some("DROP SINK".into()),
+            DroppedType => Some("DROP TYPE".into()),
+            DroppedSecret => Some("DROP SECRET".into()),
             EmptyQuery => None,
             Fetch { .. } => None,
             Inserted(n) => {
@@ -427,187 +365,16 @@ impl ExecuteResponse {
                 Some(format!("INSERT 0 {}", n))
             }
             Prepare => Some("PREPARE".into()),
+            Raised => Some("RAISE".into()),
             SendingRows { .. } => None,
-            SetVariable { tag, .. } => Some(tag.to_string()),
+            SetVariable { reset: true, .. } => Some("RESET".into()),
+            SetVariable { reset: false, .. } => Some("SET".into()),
             StartedTransaction { .. } => Some("BEGIN".into()),
             Subscribing { .. } => None,
+            TransactionCommitted => Some("COMMIT".into()),
+            TransactionRolledBack => Some("ROLLBACK".into()),
             Updated(n) => Some(format!("UPDATE {}", n)),
-            Raise { .. } => Some("RAISE".into()),
         }
-    }
-
-    /// When an appropriate error response can be totally determined by the
-    /// `ExecuteResponse`, generate it if it is non-terminal, i.e. should not be
-    /// returned as an error instead of the value.
-    ///
-    /// # Panics
-    /// - If returns an error with [`ClientSeverity::Error`].
-    pub fn partial_err(&self) -> Option<ExecuteResponsePartialError> {
-        use ExecuteResponse::*;
-
-        macro_rules! existed {
-            ($existed:expr, $code:expr, $type:expr) => {{
-                if $existed {
-                    Some(ExecuteResponsePartialError {
-                        severity: ClientSeverity::Notice,
-                        code: $code,
-                        message: format!("{} already exists, skipping", $type),
-                    })
-                } else {
-                    None
-                }
-            }};
-        }
-
-        let r = match self {
-            CreatedConnection { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "connection")
-            }
-            CreatedDatabase { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_DATABASE, "database")
-            }
-            CreatedSchema { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_SCHEMA, "schema")
-            }
-            CreatedRole => {
-                existed!(false, SqlState::DUPLICATE_OBJECT, "role")
-            }
-            CreatedComputeInstance { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "cluster")
-            }
-            CreatedComputeReplica { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "cluster replica")
-            }
-            CreatedTable { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_TABLE, "table")
-            }
-            CreatedIndex { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "index")
-            }
-            CreatedSecret { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "secret")
-            }
-            CreatedSource { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "source")
-            }
-            CreatedSink { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "sink")
-            }
-            CreatedView { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "view")
-            }
-            CreatedViews { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "views")
-            }
-            CreatedMaterializedView { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "materialized view")
-            }
-
-            Raise { severity } => Some(match severity {
-                NoticeSeverity::Debug => ExecuteResponsePartialError {
-                    severity: ClientSeverity::Debug1,
-                    code: SqlState::WARNING,
-                    message: "raised a test debug".to_string(),
-                },
-                NoticeSeverity::Info => ExecuteResponsePartialError {
-                    severity: ClientSeverity::Info,
-                    code: SqlState::WARNING,
-                    message: "raised a test info".to_string(),
-                },
-                NoticeSeverity::Log => ExecuteResponsePartialError {
-                    severity: ClientSeverity::Log,
-                    code: SqlState::WARNING,
-                    message: "raised a test log".to_string(),
-                },
-                NoticeSeverity::Notice => ExecuteResponsePartialError {
-                    severity: ClientSeverity::Notice,
-                    code: SqlState::WARNING,
-                    message: "raised a test notice".to_string(),
-                },
-                NoticeSeverity::Warning => ExecuteResponsePartialError {
-                    severity: ClientSeverity::Warning,
-                    code: SqlState::WARNING,
-                    message: "raised a test warning".to_string(),
-                },
-            }),
-
-            StartedTransaction { duplicated } => {
-                if *duplicated {
-                    Some(ExecuteResponsePartialError {
-                        severity: ClientSeverity::Warning,
-                        code: SqlState::ACTIVE_SQL_TRANSACTION,
-                        message: "there is already a transaction in progress".to_string(),
-                    })
-                } else {
-                    None
-                }
-            }
-
-            TransactionExited { was_implicit, .. } => {
-                // In Postgres, if a user sends a COMMIT or ROLLBACK in an implicit
-                // transaction, a warning is sent warning them. (The transaction is still closed
-                // and a new implicit transaction started, though.)
-                if *was_implicit {
-                    Some(ExecuteResponsePartialError {
-                        severity: ClientSeverity::Warning,
-                        code: SqlState::NO_ACTIVE_SQL_TRANSACTION,
-                        message: "there is no transaction in progress".to_string(),
-                    })
-                } else {
-                    None
-                }
-            }
-
-            CreatedSources
-            | CreatedType
-            | AlteredObject(..)
-            | AlteredIndexLogicalCompaction
-            | AlteredSystemConfiguraion
-            | Canceled
-            | ClosedCursor
-            | CopyTo { .. }
-            | CopyFrom { .. }
-            | Deallocate { .. }
-            | DeclaredCursor
-            | Deleted(..)
-            | DiscardedTemp
-            | DiscardedAll
-            | DroppedConnection
-            | DroppedComputeInstance
-            | DroppedComputeReplica
-            | DroppedDatabase
-            | DroppedRole
-            | DroppedSchema
-            | DroppedSource
-            | DroppedTable
-            | DroppedView
-            | DroppedMaterializedView
-            | DroppedIndex
-            | DroppedSink
-            | DroppedType
-            | DroppedSecret
-            | EmptyQuery
-            | Fetch { .. }
-            | Inserted(..)
-            | Prepare
-            | SendingRows { .. }
-            | SetVariable { .. }
-            | Subscribing { .. }
-            | Updated(..) => None,
-        };
-
-        assert!(
-            !matches!(
-                r,
-                Some(ExecuteResponsePartialError {
-                    severity: ClientSeverity::Error,
-                    ..
-                })
-            ),
-            "partial_err cannot generate errors"
-        );
-
-        r
     }
 
     /// Expresses which [`PlanKind`] generate which set of
@@ -617,7 +384,7 @@ impl ExecuteResponse {
         use PlanKind::*;
 
         match plan {
-            AbortTransaction | CommitTransaction => vec![TransactionExited],
+            AbortTransaction => vec![TransactionRolledBack],
             AlterItemRename | AlterNoop | AlterSecret | AlterSource | RotateKeys => {
                 vec![AlteredObject]
             }
@@ -629,6 +396,7 @@ impl ExecuteResponse {
             }
             Close => vec![ClosedCursor],
             PlanKind::CopyFrom => vec![ExecuteResponseKind::CopyFrom],
+            CommitTransaction => vec![TransactionCommitted, TransactionRolledBack],
             CreateConnection => vec![CreatedConnection],
             CreateDatabase => vec![CreatedDatabase],
             CreateSchema => vec![CreatedSchema],
@@ -671,7 +439,7 @@ impl ExecuteResponse {
             PlanKind::Fetch => vec![ExecuteResponseKind::Fetch],
             Insert => vec![Inserted, SendingRows],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],
-            PlanKind::Raise => vec![ExecuteResponseKind::Raise],
+            PlanKind::Raise => vec![ExecuteResponseKind::Raised],
             PlanKind::SetVariable | ResetVariable => vec![ExecuteResponseKind::SetVariable],
             PlanKind::Subscribe => vec![Subscribing, CopyTo],
             StartTransaction => vec![StartedTransaction],

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -336,7 +336,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     // Kafka topic) they need to clean up.
                 }
                 if let Some((session, tx)) = session_and_tx {
-                    tx.send(Ok(ExecuteResponse::CreatedSink { existed: false }), session);
+                    tx.send(Ok(ExecuteResponse::CreatedSink), session);
                 }
             }
             Err(e) => {

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -36,6 +36,7 @@ mod command;
 mod coord;
 mod error;
 mod explain_new;
+mod notice;
 mod subscribe;
 mod util;
 
@@ -45,9 +46,9 @@ pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{
-    Canceled, ExecuteResponse, ExecuteResponseKind, ExecuteResponsePartialError, RowsFuture,
-    StartupMessage, StartupResponse,
+    Canceled, ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupMessage, StartupResponse,
 };
 pub use crate::coord::peek::PeekResponseUnary;
 pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};
 pub use crate::error::AdapterError;
+pub use crate::notice::AdapterNotice;

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -1,0 +1,68 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+
+use mz_ore::str::StrExt;
+use mz_sql::ast::NoticeSeverity;
+
+/// Notices that can occur in the adapter layer.
+///
+/// These are diagnostic warnings or informational messages that are not
+/// severe enough to warrant failing a query entirely.
+#[derive(Debug)]
+pub enum AdapterNotice {
+    DatabaseAlreadyExists { name: String },
+    SchemaAlreadyExists { name: String },
+    TableAlreadyExists { name: String },
+    ObjectAlreadyExists { name: String, ty: &'static str },
+    ExistingTransactionInProgress,
+    ExplicitTransactionControlInImplicitTransaction,
+    UserRequested { severity: NoticeSeverity },
+}
+
+impl AdapterNotice {
+    /// Reports additional details about the notice, if any are available.
+    pub fn detail(&self) -> Option<String> {
+        None
+    }
+
+    /// Reports a hint for the user about how the notice could be addressed.
+    pub fn hint(&self) -> Option<String> {
+        None
+    }
+}
+
+impl fmt::Display for AdapterNotice {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AdapterNotice::DatabaseAlreadyExists { name } => {
+                write!(f, "database {} already exists, skipping", name.quoted())
+            }
+            AdapterNotice::SchemaAlreadyExists { name } => {
+                write!(f, "schema {} already exists, skipping", name.quoted())
+            }
+            AdapterNotice::TableAlreadyExists { name } => {
+                write!(f, "table {} already exists, skipping", name.quoted())
+            }
+            AdapterNotice::ObjectAlreadyExists { name, ty } => {
+                write!(f, "{} {} already exists, skipping", ty, name.quoted())
+            }
+            AdapterNotice::ExistingTransactionInProgress => {
+                write!(f, "there is already a transaction in progress")
+            }
+            AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
+                write!(f, "there is no transaction in progress")
+            }
+            AdapterNotice::UserRequested { severity } => {
+                write!(f, "raised a test {}", severity.to_string().to_lowercase())
+            }
+        }
+    }
+}

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -15,10 +15,8 @@ use itertools::izip;
 use serde::{Deserialize, Serialize};
 
 use mz_adapter::session::{EndTransactionAction, TransactionStatus};
-use mz_adapter::{
-    ExecuteResponse, ExecuteResponseKind, ExecuteResponsePartialError, PeekResponseUnary,
-    SessionClient,
-};
+use mz_adapter::{ExecuteResponse, ExecuteResponseKind, PeekResponseUnary, SessionClient};
+use mz_pgwire::Severity;
 use mz_repr::{Datum, RowArena};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Raw, Statement};
@@ -86,33 +84,56 @@ enum SqlResult {
         rows: Vec<Vec<serde_json::Value>>,
         /// The name of the columns in the row.
         col_names: Vec<String>,
+        /// Any notices generated during execution of the query.
+        notices: Vec<Notice>,
     },
     /// The query executed successfully but did not return rows.
     Ok {
         ok: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        partial_err: Option<ExecuteResponsePartialError>,
+        /// Any notices generated during execution of the query.
+        notices: Vec<Notice>,
     },
     /// The query returned an error.
-    Err { error: String },
+    Err {
+        /// The error message.
+        error: String,
+        /// Any notices generated during execution of the query.
+        notices: Vec<Notice>,
+    },
 }
 
 impl SqlResult {
-    fn err(msg: impl std::fmt::Display) -> SqlResult {
-        SqlResult::Err {
-            error: msg.to_string(),
+    fn rows(
+        client: &mut SessionClient,
+        rows: Vec<Vec<serde_json::Value>>,
+        col_names: Vec<String>,
+    ) -> SqlResult {
+        SqlResult::Rows {
+            rows,
+            col_names,
+            notices: make_notices(client),
         }
     }
 
-    /// Generates a `SimpleResult::Ok` based on an `ExecuteResponse`.
-    ///
-    /// # Panics
-    /// - If `ExecuteResponse::partial_err(&res)` panics.
-    fn ok(res: ExecuteResponse) -> SqlResult {
-        let ok = res.tag();
-        let partial_err = res.partial_err();
-        SqlResult::Ok { ok, partial_err }
+    fn err(client: &mut SessionClient, msg: impl std::fmt::Display) -> SqlResult {
+        SqlResult::Err {
+            error: msg.to_string(),
+            notices: make_notices(client),
+        }
     }
+
+    fn ok(client: &mut SessionClient, res: ExecuteResponse) -> SqlResult {
+        SqlResult::Ok {
+            ok: res.tag(),
+            notices: make_notices(client),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Notice {
+    message: String,
+    severity: String,
 }
 
 /// Executes an entire [`SqlRequest`].
@@ -139,7 +160,6 @@ async fn execute_request(
                     | ExecuteResponseKind::Subscribing
                     | ExecuteResponseKind::CopyTo
                     | ExecuteResponseKind::CopyFrom
-                    | ExecuteResponseKind::Raise
                     | ExecuteResponseKind::DeclaredCursor
                     | ExecuteResponseKind::ClosedCursor
             )
@@ -200,7 +220,7 @@ async fn execute_request(
             // Mirror the behavior of the PostgreSQL simple query protocol.
             // See the pgwire::protocol::StateMachine::query method for details.
             if let Err(e) = client.start_transaction(Some(num_stmts)).await {
-                results.push(SqlResult::err(e));
+                results.push(SqlResult::err(client, e));
                 break;
             }
             let res = execute_stmt(client, stmt, params).await;
@@ -214,6 +234,7 @@ async fn execute_request(
     if client.session().transaction().is_implicit() {
         client.end_transaction(EndTransactionAction::Commit).await?;
     }
+
     Ok(SqlResponse { results })
 }
 
@@ -228,13 +249,13 @@ async fn execute_stmt(
         .describe(EMPTY_PORTAL.into(), Some(stmt.clone()), vec![])
         .await
     {
-        return SqlResult::err(e);
+        return SqlResult::err(client, e);
     }
 
     let prep_stmt = match client.get_prepared_statement(EMPTY_PORTAL).await {
         Ok(stmt) => stmt,
         Err(err) => {
-            return SqlResult::err(err);
+            return SqlResult::err(client, err);
         }
     };
 
@@ -247,7 +268,7 @@ async fn execute_stmt(
             actual = raw_params.len(),
             expected = param_types.len()
         );
-        return SqlResult::err(message);
+        return SqlResult::err(client, message);
     }
 
     let buf = RowArena::new();
@@ -265,7 +286,7 @@ async fn execute_stmt(
                     Ok(param) => param.into_datum(&buf, &pg_typ),
                     Err(err) => {
                         let msg = format!("unable to decode parameter: {}", err);
-                        return SqlResult::err(msg);
+                        return SqlResult::err(client, msg);
                     }
                 }
             }
@@ -294,7 +315,7 @@ async fn execute_stmt(
         result_formats,
         revision,
     ) {
-        return SqlResult::err(err.to_string());
+        return SqlResult::err(client, err.to_string());
     }
 
     let desc = client
@@ -307,13 +328,13 @@ async fn execute_stmt(
     let res = match client.execute(EMPTY_PORTAL.into()).await {
         Ok(res) => res,
         Err(e) => {
-            return SqlResult::err(e);
+            return SqlResult::err(client, e);
         }
     };
 
     match res {
         ExecuteResponse::Canceled => {
-            SqlResult::err("statement canceled due to user request")
+            SqlResult::err(client, "statement canceled due to user request")
         }
         res @ (ExecuteResponse::CreatedConnection { .. }
         | ExecuteResponse::CreatedDatabase { .. }
@@ -350,17 +371,17 @@ async fn execute_stmt(
         | ExecuteResponse::DroppedConnection
         | ExecuteResponse::EmptyQuery
         | ExecuteResponse::Inserted(_)
+        | ExecuteResponse::Raised
         | ExecuteResponse::SetVariable { .. }
         | ExecuteResponse::StartedTransaction { .. }
-        | ExecuteResponse::TransactionExited {
-            ..
-        }
+        | ExecuteResponse::TransactionCommitted
+        | ExecuteResponse::TransactionRolledBack
         | ExecuteResponse::Updated(_)
         | ExecuteResponse::AlteredObject(_)
         | ExecuteResponse::AlteredIndexLogicalCompaction
         | ExecuteResponse::AlteredSystemConfiguraion
         | ExecuteResponse::Deallocate { .. }
-        | ExecuteResponse::Prepare) => SqlResult::ok(res),
+        | ExecuteResponse::Prepare) => SqlResult::ok(client, res),
         ExecuteResponse::SendingRows {
             future: rows,
             span: _,
@@ -368,10 +389,10 @@ async fn execute_stmt(
             let rows = match rows.await {
                 PeekResponseUnary::Rows(rows) => rows,
                 PeekResponseUnary::Error(e) => {
-                    return SqlResult::err(e);
+                    return SqlResult::err(client, e);
                 }
                 PeekResponseUnary::Canceled => {
-                    return SqlResult::err("statement canceled due to user request");
+                    return SqlResult::err(client, "statement canceled due to user request");
                 }
             };
             let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
@@ -384,23 +405,33 @@ async fn execute_stmt(
                 let datums = datum_vec.borrow_with(&row);
                 sql_rows.push(datums.iter().map(From::from).collect());
             }
-            SqlResult::Rows {
-                rows: sql_rows,
-                col_names,
-            }
+            SqlResult::rows(client, sql_rows, col_names)
         }
         res @ (ExecuteResponse::Fetch { .. }
         | ExecuteResponse::Subscribing { .. }
         | ExecuteResponse::CopyTo { .. }
         | ExecuteResponse::CopyFrom { .. }
-        | ExecuteResponse::Raise { .. }
         | ExecuteResponse::DeclaredCursor
         | ExecuteResponse::ClosedCursor) => {
             SqlResult::err(
+                client,
                 format!("internal error: encountered prohibited ExecuteResponse {:?}.\n\n
 This is a bug. Can you please file an issue letting us know?\n
 https://github.com/MaterializeInc/materialize/issues/new?assignees=&labels=C-bug%2CC-triage&template=01-bug.yml",
             ExecuteResponseKind::from(res)))
         }
     }
+}
+
+fn make_notices(client: &mut SessionClient) -> Vec<Notice> {
+    client
+        .session()
+        .drain_notices()
+        .map(|notice| Notice {
+            message: notice.to_string(),
+            severity: Severity::for_adapter_notice(&notice)
+                .as_str()
+                .to_lowercase(),
+        })
+        .collect()
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -131,43 +131,43 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCaseSimple {
             query: "select 1+2 as col",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[3]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[3]],"col_names":["col"],"notices":[]}]}"#,
         },
         // Multiple queries are ok.
         TestCaseSimple {
             query: "select 1; select 2",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"rows":[[2]],"col_names":["?column?"]}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"rows":[[2]],"col_names":["?column?"],"notices":[]}]}"#,
         },
         // Arrays + lists work
         TestCaseSimple {
             query: "select array[1], list[2]",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[[1],[2]]],"col_names":["array","list"]}]}"#,
+            body: r#"{"results":[{"rows":[[[1],[2]]],"col_names":["array","list"],"notices":[]}]}"#,
         },
         // Succeeding and failing queries can mix and match.
         TestCaseSimple {
             query: "select 1; select * from noexist;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"error":"unknown catalog item 'noexist'"}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"error":"unknown catalog item 'noexist'","notices":[]}]}"#,
         },
         // CREATEs should work when provided alone.
         TestCaseSimple {
             query: "create view v as select 1",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"CREATE VIEW"}]}"#,
+            body: r#"{"results":[{"ok":"CREATE VIEW","notices":[]}]}"#,
         },
         // Partial errors make it to the client.
         TestCaseSimple {
             query: "create view if not exists v as select 1",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"CREATE VIEW","partial_err":{"severity":"notice","message":"view already exists, skipping"}}]}"#,
+            body: r#"{"results":[{"ok":"CREATE VIEW","notices":[{"message":"view \"v\" already exists, skipping","severity":"notice"}]}]}"#,
         },
         // Multiple CREATEs do not work.
         TestCaseSimple {
             query: "create view v1 as select 1; create view v2 as select 1",
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block"}]}"#,
+            body: r#"{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block","notices":[]}]}"#,
         },
         // Syntax errors fail the request.
         TestCaseSimple {
@@ -179,128 +179,128 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCaseSimple {
             query: "create table t (a int);",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"CREATE TABLE"}]}"#,
+            body: r#"{"results":[{"ok":"CREATE TABLE","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "insert into t values (1)",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"INSERT 0 1"}]}"#,
+            body: r#"{"results":[{"ok":"INSERT 0 1","notices":[]}]}"#,
         },
         // n.b. this used to fail because the insert was treated as an
         // uncommitted explicit transaction
         TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["a"],"notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "delete from t",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
+            body: r#"{"results":[{"ok":"DELETE 1","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "delete from t",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
+            body: r#"{"results":[{"ok":"DELETE 0","notices":[]}]}"#,
         },
         // # Txns
         // ## Txns, read only
         TestCaseSimple {
             query: "begin; select 1; commit",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "begin; select 1; commit; select 2;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"rows":[[2]],"col_names":["?column?"]}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]},{"rows":[[2]],"col_names":["?column?"],"notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "select 1; begin; select 2; commit;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"rows":[[2]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"BEGIN","notices":[]},{"rows":[[2]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "begin; select 1/0; commit; select 2;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "begin; select 1; commit; select 1/0;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"COMMIT","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "select 1/0; begin; select 2; commit;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"error":"division by zero","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "select 1; begin; select 1/0; commit;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"],"notices":[]},{"ok":"BEGIN","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         // ## Txns w/ writes
         // Implicit txn aborted on first error
         TestCaseSimple {
             query: "insert into t values (1); select 1/0; insert into t values (2)",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         // Values not successfully written due to aborted txn
         TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[],"col_names":["a"],"notices":[]}]}"#,
         },
         // Explicit txn invocation commits values w/in txn, irrespective of results outside txn
         TestCaseSimple {
             query: "begin; insert into t values (1); commit; insert into t values (2); select 1/0;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["a"],"notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "delete from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
+            body: r#"{"results":[{"ok":"DELETE 1","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "delete from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
+            body: r#"{"results":[{"ok":"DELETE 0","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "insert into t values (1); begin; insert into t values (2); insert into t values (3); commit;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"}]}"#,
+            body: r#"{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"],"notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "delete from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"DELETE 3"}]}"#,
+            body: r#"{"results":[{"ok":"DELETE 3","notices":[]}]}"#,
         },
         // Explicit txn must be terminated to commit
         TestCaseSimple {
             query: "begin; insert into t values (1)",
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[],"col_names":["a"],"notices":[]}]}"#,
         },
-        // Emtpy query OK.
+        // Empty query OK.
         TestCaseSimple {
             query: "",
             status: StatusCode::OK,
@@ -310,7 +310,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCaseSimple {
             query: "select $1",
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"request supplied 0 parameters, but SELECT $1 requires 1"}]}"#,
+            body: r#"{"results":[{"error":"request supplied 0 parameters, but SELECT $1 requires 1","notices":[]}]}"#,
         },
         TestCaseSimple {
             query: "subscribe (select * from t)",
@@ -341,13 +341,13 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCaseExtended {
             requests: vec![("select $1+$2::int as col", vec![Some("1"), Some("2")])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[3]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[3]],"col_names":["col"],"notices":[]}]}"#,
         },
         // Parameters can be present and empty
         TestCaseExtended {
             requests: vec![("select 3 as col", vec![])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[3]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[3]],"col_names":["col"],"notices":[]}]}"#,
         },
         // Multiple statements
         TestCaseExtended {
@@ -356,7 +356,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("select $1+$2::int as col", vec![Some("1"), Some("2")]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"rows":[[3]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["col"],"notices":[]},{"rows":[[3]],"col_names":["col"],"notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![
@@ -364,7 +364,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("select 1 as col", vec![]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[3]],"col_names":["col"]},{"rows":[[1]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[3]],"col_names":["col"],"notices":[]},{"rows":[[1]],"col_names":["col"],"notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![
@@ -372,7 +372,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("select $1*$2::int as col", vec![Some("2"), Some("3")]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[3]],"col_names":["col"]},{"rows":[[6]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[3]],"col_names":["col"],"notices":[]},{"rows":[[6]],"col_names":["col"],"notices":[]}]}"#,
         },
         // Quotes escaped
         TestCaseExtended {
@@ -381,7 +381,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 vec![Some("abc"), Some("'abc'")],
             )],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[3,5]],"col_names":["length","length"]}]}"#,
+            body: r#"{"results":[{"rows":[[3,5]],"col_names":["length","length"],"notices":[]}]}"#,
         },
         // All parameters values treated as strings
         TestCaseExtended {
@@ -390,31 +390,31 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 vec![Some("sum(a)"), Some("SELECT * FROM t;")],
             )],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[6,16]],"col_names":["length","length"]}]}"#,
+            body: r#"{"results":[{"rows":[[6,16]],"col_names":["length","length"],"notices":[]}]}"#,
         },
         // Too many parameters
         TestCaseExtended {
             requests: vec![("select $1 as col", vec![Some("1"), Some("2")])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"request supplied 2 parameters, but SELECT $1 AS col requires 1"}]}"#,
+            body: r#"{"results":[{"error":"request supplied 2 parameters, but SELECT $1 AS col requires 1","notices":[]}]}"#,
         },
         // Too few parameters
         TestCaseExtended {
             requests: vec![("select $1+$2::int as col", vec![Some("1")])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2"}]}"#,
+            body: r#"{"results":[{"error":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2","notices":[]}]}"#,
         },
         // NaN
         TestCaseExtended {
             requests: vec![("select $1::decimal+2 as col", vec![Some("nan")])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[["NaN"]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[["NaN"]],"col_names":["col"],"notices":[]}]}"#,
         },
         // Null string value parameters
         TestCaseExtended {
             requests: vec![("select $1+$2::int as col", vec![Some("1"), None])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[null]],"col_names":["col"]}]}"#,
+            body: r#"{"results":[{"rows":[[null]],"col_names":["col"],"notices":[]}]}"#,
         },
         // Empty query
         TestCaseExtended {
@@ -451,7 +451,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("rollback", vec![]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"ROLLBACK"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"ROLLBACK","notices":[]}]}"#,
         },
         // - Implicit txn
         TestCaseExtended {
@@ -460,7 +460,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("select 1/0;", vec![]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         // - Errors prevent commit + further execution
         TestCaseExtended {
@@ -472,18 +472,18 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("commit", vec![]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         // - Requires explicit commit in explicit txn
         TestCaseExtended {
             requests: vec![("begin;", vec![]), ("insert into t values (1);", vec![])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
+            body: r#"{"results":[{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![("select * from t", vec![])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[],"col_names":["a"],"notices":[]}]}"#,
         },
         // Writes
         TestCaseExtended {
@@ -496,12 +496,12 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("select 1/0", vec![]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"INSERT 0 1","notices":[]},{"ok":"COMMIT","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![("select * from t", vec![])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"],"notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![
@@ -511,12 +511,12 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("commit;", vec![]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+            body: r#"{"results":[{"ok":"INSERT 0 1","notices":[]},{"ok":"BEGIN","notices":[]},{"error":"division by zero","notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![("select * from t", vec![])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
+            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"],"notices":[]}]}"#,
         },
         TestCaseExtended {
             requests: vec![("subscribe (select * from t)", vec![])],

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -27,5 +27,6 @@ mod message;
 mod protocol;
 mod server;
 
+pub use message::Severity;
 pub use protocol::match_handshake;
 pub use server::{Config, Server, TlsConfig, TlsMode};

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -10,15 +10,14 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use mz_adapter::session::ClientSeverity;
-use mz_adapter::ExecuteResponsePartialError;
 use postgres::error::SqlState;
 
 use mz_adapter::session::ClientSeverity as AdapterClientSeverity;
 use mz_adapter::session::TransactionStatus as AdapterTransactionStatus;
-use mz_adapter::{AdapterError, StartupMessage};
+use mz_adapter::{AdapterError, AdapterNotice, StartupMessage};
 use mz_expr::EvalError;
 use mz_repr::{ColumnName, NotNullViolation, RelationDesc};
+use mz_sql::ast::NoticeSeverity;
 
 // Pgwire protocol versions are represented as 32-bit integers, where the
 // high 16 bits represent the major version and the low 16 bits represent the
@@ -316,34 +315,6 @@ impl ErrorResponse {
         ErrorResponse::new(Severity::Notice, code, message)
     }
 
-    pub fn warning<S>(code: SqlState, message: S) -> ErrorResponse
-    where
-        S: Into<String>,
-    {
-        ErrorResponse::new(Severity::Warning, code, message)
-    }
-
-    pub fn info<S>(code: SqlState, message: S) -> ErrorResponse
-    where
-        S: Into<String>,
-    {
-        ErrorResponse::new(Severity::Info, code, message)
-    }
-
-    pub fn log<S>(code: SqlState, message: S) -> ErrorResponse
-    where
-        S: Into<String>,
-    {
-        ErrorResponse::new(Severity::Log, code, message)
-    }
-
-    pub fn debug<S>(code: SqlState, message: S) -> ErrorResponse
-    where
-        S: Into<String>,
-    {
-        ErrorResponse::new(Severity::Debug, code, message)
-    }
-
     fn new<S>(severity: Severity, code: SqlState, message: S) -> ErrorResponse
     where
         S: Into<String>,
@@ -358,7 +329,7 @@ impl ErrorResponse {
         }
     }
 
-    pub fn from_adapter(severity: Severity, e: AdapterError) -> ErrorResponse {
+    pub fn from_adapter_error(severity: Severity, e: AdapterError) -> ErrorResponse {
         // TODO(benesch): we should only use `SqlState::INTERNAL_ERROR` for
         // those errors that are truly internal errors. At the moment we have
         // a various classes of uncategorized errors that use this error code
@@ -440,6 +411,28 @@ impl ErrorResponse {
         }
     }
 
+    pub fn from_adapter_notice(notice: AdapterNotice) -> ErrorResponse {
+        let code = match &notice {
+            AdapterNotice::DatabaseAlreadyExists { .. } => SqlState::DUPLICATE_DATABASE,
+            AdapterNotice::SchemaAlreadyExists { .. } => SqlState::DUPLICATE_SCHEMA,
+            AdapterNotice::TableAlreadyExists { .. } => SqlState::DUPLICATE_TABLE,
+            AdapterNotice::ObjectAlreadyExists { .. } => SqlState::DUPLICATE_OBJECT,
+            AdapterNotice::ExistingTransactionInProgress => SqlState::ACTIVE_SQL_TRANSACTION,
+            AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
+                SqlState::NO_ACTIVE_SQL_TRANSACTION
+            }
+            AdapterNotice::UserRequested { .. } => SqlState::WARNING,
+        };
+        ErrorResponse {
+            severity: Severity::for_adapter_notice(&notice),
+            code,
+            message: notice.to_string(),
+            detail: notice.detail(),
+            hint: notice.hint(),
+            position: None,
+        }
+    }
+
     pub fn from_startup_message(message: StartupMessage) -> ErrorResponse {
         ErrorResponse {
             severity: Severity::Notice,
@@ -457,31 +450,6 @@ impl ErrorResponse {
     }
 }
 
-impl From<ExecuteResponsePartialError> for ErrorResponse {
-    fn from(
-        ExecuteResponsePartialError {
-            severity,
-            code,
-            message,
-        }: ExecuteResponsePartialError,
-    ) -> Self {
-        let gen = match severity {
-            ClientSeverity::Debug1
-            | ClientSeverity::Debug2
-            | ClientSeverity::Debug3
-            | ClientSeverity::Debug4
-            | ClientSeverity::Debug5 => Self::debug,
-            ClientSeverity::Error => Self::error,
-            ClientSeverity::Info => Self::info,
-            ClientSeverity::Log => Self::log,
-            ClientSeverity::Notice => Self::notice,
-            ClientSeverity::Warning => Self::warning,
-        };
-        gen(code, &message)
-    }
-}
-
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Severity {
     Panic,
@@ -582,6 +550,24 @@ impl Severity {
             (AdapterClientSeverity::Notice, Severity::Log | Severity::Debug) => false,
             (AdapterClientSeverity::Info, Severity::Log | Severity::Debug) => false,
             (AdapterClientSeverity::Log, Severity::Debug) => false,
+        }
+    }
+
+    pub fn for_adapter_notice(notice: &AdapterNotice) -> Severity {
+        match notice {
+            AdapterNotice::DatabaseAlreadyExists { .. } => Severity::Notice,
+            AdapterNotice::SchemaAlreadyExists { .. } => Severity::Notice,
+            AdapterNotice::TableAlreadyExists { .. } => Severity::Notice,
+            AdapterNotice::ObjectAlreadyExists { .. } => Severity::Notice,
+            AdapterNotice::ExistingTransactionInProgress => Severity::Warning,
+            AdapterNotice::ExplicitTransactionControlInImplicitTransaction => Severity::Warning,
+            AdapterNotice::UserRequested { severity } => match severity {
+                NoticeSeverity::Debug => Severity::Debug,
+                NoticeSeverity::Info => Severity::Info,
+                NoticeSeverity::Log => Severity::Log,
+                NoticeSeverity::Notice => Severity::Notice,
+                NoticeSeverity::Warning => Severity::Warning,
+            },
         }
     }
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -241,7 +241,7 @@ where
             Ok(startup) => startup,
             Err(e) => {
                 return conn
-                    .send(ErrorResponse::from_adapter(Severity::Fatal, e))
+                    .send(ErrorResponse::from_adapter_error(Severity::Fatal, e))
                     .await
             }
         };
@@ -303,6 +303,7 @@ where
         async move {
             let mut state = State::Ready;
             loop {
+                self.send_pending_notices().await?;
                 state = match state {
                     State::Ready => self.advance_ready().await?,
                     State::Drain => self.advance_drain().await?,
@@ -409,7 +410,7 @@ where
             .await
         {
             return self
-                .error(ErrorResponse::from_adapter(Severity::Error, e))
+                .error(ErrorResponse::from_adapter_error(Severity::Error, e))
                 .await;
         }
 
@@ -441,6 +442,7 @@ where
 
         let result = match self.adapter_client.execute(EMPTY_PORTAL.to_string()).await {
             Ok(response) => {
+                self.send_pending_notices().await?;
                 self.send_execute_response(
                     response,
                     stmt_desc.relation_desc,
@@ -453,7 +455,8 @@ where
                 .await
             }
             Err(e) => {
-                self.error(ErrorResponse::from_adapter(Severity::Error, e))
+                self.send_pending_notices().await?;
+                self.error(ErrorResponse::from_adapter_error(Severity::Error, e))
                     .await
             }
         };
@@ -587,7 +590,7 @@ where
                 Ok(State::Ready)
             }
             Err(e) => {
-                self.error(ErrorResponse::from_adapter(Severity::Error, e))
+                self.error(ErrorResponse::from_adapter_error(Severity::Error, e))
                     .await
             }
         }
@@ -607,10 +610,9 @@ where
     async fn end_transaction(&mut self, action: EndTransactionAction) -> Result<(), io::Error> {
         let resp = self.adapter_client.end_transaction(action).await;
         if let Err(err) = resp {
-            self.send(BackendMessage::ErrorResponse(ErrorResponse::from_adapter(
-                Severity::Error,
-                err,
-            )))
+            self.send(BackendMessage::ErrorResponse(
+                ErrorResponse::from_adapter_error(Severity::Error, err),
+            ))
             .await?;
         }
         Ok(())
@@ -636,7 +638,7 @@ where
             Ok(stmt) => stmt,
             Err(err) => {
                 return self
-                    .error(ErrorResponse::from_adapter(Severity::Error, err))
+                    .error(ErrorResponse::from_adapter_error(Severity::Error, err))
                     .await
             }
         };
@@ -736,7 +738,7 @@ where
             revision,
         ) {
             return self
-                .error(ErrorResponse::from_adapter(Severity::Error, err))
+                .error(ErrorResponse::from_adapter_error(Severity::Error, err))
                 .await;
         }
 
@@ -790,6 +792,7 @@ where
 
                     match self.adapter_client.execute(portal_name.clone()).await {
                         Ok(response) => {
+                            self.send_pending_notices().await?;
                             self.send_execute_response(
                                 response,
                                 row_desc,
@@ -802,7 +805,8 @@ where
                             .await
                         }
                         Err(e) => {
-                            self.error(ErrorResponse::from_adapter(Severity::Error, e))
+                            self.send_pending_notices().await?;
+                            self.error(ErrorResponse::from_adapter_error(Severity::Error, e))
                                 .await
                         }
                     }
@@ -854,7 +858,7 @@ where
             Ok(stmt) => stmt,
             Err(err) => {
                 return self
-                    .error(ErrorResponse::from_adapter(Severity::Error, err))
+                    .error(ErrorResponse::from_adapter_error(Severity::Error, err))
                     .await
             }
         };
@@ -1091,13 +1095,9 @@ where
         timeout: ExecuteTimeout,
     ) -> Result<State, io::Error> {
         let mut tag = response.tag();
-        let mut non_term_err = response.partial_err().map(ErrorResponse::from);
 
         macro_rules! command_complete {
             () => {{
-                if let Some(msg) = non_term_err.take() {
-                    self.send(msg).await?;
-                }
                 self.send(BackendMessage::CommandComplete {
                     tag: tag
                         .take()
@@ -1278,19 +1278,15 @@ where
             | ExecuteResponse::DroppedView
             | ExecuteResponse::Inserted(..)
             | ExecuteResponse::Prepare
-            | ExecuteResponse::Raise { .. }
+            | ExecuteResponse::Raised
             | ExecuteResponse::StartedTransaction { .. }
-            | ExecuteResponse::TransactionExited { .. }
+            | ExecuteResponse::TransactionCommitted
+            | ExecuteResponse::TransactionRolledBack
             | ExecuteResponse::Updated(..) => {
                 command_complete!()
             }
         };
 
-        assert!(
-            non_term_err.is_none(),
-            "non-terminal error created but not consumed: {:?}",
-            non_term_err
-        );
         assert!(tag.is_none(), "tag created but not consumed: {:?}", tag);
         r
     }
@@ -1666,7 +1662,7 @@ where
 
             if let Err(e) = self.adapter_client.insert_rows(id, columns, rows).await {
                 return self
-                    .error(ErrorResponse::from_adapter(Severity::Error, e))
+                    .error(ErrorResponse::from_adapter_error(Severity::Error, e))
                     .await;
             }
 
@@ -1675,6 +1671,17 @@ where
         }
 
         Ok(next_state)
+    }
+
+    async fn send_pending_notices(&mut self) -> Result<(), io::Error> {
+        let mut notices = vec![];
+        for notice in self.adapter_client.session().drain_notices() {
+            notices.push(BackendMessage::ErrorResponse(
+                ErrorResponse::from_adapter_notice(notice),
+            ));
+        }
+        self.send_all(notices).await?;
+        Ok(())
     }
 
     async fn error(&mut self, err: ErrorResponse) -> Result<State, io::Error> {


### PR DESCRIPTION
@sploiselle @mjibson I didn't adjust the tests yet because I wanted to get buy in on the design first!

----

Adjust the "partial errors" introduced in #14550 to "notices", which is the PostgreSQL term for these sorts of diagnostic errors generated during query execution.

The key generalization here is that a query execution may generate *any* number of notices, not just one.

The approach taken here is to attach notices on the Session during planning, where they can be later drained by the pgwire/http layer. This is *much* more convenient than needing plumbing booleans through `ExecuteResponse` that get turned into notices by `pgwire`, and will hopefully lead to additional notices being added in the future.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a