### PR TITLE
persist: parallelize initial parts fetch into compaction

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -546,7 +546,7 @@ pub struct BatchPartReadMetrics {
     pub(crate) compaction: ReadMetrics,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReadMetrics {
     pub(crate) part_bytes: IntCounter,
     pub(crate) part_goodbytes: IntCounter,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -215,8 +215,8 @@ pub struct PersistConfig {
     /// if the number of updates is at least this many. Compaction is performed
     /// if any of the heuristic criteria are met (they are OR'd).
     pub compaction_heuristic_min_updates: usize,
-    /// The maximum number of parts (s3 blobs) that [crate::internal::compact::Compactor]
-    /// will read in parallel before back-pressuring calls on previous ones finishing.
+    /// The maximum number of parts (s3 blobs) that compaction will read in
+    /// parallel before back-pressuring calls on previous ones finishing.
     pub compaction_reads_max_outstanding_parts: usize,
     /// The maximum size of the connection pool to Postgres/CRDB when performing
     /// consensus reads and writes.

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -215,6 +215,9 @@ pub struct PersistConfig {
     /// if the number of updates is at least this many. Compaction is performed
     /// if any of the heuristic criteria are met (they are OR'd).
     pub compaction_heuristic_min_updates: usize,
+    /// The maximum number of parts (s3 blobs) that [crate::internal::compact::Compactor]
+    /// will read in parallel before back-pressuring calls on previous ones finishing.
+    pub compaction_reads_max_outstanding_parts: usize,
     /// The maximum size of the connection pool to Postgres/CRDB when performing
     /// consensus reads and writes.
     pub consensus_connection_pool_max_size: usize,
@@ -283,6 +286,7 @@ impl PersistConfig {
             compaction_memory_bound_bytes: 1024 * MB,
             compaction_heuristic_min_inputs: 8,
             compaction_heuristic_min_updates: 1024,
+            compaction_reads_max_outstanding_parts: 8,
             consensus_connection_pool_max_size: 50,
             writer_lease_duration: Duration::from_secs(60 * 15),
             reader_lease_duration: Self::DEFAULT_READ_LEASE_DURATION,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The majority of compaction time (>50%) is spent blocked while reading in batch parts. 

<img width="784" alt="Screen Shot 2022-10-03 at 2 04 43 PM" src="https://user-images.githubusercontent.com/785446/193647532-4b605c18-bb19-49d5-84e5-9fc0543d8d1e.png">

The initial step of a compaction is to fetch the first batch part from each input run to feed into our heap. This is easily parallelizable without changing our memory footprint or introducing a lock. This PR fetches the initial parts in parallel (up to a concurrency limit), and then feeds them in one-by-one into our heap, which our timings show is super fast.

### Motivation

  * This PR fixes a previously unreported bug.

One source fell far behind on compaction after doing a big ingest. While https://github.com/MaterializeInc/materialize/pull/15105 and https://github.com/MaterializeInc/materialize/pull/15107 are smarter ways to do less work, it also seems useful to shorten the longest step when there is work to do.

<img width="1198" alt="Screen Shot 2022-10-03 at 2 49 01 PM" src="https://user-images.githubusercontent.com/785446/193655235-a1a49ec6-0c7b-4eb5-bba1-ce7c64ea7ee3.png">


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
