### PR TITLE
adapter,sql: expose sink sizes in mz_sinks and SHOW SINKS

### DIFF
--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -33,7 +33,8 @@ name  | type
 Field | Meaning
 ------|--------
 **name** | The name of the sink.
-**type** | Whether the sink was created by the `user` or the `system`.
+**type** | The type of the sink: currently only `kafka` is supported.
+**size** | The size of the sink.
 
 ## Examples
 
@@ -41,10 +42,10 @@ Field | Meaning
 SHOW SINKS;
 ```
 ```nofmt
-name    | type
---------+-------
-my_sink | user
-my_sink
+name    | type  | size
+--------+-------+--------
+my_sink | kafka | small
+xl_sink | kafka | xlarge
 ```
 
 ## Related pages

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -234,6 +234,7 @@ Field            | Type        | Meaning
 `name`           | [`text`]    | The name of the sink.
 `type`           | [`text`]    | The type of the sink: `kafka`.
 `connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any.
+`size`           | [`text`]    | The size of the sink.
 
 ### `mz_sources`
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1223,7 +1223,8 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("schema_id", ScalarType::UInt64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("type", ScalarType::String.nullable(false))
-        .with_column("connection_id", ScalarType::String.nullable(true)),
+        .with_column("connection_id", ScalarType::String.nullable(true))
+        .with_column("size", ScalarType::String.nullable(true)),
 });
 pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_views",

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -514,6 +514,12 @@ impl CatalogState {
                     });
                 }
             }
+            let size = match &sink.host_config {
+                mz_storage::types::hosts::StorageHostConfig::Remote { .. } => Datum::Null,
+                mz_storage::types::hosts::StorageHostConfig::Managed { size, .. } => {
+                    Datum::String(size)
+                }
+            };
             updates.push(BuiltinTableUpdate {
                 id: self.resolve_builtin_table(&MZ_SINKS),
                 row: Row::pack_slice(&[
@@ -523,6 +529,7 @@ impl CatalogState {
                     Datum::String(name),
                     Datum::String(connection.name()),
                     Datum::from(sink.connection_id.map(|id| id.to_string()).as_deref()),
+                    size,
                 ]),
                 diff,
             });

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -407,7 +407,7 @@ fn show_sinks<'a>(
     let query_filters = itertools::join(query_filters.iter(), " AND ");
 
     let query = format!(
-        "SELECT sinks.name
+        "SELECT sinks.name, sinks.type, sinks.size
         FROM mz_catalog.mz_sinks AS sinks
         WHERE {query_filters}",
     );

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -170,9 +170,9 @@ renamed_mz_data    kafka  1
 
 # Sink was successfully renamed
 > SHOW SINKS
-name
-------------
-renamed_sink
+name               type   size
+------------------------------
+renamed_sink       kafka  1
 
 # View was successfully renamed
 > SHOW VIEWS

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -49,8 +49,8 @@ goofus,gallant
 contains:Expected one of SIZE or SNAPSHOT
 
 > SHOW SINKS
-name
-----
+name               type   size
+------------------------------
 
 # # We should refuse to create a sink with an invalid schema registry URL.
 #
@@ -85,8 +85,8 @@ name
 # contains:v2 is a view, which cannot be exported as a sink
 
 > SHOW SINKS
-name
-----
+name               type   size
+------------------------------
 
 # N.B. it is important to test sinks that depend on sources directly vs. sinks
 # that depend on views, as the code paths are different.
@@ -107,11 +107,11 @@ name
   ENVELOPE DEBEZIUM
 
 > SHOW SINKS
-name
-----
-snk1
-snk2
-snk3
+name               type   size
+------------------------------
+snk1               kafka  1
+snk2               kafka  1
+snk3               kafka  1
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
@@ -201,17 +201,17 @@ $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"column1": 3}}}
 
 > SHOW SINKS
-name
-----
-snk1
-snk2
-snk3
-snk4
-snk5
-snk6
-snk7
-snk8
-snk_unsigned
+name               type   size
+------------------------------
+snk1               kafka  1
+snk2               kafka  1
+snk3               kafka  1
+snk4               kafka  1
+snk5               kafka  1
+snk6               kafka  1
+snk7               kafka  1
+snk8               kafka  1
+snk_unsigned       kafka  1
 
 # test explicit partition count
 > CREATE SINK snk9 FROM foo
@@ -251,7 +251,7 @@ snk_unsigned
   WITH (SIZE = '2')
 
 # create sink with SIZE and SNAPSHOT set
-> CREATE SINK sink_with_size_and_snapshot FROM src
+> CREATE SINK sink_with_options FROM src
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
@@ -264,3 +264,24 @@ snk_unsigned
 # Including for sinks with default size
 > SELECT size FROM mz_sinks WHERE name = 'snk13'
 1
+
+# Check that SHOW SINKS shows the size correctly
+> SHOW SINKS
+name               type   size
+------------------------------
+snk1               kafka  1
+snk2               kafka  1
+snk3               kafka  1
+snk4               kafka  1
+snk5               kafka  1
+snk6               kafka  1
+snk7               kafka  1
+snk8               kafka  1
+snk9               kafka  1
+snk10              kafka  1
+snk11              kafka  1
+snk12              kafka  1
+snk13              kafka  1
+sink_with_size     kafka  2
+sink_with_options  kafka  2
+snk_unsigned       kafka  1

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -256,3 +256,11 @@ snk_unsigned
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
   WITH (SIZE = '2', SNAPSHOT = false)
+
+# Check that the size is properly filled in the `mz_sinks` table
+> SELECT size FROM mz_sinks WHERE name = 'sink_with_size'
+2
+
+# Including for sinks with default size
+> SELECT size FROM mz_sinks WHERE name = 'snk13'
+1


### PR DESCRIPTION
This PR should be backwards compatible due to only adding a new nullable column to an existing system table.

Closes #15215. Closes #15216.

### Motivation

  * This PR adds a known-desirable feature: #15215 and #15216

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `mz_catalog.mz_sinks` now includes an extra column `size` with the size of each sink.
  - `SHOW SINKS` now returns two extra columns, `type` and `size`, with the type and the size of each sink.