### PR TITLE
adapter: prepare cluster replica tables for stabilization

### DIFF
--- a/doc/developer/design/20220728_persisting_introspection_data.md
+++ b/doc/developer/design/20220728_persisting_introspection_data.md
@@ -127,7 +127,7 @@ The idea is to expose to the user one source per replica-introspection type pair
 
 `mz_catalog.dataflow_operators_2` (for the cluster c1)
 
-Each table name has a cluster id suffix, users can determine the cluster id using the table `mz_catalog.mz_cluster_replicas_base`.
+Each table name has a cluster id suffix, users can determine the cluster id using the table `mz_catalog.mz_cluster_replicas`.
 
 **Benefits**: It allows the user to query up-to-date data from a single replica. There is nothing that blocks a computed of writing into the logging sources as fast as persist allows, thus the queried data should be fresh. This approach synergizes well with storage renditions, if a computed restarts, it could start a new rendition, elegantly solving the problem that a “zombie” computed writes to the same shard.
 

--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -29,7 +29,8 @@ Materialize also directly exposes replica-specific introspection sources by
 suffixing the respective catalog relation names with a replica ID that is unique
 across clusters. For example, `mz_internal.mz_compute_frontiers_1` corresponds to
 the introspection source `mz_internal.mz_compute_frontiers` in the replica with
-a unique ID of `1`.
+the unique ID of `1`. A mapping of replica IDs to clusters and replica names is
+provided by the [`mz_cluster_replicas`] system table.
 
 As a consequence of the above, you should expect the answers to the queries below
 to vary dependending on which cluster you are working in. In particular, indexes
@@ -314,3 +315,5 @@ SELECT count(1) FROM (
     GROUP BY id
 );
 ```
+
+[`mz_cluster_replicas`]: /sql/system-catalog/mz_catalog/#mz_cluster_replicas

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -73,9 +73,9 @@ The `mz_cluster_replicas` table contains a row for each cluster replica in the s
 
 Field               | Type       | Meaning
 --------------------|------------|--------
-`cluster_id`        | [`bigint`] | The ID of the cluster to which the replica belongs.
 `id`                | [`bigint`] | Materialize's unique ID for the cluster replica.
 `name`              | [`text`]   | The name of the cluster replica.
+`cluster_id`        | [`bigint`] | The ID of the cluster to which the replica belongs.
 `size`              | [`text`]   | The cluster replica's size, selected during creation.
 `availability_zone` | [`text`]   | The cluster replica's target availability zone, selected during creation. This value is `NULL` if no availability zone was specified when the replica was created.
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -58,6 +58,27 @@ Field            | Type        | Meaning
 `default`        | [`text`]    | The default expression of the column.
 `type_oid`       | [`oid`]     | The OID of the type of the column (references `mz_types`).
 
+### `mz_clusters`
+
+The `mz_clusters` table contains a row for each cluster in the system.
+
+Field          | Type       | Meaning
+---------------|------------|--------
+`id`           | [`bigint`] | Materialize's unique ID for the cluster.
+`name`         | [`text`]   | The name of the cluster.
+
+### `mz_cluster_replicas`
+
+The `mz_cluster_replicas` table contains a row for each cluster replica in the system.
+
+Field               | Type       | Meaning
+--------------------|------------|--------
+`cluster_id`        | [`bigint`] | The ID of the cluster to which the replica belongs.
+`id`                | [`bigint`] | Materialize's unique ID for the cluster replica.
+`name`              | [`text`]   | The name of the cluster replica.
+`size`              | [`text`]   | The cluster replica's size, selected during creation.
+`availability_zone` | [`text`]   | The cluster replica's target availability zone, selected during creation. This value is `NULL` if no availability zone was specified when the replica was created.
+
 ### `mz_databases`
 
 The `mz_databases` table contains a row for each database in the system.

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1330,7 +1330,7 @@ pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 });
 pub static MZ_CLUSTER_REPLICAS_BASE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas_base",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("cluster_id", ScalarType::UInt64.nullable(false))
         .with_column("id", ScalarType::UInt64.nullable(false))
@@ -1341,7 +1341,7 @@ pub static MZ_CLUSTER_REPLICAS_BASE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
 
 pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_statuses",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::UInt64.nullable(false))
         .with_column("process_id", ScalarType::Int64.nullable(false))
@@ -1351,7 +1351,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
 
 pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_heartbeats",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::UInt64.nullable(false))
         .with_column("last_heartbeat", ScalarType::TimestampTz.nullable(false)),
@@ -1502,7 +1502,7 @@ WITH counts AS (
         count(*) AS total,
         sum(CASE WHEN status = 'ready' THEN 1 else 0 END) AS ready,
         sum(CASE WHEN status = 'not_ready' THEN 1 else 0 END) AS not_ready
-    FROM mz_catalog.mz_cluster_replica_statuses
+    FROM mz_internal.mz_cluster_replica_statuses
     GROUP BY replica_id
 )
 SELECT
@@ -1514,7 +1514,7 @@ SELECT
             THEN 'healthy'
         ELSE 'unknown'
         END AS status
-FROM mz_catalog.mz_cluster_replicas_base
+FROM mz_internal.mz_cluster_replicas_base
 LEFT OUTER JOIN counts
     ON mz_cluster_replicas_base.id = counts.replica_id",
 };

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1332,9 +1332,9 @@ pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("cluster_id", ScalarType::UInt64.nullable(false))
         .with_column("id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
+        .with_column("cluster_id", ScalarType::UInt64.nullable(false))
         .with_column("size", ScalarType::String.nullable(true))
         .with_column("availability_zone", ScalarType::String.nullable(true)),
 });

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -29,7 +29,7 @@ use mz_storage::types::hosts::StorageHostConfig;
 use mz_storage::types::sinks::{KafkaSinkConnection, StorageSinkConnection};
 
 use crate::catalog::builtin::{
-    MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS_BASE,
+    MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS,
     MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS,
     MZ_DATABASES, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS,
     MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS,
@@ -139,7 +139,7 @@ impl CatalogState {
         };
 
         BuiltinTableUpdate {
-            id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS_BASE),
+            id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
                 Datum::UInt64(compute_instance_id),
                 Datum::UInt64(id),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -141,9 +141,9 @@ impl CatalogState {
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
-                Datum::UInt64(compute_instance_id),
                 Datum::UInt64(id),
                 Datum::String(name),
+                Datum::UInt64(compute_instance_id),
                 Datum::from(size),
                 Datum::from(az),
             ]),

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -516,13 +516,13 @@ CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1']
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_32 (SIZE '32'), size_2_2 (SIZE '2-2'))
 
-query TTT
-SELECT name, size, status FROM mz_cluster_replicas ORDER BY name
+query TT
+SELECT name, size FROM mz_cluster_replicas ORDER BY name
 ----
-default_replica  1        unknown
-size_1           1        unknown
-size_2_2         2-2      unknown
-size_32          32       unknown
+default_replica  1
+size_1           1
+size_2_2         2-2
+size_32          32
 
 statement ok
 DROP CLUSTER foo CASCADE

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -30,7 +30,7 @@ SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1') - 
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name NOT LIKE '%_1') - (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name LIKE '%_1');
 ----
-28
+27
 
 
 # The default cluster also has log sources, thus we should have one set active at boot.

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -459,6 +459,7 @@ mz_array_types
 mz_audit_events
 mz_base_types
 mz_clusters
+mz_cluster_replicas
 mz_columns
 mz_connections
 mz_databases
@@ -484,7 +485,6 @@ mz_views
 > SHOW VIEWS FROM mz_catalog
 name
 -----------------------------------
-mz_cluster_replicas
 mz_objects
 mz_relations
 mz_storage_usage
@@ -543,7 +543,6 @@ name
 ----
 mz_cluster_replica_heartbeats
 mz_cluster_replica_statuses
-mz_cluster_replicas_base
 mz_storage_usage_by_shard
 mz_view_foreign_keys
 mz_view_keys

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -459,9 +459,6 @@ mz_array_types
 mz_audit_events
 mz_base_types
 mz_clusters
-mz_cluster_replicas_base
-mz_cluster_replica_statuses
-mz_cluster_replica_heartbeats
 mz_columns
 mz_connections
 mz_databases
@@ -544,6 +541,9 @@ mz_worker_compute_import_frontiers_1            log   <null>
 > SHOW TABLES FROM mz_internal
 name
 ----
+mz_cluster_replica_heartbeats
+mz_cluster_replica_statuses
+mz_cluster_replicas_base
 mz_storage_usage_by_shard
 mz_view_foreign_keys
 mz_view_keys

--- a/test/testdrive/github-15095.td
+++ b/test/testdrive/github-15095.td
@@ -15,6 +15,6 @@
 # the first replica heartbeat to arrive.
 
 > SELECT count(*)
-  FROM mz_cluster_replicas r, mz_cluster_replica_heartbeats h
+  FROM mz_cluster_replicas r, mz_internal.mz_cluster_replica_heartbeats h
   WHERE r.id = h.replica_id AND r.name = 'r'
 1


### PR DESCRIPTION
This PR makes a couple last changes to the system tables around cluster replicas, to prepare stable Materialize. Specifically:

* It moves `mz_cluster_replica_statuses` and `mz_cluster_replica_heartbeats` into `mz_internal`, declaring them as unstable.
* It removes the `mz_cluster_replicas.status` field, which was a potential source of confusion for users because it only tracked the pod-level status and not if the replica was actually able to serve requests.
* It removes the `mz_cluster_replicas_base` table, which is no longer needed after the removal of `mz_cluster_replicas.status`.
* It adds user documentation for `mz_clusters` and `mz_cluster_replicas`.

### Motivation

  * This PR future-proofs our system catalog.

[Slack thread](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1665034990205809)

### Tips for reviewer

The PR is split into commits as follows:
* Commit 1 moves the unstable tables into `mz_internal`.
* Commit 2 removes `mz_cluster_replicas.status` and `mz_cluster_replicas_base`.
* Commit 3 adds `mz_clusters` and `mz_cluster_replicas` to the user docs.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Move the system tables `mz_cluster_replica_statuses` and `mz_cluster_replica_heartbeats` into the `mz_internal` schema, declaring them unstable.
  - Remove the `status` field from `mz_cluster_replicas`.
  - Remove the system table `mz_cluster_replicas_base`.
