### PR TITLE
compute: Add arbitrary precision accum for float

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2126,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gmp-mpfr-sys"
+version = "1.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3f42dadb6c75f122e9aa87e757ef11d4282f664c9f2e6476a9c2c8970f9d19"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,8 +3207,10 @@ dependencies = [
  "mz-service",
  "mz-storage",
  "mz-timely-util",
+ "num-traits",
  "once_cell",
  "prometheus",
+ "rug",
  "scopeguard",
  "serde",
  "tikv-jemallocator",
@@ -5645,6 +5663,18 @@ checksum = "26b763cb66df1c928432cc35053f8bd4cec3335d8559fc16010017d16b3c1680"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "rug"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203180f444c95eac53586ed04793ecf6454c5d28f9eca8eead815fc19e136c47"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "serde",
 ]
 
 [[package]]

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -30,6 +30,7 @@ mz-repr = { path = "../repr" }
 mz-service = { path = "../service" }
 mz-storage = { path = "../storage", default-features = false }
 mz-timely-util = { path = "../timely-util" }
+num-traits = "0.2.15"
 once_cell = "1.14.0"
 prometheus = { version = "0.13.2", default-features = false }
 scopeguard = "1.1.0"
@@ -51,6 +52,11 @@ tikv-jemallocator = { version = "0.4.3", features = ["profiling", "stats", "unpr
 default = ["jemalloc"]
 jemalloc = ["tikv-jemallocator", "mz-prof/jemalloc"]
 tokio-console = ["mz-ore/tokio-console"]
+
+[dependencies.rug]
+version = "1.17"
+default-features = false
+features = ["rational", "serde"]
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux


### PR DESCRIPTION
Do not merge, we first need to understand performance implications.

Fixes #15186 by using a arbitrary precision lib (rug, LGPLv3 licensed). 

Correctness wise, it looks good:

```
materialize=> CREATE TABLE t8 (a bigint);
CREATE TABLE
materialize=> INSERT INTO t8 VALUES (13), (65536), (4294967296), (9223372036854775807);
INSERT 0 4
materialize=> select STDDEV(a) from t8;
        stddev         
-----------------------
 4.611686017711549e+18
(1 row)

materialize=> CREATE TABLE fl (f double);
CREATE TABLE
materialize=> INSERT INTO fl VALUES (1e31),(1e31),(1e31);
INSERT 0 3
materialize=> SELECT SUM(f) FROM fl;
  sum  
-------
 3e+31
(1 row)

materialize=>
```

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
