### PR TITLE
compute: use explicit wrapping in float reduction

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -704,7 +704,7 @@ where
 ///
 /// The float accumulator performs accumulation in fixed point arithmetic. The fixed
 /// point representation has less precision than a double. It is entirely possible
-/// that the values of the accumulator overflows, thus we have to use wrapping arithmetic
+/// that the values of the accumulator overflow, thus we have to use wrapping arithmetic
 /// to preserve group guarantees.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 enum AccumInner {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -700,7 +700,7 @@ where
 ///
 /// We assume that there are not more than 2^32 elements for the aggregation.
 /// Thus we can perform a summation over i32 in an i64 accumulator
-/// and not worry about exceeding it's bounds.
+/// and not worry about exceeding its bounds.
 ///
 /// The float accumulator performs accumulation in fixed point arithmetic. The fixed
 /// point representation has less precision than a double. It is entirely possible

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -697,6 +697,15 @@ where
 }
 
 /// Accumulates values for the various types of accumulable aggregations.
+///
+/// We assume that there are not more than 2^32 elements for the aggregation.
+/// Thus we can perform a summation over i32 in an i64 accumulator
+/// and not worry about exceeding it's bounds.
+///
+/// The float accumulator performs accumulation in fixed point arithmetic. The fixed
+/// point representation has less precision than a double. It is entirely possible
+/// that the values of the accumulator overflows, thus we have to use wrapping arithmetic
+/// to preserve group guarantees.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 enum AccumInner {
     /// Accumulates boolean values.
@@ -814,7 +823,7 @@ impl Semigroup for AccumInner {
                     non_nulls: other_non_nulls,
                 },
             ) => {
-                *accum += other_accum;
+                *accum = accum.wrapping_add(*other_accum);
                 *pos_infs += other_pos_infs;
                 *neg_infs += other_neg_infs;
                 *nans += other_nans;
@@ -897,7 +906,7 @@ impl Multiply<Diff> for AccumInner {
                 nans,
                 non_nulls,
             } => AccumInner::Float {
-                accum: accum * i128::from(factor),
+                accum: accum.wrapping_mul(i128::from(factor)),
                 pos_infs: pos_infs * factor,
                 neg_infs: neg_infs * factor,
                 nans: nans * factor,
@@ -1088,6 +1097,7 @@ where
                 let accum = if nans > 0 || pos_infs > 0 || neg_infs > 0 {
                     0
                 } else {
+                    // This operation will truncate to i128::MAX if out of range.
                     (n * float_scale) as i128
                 };
 
@@ -1291,6 +1301,8 @@ where
                             // If any non-nulls, just report the aggregate.
                             (AggregateFunc::SumInt16, AccumInner::SimpleNumber { accum, .. })
                             | (AggregateFunc::SumInt32, AccumInner::SimpleNumber { accum, .. }) => {
+                                // This conversion is safe, as long as we have less than 2^32
+                                // summands.
                                 Datum::Int64(*accum as i64)
                             }
                             (AggregateFunc::SumInt64, AccumInner::SimpleNumber { accum, .. }) => {

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -80,3 +80,29 @@ SELECT 1::float(0);
 
 query error precision for type float must be within \(\[1-53\]\)
 SELECT 1::float(55);
+
+
+# Test SUM() with floats
+
+statement ok
+create table t1 (f1 double, f2 double)
+
+statement ok
+insert into t1 values (1e31, 1e31), (1e31, 1e31)
+
+query T
+SELECT f1+f2 FROM t1
+----
+19999999999999999271792589930496.000
+19999999999999999271792589930496.000
+
+query T
+SELECT SUM(f1) FROM t1
+----
+-282409603651671152154661355520.000
+
+# This *should* be zero, known issue https://github.com/MaterializeInc/materialize/issues/15186
+query T
+SELECT MIN(f1+f2)-SUM(f1) FROM t1
+----
+20282409603651670423947251286016.000

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -1327,6 +1327,11 @@ SELECT STDDEV(a) FROM t4
 ----
 1239831340.320
 
+# This query overflows, thus the result is wrong
+# known issue https://github.com/MaterializeInc/materialize/issues/15186
+query error cannot take square root
+SELECT STDDEV(a) FROM t8
+
 # Avoid overflow (known issue https://github.com/MaterializeInc/materialize/issues/14695)
 statement ok
 DROP TABLE t8


### PR DESCRIPTION
Related to #14695

This PR removes the disparity between debug and release mode by using explicit wrapping operations.

This PR does so only for data accumulator values, but not counts of elements (for example we count how many trues we encounter in boolean aggregation). I think this ok, but we should be more explicit about the number of elements supported in an aggregation (currently 2^32) in the docs.

Implementing a proper solution is tracked in issue #15186. 

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): None (users shouldn't run debug mode)
