### PR TITLE
persist: inspect cli tools for blob counts / unreferenced blobs

### DIFF
--- a/src/persist-client/examples/inspect.rs
+++ b/src/persist-client/examples/inspect.rs
@@ -30,7 +30,7 @@ pub(crate) enum Command {
     /// Prints latest consensus rollup state as JSON
     StateRollup(StateArgs),
 
-    /// Prints the number of blobs
+    /// Prints the count and size of blobs in an environment
     BlobCount(BlobCountArgs),
 
     /// Prints the unreferenced blobs across all shards

--- a/src/persist-client/examples/inspect.rs
+++ b/src/persist-client/examples/inspect.rs
@@ -30,6 +30,12 @@ pub(crate) enum Command {
     /// Prints latest consensus rollup state as JSON
     StateRollup(StateArgs),
 
+    /// Prints the number of blobs
+    BlobCount(BlobCountArgs),
+
+    /// Prints the unreferenced blobs across all shards
+    UnreferencedBlobs(StateArgs),
+
     /// Prints each consensus state change as JSON. Output includes the full consensus state
     /// before and after each state transitions:
     ///
@@ -84,6 +90,18 @@ pub struct StateArgs {
     blob_uri: String,
 }
 
+/// Arguments for viewing the blobs of a given shard
+#[derive(Debug, Clone, clap::Parser)]
+pub struct BlobCountArgs {
+    /// Blob to use
+    ///
+    /// When connecting to a deployed environment's blob, the necessary connection glue must be in
+    /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
+    /// URI scoped to the environment's bucket prefix.
+    #[clap(long)]
+    blob_uri: String,
+}
+
 pub async fn run(command: InspectArgs) -> Result<(), anyhow::Error> {
     match command.command {
         Command::State(args) => {
@@ -129,6 +147,20 @@ pub async fn run(command: InspectArgs) -> Result<(), anyhow::Error> {
                     })
                 );
             }
+        }
+        Command::BlobCount(args) => {
+            let blob_counts = mz_persist_client::inspect::blob_counts(&args.blob_uri).await?;
+            println!("{}", json!(blob_counts));
+        }
+        Command::UnreferencedBlobs(args) => {
+            let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
+            let unreferenced_blobs = mz_persist_client::inspect::unreferenced_blobs(
+                &shard_id,
+                &args.consensus_uri,
+                &args.blob_uri,
+            )
+            .await?;
+            println!("{}", json!(unreferenced_blobs));
         }
     }
 

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -220,7 +220,7 @@ pub async fn unreferenced_blobs(
 
     let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(&shard_id)
+        .fetch_live_states::<K, V, u64, D>(shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -230,7 +230,7 @@ pub async fn unreferenced_blobs(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(&shard_id)
+                .fetch_live_states::<K, V, u64, D>(shard_id)
                 .await?
         }
     };

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -118,7 +118,7 @@ impl RollupId {
 /// Used to reduce the bytes needed to refer to a blob key in memory and in
 /// persistent state, all access to blobs are always within the context of an
 /// individual shard.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PartialRollupKey(pub(crate) String);
 
 impl PartialRollupKey {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds a `persistcli inspect` command to view blob count / bytes per shard over an environment, and to identify any unreferenced blobs for a given shard. These have been handy for understanding compaction behavior lately

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
