### PR TITLE
environmentd: remove deprecated sql parameter from HTTP API

### DIFF
--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -44,9 +44,6 @@ pub enum SqlRequest {
     Simple {
         /// A query string containing zero or more queries delimited by
         /// semicolons.
-        // TODO: we can remove this alias once platforms issues these requests
-        // using `query`.
-        #[serde(alias = "sql")]
         query: String,
     },
     /// An extended query request.
@@ -59,9 +56,6 @@ pub enum SqlRequest {
 /// An request to execute a SQL query using the extended protocol.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ExtendedRequest {
-    // TODO: we can remove this alias once platforms issues these requests
-    // using `query`.
-    #[serde(alias = "sql")]
     /// A query string containing zero or one queries.
     query: String,
     /// Optional parameters for the query.

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -318,7 +318,7 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                                 HeaderValue::from_static("application/json"),
                             );
                             req.body(Body::from(
-                                json!({"sql": "SELECT pg_catalog.current_user()"}).to_string(),
+                                json!({"query": "SELECT pg_catalog.current_user()"}).to_string(),
                             ))
                             .unwrap()
                         }),


### PR DESCRIPTION
`query` is now the preferred spelling. Remove the deprecated `sql` alias.

This can merge as long as MaterializeInc/cloud#4165 makes it to production before tomorrow's release.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR removes a deprecated feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
