### PR TITLE
platform checks: Add upgrade scenarios from v0.27.0-alpha.23

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -44,6 +44,9 @@ steps:
           - { value: checks-oneatatime-restart-environmentd-storaged }
           - { value: checks-oneatatime-kill-storaged }
           - { value: checks-oneatatime-restart-postgres-backend }
+          - { value: checks-upgrade-entire-mz }
+          - { value: checks-upgrade-computed-first }
+          - { value: checks-upgrade-computed-last }
           - { value: persist-maelstrom-single-node }
           - { value: persist-maelstrom-multi-node }
           - { value: unused-deps }
@@ -365,6 +368,36 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
+
+  - id: checks-upgrade-entire-mz
+    label: "Upgrade entire Mz from v0.27.0-alpha.23"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=UpgradeEntireMz]
+
+  - id: checks-upgrade-computed-first
+    label: "Upgrade computed from v0.27.0-alpha.23 first"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=UpgradeComputedFirst]
+
+  - id: checks-upgrade-computed-last
+    label: "Upgrade computed from v0.27.0-alpha.23 last"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=UpgradeComputedLast]
 
   - id: persist-maelstrom-single-node
     label: Long single-node Maelstrom coverage of persist

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -21,10 +21,9 @@ from materialize.checks.actions import Action
 from materialize.checks.actions import (
     DropCreateDefaultReplica as DropCreateDefaultReplicaAction,
 )
-from materialize.checks.actions import Initialize, KillComputed
+from materialize.checks.actions import Initialize, KillComputed, KillMz
 from materialize.checks.actions import KillStoraged as KillStoragedAction
 from materialize.checks.actions import Manipulate
-from materialize.checks.actions import RestartMz as RestartMzAction
 from materialize.checks.actions import (
     RestartPostgresBackend as RestartPostgresBackendAction,
 )
@@ -64,11 +63,14 @@ class RestartEntireMz(Scenario):
         return [
             StartMz(),
             Initialize(self.checks),
-            RestartMzAction(),
+            KillMz(),
+            StartMz(),
             Manipulate(self.checks, phase=1),
-            RestartMzAction(),
+            KillMz(),
+            StartMz(),
             Manipulate(self.checks, phase=2),
-            RestartMzAction(),
+            KillMz(),
+            StartMz(),
             Validate(self.checks),
         ]
 
@@ -115,11 +117,14 @@ class RestartEnvironmentdStoraged(Scenario):
             StartComputed(),
             UseComputed(),
             Initialize(self.checks),
-            RestartMzAction(),
+            KillMz(),
+            StartMz(),
             Manipulate(self.checks, phase=1),
-            RestartMzAction(),
+            KillMz(),
+            StartMz(),
             Manipulate(self.checks, phase=2),
-            RestartMzAction(),
+            KillMz(),
+            StartMz(),
             Validate(self.checks),
         ]
 

--- a/misc/python/materialize/checks/upgrade_scenarios.py
+++ b/misc/python/materialize/checks/upgrade_scenarios.py
@@ -1,0 +1,108 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List
+
+from materialize.checks.actions import (
+    Action,
+    Initialize,
+    KillComputed,
+    KillMz,
+    Manipulate,
+    Sleep,
+    StartComputed,
+    StartMz,
+    UseComputed,
+    Validate,
+)
+from materialize.checks.scenarios import Scenario
+
+LAST_RELEASED_VERSION = "v0.27.0-alpha.23"
+
+
+class UpgradeEntireMz(Scenario):
+    """Upgrade the entire Mz instance from LAST_RELEASED_VERSION all at once."""
+
+    def actions(self) -> List[Action]:
+        return [
+            StartMz(tag=LAST_RELEASED_VERSION),
+            Initialize(self.checks),
+            Manipulate(self.checks, phase=1),
+            KillMz(),
+            StartMz(tag=None),
+            Manipulate(self.checks, phase=2),
+            Validate(self.checks),
+        ]
+
+
+#
+# We are limited with respect to the different orders in which stuff can be upgraded:
+# - some sequences of events are invalid
+# - environmentd and storaged are located in the same container
+#
+# Still, we would like to try as many scenarios as we can
+#
+
+
+class UpgradeComputedLast(Scenario):
+    """Upgrade computed separately after upgrading environmentd+storaged"""
+
+    def actions(self) -> List[Action]:
+        return [
+            StartMz(tag=LAST_RELEASED_VERSION),
+            StartComputed(tag=LAST_RELEASED_VERSION),
+            UseComputed(),
+            Initialize(self.checks),
+            Manipulate(self.checks, phase=1),
+            KillMz(),
+            StartMz(tag=None),
+            # No useful work can be done while computed is old-verison
+            # and environmentd/storaged is new-version. So we proceed
+            # to upgrade computed as well.
+            # We sleep here to allow some period of coexistence, even
+            # though we are not issuing queries during that time.
+            Sleep(10),
+            KillComputed(),
+            StartComputed(tag=None),
+            Manipulate(self.checks, phase=2),
+            Validate(self.checks),
+        ]
+
+
+class UpgradeComputedFirst(Scenario):
+    """Upgrade computed separately before environmentd and storaged"""
+
+    def actions(self) -> List[Action]:
+        return [
+            StartMz(tag=LAST_RELEASED_VERSION),
+            StartComputed(tag=LAST_RELEASED_VERSION),
+            UseComputed(),
+            Initialize(self.checks),
+            Manipulate(self.checks, phase=1),
+            KillComputed(),
+            StartComputed(tag=None),
+            # No useful work can be done while computed is new-verison
+            # and environmentd/storaged is old-version. So we
+            # proceed to upgrade them as well.
+            # We sleep here to allow some period of coexistence, even
+            # though we are not issuing queries during that time.
+            Sleep(10),
+            KillMz(),
+            StartMz(tag=None),
+            Manipulate(self.checks, phase=2),
+            Validate(self.checks),
+        ]

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -54,6 +54,7 @@ from materialize.checks.text_bytea_types import *  # noqa: F401 F403
 from materialize.checks.threshold import *  # noqa: F401 F403
 from materialize.checks.top_k import *  # noqa: F401 F403
 from materialize.checks.update import *  # noqa: F401 F403
+from materialize.checks.upgrade_scenarios import *  # noqa: F401 F403
 from materialize.checks.upsert import *  # noqa: F401 F403
 from materialize.checks.users import *  # noqa: F401 F403
 from materialize.checks.window_functions import *  # noqa: F401 F403
@@ -75,15 +76,7 @@ SERVICES = [
     Computed(
         name="computed_1"
     ),  # Started by some Scenarios, defined here only for the teardown
-    Materialized(
-        options=" ".join(
-            [
-                "--persist-consensus-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=consensus",
-                "--storage-stash-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=storage",
-                "--adapter-stash-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=adapter",
-            ]
-        )
-    ),
+    Materialized(),
     TestdriveService(default_timeout="300s", no_reset=True, seed=1),
 ]
 


### PR DESCRIPTION
Until the details are sorted out, add upgrade jobs to Nightly CI:
- upgrading from hard-coded tag v0.27.0-alpha.23
- the upgrade scenarios mirror the currently-available restart scenarios
- environmentd and storaged are upgraded together as they reside on the same container.

### Motivation

  * This PR adds a known-desirable feature.
- #14950