### PR TITLE
adapter: add metrics for query counts and active sessions/subscribes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "mz-storage",
  "mz-transform",
  "once_cell",
+ "prometheus",
  "prost",
  "rand",
  "rdkafka",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -41,6 +41,7 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
 mz-storage = { path = "../storage" }
 mz-transform = { path = "../transform" }
+prometheus = { version = "0.13.2", default-features = false }
 prost = { version = "0.11.0", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -118,6 +118,7 @@ use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
 use crate::coord::appends::{BuiltinTableUpdateSource, Deferred, PendingWriteTxn};
 use crate::coord::id_bundle::CollectionIdBundle;
+use crate::coord::metrics::Metrics;
 use crate::coord::peek::PendingPeek;
 use crate::coord::read_policy::{ReadCapability, ReadHolds};
 use crate::coord::timeline::{TimelineState, WriteTimestamp};
@@ -136,6 +137,7 @@ mod dataflows;
 mod ddl;
 mod indexes;
 mod message_handler;
+mod metrics;
 mod read_policy;
 mod sequencer;
 mod sql;
@@ -361,6 +363,9 @@ pub struct Coordinator<S> {
 
     /// Segment analytics client.
     segment_client: Option<mz_segment::Client>,
+
+    /// Coordinator metrics.
+    metrics: Metrics,
 }
 
 impl<S: Append + 'static> Coordinator<S> {
@@ -931,6 +936,7 @@ pub async fn serve<S: Append + 'static>(
                 storage_usage_client,
                 storage_usage_collection_interval,
                 segment_client,
+                metrics: Metrics::register_with(&metrics_registry),
             };
             let bootstrap =
                 handle.block_on(coord.bootstrap(builtin_migration_metadata, builtin_table_updates));

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -180,6 +180,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     let remove = pending_subscribes.process_response(response);
                     if remove {
                         self.pending_subscribes.remove(&sink_id);
+                        self.metrics.active_subscribes.dec();
                     }
                 }
             }

--- a/src/adapter/src/coord/metrics.rs
+++ b/src/adapter/src/coord/metrics.rs
@@ -1,0 +1,100 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use prometheus::{IntCounterVec, IntGauge};
+
+use mz_ore::metric;
+use mz_ore::metrics::MetricsRegistry;
+use mz_sql::ast::{AstInfo, Statement, StatementKind};
+
+pub struct Metrics {
+    pub query_total: IntCounterVec,
+    pub active_sessions: IntGauge,
+    pub active_subscribes: IntGauge,
+}
+
+impl Metrics {
+    pub fn register_with(registry: &MetricsRegistry) -> Self {
+        Self {
+            query_total: registry.register(metric!(
+                name: "mz_query_total",
+                help: "The total number of queries issued of the given type since process start.",
+                var_labels: ["statement_type"],
+            )),
+            active_sessions: registry.register(metric!(
+                name: "mz_active_sessions",
+                help: "The number of active coordinator sessions.",
+            )),
+            active_subscribes: registry.register(metric!(
+                name: "mz_active_subscribes",
+                help: "The number of active SUBSCRIBE queries.",
+            )),
+        }
+    }
+}
+
+pub fn statement_type_label_value<T>(stmt: &Statement<T>) -> &'static str
+where
+    T: AstInfo,
+{
+    let kind = StatementKind::from(stmt);
+    match kind {
+        StatementKind::Select => "select",
+        StatementKind::Insert => "insert",
+        StatementKind::Copy => "copy",
+        StatementKind::Update => "update",
+        StatementKind::Delete => "delete",
+        StatementKind::CreateConnection => "create_connection",
+        StatementKind::CreateDatabase => "create_database",
+        StatementKind::CreateSchema => "create_schema",
+        StatementKind::CreateSource => "create_source",
+        StatementKind::CreateSink => "create_sink",
+        StatementKind::CreateView => "create_view",
+        StatementKind::CreateViews => "create_views",
+        StatementKind::CreateMaterializedView => "create_materialized_view",
+        StatementKind::CreateTable => "create_table",
+        StatementKind::CreateIndex => "create_index",
+        StatementKind::CreateType => "create_type",
+        StatementKind::CreateRole => "create_role",
+        StatementKind::CreateCluster => "create_cluster",
+        StatementKind::CreateClusterReplica => "create_cluster_replica",
+        StatementKind::CreateSecret => "create_secret",
+        StatementKind::AlterObjectRename => "alter_object_rename",
+        StatementKind::AlterIndex => "alter_index",
+        StatementKind::AlterSecret => "alter_secret",
+        StatementKind::AlterSource => "alter_source",
+        StatementKind::AlterSystemSet => "alter_system_set",
+        StatementKind::AlterSystemReset => "alter_system_reset",
+        StatementKind::AlterSystemResetAll => "alter_system_reset_all",
+        StatementKind::AlterConnection => "alter_connection",
+        StatementKind::Discard => "discard",
+        StatementKind::DropDatabase => "drop_database",
+        StatementKind::DropSchema => "drop_schema",
+        StatementKind::DropObjects => "drop_objects",
+        StatementKind::DropRoles => "drop_roles",
+        StatementKind::DropClusters => "drop_clusters",
+        StatementKind::DropClusterReplicas => "drop_cluster_replicas",
+        StatementKind::SetVariable => "set_variable",
+        StatementKind::ResetVariable => "reset_variable",
+        StatementKind::Show => "show",
+        StatementKind::StartTransaction => "start_transaction",
+        StatementKind::SetTransaction => "set_transaction",
+        StatementKind::Commit => "commit",
+        StatementKind::Rollback => "rollback",
+        StatementKind::Subscribe => "subscribe",
+        StatementKind::Explain => "explain",
+        StatementKind::Declare => "declare",
+        StatementKind::Fetch => "fetch",
+        StatementKind::Close => "close",
+        StatementKind::Prepare => "prepare",
+        StatementKind::Execute => "execute",
+        StatementKind::Deallocate => "deallocate",
+        StatementKind::Raise => "raise",
+    }
+}

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2204,6 +2204,7 @@ impl<S: Append + 'static> Coordinator<S> {
         });
         let arity = sink_desc.from_desc.arity();
         let (tx, rx) = mpsc::unbounded_channel();
+        self.metrics.active_subscribes.inc();
         self.pending_subscribes
             .insert(*sink_id, PendingSubscribe::new(tx, emit_progress, arity));
         self.ship_dataflow(dataflow, compute_instance).await;


### PR DESCRIPTION
This commit provides most of the metrics requested in MaterializeInc/cloud#4146. It ends up being much easier to track these metrics in the coordinator rather than the pgwire crate, so that we have visibility into queries issued both via HTTP and pgwire.

Note that the active subscribes metric is currently broken and never decrements, due to a pre-existing bug that causes the coordinator to never hear about dropped subscribes.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
