### PR TITLE
cloudtest: Run Platform Checks upgrade in K8s

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -48,6 +48,7 @@ steps:
           - { value: checks-upgrade-entire-mz }
           - { value: checks-upgrade-computed-first }
           - { value: checks-upgrade-computed-last }
+          - { value: cloudtest-upgrade }
           - { value: persist-maelstrom-single-node }
           - { value: persist-maelstrom-multi-node }
           - { value: unused-deps }
@@ -409,6 +410,20 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeComputedLast]
+
+  - id: cloudtest-upgrade
+    label: "Cloudtest upgrade from main to main"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=UpgradeComputedLast]
+    artifact_paths: junit_cloudtest_*.xml
+    plugins:
+      - ./ci/plugins/cloudtest:
+          args: [-m=long, test/cloudtest/test_upgrade.py]
 
   - id: persist-maelstrom-single-node
     label: Long single-node Maelstrom coverage of persist

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.checks.aggregation import *  # noqa: F401 F403
+from materialize.checks.alter_index import *  # noqa: F401 F403
+from materialize.checks.boolean_type import *  # noqa: F401 F403
+from materialize.checks.cluster import *  # noqa: F401 F403
+from materialize.checks.commit import *  # noqa: F401 F403
+from materialize.checks.constant_plan import *  # noqa: F401 F403
+from materialize.checks.create_index import *  # noqa: F401 F403
+from materialize.checks.create_table import *  # noqa: F401 F403
+from materialize.checks.databases import *  # noqa: F401 F403
+from materialize.checks.debezium import *  # noqa: F401 F403
+from materialize.checks.delete import *  # noqa: F401 F403
+from materialize.checks.drop_index import *  # noqa: F401 F403
+from materialize.checks.drop_table import *  # noqa: F401 F403
+from materialize.checks.error import *  # noqa: F401 F403
+from materialize.checks.float_types import *  # noqa: F401 F403
+from materialize.checks.having import *  # noqa: F401 F403
+from materialize.checks.insert_select import *  # noqa: F401 F403
+from materialize.checks.join_implementations import *  # noqa: F401 F403
+from materialize.checks.join_types import *  # noqa: F401 F403
+from materialize.checks.jsonb_type import *  # noqa: F401 F403
+from materialize.checks.kafka_formats import *  # noqa: F401 F403
+from materialize.checks.large_tables import *  # noqa: F401 F403
+from materialize.checks.like import *  # noqa: F401 F403
+from materialize.checks.materialized_views import *  # noqa: F401 F403
+from materialize.checks.nested_types import *  # noqa: F401 F403
+from materialize.checks.null_value import *  # noqa: F401 F403
+from materialize.checks.numeric_types import *  # noqa: F401 F403
+from materialize.checks.pg_cdc import *  # noqa: F401 F403
+from materialize.checks.regex import *  # noqa: F401 F403
+from materialize.checks.rename_index import *  # noqa: F401 F403
+from materialize.checks.rename_source import *  # noqa: F401 F403
+from materialize.checks.rename_table import *  # noqa: F401 F403
+from materialize.checks.rename_view import *  # noqa: F401 F403
+from materialize.checks.replica import *  # noqa: F401 F403
+from materialize.checks.roles import *  # noqa: F401 F403
+from materialize.checks.rollback import *  # noqa: F401 F403
+from materialize.checks.sink import *  # noqa: F401 F403
+from materialize.checks.temporal_types import *  # noqa: F401 F403
+from materialize.checks.text_bytea_types import *  # noqa: F401 F403
+from materialize.checks.threshold import *  # noqa: F401 F403
+from materialize.checks.top_k import *  # noqa: F401 F403
+from materialize.checks.update import *  # noqa: F401 F403
+from materialize.checks.upsert import *  # noqa: F401 F403
+from materialize.checks.users import *  # noqa: F401 F403
+from materialize.checks.window_functions import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -18,7 +18,7 @@
 from typing import List
 
 from materialize.checks.actions import Testdrive
-from materialize.mzcompose import Composition
+from materialize.checks.executors import Executor
 
 
 class Check:
@@ -36,14 +36,14 @@ class Check:
     def validate(self) -> Testdrive:
         assert False
 
-    def run_initialize(self, c: Composition) -> None:
-        self._initialize.execute(c)
+    def run_initialize(self, e: Executor) -> None:
+        self._initialize.execute(e)
 
-    def run_manipulate(self, c: Composition, phase: int) -> None:
-        self._manipulate[phase].execute(c)
+    def run_manipulate(self, e: Executor, phase: int) -> None:
+        self._manipulate[phase].execute(e)
 
-    def run_validate(self, c: Composition) -> None:
-        self._validate.execute(c)
+    def run_validate(self, e: Executor) -> None:
+        self._validate.execute(e)
 
 
 class CheckDisabled(Check):

--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.mzcompose import Composition
+
+# from materialize.cloudtest import
+
+
+class Executor:
+    pass
+
+    def testdrive(self, input: str) -> None:
+        assert False
+
+    def mzcompose_composition(self) -> Composition:
+        assert False
+
+    def cloudtest_application(self) -> MaterializeApplication:
+        assert False
+
+
+class MzcomposeExecutor(Executor):
+    def __init__(self, composition: Composition) -> None:
+        self.composition = composition
+
+    def mzcompose_composition(self) -> Composition:
+        return self.composition
+
+    def testdrive(self, input: str) -> None:
+        self.composition.testdrive(input)
+
+
+class CloudtestExecutor(Executor):
+    def __init__(self, application: MaterializeApplication) -> None:
+        self.application = application
+
+    def cloudtest_application(self) -> MaterializeApplication:
+        return self.application
+
+    def testdrive(self, input: str) -> None:
+        self.application.testdrive.run(input=input, no_reset=True, seed=1)

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -1,0 +1,143 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Optional
+
+from materialize.checks.actions import Action
+from materialize.checks.executors import Executor
+from materialize.mzcompose.services import Computed, Materialized
+
+
+class MzcomposeAction(Action):
+    pass
+
+
+class StartMz(MzcomposeAction):
+    DEFAULT_MZ_OPTIONS = " ".join(
+        [
+            "--persist-consensus-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=consensus",
+            "--storage-stash-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=storage",
+            "--adapter-stash-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=adapter",
+        ]
+    )
+
+    def __init__(self, tag: Optional[str] = None) -> None:
+        self.tag = tag
+
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        image = f"materialize/materialized:{self.tag}" if self.tag is not None else None
+        print(f"Starting Mz using image {image}")
+        mz = Materialized(image=image, options=StartMz.DEFAULT_MZ_OPTIONS)
+
+        with c.override(mz):
+            c.up("materialized")
+
+        c.wait_for_materialized()
+
+        for config_param in ["max_tables", "max_sources"]:
+            c.sql(
+                f"ALTER SYSTEM SET {config_param} TO 1000",
+                user="mz_system",
+                port=6877,
+            )
+
+
+class KillMz(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+        c.kill("materialized")
+
+
+class UseComputed(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        c.sql(
+            """
+            DROP CLUSTER REPLICA default.default_replica;
+            CREATE CLUSTER REPLICA default.default_replica
+                REMOTE ['computed_1:2100'],
+                COMPUTE ['computed_1:2102'],
+                WORKERS 1;
+        """
+        )
+
+
+class KillComputed(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+        with c.override(Computed(name="computed_1")):
+            c.kill("computed_1")
+
+
+class StartComputed(MzcomposeAction):
+    def __init__(self, tag: Optional[str] = None) -> None:
+        self.tag = tag
+
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        image = f"materialize/computed:{self.tag}" if self.tag is not None else None
+        print(f"Starting Computed using image {image}")
+
+        computed = Computed(
+            name="computed_1",
+            image=image,
+        )
+
+        with c.override(computed):
+            c.up("computed_1")
+
+
+class RestartPostgresBackend(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        c.kill("postgres-backend")
+        c.up("postgres-backend")
+        c.wait_for_postgres(service="postgres-backend")
+
+
+class RestartSourcePostgres(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        c.kill("postgres-source")
+        c.up("postgres-source")
+        c.wait_for_postgres(service="postgres-source")
+
+
+class KillStoraged(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        # Depending on the workload, storaged may not be running, hence the || true
+        c.exec("materialized", "bash", "-c", "kill -9 `pidof storaged` || true")
+
+
+class DropCreateDefaultReplica(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        c.sql(
+            """
+           DROP CLUSTER REPLICA default.default_replica;
+           CREATE CLUSTER REPLICA default.default_replica SIZE '1';
+        """
+        )

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -17,34 +17,34 @@
 
 from typing import List, Type
 
-from materialize.checks.actions import Action
-from materialize.checks.actions import (
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.checks.mzcompose_actions import (
     DropCreateDefaultReplica as DropCreateDefaultReplicaAction,
 )
-from materialize.checks.actions import Initialize, KillComputed, KillMz
-from materialize.checks.actions import KillStoraged as KillStoragedAction
-from materialize.checks.actions import Manipulate
-from materialize.checks.actions import (
+from materialize.checks.mzcompose_actions import KillComputed, KillMz
+from materialize.checks.mzcompose_actions import KillStoraged as KillStoragedAction
+from materialize.checks.mzcompose_actions import (
     RestartPostgresBackend as RestartPostgresBackendAction,
 )
-from materialize.checks.actions import (
+from materialize.checks.mzcompose_actions import (
     RestartSourcePostgres as RestartSourcePostgresAction,
 )
-from materialize.checks.actions import StartComputed, StartMz, UseComputed, Validate
-from materialize.checks.checks import Check
-from materialize.mzcompose import Composition
+from materialize.checks.mzcompose_actions import StartComputed, StartMz, UseComputed
 
 
 class Scenario:
-    def __init__(self, checks: List[Type[Check]]) -> None:
+    def __init__(self, checks: List[Type[Check]], executor: Executor) -> None:
         self.checks = checks
+        self.executor = executor
 
     def actions(self) -> List[Action]:
         assert False
 
-    def run(self, c: Composition) -> None:
+    def run(self) -> None:
         for action in self.actions():
-            action.execute(c)
+            action.execute(self.executor)
 
 
 class NoRestartNoUpgrade(Scenario):

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -17,17 +17,13 @@
 
 from typing import List
 
-from materialize.checks.actions import (
-    Action,
-    Initialize,
+from materialize.checks.actions import Action, Initialize, Manipulate, Sleep, Validate
+from materialize.checks.mzcompose_actions import (
     KillComputed,
     KillMz,
-    Manipulate,
-    Sleep,
     StartComputed,
     StartMz,
     UseComputed,
-    Validate,
 )
 from materialize.checks.scenarios import Scenario
 

--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import subprocess
-from typing import List
+from typing import List, Optional
 
 from materialize import ROOT, mzbuild
 from materialize.cloudtest.k8s import K8sResource
@@ -64,7 +64,7 @@ class Application:
 
 
 class MaterializeApplication(Application):
-    def __init__(self, release_mode: bool) -> None:
+    def __init__(self, release_mode: bool = True, tag: Optional[str] = None) -> None:
         self.environmentd = EnvironmentdService()
         self.testdrive = Testdrive(release_mode=release_mode)
         self.release_mode = release_mode
@@ -76,7 +76,7 @@ class MaterializeApplication(Application):
             *SSH_RESOURCES,
             Minio(),
             AdminRoleBinding(),
-            EnvironmentdStatefulSet(release_mode=release_mode),
+            EnvironmentdStatefulSet(release_mode=release_mode, tag=tag),
             self.environmentd,
             self.testdrive,
         ]

--- a/misc/python/materialize/cloudtest/k8s/postgres.py
+++ b/misc/python/materialize/cloudtest/k8s/postgres.py
@@ -72,7 +72,7 @@ class PostgresService(K8sService):
 
 
 class PostgresStatefulSet(K8sStatefulSet):
-    def __init__(self) -> None:
+    def generate_stateful_set(self) -> V1StatefulSet:
         metadata = V1ObjectMeta(name="postgres", labels={"app": "postgres"})
         label_selector = V1LabelSelector(match_labels={"app": "postgres"})
         env = [V1EnvVar(name="POSTGRES_HOST_AUTH_METHOD", value="trust")]
@@ -110,7 +110,7 @@ class PostgresStatefulSet(K8sStatefulSet):
             )
         ]
 
-        self.stateful_set = V1StatefulSet(
+        return V1StatefulSet(
             api_version="apps/v1",
             kind="StatefulSet",
             metadata=metadata,

--- a/misc/python/materialize/cloudtest/k8s/postgres_source.py
+++ b/misc/python/materialize/cloudtest/k8s/postgres_source.py
@@ -52,7 +52,7 @@ class PostgresSourceDeployment(K8sDeployment):
         ports = [V1ContainerPort(container_port=5432, name="sql")]
         container = V1Container(
             name="postgres-source",
-            image=self.image("postgres", True),
+            image=self.image("postgres", tag=None, release_mode=True),
             args=["-c", "wal_level=logical"],
             env=env,
             ports=ports,

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -22,7 +22,7 @@ class Testdrive(K8sPod):
 
         container = V1Container(
             name="testdrive",
-            image=self.image("testdrive", release_mode),
+            image=self.image("testdrive", release_mode=release_mode),
             command=["sleep", "infinity"],
         )
 

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -1,0 +1,95 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+from typing import List, Optional
+
+import pytest
+
+from materialize.checks.actions import Action, Initialize, Manipulate, Validate
+from materialize.checks.all_checks import *  # noqa: F401 F403
+from materialize.checks.checks import Check
+from materialize.checks.executors import CloudtestExecutor, Executor
+from materialize.checks.scenarios import Scenario
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
+from materialize.cloudtest.wait import wait
+
+# This will 'upgrade' from the current source.
+# Once a stable release is out, we need to get its DockerHub tag in here
+LAST_RELEASED_VERSION = None
+
+# Debezium is not available in cloudtest yet
+DISABLED_CHECKS = [DebeziumPostgres]  # noqa: F405
+
+
+class ReplaceEnvironmentdStatefulSet(Action):
+    """Change the image tag of the environmentd stateful set, re-create the definition and replace the existing one."""
+
+    def __init__(self, new_tag: Optional[str] = None) -> None:
+        self.new_tag = new_tag
+
+    def execute(self, e: Executor) -> None:
+        mz = e.cloudtest_application()
+        stateful_set = [
+            resource
+            for resource in mz.resources
+            if type(resource) == EnvironmentdStatefulSet
+        ]
+        assert len(stateful_set) == 1
+        stateful_set = stateful_set[0]
+
+        stateful_set.tag = self.new_tag
+        stateful_set.replace()
+
+
+class LiftClusterLimits(Action):
+    def execute(self, e: Executor) -> None:
+        e.testdrive(
+            input=dedent(
+                """
+                $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+                $ postgres-execute connection=mz_system
+                ALTER SYSTEM SET max_tables = 100;
+
+                ALTER SYSTEM SET max_sources = 100;
+
+                ALTER SYSTEM SET max_materialized_views = 100;
+                ALTER SYSTEM SET max_objects_per_schema = 1000;
+                """
+            )
+        )
+
+
+class CloudtestUpgrade(Scenario):
+    """A Platform Checks scenario that performs an upgrade in cloudtest/K8s"""
+
+    def actions(self) -> List[Action]:
+        return [
+            LiftClusterLimits(),
+            Initialize(self.checks),
+            Manipulate(self.checks, phase=1),
+            ReplaceEnvironmentdStatefulSet(new_tag=None),
+            Manipulate(self.checks, phase=2),
+            Validate(self.checks),
+        ]
+
+
+@pytest.mark.long
+def test_upgrade() -> None:
+    """Test upgrade from LAST_RELEASED_VERSION to the current source by running all the Platform Checks"""
+    checks = [check for check in Check.__subclasses__() if check not in DISABLED_CHECKS]
+
+    mz = MaterializeApplication(tag=LAST_RELEASED_VERSION)
+    wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+
+    executor = CloudtestExecutor(application=mz)
+    scenario = CloudtestUpgrade(checks=checks, executor=executor)
+    scenario.run()


### PR DESCRIPTION
Use the test content from Platform Checks to run an upgrade scenario in K8s. The upgrade is performed by replacing the image tag and command line in the environmentd stateful set and then using replace_named_statefulset Python API to install the new stateful set definition in K8s.

### Motivation

  * This PR adds a feature that has not yet been specified.

For maximum realism, the upgrade tests should run in K8s as to mimic what would happen in the cloud.