### PR TITLE
[sinks] create sinks in storaged before in catalog

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -463,33 +463,39 @@ impl<S: Append + 'static> Coordinator<S> {
             ..sink.clone()
         };
 
-        let ops = vec![
-            catalog::Op::DropItem(id),
-            catalog::Op::CreateItem {
-                id,
-                oid,
-                name,
-                item: CatalogItem::Sink(sink.clone()),
-            },
-        ];
+        // We always need to drop the already existing item: either because we fail to create it or we're replacing it.
+        let mut ops = vec![catalog::Op::DropItem(id)];
 
-        let () = self.catalog_transact(session, ops, move |_| Ok(())).await?;
-        // TODO(#14220): should this happen in the same task where we build the connection?  Or should it need to happen
-        // after we update the catalog?
+        // Speculatively create the storage export before confirming in the catalog.  We chose this order of operations
+        // for the following reasons:
+        // - We want to avoid ever putting into the catalog a sink in `StorageSinkConnectionState::Ready`
+        //   if we're not able to actually create the sink for some reason
+        // - Dropping the sink will either succeed (or panic) so it's easier to reason about rolling that change back
+        //   than it is rolling back a catalog change.
         match self.create_storage_export(id, &sink, connection).await {
-            Ok(()) => Ok(()),
-            Err(storage_error) =>
-            // TODO: catalog_transact that can take async function to actually make the `CreateItem` above transactional.
-            {
-                match self
-                    .catalog_transact(session, vec![catalog::Op::DropItem(id)], move |_| Ok(()))
-                    .await
-                {
-                    Ok(()) => Err(storage_error),
-                    Err(e) => Err(e),
+            Ok(()) => {
+                ops.push(catalog::Op::CreateItem {
+                    id,
+                    oid,
+                    name,
+                    item: CatalogItem::Sink(sink.clone()),
+                });
+                match self.catalog_transact(session, ops, move |_| Ok(())).await {
+                    Ok(()) => (),
+                    catalog_err @ Err(_) => {
+                        let () = self.drop_storage_sinks(vec![id]).await;
+                        catalog_err?
+                    }
                 }
             }
-        }
+            storage_err @ Err(_) => {
+                match self.catalog_transact(session, ops, move |_| Ok(())).await {
+                    Ok(()) => storage_err?,
+                    catalog_err @ Err(_) => catalog_err?,
+                }
+            }
+        };
+        Ok(())
     }
 
     /// Validate all resource limits in a catalog transaction and return an error if that limit is


### PR DESCRIPTION
Doing things in this order is preferable for two reasons:
(1) Dropping a sink that was erroneously created is more straightforward than unwinding a catalog transaction after the fact
(2) We avoid ever putting the sink in the catalog with `StorageSinkConnectionState::Ready` if the sink can't be created for whatever reason

The downside is that the call to `catalog_transact` to create the new sink could fail, and, in the meantime, we've created external state via the sink.  I think this is acceptable because we don't often expect the catalog transaction to fail -- and the external state would be limited to creating kafka topics that the user asked us to create

### Motivation
Fixes #14220.   More realistically kinda sidesteps this issue.  One of the reasons that we were looking into putting that creation in the async task was reason number (2) above.  The second was to move spinning up the new process off the main coordinator thread.  We don't really address that here but there is genuinely a lot of coordination that needs to be done to create the export so we can't really move it off thread: 1) validating the `from` collection properly exists in the storage controller, 2) retrieving the timeline for the `from` collection to determine a proper AS OF, 3) retrieving the catalog entry of the `from` from the catalog.  The `&mut self` in `Coordinator::create_storage_export` is doing a lot of work that we wouldn't be able to do off the main coordinator thread

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - none