### PR TITLE
environmentd: improve HTTP servers

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -320,7 +320,12 @@ impl IntoResponse for AuthError {
             AuthError::HttpsRequired => self.to_string(),
             _ => "unauthorized".into(),
         };
-        (StatusCode::UNAUTHORIZED, message).into_response()
+        (
+            StatusCode::UNAUTHORIZED,
+            [(http::header::WWW_AUTHENTICATE, "Basic realm=Materialize")],
+            message,
+        )
+            .into_response()
     }
 }
 

--- a/src/environmentd/src/http/root.rs
+++ b/src/environmentd/src/http/root.rs
@@ -20,13 +20,15 @@ struct HomeTemplate<'a> {
     version: &'a str,
     build_time: &'a str,
     build_sha: &'static str,
+    profiling: bool,
 }
 
-pub async fn handle_home() -> impl IntoResponse {
+pub async fn handle_home(profiling: bool) -> impl IntoResponse {
     mz_http_util::template_response(HomeTemplate {
         version: BUILD_INFO.version,
         build_time: BUILD_INFO.time,
         build_sha: BUILD_INFO.sha,
+        profiling,
     })
 }
 

--- a/src/environmentd/src/http/templates/home.html
+++ b/src/environmentd/src/http/templates/home.html
@@ -5,7 +5,9 @@
 {% block content %}
 <p>environmentd {{ version }} (built at {{ build_time }} from <code>{{ build_sha }}</code>)</p>
 <ul>
-    <li><a href="/prof/">profiling functions</a></li>
+    {% if profiling %}
+        <li><a href="/prof/">profiling functions</a></li>
+    {% endif %}
     <li><a href="/memory">memory visualization</a></li>
     <li><a href="/hierarchical-memory">hierarchical memory visualization</a></li>
 </ul>


### PR DESCRIPTION
Two commits in here:

  * The first commit makes web browsers prompt for a username/password if not provided in the URL. This will make the HTTP web interface immediately usable in Materialize Cloud, albeit with a subpar UX.
  * The second commit ensures that all HTTP routes available on the public HTTP port are also available on the private HTTP port—and also moves the CPU/memory profiling functionality to *just* the private HTTP port.

A few more details in the commit messages within.

### Motivation

   * This PR tinkers with some code based on Slack conversations to make debugging customer environments easier.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
