### PR TITLE
Add SIZE Parameter to CREATE SINK

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1402,6 +1402,7 @@ pub struct Sink {
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
     pub depends_on: Vec<GlobalId>,
+    pub host_config: StorageHostConfig,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -4493,6 +4494,7 @@ impl<S: Append> Catalog<S> {
             Plan::CreateSink(CreateSinkPlan {
                 sink,
                 with_snapshot,
+                host_config,
                 ..
             }) => CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
@@ -4502,6 +4504,7 @@ impl<S: Append> Catalog<S> {
                 envelope: sink.envelope,
                 with_snapshot,
                 depends_on,
+                host_config: self.resolve_storage_host_config(host_config)?,
             }),
             Plan::CreateType(CreateTypePlan { typ, .. }) => CatalogItem::Type(Type {
                 create_sql: typ.create_sql,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -438,7 +438,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 id,
                 ExportDescription {
                     sink: storage_sink_desc,
-                    remote_addr: None,
+                    host_config: sink.host_config.clone(),
                 },
             )])
             .await?)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1059,6 +1059,7 @@ impl<S: Append + 'static> Coordinator<S> {
             sink,
             with_snapshot,
             if_not_exists,
+            host_config: _host_config,
         } = plan;
 
         // First try to allocate an ID and an OID. If either fails, we're done.

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -517,12 +517,16 @@ impl_display_t!(CreateSourceStatement);
 /// An option in a `CREATE SINK` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSinkOptionName {
+    Size,
     Snapshot,
 }
 
 impl AstDisplay for CreateSinkOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
+            CreateSinkOptionName::Size => {
+                f.write_str("SIZE");
+            }
             CreateSinkOptionName::Snapshot => {
                 f.write_str("SNAPSHOT");
             }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2361,7 +2361,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_sink_option(&mut self) -> Result<CreateSinkOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[SNAPSHOT])? {
+        let name = match self.expect_one_of_keywords(&[SIZE, SNAPSHOT])? {
+            SIZE => CreateSinkOptionName::Size,
             SNAPSHOT => CreateSinkOptionName::Snapshot,
             _ => unreachable!(),
         };

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -459,6 +459,34 @@ CREATE SINK IF EXISTS foo FROM bar INTO 'baz'
                ^
 
 parse-statement
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SNAPSHOT = true)
+----
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SNAPSHOT = true)
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SNAPSHOT = false)
+----
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SNAPSHOT = false)
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(false))) }] })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SIZE = 'xlarge')
+----
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SIZE = 'xlarge')
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }] })
+
+parse-statement
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') FORMAT BYTES WITH (SIZE = 'xlarge', SNAPSHOT = true)
+----
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') FORMAT BYTES WITH (SIZE = 'xlarge', SNAPSHOT = true)
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: KafkaConnection { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [CreateSinkOption { name: Size, value: Some(Value(String("xlarge"))) }, CreateSinkOption { name: Snapshot, value: Some(Value(Boolean(true))) }] })
+
+parse-statement
 CREATE INDEX foo ON myschema.bar (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -349,6 +349,7 @@ pub struct CreateSinkPlan {
     pub sink: Sink,
     pub with_snapshot: bool,
     pub if_not_exists: bool,
+    pub host_config: StorageHostConfig,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1619,10 +1619,15 @@ pub fn plan_create_sink(
     };
 
     let CreateSinkOptionExtracted {
-        size: _size,
+        size,
         snapshot,
         seen: _,
     } = with_options.try_into()?;
+
+    let host_config = match size {
+        None => StorageHostConfig::Undefined,
+        Some(size) => StorageHostConfig::Managed { size },
+    };
 
     Ok(Plan::CreateSink(CreateSinkPlan {
         name,
@@ -1635,6 +1640,7 @@ pub fn plan_create_sink(
         },
         with_snapshot: snapshot,
         if_not_exists,
+        host_config,
     }))
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1508,7 +1508,11 @@ pub fn describe_create_sink(
     Ok(StatementDesc::new(None))
 }
 
-generate_extracted_config!(CreateSinkOption, (Snapshot, bool, Default(true)));
+generate_extracted_config!(
+    CreateSinkOption,
+    (Size, String),
+    (Snapshot, bool, Default(true))
+);
 
 pub fn plan_create_sink(
     scx: &StatementContext,
@@ -1614,7 +1618,11 @@ pub fn plan_create_sink(
         )?,
     };
 
-    let CreateSinkOptionExtracted { snapshot, seen: _ } = with_options.try_into()?;
+    let CreateSinkOptionExtracted {
+        size: _size,
+        snapshot,
+        seen: _,
+    } = with_options.try_into()?;
 
     Ok(Plan::CreateSink(CreateSinkPlan {
         name,

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -61,7 +61,7 @@ use crate::protocol::client::{
     StorageCommand, StorageResponse, Update,
 };
 use crate::types::errors::DataflowError;
-use crate::types::hosts::{StorageHostConfig, StorageHostResourceAllocation};
+use crate::types::hosts::StorageHostConfig;
 use crate::types::sinks::{ProtoDurableExportMetadata, SinkAsOf, StorageSinkDesc};
 use crate::types::sources::{IngestionDescription, MzOffset, SourceData, SourceEnvelope};
 
@@ -125,11 +125,9 @@ impl<T> From<RelationDesc> for CollectionDescription<T> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExportDescription<T = mz_repr::Timestamp> {
     pub sink: StorageSinkDesc<(), T>,
-    /// The address of a `storaged` process on which to install the source.
-    ///
-    /// If `None`, the controller manages the lifetime of the `storaged`
-    /// process.
-    pub remote_addr: Option<String>,
+    /// The address of a `storaged` process on which to install the sink or the
+    /// settings for spinning up a controller-managed process.
+    pub host_config: StorageHostConfig,
 }
 
 #[async_trait(?Send)]
@@ -1084,16 +1082,8 @@ where
                 },
             };
 
-            // TODO: allow specifying a size parameter for sinks, tracked in #13889
-            let host_config = match description.remote_addr {
-                Some(addr) => StorageHostConfig::Remote { addr },
-                None => StorageHostConfig::Managed {
-                    allocation: StorageHostResourceAllocation::temp_default_for_sinks(),
-                    size: "arbitrary".to_string(),
-                },
-            };
             // Provision a storage host for the ingestion.
-            let client = self.hosts.provision(id, host_config).await?;
+            let client = self.hosts.provision(id, description.host_config).await?;
 
             client.send(StorageCommand::CreateSinks(vec![cmd]));
         }

--- a/src/storage/src/types/hosts.rs
+++ b/src/storage/src/types/hosts.rs
@@ -11,7 +11,6 @@
 
 use std::num::NonZeroUsize;
 
-use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
 
 use mz_orchestrator::{CpuLimit, MemoryLimit};
@@ -28,17 +27,6 @@ pub struct StorageHostResourceAllocation {
     pub cpu_limit: Option<CpuLimit>,
     /// The number of worker threads in the replica.
     pub workers: NonZeroUsize,
-}
-
-impl StorageHostResourceAllocation {
-    /// Temporary default size used for sinks, should be updated after #13889
-    pub fn temp_default_for_sinks() -> Self {
-        StorageHostResourceAllocation {
-            memory_limit: Some(MemoryLimit(ByteSize::gib(8))),
-            cpu_limit: Some(CpuLimit::from_millicpus(1000)),
-            workers: NonZeroUsize::new(1).unwrap(),
-        }
-    }
 }
 
 /// Size or address of a storage instance

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -242,3 +242,17 @@ snk_unsigned
   INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=-1, REPLICATION FACTOR=-1, TOPIC 'testdrive-snk13-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
+
+# create sink with SIZE set
+> CREATE SINK sink_with_size FROM src
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+  WITH (SIZE = '2')
+
+# create sink with SIZE and SNAPSHOT set
+> CREATE SINK sink_with_size_and_snapshot FROM src
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+  WITH (SIZE = '2', SNAPSHOT = false)

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -46,7 +46,7 @@ goofus,gallant
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-contains:Expected one of SNAPSHOT
+contains:Expected one of SIZE or SNAPSHOT
 
 > SHOW SINKS
 name


### PR DESCRIPTION
The sink-equivalent of #13891. Mostly straight-forward, due to reusing all the logic added in that PR, since both are just processes/pods provisioned via the storage controller.

No breaking changes are expected from this PR. Due to not really including any new logic, I'm not gating it behind unsafe mode, but that's easy to change if we want to.

Closes #15214.

### Motivation

  * This PR adds a known-desirable feature: #15214

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `SIZE` parameter to `CREATE SINK`, with the same behavior and set of valid sizes as the one from `CREATE SOURCE`.
