### PR TITLE
doc/user: switch build from `/docs/unstable` to `/docs`

### DIFF
--- a/ci/deploy/website.sh
+++ b/ci/deploy/website.sh
@@ -33,7 +33,7 @@ declare -A shortlinks=(
 )
 
 cd doc/user
-hugo --gc --baseURL /docs/unstable --destination public/docs/unstable
+hugo --gc --baseURL /docs --destination public/docs
 cp -R ../../ci/deploy/website/. public/
 hugo deploy
 

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -22,8 +22,6 @@
 <meta name="twitter:title" content="{{ $title }}">
 <meta name="twitter:image" content="https://user-images.githubusercontent.com/11527560/159138593-09223308-ce91-4582-a47a-a03166fef26b.gif">
 <meta name="twitter:description" content="{{ $description }}">
-{{/* TODO(benesch): allow indexing when platform docs become the live docs. */}}
-<meta name="robots" content="noindex">
 <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
 <link rel=apple-touch-icon sizes=180x180 href="{{ .Site.BaseURL }}/images/materialize_logo_180.png">
 <link rel=icon type="image/png" sizes=32x32 href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
@@ -50,7 +48,7 @@ addEventListener("DOMContentLoaded", () => {
   docsearch({
     apiKey: "5fb0a95d60e603d3c83c2506e1de4a64",
     appId: "9LF5B9GMOF",
-    indexName: "materialize_unstable",
+    indexName: "materialize",
     container: '#docsearch',
   });
 });


### PR DESCRIPTION
> ✈️  **Not sure how my internet will fare on the plane, so if someone could see this through when the time comes, it'd be great!**

Complement to #15129, switching the current `/docs/unstable` to `/docs`. The same questions about Algolia indexes apply!

### TODO

Once we're ready to merge, there is the additional step of updating the crawler in Algolia (IIUC):

* Rename the [`materialize_unstable` crawler](https://crawler.algolia.com/admin/crawlers/a2fc6913-e2ea-490c-95bd-f4dc4e340dbf/overview) to `materialize` 
* [Edit](https://crawler.algolia.com/admin/crawlers/a2fc6913-e2ea-490c-95bd-f4dc4e340dbf/configuration/edit) the crawler to use:
  * `indexName: "materialize"`
  * ` startUrls: ["https://materialize.com/docs", "https://materialize.com/"],`
  * `discoveryPatterns: ["https://materialize.com/**"],`
  * `pathsToMatch: ["https://materialize.com/docs**/**"],`
* Save and trigger a recrawl from the UI