### PR TITLE
doc/user: cleanup links in system-catalog

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -295,23 +295,11 @@ Field          | Type        | Meaning
 `definition`   | [`text`]    | The view definition (a `SELECT` query).
 
 [`bigint`]: /sql/types/bigint
-[`bigint list`]: /sql/types/list
 [`boolean`]: /sql/types/boolean
-[`bytea`]: /sql/types/bytea
-[`double precision`]: /sql/types/double-precision
 [`jsonb`]: /sql/types/jsonb
-[`mz_timestamp`]: /sql/types/mz_timestamp
-[`numeric`]: /sql/types/numeric
 [`oid`]: /sql/types/oid
 [`text`]: /sql/types/text
-[`timestamp`]: /sql/types/timestamp
 [`timestamp with time zone`]: /sql/types/timestamp
-[`uuid`]: /sql/types/uuid
-[gh-issue]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md
 [oid]: /sql/types/oid
 [`text array`]: /sql/types/array
-[arrangement]: /overview/arrangements/#arrangements
-[dataflow]: /overview/arrangements/#dataflows
 [`record`]: /sql/types/record
-[librdkafka]: https://github.com/edenhill/librdkafka/tree/v{{< librdkafka-version >}}
-[`STATISTICS.md`]: https://github.com/edenhill/librdkafka/tree/v{{< librdkafka-version >}}/STATISTICS.md

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -314,22 +314,9 @@ Field       | Type       | Meaning
 
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list
-[`boolean`]: /sql/types/boolean
-[`bytea`]: /sql/types/bytea
-[`double precision`]: /sql/types/double-precision
-[`jsonb`]: /sql/types/jsonb
 [`mz_timestamp`]: /sql/types/mz_timestamp
 [`numeric`]: /sql/types/numeric
-[`oid`]: /sql/types/oid
 [`text`]: /sql/types/text
-[`timestamp`]: /sql/types/timestamp
-[`timestamp with time zone`]: /sql/types/timestamp
 [`uuid`]: /sql/types/uuid
-[gh-issue]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md
-[oid]: /sql/types/oid
-[`text array`]: /sql/types/array
 [arrangement]: /overview/arrangements/#arrangements
 [dataflow]: /overview/arrangements/#dataflows
-[`record`]: /sql/types/record
-[librdkafka]: https://github.com/edenhill/librdkafka/tree/v{{< librdkafka-version >}}
-[`STATISTICS.md`]: https://github.com/edenhill/librdkafka/tree/v{{< librdkafka-version >}}/STATISTICS.md

--- a/doc/user/content/sql/system-catalog/pg_catalog.md
+++ b/doc/user/content/sql/system-catalog/pg_catalog.md
@@ -41,3 +41,5 @@ the documented [`mz_catalog`](../mz_catalog) API instead.
 If you are having trouble making a PostgreSQL tool work with Materialize, please
 [file a GitHub issue][gh-issue]. Many PostgreSQL tools can be made to work with
 Materialize with minor changes to the `pg_catalog` compatibility shim.
+
+[gh-issue]: https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md


### PR DESCRIPTION
This commit cleans up the links in the system catalog docs by:
* removing unused link definitions
* adding a missing link on the `pg_catalog` page

### Motivation

* This PR improves documentation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
