### PR TITLE
doc/user: switch build from `/docs` to `/docs/lts`

### DIFF
--- a/ci/deploy/website.sh
+++ b/ci/deploy/website.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 cd doc/user
-hugo --gc --baseURL /docs --destination public/docs
+hugo --gc --baseURL /docs/lts --destination public/docs/lts
 cp -R ../../ci/deploy/website/. public/
 hugo deploy
 

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -22,6 +22,8 @@
 <meta name="twitter:title" content="{{ $title }}">
 <meta name="twitter:image" content="https://user-images.githubusercontent.com/11527560/159138593-09223308-ce91-4582-a47a-a03166fef26b.gif">
 <meta name="twitter:description" content="{{ $description }}">
+{{/* Avoid indexing the LTS documentation. */}}
+<meta name="robots" content="noindex">
 <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
 <link rel=apple-touch-icon sizes=180x180 href="{{ .Site.BaseURL }}/images/materialize_logo_180.png">
 <link rel=icon type="image/png" sizes=32x32 href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
@@ -45,7 +47,7 @@ addEventListener("DOMContentLoaded", () => {
   docsearch({
     apiKey: "cf315153e0b62d66538a2f8b86bfb93f",
     appId: "9LF5B9GMOF",
-    indexName: "materialize",
+    indexName: "materialize_lts",
     inputSelector: '#search-input',
     debug: true,
   });


### PR DESCRIPTION
> ✈️  **Not sure how my internet will fare on the plane, so if someone could see this through when the time comes, it'd be great!**

The documentation for the LTS version of Materialize should be deployed to `/docs/lts`, moving forward. This PR adjusts the URLs Hugo points to, and updates the Algolia index.

I wasn't sure if the existing indexes could be repurposed, but created a new `materialize_lts` index for this. For the inverse process: would we need to drop the existing `materialize` index and create a new one with the ported configuration from `materialize_unstable`? @ruf-io 

### TODO

Once we're ready to merge, there is the additional step of updating the crawler in Algolia (IIUC):

* Rename the [`materialize` crawler](https://crawler.algolia.com/admin/crawlers/?sort=status&order=ASC&limit=20&appId=9LF5B9GMOF) to `materialize_lts` 
* [Edit](https://crawler.algolia.com/admin/crawlers/9ba7ecc4-1d7e-41e5-a7bb-d80945a4c3b0/configuration/edit) the crawler to use:
  * `indexName: "materialize_lts"`
  * ` startUrls: ["https://materialize.com/docs/lts/"]`
  * `discoveryPatterns: ["https://materialize.com/docs/lts/*"]`
  * `pathsToMatch: ["https://materialize.com/docs/lts/**"]`
* Save and trigger a recrawl from the UI