### PR TITLE
adapter,expr: reject unmaterializable functions in WHERE clauses

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -508,7 +508,9 @@ pub fn prep_relation_expr(
                         MapFilterProject::new(input.arity()).filter(predicates.iter().cloned());
                     match mfp.into_plan() {
                         Err(e) => coord_bail!("{:?}", e),
-                        Ok(_) => Ok(()),
+                        Ok(_) => {
+                            e.try_visit_scalars_mut1(&mut |s| prep_scalar_expr(catalog, s, style))
+                        }
                     }
                 } else {
                     e.try_visit_scalars_mut1(&mut |s| prep_scalar_expr(catalog, s, style))

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -222,6 +222,9 @@ impl AdapterError {
                 "The object depends on the following log sources:\n    {}",
                 log_names.join("\n    "),
             )),
+            AdapterError::UnmaterializableFunction(UnmaterializableFunc::CurrentTimestamp) => {
+                Some("See: https://materialize.com/docs/sql/functions/now_and_mz_now/".into())
+            }
             AdapterError::UnstableDependency { unstable_dependencies, .. } => Some(format!(
                 "The object depends on the following unstable objects:\n    {}",
                 unstable_dependencies.join("\n    "),
@@ -266,6 +269,9 @@ impl AdapterError {
             }
             AdapterError::NoClusterReplicasAvailable(_) => {
                 Some("You can create cluster replicas using CREATE CLUSTER REPLICA".into())
+            }
+            AdapterError::UnmaterializableFunction(UnmaterializableFunc::CurrentTimestamp) => {
+                Some("Try using `mz_now()` here instead.".into())
             }
             AdapterError::UntargetedLogRead { .. } => Some(
                 "Use `SET cluster_replica = <replica-name>` to target a specific replica in the \

--- a/test/sqllogictest/github-15171.slt
+++ b/test/sqllogictest/github-15171.slt
@@ -1,0 +1,19 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement error cannot materialize call
+create materialized view temp as select mz_version()
+
+statement error cannot materialize call
+create materialized view temp as select 1 where mz_version() = ''
+
+statement error cannot materialize call.*Try using `mz_now
+create materialized view temp as select 1 where current_timestamp() > current_timestamp()


### PR DESCRIPTION
The logic in `prep_relation_expr` was not being careful to look for unmaterializable expressions in non-temporal expressions in an MfpPlan, which could allow invalid references to unmaterializable functions in WHERE clauses.
    
Also improve the error message for current_timestamp specifically to give a hint to use mz_now instead.
    
Fix #15171.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
