### PR TITLE
sql: move remaining AWS options to connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,6 +4056,7 @@ dependencies = [
  "enum-kinds",
  "globset",
  "hex",
+ "http",
  "itertools",
  "mz-build-info",
  "mz-ccsr",

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -67,7 +67,7 @@ of queries that obey the spacing rules
 ```sql
 CREATE TABLE t (a varchar(40));
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'localhost:9092';
-CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn (TOPIC 'top') LEGACYWITH (config_param = 'yes') FORMAT BYTES;
+CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn (TOPIC 'top') WITH (size = 'small') FORMAT BYTES;
 SELECT coalesce(1, NULL, 2);
 SELECT CAST (1 AS text); -- note the space after CAST
 SELECT (1 + 2) - (7 * 4);
@@ -78,7 +78,7 @@ and several queries that don't:
 ```sql
 CREATE TABLE t (a varchar (40));
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'localhost:9092';
-CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn )TOPIC 'top') LEGACYWITH(tail=true);
+CREATE SOURCE test FROM KAFKA CONNECTION kafka_conn (TOPIC'top') WITH (size='small');
 SELECT coalesce (1, NULL,2);
 SELECT CAST(1 AS text);
 SELECT 1+2;

--- a/doc/user/content/overview/timelines.md
+++ b/doc/user/content/overview/timelines.md
@@ -40,13 +40,13 @@ CREATE SOURCE source_1
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'topic-1')
   FORMAT AVRO USING SCHEMA 'schema-1'
   ENVELOPE MATERIALIZE
-  LEGACYWITH (TIMELINE 'my_user_timeline');
+  WITH (TIMELINE 'my_user_timeline');
 
 CREATE SOURCE source_2
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'topic-2')
   FORMAT AVRO USING SCHEMA 'schema-2'
   ENVELOPE MATERIALIZE
-  LEGACYWITH (TIMELINE 'my_user_timeline');
+  WITH (TIMELINE 'my_user_timeline');
 ```
 
 ## CDC Sources
@@ -63,7 +63,7 @@ CREATE SOURCE source_3
   FROM KAFKA CONDITION kafka_conn (TOPIC 'topic-3')
   FORMAT AVRO USING SCHEMA 'schema'
   ENVELOPE MATERIALIZE
-  LEGACYWITH (TIMELINE 'mz_epoch_ms')
+  WITH (TIMELINE 'mz_epoch_ms')
 ```
 
 [cdc-sources]: /connect/materialize-cdc

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -688,6 +688,9 @@ impl_display_t!(PostgresConnectionOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AwsConnectionOptionName {
     AccessKeyId,
+    Endpoint,
+    Region,
+    RoleArn,
     SecretAccessKey,
     Token,
 }
@@ -696,6 +699,9 @@ impl AstDisplay for AwsConnectionOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             AwsConnectionOptionName::AccessKeyId => "ACCESS KEY ID",
+            AwsConnectionOptionName::Endpoint => "ENDPOINT",
+            AwsConnectionOptionName::Region => "REGION",
+            AwsConnectionOptionName::RoleArn => "ROLE ARN",
             AwsConnectionOptionName::SecretAccessKey => "SECRET ACCESS KEY",
             AwsConnectionOptionName::Token => "TOKEN",
         })

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -454,7 +454,6 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
     pub connection: CreateSourceConnection<T>,
-    pub legacy_with_options: Vec<WithOption<T>>,
     pub include_metadata: Vec<SourceIncludeMetadata>,
     pub format: CreateSourceFormat<T>,
     pub envelope: Option<Envelope>,
@@ -486,11 +485,6 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
         }
         f.write_str("FROM ");
         f.write_node(&self.connection);
-        if !self.legacy_with_options.is_empty() {
-            f.write_str(" LEGACYWITH (");
-            f.write_node(&display::comma_separated(&self.legacy_with_options));
-            f.write_str(")");
-        }
         f.write_node(&self.format);
         if !self.include_metadata.is_empty() {
             f.write_str(" INCLUDE ");

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -111,6 +111,7 @@ Drop
 Else
 Enable
 End
+Endpoint
 Enforced
 Envelope
 Escape
@@ -181,7 +182,6 @@ Latest
 Leading
 Least
 Left
-Legacywith
 Level
 Like
 Limit
@@ -258,6 +258,7 @@ Real
 References
 Refresh
 Regex
+Region
 Registry
 Remote
 Rename

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2163,18 +2163,25 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_aws_connection_option(&mut self) -> Result<AwsConnectionOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[ACCESS, SECRET, TOKEN])? {
-            ACCESS => {
-                self.expect_keywords(&[KEY, ID])?;
-                AwsConnectionOptionName::AccessKeyId
-            }
-            SECRET => {
-                self.expect_keywords(&[ACCESS, KEY])?;
-                AwsConnectionOptionName::SecretAccessKey
-            }
-            TOKEN => AwsConnectionOptionName::Token,
-            _ => unreachable!(),
-        };
+        let name =
+            match self.expect_one_of_keywords(&[ACCESS, ENDPOINT, REGION, ROLE, SECRET, TOKEN])? {
+                ACCESS => {
+                    self.expect_keywords(&[KEY, ID])?;
+                    AwsConnectionOptionName::AccessKeyId
+                }
+                ENDPOINT => AwsConnectionOptionName::Endpoint,
+                REGION => AwsConnectionOptionName::Region,
+                ROLE => {
+                    self.expect_keyword(ARN)?;
+                    AwsConnectionOptionName::RoleArn
+                }
+                SECRET => {
+                    self.expect_keywords(&[ACCESS, KEY])?;
+                    AwsConnectionOptionName::SecretAccessKey
+                }
+                TOKEN => AwsConnectionOptionName::Token,
+                _ => unreachable!(),
+            };
 
         let _ = self.consume_token(&Token::Eq);
         Ok(AwsConnectionOption {
@@ -2205,7 +2212,6 @@ impl<'a> Parser<'a> {
         let (col_names, key_constraint) = self.parse_source_columns()?;
         self.expect_keyword(FROM)?;
         let connection = self.parse_create_source_connection()?;
-        let legacy_with_options = self.parse_legacy_with_options()?;
         let format = match self.parse_one_of_keywords(&[KEY, FORMAT]) {
             Some(KEY) => {
                 self.expect_keyword(FORMAT)?;
@@ -2240,7 +2246,6 @@ impl<'a> Parser<'a> {
             name,
             col_names,
             connection,
-            legacy_with_options,
             format,
             include_metadata,
             envelope,
@@ -3279,14 +3284,6 @@ impl<'a> Parser<'a> {
 
     fn parse_opt_with_options(&mut self) -> Result<Vec<WithOption<Raw>>, ParserError> {
         if self.parse_keyword(WITH) {
-            self.parse_with_options(true)
-        } else {
-            Ok(vec![])
-        }
-    }
-
-    fn parse_legacy_with_options(&mut self) -> Result<Vec<WithOption<Raw>>, ParserError> {
-        if self.parse_keyword(LEGACYWITH) {
             self.parse_with_options(true)
         } else {
             Ok(vec![])

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1176,7 +1176,7 @@ DROP CONNECTION conn1
 DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT BYTES
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
 =>
@@ -1270,9 +1270,9 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') WITH
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("red"))) }] }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
-# Ensure that we can parse legacy and non-legacy options
+# Ensure that we can parse options
 parse-statement
-CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') legacywith (a = 'hmm') with (REMOTE 'johto:42');
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red') with (REMOTE 'johto:42');
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION = 'red') LEGACYWITH (a = 'hmm') WITH (REMOTE = 'johto:42')
 =>

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4.22", default-features = false, features = ["clock", "s
 enum-kinds = "0.5.1"
 globset = "0.4.9"
 hex = "0.4.3"
+http = "0.2.8"
 itertools = "0.10.4"
 once_cell = "1.14.0"
 mz-build-info = { path = "../build-info" }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -41,7 +41,7 @@ use mz_sql_parser::ast::{
     SshConnectionOption,
 };
 use mz_storage::source::generator::as_generator;
-use mz_storage::types::connections::aws::AwsCredentials;
+use mz_storage::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
 use mz_storage::types::connections::{
     Connection, CsrConnectionHttpAuth, KafkaConnection, KafkaSecurity, KafkaTlsConfig, SaslConfig,
     StringOrSecret, TlsIdentity,
@@ -328,7 +328,6 @@ pub fn plan_create_source(
         name,
         col_names,
         connection,
-        legacy_with_options,
         envelope,
         if_not_exists,
         format,
@@ -339,15 +338,11 @@ pub fn plan_create_source(
 
     let envelope = envelope.clone().unwrap_or(Envelope::None);
 
-    let legacy_with_options_original = legacy_with_options;
-    let mut legacy_with_options = normalize::options(legacy_with_options_original)?;
-
     const SAFE_WITH_OPTIONS: &[CreateSourceOptionName] = &[CreateSourceOptionName::Size];
 
-    if !legacy_with_options.is_empty()
-        || with_options
-            .iter()
-            .any(|op| !SAFE_WITH_OPTIONS.contains(&op.name))
+    if with_options
+        .iter()
+        .any(|op| !SAFE_WITH_OPTIONS.contains(&op.name))
     {
         scx.require_unsafe_mode(&format!(
             "creating sources with WITH options other than {}",
@@ -508,21 +503,12 @@ pub fn plan_create_source(
                 ),
             };
 
-            let region = arn
-                .region
-                .ok_or_else(|| sql_err!("Provided ARN does not include an AWS region"))?;
-
             let item = scx.get_item_by_resolved_name(aws_connection)?;
-            let aws_connection = match item.connection()? {
-                Connection::Aws(connection) => connection.clone(),
+            let aws = match item.connection()? {
+                Connection::Aws(aws) => aws.clone(),
                 _ => sql_bail!("{} is not an AWS connection", item.name()),
             };
 
-            let aws = normalize::aws_config(
-                &mut legacy_with_options,
-                Some(region.into()),
-                aws_connection,
-            )?;
             let encoding = get_encoding(scx, format, &envelope, connection)?;
             let connection =
                 SourceConnection::Kinesis(KinesisSourceConnection { stream_name, aws });
@@ -537,12 +523,11 @@ pub fn plan_create_source(
             scx.require_unsafe_mode("CREATE SOURCE ... FROM S3")?;
 
             let item = scx.get_item_by_resolved_name(aws_connection)?;
-            let aws_connection = match item.connection()? {
-                Connection::Aws(connection) => connection.clone(),
+            let aws = match item.connection()? {
+                Connection::Aws(aws) => aws.clone(),
                 _ => sql_bail!("{} is not an AWS connection", item.name()),
             };
 
-            let aws = normalize::aws_config(&mut legacy_with_options, None, aws_connection)?;
             let mut converted_sources = Vec::new();
             for ks in key_sources {
                 let dtks = match ks {
@@ -792,8 +777,6 @@ pub fn plan_create_source(
         },
         desc,
     };
-
-    normalize::ensure_empty_options(&legacy_with_options, "CREATE SOURCE")?;
 
     Ok(Plan::CreateSource(CreateSourcePlan {
         name,
@@ -2065,7 +2048,12 @@ pub fn plan_create_type(
                 };
             }
 
-            normalize::ensure_empty_options(&with_options, "CREATE TYPE")?;
+            if !with_options.is_empty() {
+                sql_bail!(
+                    "unexpected parameters for CREATE TYPE: {}",
+                    with_options.keys().join(",")
+                )
+            }
         }
         CreateTypeAs::Record { ref column_defs } => {
             for column_def in column_defs {
@@ -2662,22 +2650,41 @@ generate_extracted_config!(
     AwsConnectionOption,
     (AccessKeyId, StringOrSecret),
     (SecretAccessKey, with_options::Secret),
-    (Token, StringOrSecret)
+    (Token, StringOrSecret),
+    (Endpoint, String),
+    (Region, String),
+    (RoleArn, String)
 );
 
-impl TryFrom<AwsConnectionOptionExtracted> for AwsCredentials {
+impl TryFrom<AwsConnectionOptionExtracted> for AwsConfig {
     type Error = PlanError;
 
     fn try_from(options: AwsConnectionOptionExtracted) -> Result<Self, Self::Error> {
-        Ok(AwsCredentials {
-            access_key_id: options
-                .access_key_id
-                .ok_or_else(|| sql_err!("ACCESS KEY ID option is required"))?,
-            secret_access_key: options
-                .secret_access_key
-                .ok_or_else(|| sql_err!("SECRET ACCESS KEY option is required"))?
-                .into(),
-            session_token: options.token,
+        Ok(AwsConfig {
+            credentials: AwsCredentials {
+                access_key_id: options
+                    .access_key_id
+                    .ok_or_else(|| sql_err!("ACCESS KEY ID option is required"))?,
+                secret_access_key: options
+                    .secret_access_key
+                    .ok_or_else(|| sql_err!("SECRET ACCESS KEY option is required"))?
+                    .into(),
+                session_token: options.token,
+            },
+            endpoint: match options.endpoint {
+                // TODO(benesch): this should not treat an empty endpoint as
+                // equivalent to a `NULL` endpoint, but making that change now
+                // would break testdrive. AWS connections are all behind unsafe
+                // mode right now, so no particular urgency to correct this.
+                Some(endpoint) if !endpoint.is_empty() => {
+                    let endpoint = http::Uri::from_str(&endpoint)
+                        .map_err(|e| PlanError::Unstructured(e.to_string()))?;
+                    Some(SerdeUri(endpoint))
+                }
+                _ => None,
+            },
+            region: options.region,
+            role: options.role_arn.map(|arn| AwsAssumeRole { arn }),
         })
     }
 }
@@ -2709,7 +2716,7 @@ pub fn plan_create_connection(
         }
         CreateConnection::Aws { with_options } => {
             let c = AwsConnectionOptionExtracted::try_from(with_options)?;
-            let connection = AwsCredentials::try_from(c)?;
+            let connection = AwsConfig::try_from(c)?;
             Connection::Aws(connection)
         }
         CreateConnection::Ssh { with_options } => {

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -28,9 +28,7 @@ use mz_repr::url::any_url;
 use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 
-use crate::types::connections::aws::AwsExternalIdPrefix;
-
-use self::aws::AwsCredentials;
+use crate::types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
 
 pub mod aws;
 
@@ -148,7 +146,7 @@ pub enum Connection {
     Csr(CsrConnection),
     Postgres(PostgresConnection),
     Ssh(SshConnection),
-    Aws(AwsCredentials),
+    Aws(AwsConfig),
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/src/storage/src/types/connections/aws.rs
+++ b/src/storage/src/types/connections/aws.rs
@@ -79,7 +79,7 @@ pub struct AwsExternalIdPrefix(pub(super) String);
 ///
 /// This is a distinct type from any of the configuration types built into the
 /// AWS SDK so that we can implement `Serialize` and `Deserialize`.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct AwsConfig {
     /// AWS Credentials, or where to find them
     pub credentials: AwsCredentials,
@@ -146,7 +146,7 @@ impl RustType<ProtoAwsCredentials> for AwsCredentials {
 }
 
 /// A role for Materialize to assume when performing AWS API calls.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct AwsAssumeRole {
     /// The Amazon Resource Name of the role to assume.
     pub arn: String,

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -66,15 +66,6 @@ $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
 {"before": null, "after": {"row": {"a": 1}}}
 {"before": null, "after": {"row": {"a": 2}}}
 
-# Old with options do not work
-! CREATE SOURCE connector_source
-  FROM KAFKA CONNECTION kafka_sasl (TOPIC 'testdrive-data-${testdrive.seed}')
-  LEGACYWITH (
-    security_protocol = 'sasl_ssl'
-  )
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
-contains:unexpected parameters for CREATE SOURCE: security_protocol
-
 # Ensure that connectors do not require the certificate authority
 > CREATE CONNECTION kafka_sasl_no_ca
   FOR KAFKA

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -40,21 +40,3 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     SASL USERNAME = 'materialize',
     SSL CERTIFICATE AUTHORITY = '${arg.ca}';
 contains:invalid CONNECTION: under-specified security configuration
-
-# > CREATE CONNECTION kafka_conn
-#  FOR KAFKA BROKER '${testdrive.kafka-addr}';
-#
-# ! CREATE SOURCE data
-#   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
-#   LEGACYWITH (
-#       security_protocol = 'SASL_SSL',
-#       sasl_mechanisms = 'PLAIN',
-#       sasl_username = 'materialize',
-#       sasl_password_env = 'SASL_PASSWORD',
-#       ssl_ca_location = '/share/secrets/ca.crt'
-#   )
-#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-#   WITH (
-#       ssl_ca_location = '/share/secrets/ca.crt'
-#   )
-#   ENVELOPE DEBEZIUM

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -129,9 +129,6 @@ a
 # Old with_options do not work
 ! CREATE SOURCE IF NOT EXISTS duplicate_option_specified
   FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
-  LEGACYWITH (
-    security_protocol = 'ssl'
-  )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
 contains:unexpected parameters for CREATE SOURCE: security_protocol
 

--- a/test/s3-resumption/configure-materialize.td
+++ b/test/s3-resumption/configure-materialize.td
@@ -12,16 +12,14 @@
 > CREATE CONNECTION IF NOT EXISTS s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE s3_text
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 's3/*.text'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > CREATE SOURCE s3_gzip
@@ -29,8 +27,4 @@
   DISCOVER OBJECTS MATCHING 's3/*.gzip'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
   COMPRESSION GZIP
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -25,4 +25,4 @@ statement ok
 CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker';
 
 statement error materialize.public.not_a_secret is not a secret
-CREATE SOURCE source FROM KAFKA CONNECTION kafka_conn (TOPIC 'topic') LEGACYWITH (secret = SECRET not_a_secret);
+CREATE CONNECTION kafka_conn FOR KAFKA BROKER 'broker', SASL PASSWORD = SECRET not_a_secret;

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -21,27 +21,13 @@ place""",CA,92679
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
-
-# We should refuse to create a source with invalid LEGACYWITH options
-! CREATE SOURCE invalid_with_option
-  FROM S3 CONNECTION s3_conn
-  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    badoption = true
-  )
-  FORMAT CSV WITH 3 COLUMNS
-contains:unexpected parameters for CREATE SOURCE: badoption
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE mismatched_column_count
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH 2 COLUMNS
 ! SELECT * FROM mismatched_column_count
 contains:CSV error at record number 1: expected 2 columns, got 3.
@@ -49,10 +35,6 @@ contains:CSV error at record number 1: expected 2 columns, got 3.
 > CREATE SOURCE matching_column_names
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names where zip = '14618'
@@ -63,10 +45,6 @@ Rochester NY 14618
 > CREATE SOURCE matching_column_names_alias (a, b, c)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names_alias where c = '14618'
@@ -77,10 +55,6 @@ Rochester NY 14618
 > CREATE SOURCE mismatched_column_names
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (cities, country, zip)
 ! SELECT * FROM mismatched_column_names
 contains:first mismatched column at index 1 expected=cities actual="city"
@@ -88,10 +62,6 @@ contains:first mismatched column at index 1 expected=cities actual="city"
 > CREATE SOURCE mismatched_column_names_count
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (cities, state)
 ! SELECT * FROM mismatched_column_names_count
 contains:CSV error at record number 1: expected 2 columns, got 3
@@ -100,10 +70,6 @@ contains:CSV error at record number 1: expected 2 columns, got 3
 > CREATE SOURCE static_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH 3 COLUMNS
 
 > SELECT * FROM static_csv
@@ -117,10 +83,6 @@ Rochester      NY        14618
 ! CREATE SOURCE static_csv_nothing_demanded_src
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER
 contains:Expected a list of columns in parentheses, found EOF
 
@@ -134,10 +96,6 @@ $ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM static_csv_manual_header
@@ -188,10 +146,6 @@ badint,
 > CREATE SOURCE malformed_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'malformed.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM malformed_csv
@@ -205,10 +159,6 @@ dollars,category
 > CREATE SOURCE bad_text_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'bad-text.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM bad_text_csv
@@ -221,10 +171,6 @@ $ kafka-create-topic topic=static-csv-pkne-sink partitions=1
 > CREATE SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -18,15 +18,13 @@ bar
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE posix
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT BYTES;
 
 > SELECT data FROM posix
@@ -40,10 +38,6 @@ bar
 > CREATE SOURCE non_posix
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'non-posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT BYTES;
 
 > SELECT data FROM non_posix

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -116,15 +116,6 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 > CREATE CONNECTION kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
-# We should refuse to create a source with invalid WITH options
-! CREATE SOURCE invalid_with_option
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
-  LEGACYWITH (badoption = true)
-  KEY FORMAT AVRO USING SCHEMA '${key-schema}'
-  VALUE FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
-contains:unexpected parameters for CREATE SOURCE: badoption
-
 > SHOW SOURCES
 name    type
 ------------

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -61,15 +61,13 @@ $ s3-put-object bucket=test key=static.csv
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 ! CREATE SOURCE headers_src
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (city, state, zip)
   INCLUDE HEADERS
 contains:INCLUDE HEADERS with non-Kafka sources not supported

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -198,15 +198,6 @@ id creature
 -----------
 3  triceratops
 
-# Test that it doesn't work with full deduplication
-! CREATE SOURCE upsert_full_dedupe
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
-  LEGACYWITH (deduplication = 'full')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM
-contains:unexpected parameters for CREATE SOURCE: deduplication
-
-
 # test include metadata
 > CREATE SOURCE upsert_metadata
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -26,7 +26,8 @@ here is a second test string
 
 > CREATE CONNECTION kinesis_bad_conn FOR AWS
   ACCESS KEY ID = 'fake_access_key_id',
-  SECRET ACCESS KEY = SECRET kinesis_bad_conn_secret;
+  SECRET ACCESS KEY = SECRET kinesis_bad_conn_secret,
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 ! CREATE SOURCE custom_source
   FROM KINESIS CONNECTION kinesis_bad_conn
@@ -44,7 +45,6 @@ contains:dns error: failed to lookup address information: Name or service not kn
 > CREATE SOURCE f
   FROM KINESIS CONNECTION kinesis_conn
   ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
-  LEGACYWITH (endpoint = '${testdrive.aws-endpoint}')
   FORMAT BYTES;
 
 > CREATE MATERIALIZED VIEW f_view

--- a/test/testdrive/s3-gzip.td
+++ b/test/testdrive/s3-gzip.td
@@ -26,16 +26,14 @@ b3
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE s3_all_none
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-no-compression-${testdrive.seed}'
   COMPRESSION NONE
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_all_none
@@ -67,10 +65,6 @@ b3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-gzip-compression-${testdrive.seed}'
   COMPRESSION GZIP
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_all_gzip

--- a/test/testdrive/s3.td
+++ b/test/testdrive/s3.td
@@ -24,15 +24,13 @@ b3
 > CREATE CONNECTION s3_conn FOR AWS
   ACCESS KEY ID = '${testdrive.aws-access-key-id}',
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
-  TOKEN = '${testdrive.aws-token}';
+  TOKEN = '${testdrive.aws-token}',
+  REGION = '${testdrive.aws-region}',
+  ENDPOINT = '${testdrive.aws-endpoint}';
 
 > CREATE SOURCE s3_all
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_all
@@ -46,10 +44,6 @@ b3
 > CREATE SOURCE s3_glob_a
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING '**/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_glob_a
@@ -60,10 +54,6 @@ a3
 > CREATE SOURCE s3_just_a
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'short/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT * FROM s3_just_a
@@ -79,10 +69,6 @@ c,9
 > CREATE SOURCE csv_example (name, counts)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING '*.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH 2 COLUMNS;
 
 > SELECT * FROM csv_example
@@ -118,10 +104,6 @@ $ s3-put-object bucket=test key=logs/2021/01/01/frontend.log
 > CREATE SOURCE frontend_logs
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'logs/**/*.log' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT REGEX '(?P<ip>[^ ]+) - - \[(?P<dt>[^]]+)\] "(?P<method>\w+) (?P<path>[^ ]+)[^"]+" (?P<status>\d+) (?P<content_length>\d+) "-" "(?P<user_agent>[^"]+)"';
 
 > SELECT dt, ip, user_agent FROM frontend_logs WHERE path = '/updates' ORDER BY dt
@@ -144,10 +126,6 @@ c3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'short/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}', BUCKET SCAN 'testdrive-other-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT TEXT;
 
 > SELECT text FROM s3_multi ORDER BY text;
@@ -182,10 +160,6 @@ id,value
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'csv/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  LEGACYWITH (
-    region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}'
-  )
   FORMAT CSV WITH HEADER (id, value);
 
 > SELECT id, value FROM s3_csv_headers


### PR DESCRIPTION
Extracted from #15113. Part of #14341.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
