### PR TITLE
limits test: use correct compute port number

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1414,7 +1414,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                         f"{replica_name} (REMOTE ["
                         + ", ".join(f"'{n}:2100'" for n in nodes)
                         + "], COMPUTE ["
-                        + ", ".join(f"'{n}:2100'" for n in nodes)
+                        + ", ".join(f"'{n}:2102'" for n in nodes)
                         + f"], WORKERS {args.workers})"
                     )
 


### PR DESCRIPTION
Fixes #15132

### Tips for reviewer

Must run nightlies on this branch

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

 None

