### PR TITLE
ci: Increase the timeout of the replica isolation test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -197,7 +197,7 @@ steps:
   - id: replica-isolation
     label: Replica isolation
     depends_on: build-x86_64
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     inputs: [test/replica-isolation]
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
The test was timing out because its execution time approached the 10-minute timeout.

Fixes #15167

### Motivation

  * This PR fixes a recognized bug.
- #15167
