### PR TITLE
doc/user: prepare LTS documentation for switch

### DIFF
--- a/ci/deploy/website.sh
+++ b/ci/deploy/website.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 cd doc/user
-hugo --gc --baseURL /docs --destination public/docs
+hugo --gc --baseURL /docs/lts --destination public/docs/lts
 cp -R ../../ci/deploy/website/. public/
 hugo deploy
 

--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -312,7 +312,7 @@ header {
 }
 
 .navbar {
-    background: $darkest-purple-v2;
+    background-image: linear-gradient( 90deg, hsl(313deg, 93%, 55%) 0%, hsl(309deg, 84%, 52%) 11%, hsl(304deg, 76%, 49%) 22%, hsl(298deg, 73%, 48%) 33%, hsl(292deg, 71%, 49%) 44%, hsl(286deg, 72%, 51%) 56%, hsl(279deg, 73%, 52%) 67%, hsl(271deg, 75%, 53%) 78%, hsl(262deg, 76%, 55%) 89%, hsl(252deg, 77%, 56%) 100% );
     color: $white-v2;
     font-weight: 600;
     font-size: 14px;
@@ -384,30 +384,21 @@ header {
         transition: background-position 0.3s ease-out;
     }
 
-    &:hover {
-        background-position: 100% 100%;
-        text-decoration: none;
-    }
+        &:hover {
+            background-position: 100% 100%;
+            text-decoration: none;
+        }
 
-    &:featured {
-        background-size: 200% 200%;
-        background-image: linear-gradient(
-            300deg,
-            #c13aff 0%,
-            #7e52ff 31.36%,
-            #5c29f1 43.94%,
-            #e37ac2 76.56%,
-            #ff9067 85.53%
-        );
-        transition: all 0.2s ease-out;
-    }
+        &:featured {
+            background: $medium-purple-v2;
+        }
 
-    &:featured:hover {
-        color: #fff;
-    }
+        &:featured:hover {
+            background: $dark-purple-v2;
+        }
 
     .secondary {
-        opacity: 0.5;
+        opacity: 0.85;
     }
 }
 

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -9,10 +9,10 @@ weight: 1
 
 Materialize is a streaming database for real-time applications. It lets you ask complex questions about your data using SQL, and incrementally maintains the results of these SQL queries up-to-date as the underlying data changes.
 
-{{< callout primary_url="/docs/get-started/" primary_text="Get Early Access">}}
-  # Materialize is going cloud-native 🚀
+{{< callout primary_url="https://materialize.com/register/" primary_text="Get Early Access">}}
+  # Materialize has gone cloud-native 🚀
 
-  We are evolving the `materialized` binary into a cloud-native platform that extends the core Materialize functionality with **horizontal scaling**, **active replication** and **decoupled storage**.
+  We have evolved the `materialized` binary into a cloud-native platform that extends the core Materialize functionality with **horizontal scaling**, **active replication** and **decoupled storage**.
 
 {{</ callout >}}
 

--- a/doc/user/content/overview/_index.md
+++ b/doc/user/content/overview/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "What is Materialize?"
 description: "Learn more about Materialize"
+disable_list: true
 aliases:
   - /overview/what-is-materialize/
 menu:

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -22,6 +22,8 @@
 <meta name="twitter:title" content="{{ $title }}">
 <meta name="twitter:image" content="https://user-images.githubusercontent.com/11527560/159138593-09223308-ce91-4582-a47a-a03166fef26b.gif">
 <meta name="twitter:description" content="{{ $description }}">
+{{/* Avoid indexing the LTS documentation. */}}
+<meta name="robots" content="noindex">
 <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
 <link rel=apple-touch-icon sizes=180x180 href="{{ .Site.BaseURL }}/images/materialize_logo_180.png">
 <link rel=icon type="image/png" sizes=32x32 href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
@@ -45,7 +47,7 @@ addEventListener("DOMContentLoaded", () => {
   docsearch({
     apiKey: "cf315153e0b62d66538a2f8b86bfb93f",
     appId: "9LF5B9GMOF",
-    indexName: "materialize",
+    indexName: "materialize_lts",
     inputSelector: '#search-input',
     debug: true,
   });

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -11,15 +11,10 @@
         <path class="logo--mark-4" d="M25.0888 19.7874C24.1549 18.8714 23.2122 17.9642 22.2872 17.0392C21.0287 15.7852 19.7836 14.5178 18.534 13.2593C18.534 12.281 18.534 11.3071 18.534 10.3288C18.5242 10.2288 18.5367 10.1279 18.5705 10.0334C18.6043 9.9388 18.6587 9.85289 18.7297 9.78181L24.8531 3.68951C24.902 3.64059 24.9643 3.60057 25.0087 3.56055C25.1466 3.60946 25.1066 3.71174 25.1066 3.78734C25.1066 9.04955 25.1066 14.3103 25.1066 19.5695C25.1052 19.6425 25.0993 19.7152 25.0888 19.7874V19.7874Z" fill="white" fill-opacity="0.5"></path>
       </svg>
     </a>
-    <a role="menuitem" href="https://materialize.com/">Materialize</a>
-    <div class="flex_grow text_center">
-      <a role="menuitem" class="active" href="{{.Site.BaseURL}}">Docs</a>
-      <a role="menuitem" class="hoverable" href="https://materialize.com/blog">Blog</a>
-      <a role="menuitem" class="hoverable" href="https://materialize.com/case-study">Customers</a>
-      <a role="menuitem" class="hoverable" href="https://materialize.com/about">Company</a>
-    </div>
+    <div class="flex_grow"><a role="menuitem" href="https://materialize.com/">Materialize</a>/ Long-Term Support (LTS)</div>
+    <a class="secondary" role="menuitem" href="https://materialize.com/docs">Back to Stable Docs ➟</a>
     <a class="secondary" role="menuitem" href="https://cloud.materialize.com/">Log In</a>
-    <a class="btn featured" role="menuitem"  href="https://materialize.com/materialize-cloud-access/">Get Early Access</a>
+    <a class="btn featured" role="menuitem"  href="https://materialize.com/register/">Get Early Access</a>
   </div>
 </nav>
 


### PR DESCRIPTION
> ✈️  **Not sure how my internet will fare on the plane, so if someone could see this through when the time comes, it'd be great!**

Changing the look of the LTS docs to signal that these are no longer the stable docs for Materialize.

This PR should be merged **before** the PR that switches the build system to deploy `lts-docs`->`/docs/lts`.

<img width="1435" alt="Screenshot 2022-10-03 at 01 35 55" src="https://user-images.githubusercontent.com/23521087/193481294-fdf9003b-5db0-4fb0-a148-b09b3ac466b5.png">
