### PR TITLE
`None` the initial `JoinClosure` when its MFP is identity

### DIFF
--- a/src/compute-client/src/plan/join/linear_join.rs
+++ b/src/compute-client/src/plan/join/linear_join.rs
@@ -191,10 +191,14 @@ impl LinearJoinPlan {
                 mfp.permute(permutation.clone(), key.len() + thinning.len());
                 let mfp = mfp.into_plan().unwrap().into_nontemporal().unwrap();
                 (
-                    Some(JoinClosure {
-                        ready_equivalences: vec![],
-                        before: mfp,
-                    }),
+                    if mfp.is_identity() {
+                        None
+                    } else {
+                        Some(JoinClosure {
+                            ready_equivalences: vec![],
+                            before: mfp,
+                        })
+                    },
                     Some(key.clone()),
                 )
             } else {

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -426,19 +426,7 @@ Query:
                               "Column": 0
                             }
                           ],
-                          "initial_closure": {
-                            "ready_equivalences": [],
-                            "before": {
-                              "mfp": {
-                                "expressions": [],
-                                "predicates": [],
-                                "projection": [
-                                  0
-                                ],
-                                "input_arity": 1
-                              }
-                            }
-                          },
+                          "initial_closure": null,
                           "stage_plans": [
                             {
                               "lookup_relation": 2,


### PR DESCRIPTION
Solving https://github.com/MaterializeInc/materialize/issues/15137 (which is a special case of https://github.com/MaterializeInc/materialize/issues/14059). When the MFP in the `initial_closure` of a Differential join is an identity MFP. Fortunately, this trivial case happens 7 times out of the 22 TPC-H queries. (The more complex case of the MFP applying some actual permutation is happening 0 times in TPC-H.)

This PR handles this case by setting `initial_closure` to `None`, which means that we can go into the first two cases of the match in `render_join`, i.e., we are not throwing away anymore the arrangement that already exists for the source collection.

This results in a 25% speedup in TPC-H Q20.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/15137

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - I put a print in both branches of the newly added `if`, and ran all slts: identity is occurring in 10 cases, non-identity in 2 cases.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None. (minor performance improvement)
