### PR TITLE
build: fix dev-web feature

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -234,8 +234,7 @@ To speed up the development cycle, you can enable the `dev-web` feature like so:
 
 ```shell
 cd src/environmentd
-cargo build --bin storaged --bin computed
-cargo run --bin environmentd --features=dev-web
+bin/environmentd --features=dev-web
 ```
 
 In this mode, every request for a static file will reload the file from disk.

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -67,6 +67,10 @@ def main() -> int:
         action="store_true",
     )
     parser.add_argument(
+        "--features",
+        help="Comma separated list of features to activate",
+    )
+    parser.add_argument(
         "--no-default-features",
         help="Do not activate the `default` feature",
         action="store_true",
@@ -166,9 +170,14 @@ def main() -> int:
 def _build(args: argparse.Namespace, extra_programs: list[str] = []) -> int:
     env = dict(os.environ)
     command = _cargo_command(args, "build")
+    features = []
     if args.tokio_console:
-        command += ["--features=tokio-console"]
+        features += ["tokio-console"]
         env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " --cfg=tokio_unstable"
+    if args.features:
+        features.extend(args.features.split(","))
+    if features:
+        command += [f"--features={','.join(features)}"]
     for program in [*REQUIRED_SERVICES, *extra_programs]:
         command += ["--bin", program]
     completed_proc = spawn.runv(command, env=env)


### PR DESCRIPTION
Teach the `bin/environmentd` script (and any other scripts based on run.py) to take a `--features` argument to specify the Cargo features to build with. In particular, this fixes the `dev-web` feature described in the developer guide.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
