### PR TITLE
compute-client: align explain timestamp

### DIFF
--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -340,7 +340,7 @@ impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
             writeln!(f, "source {}:", source.name)?;
             writeln!(
                 f,
-                " read frontier:{:?}",
+                "            read frontier:{:?}",
                 source
                     .read_frontier
                     .iter()
@@ -349,7 +349,7 @@ impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
             )?;
             writeln!(
                 f,
-                "write frontier:{:?}",
+                "           write frontier:{:?}",
                 source
                     .write_frontier
                     .iter()

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1052,8 +1052,8 @@ fn test_explain_timestamp_table() -> Result<(), Box<dyn Error>> {
   can respond immediately: <BOOL>
 
 source materialize.public.t1 (u1, storage):
- read frontier:[<TIMESTAMP>]
-write frontier:[<TIMESTAMP>]\n";
+            read frontier:[<TIMESTAMP>]
+           write frontier:[<TIMESTAMP>]\n";
 
     let row = client
         .query_one("EXPLAIN TIMESTAMP FOR SELECT * FROM t1;", &[])

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -128,7 +128,7 @@ contains:Expected a list of columns in parentheses, found EOF
 # since the definition of "static" means "will never change again".
 $ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -16,9 +16,9 @@ $ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true
 # Strict serializable doesn't look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'STRICT SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[<> <>]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
 
 # Serializable does look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[<> <>]\n\nsource materialize.public.t2 (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[<> <>]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n\nsource materialize.public.t2 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"


### PR DESCRIPTION
Make all timestamps fully aligned for easy visual comparing.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a