### PR TITLE
Remove storage managed table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,7 +3575,12 @@ dependencies = [
  "chrono",
  "derivative",
  "futures-core",
+ "mz-ore",
+ "mz-proto",
+ "prost",
+ "protobuf-src",
  "serde",
+ "tonic-build",
 ]
 
 [[package]]

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -203,9 +203,10 @@ impl CatalogState {
             CatalogItem::Table(_) => self.pack_table_update(id, oid, schema_id, name, diff),
             CatalogItem::Source(source) => {
                 let (source_type, connection_id) = match &source.data_source {
-                    DataSourceDesc::Ingest(ingest) => {
-                        (ingest.desc.name(), ingest.desc.connection.connection_id())
-                    }
+                    DataSourceDesc::Ingestion(ingestion) => (
+                        ingestion.desc.name(),
+                        ingestion.desc.connection.connection_id(),
+                    ),
                     DataSourceDesc::Source => ("subsource", None),
                     DataSourceDesc::Introspection(_) => ("source", None),
                 };
@@ -217,7 +218,12 @@ impl CatalogState {
                     name,
                     source_type,
                     connection_id,
-                    source.host_config.size(),
+                    source
+                        .host_config
+                        .as_ref()
+                        .as_ref()
+                        .map(|config| config.size())
+                        .flatten(),
                     diff,
                 )
             }
@@ -231,9 +237,6 @@ impl CatalogState {
             CatalogItem::Secret(_) => self.pack_secret_update(id, schema_id, name, diff),
             CatalogItem::Connection(connection) => {
                 self.pack_connection_update(id, oid, schema_id, name, connection, diff)
-            }
-            CatalogItem::StorageManagedTable(_) => {
-                self.pack_source_update(id, oid, schema_id, name, "source", None, None, diff)
             }
         };
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -504,6 +504,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 ingestion_metadata: (),
                                 source_imports,
                                 source_exports,
+                                host_config: ingestion.host_config.clone(),
                             })
                         }
                         DataSourceDesc::Source => DataSource::Source,
@@ -521,7 +522,6 @@ impl<S: Append + 'static> Coordinator<S> {
                                 data_source,
                                 since: None,
                                 status_collection_id,
-                                host_config: source.host_config.clone(),
                             },
                         )])
                         .await

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -507,7 +507,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 host_config: ingestion.host_config.clone(),
                             })
                         }
-                        DataSourceDesc::Source => DataSource::Source,
+                        DataSourceDesc::Source => DataSource::Other,
                         DataSourceDesc::Introspection(introspection) => {
                             DataSource::Introspection(*introspection)
                         }

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -261,9 +261,6 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                     CatalogItem::Log(log) => {
                         dataflow.import_source(*id, log.variant.desc().typ().clone(), false);
                     }
-                    CatalogItem::StorageManagedTable(coll) => {
-                        dataflow.import_source(*id, coll.desc.typ().clone(), false);
-                    }
                     _ => unreachable!(),
                 }
             }
@@ -417,7 +414,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
         // TODO(petrosagg): store an inverse mapping of subsource -> source in the catalog so that
         // we can retrieve monotonicity information from the parent source.
         match &source.data_source {
-            DataSourceDesc::Ingest(ingest) => ingest.desc.monotonic(),
+            DataSourceDesc::Ingestion(ingestion) => ingestion.desc.monotonic(),
             DataSourceDesc::Introspection(_) | DataSourceDesc::Source => false,
         }
     }
@@ -496,8 +493,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                 | CatalogItem::Log(_)
                 | CatalogItem::Index(_)
                 | CatalogItem::Sink(_)
-                | CatalogItem::Func(_)
-                | CatalogItem::StorageManagedTable(_) => Ok(false),
+                | CatalogItem::Func(_) => Ok(false),
             }
         })
     }

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -35,7 +35,7 @@ use mz_repr::adt::array::ArrayDimension;
 use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_stash::Append;
 
-use crate::catalog::{CatalogItem, CatalogState, MaterializedView, Source, View};
+use crate::catalog::{CatalogItem, CatalogState, DataSourceDesc, MaterializedView, Source, View};
 use crate::coord::ddl::CatalogTxn;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::{Coordinator, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS};
@@ -416,9 +416,9 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
     fn monotonic_source(&self, source: &Source) -> bool {
         // TODO(petrosagg): store an inverse mapping of subsource -> source in the catalog so that
         // we can retrieve monotonicity information from the parent source.
-        match &source.ingestion {
-            Some(ingestion) => ingestion.desc.monotonic(),
-            None => false,
+        match &source.data_source {
+            DataSourceDesc::Ingest(ingest) => ingest.desc.monotonic(),
+            DataSourceDesc::Introspection(_) | DataSourceDesc::Source => false,
         }
     }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -88,7 +88,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                     CatalogItem::Source(source) => {
                         sources_to_drop.push(*id);
-                        if let DataSourceDesc::Ingest(ingestion) = &source.data_source {
+                        if let DataSourceDesc::Ingestion(ingestion) = &source.data_source {
                             match &ingestion.desc.connection {
                                 SourceConnection::Postgres(PostgresSourceConnection {
                                     connection,
@@ -570,8 +570,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         | CatalogItem::Index(_)
                         | CatalogItem::Type(_)
                         | CatalogItem::Func(_)
-                        | CatalogItem::Connection(_)
-                        | CatalogItem::StorageManagedTable(_) => {}
+                        | CatalogItem::Connection(_) => {}
                     }
                 }
                 Op::DropDatabase { .. } => {
@@ -616,8 +615,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         | CatalogItem::Index(_)
                         | CatalogItem::Type(_)
                         | CatalogItem::Func(_)
-                        | CatalogItem::Connection(_)
-                        | CatalogItem::StorageManagedTable(_) => {}
+                        | CatalogItem::Connection(_) => {}
                     }
                 }
                 Op::AlterSink { .. }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -31,8 +31,8 @@ use mz_storage::types::sinks::{SinkAsOf, StorageSinkConnection};
 use mz_storage::types::sources::{PostgresSourceConnection, SourceConnection, Timeline};
 
 use crate::catalog::{
-    CatalogItem, CatalogState, Op, Sink, StorageSinkConnectionState, TransactionResult,
-    SYSTEM_CONN_ID,
+    CatalogItem, CatalogState, DataSourceDesc, Op, Sink, StorageSinkConnectionState,
+    TransactionResult, SYSTEM_CONN_ID,
 };
 use crate::client::ConnectionId;
 use crate::coord::appends::BuiltinTableUpdateSource;
@@ -88,7 +88,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                     CatalogItem::Source(source) => {
                         sources_to_drop.push(*id);
-                        if let Some(ingestion) = &source.ingestion {
+                        if let DataSourceDesc::Ingest(ingestion) = &source.data_source {
                             match &ingestion.desc.connection {
                                 SourceConnection::Postgres(PostgresSourceConnection {
                                     connection,

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -82,7 +82,6 @@ impl<T: TimestampManipulation> ComputeInstanceIndexOracle<'_, T> {
                     CatalogItem::Source(_)
                     | CatalogItem::Table(_)
                     | CatalogItem::MaterializedView(_)
-                    | CatalogItem::StorageManagedTable(_)
                     | CatalogItem::Log(Log {
                         has_storage_collection: true,
                         ..

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -542,7 +542,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 host_config: ingestion.host_config,
                             })
                         }
-                        DataSourceDesc::Source => DataSource::Source,
+                        DataSourceDesc::Source => DataSource::Other,
                         DataSourceDesc::Introspection(_) => {
                             unreachable!("cannot create sources with introspection data sources")
                         }
@@ -1499,7 +1499,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         id,
                         CollectionDescription {
                             desc,
-                            data_source: DataSource::Dataflow,
+                            data_source: DataSource::Other,
                             since: Some(as_of),
                             status_collection_id: None,
                         },

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -433,8 +433,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     match entry.item() {
                         CatalogItem::Table(_)
                         | CatalogItem::Source(_)
-                        | CatalogItem::MaterializedView(_)
-                        | CatalogItem::StorageManagedTable(_) => {
+                        | CatalogItem::MaterializedView(_) => {
                             id_bundle.storage_ids.insert(entry.id());
                         }
                         CatalogItem::Index(index) => {
@@ -536,9 +535,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         timelines.insert(id, table.timeline());
                     }
                     CatalogItem::Log(_) => {
-                        timelines.insert(id, Timeline::EpochMilliseconds);
-                    }
-                    CatalogItem::StorageManagedTable(_) => {
                         timelines.insert(id, Timeline::EpochMilliseconds);
                     }
                     CatalogItem::Sink(_)

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -13,4 +13,11 @@ bytesize = "1.1.0"
 chrono = { version = "0.4.22", default_features = false, features = ["serde"] }
 derivative = "2.2.0"
 futures-core = "0.3.21"
+mz-ore = { path = "../ore"}
+mz-proto = { path = "../proto" }
+prost = { version = "0.11.0", features = ["no-recursion-limit"] }
 serde = "1.0"
+
+[build-dependencies]
+protobuf-src = "1.1.0"
+tonic-build = "0.8.0"

--- a/src/orchestrator/build.rs
+++ b/src/orchestrator/build.rs
@@ -1,0 +1,24 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::env;
+
+fn main() {
+    env::set_var("PROTOC", protobuf_src::protoc());
+
+    tonic_build::configure()
+        // Enabling `emit_rerun_if_changed` will rerun the build script when
+        // anything in the include directory (..) changes. This causes quite a
+        // bit of spurious recompilation, so we disable it. The default behavior
+        // is to re-run if any file in the crate changes; that's still a bit too
+        // broad, but it's better.
+        .emit_rerun_if_changed(false)
+        .compile(&["orchestrator/src/orchtestrator.proto"], &[".."])
+        .unwrap();
+}

--- a/src/orchestrator/src/orchtestrator.proto
+++ b/src/orchestrator/src/orchtestrator.proto
@@ -1,0 +1,22 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package mz_orchestrator;
+
+message ProtoMemoryLimit {
+    uint64 inner = 1;
+}
+
+message ProtoCpuLimit {
+    uint64 millicpus = 1;
+}

--- a/src/orchestrator/src/orchtestrator.proto
+++ b/src/orchestrator/src/orchtestrator.proto
@@ -9,8 +9,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-
 package mz_orchestrator;
 
 message ProtoMemoryLimit {

--- a/src/storage/build.rs
+++ b/src/storage/build.rs
@@ -30,6 +30,7 @@ fn main() {
         .extern_path(".mz_repr.chrono", "::mz_repr::chrono")
         .extern_path(".mz_repr.antichain", "::mz_repr::antichain")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
+        .extern_path(".mz_orchestrator", "::mz_orchestrator")
         .extern_path(".mz_proto", "::mz_proto")
         .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.row", "::mz_repr")
@@ -40,6 +41,7 @@ fn main() {
                 "storage/src/controller.proto",
                 "storage/src/types/errors.proto",
                 "storage/src/types/connections/aws.proto",
+                "storage/src/types/hosts.proto",
                 "storage/src/types/sinks.proto",
                 "storage/src/types/sources.proto",
                 "storage/src/types/sources/encoding.proto",

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -97,18 +97,18 @@ pub enum IntrospectionType {
     ShardMapping,
 }
 
+/// Describes how data is written to the collection.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataSource {
     /// Ingest data from some external source.
     Ingestion(IngestionDescription),
-    /// This source's data source is some other source.
-    // TODO: embed the source's GlobalId
-    Source,
-    /// This source's data is a dataflow (i.e. it repesents a materialized view)
-    Dataflow,
     /// Data comes from introspection sources, which the controller itself is
     /// responisble for generating.
     Introspection(IntrospectionType),
+    /// This source's data is does not need to be managed by the storage
+    /// controller, e.g. it's a materialized view, table, or subsource.
+    // TODO? Add a means to track some data sources' GlobalIds.
+    Other,
 }
 
 /// Describes a request to create a source.
@@ -116,7 +116,7 @@ pub enum DataSource {
 pub struct CollectionDescription<T> {
     /// The schema of this collection
     pub desc: RelationDesc,
-    /// The description of the source of data for this collection to ingest.
+    /// The source of this collection's data.
     pub data_source: DataSource,
     /// An optional frontier to which the collection's `since` should be advanced.
     pub since: Option<Antichain<T>>,
@@ -129,7 +129,7 @@ impl<T> From<RelationDesc> for CollectionDescription<T> {
     fn from(desc: RelationDesc) -> Self {
         Self {
             desc,
-            data_source: DataSource::Dataflow,
+            data_source: DataSource::Other,
             since: None,
             status_collection_id: None,
         }
@@ -947,7 +947,7 @@ where
                         }
                     }
                 }
-                DataSource::Source | DataSource::Dataflow => {}
+                DataSource::Other => {}
             }
         }
 

--- a/src/storage/src/types/hosts.proto
+++ b/src/storage/src/types/hosts.proto
@@ -1,0 +1,36 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "orchestrator/src/orchtestrator.proto";
+
+package mz_storage.types.hosts;
+
+message ProtoStorageHostResourceAllocation {
+    optional mz_orchestrator.ProtoMemoryLimit memory_limit = 1;
+    optional mz_orchestrator.ProtoCpuLimit cpu_limit = 2;
+    uint64 workers = 3;
+}
+
+message ProtoStorageHostConfig {
+    message ProtoStorageHostConfigRemote {
+        string addr = 1;
+    }
+
+    message ProtoStorageHostConfigManaged {
+        ProtoStorageHostResourceAllocation allocation = 1;
+        string size = 2;
+    }
+
+    oneof kind {
+        ProtoStorageHostConfigRemote remote = 1;
+        ProtoStorageHostConfigManaged managed = 2;
+    }
+}

--- a/src/storage/src/types/hosts.rs
+++ b/src/storage/src/types/hosts.rs
@@ -14,6 +14,9 @@ use std::num::NonZeroUsize;
 use serde::{Deserialize, Serialize};
 
 use mz_orchestrator::{CpuLimit, MemoryLimit};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+
+include!(concat!(env!("OUT_DIR"), "/mz_storage.types.hosts.rs"));
 
 /// Resource allocations for a storage host.
 ///
@@ -27,6 +30,24 @@ pub struct StorageHostResourceAllocation {
     pub cpu_limit: Option<CpuLimit>,
     /// The number of worker threads in the replica.
     pub workers: NonZeroUsize,
+}
+
+impl RustType<ProtoStorageHostResourceAllocation> for StorageHostResourceAllocation {
+    fn into_proto(&self) -> ProtoStorageHostResourceAllocation {
+        ProtoStorageHostResourceAllocation {
+            memory_limit: self.memory_limit.into_proto(),
+            cpu_limit: self.cpu_limit.into_proto(),
+            workers: self.workers.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoStorageHostResourceAllocation) -> Result<Self, TryFromProtoError> {
+        Ok(StorageHostResourceAllocation {
+            memory_limit: proto.memory_limit.into_rust()?,
+            cpu_limit: proto.cpu_limit.into_rust()?,
+            workers: proto.workers.into_rust()?,
+        })
+    }
 }
 
 /// Size or address of a storage instance
@@ -47,6 +68,46 @@ pub enum StorageHostConfig {
         /// SQL size parameter used for allocation
         size: String,
     },
+}
+
+impl RustType<ProtoStorageHostConfig> for StorageHostConfig {
+    fn into_proto(&self) -> ProtoStorageHostConfig {
+        use proto_storage_host_config::*;
+        ProtoStorageHostConfig {
+            kind: Some(match self {
+                StorageHostConfig::Remote { addr } => Kind::Remote(ProtoStorageHostConfigRemote {
+                    addr: addr.into_proto(),
+                }),
+                StorageHostConfig::Managed { allocation, size } => {
+                    Kind::Managed(ProtoStorageHostConfigManaged {
+                        allocation: Some(allocation.into_proto()),
+                        size: size.into_proto(),
+                    })
+                }
+            }),
+        }
+    }
+
+    fn from_proto(proto: ProtoStorageHostConfig) -> Result<Self, TryFromProtoError> {
+        use proto_storage_host_config::*;
+        Ok(
+            match proto
+                .kind
+                .ok_or_else(|| TryFromProtoError::missing_field("ProtoStorageHostConfig::kind"))?
+            {
+                Kind::Remote(ProtoStorageHostConfigRemote { addr }) => {
+                    StorageHostConfig::Remote { addr }
+                }
+                Kind::Managed(ProtoStorageHostConfigManaged { allocation, size }) => {
+                    StorageHostConfig::Managed {
+                        allocation: allocation
+                            .into_rust_if_some("ProtoStorageHostConfigManaged::allocation")?,
+                        size,
+                    }
+                }
+            },
+        )
+    }
 }
 
 impl StorageHostConfig {

--- a/src/storage/src/types/hosts.rs
+++ b/src/storage/src/types/hosts.rs
@@ -11,6 +11,10 @@
 
 use std::num::NonZeroUsize;
 
+use proptest::prelude::any;
+use proptest::prelude::Arbitrary;
+use proptest::strategy::BoxedStrategy;
+use proptest::strategy::Strategy;
 use serde::{Deserialize, Serialize};
 
 use mz_orchestrator::{CpuLimit, MemoryLimit};
@@ -107,6 +111,17 @@ impl RustType<ProtoStorageHostConfig> for StorageHostConfig {
                 }
             },
         )
+    }
+}
+
+impl Arbitrary for StorageHostConfig {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (any::<String>())
+            .prop_map(|addr| Self::Remote { addr })
+            .boxed()
     }
 }
 

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -21,6 +21,7 @@ import "storage/src/controller.proto";
 import "storage/src/types/connections.proto";
 import "storage/src/types/connections/aws.proto";
 import "storage/src/types/errors.proto";
+import "storage/src/types/hosts.proto";
 import "storage/src/types/sources/encoding.proto";
 import "expr/src/scalar.proto";
 
@@ -252,4 +253,5 @@ message ProtoIngestionDescription {
     repeated ProtoSourceExport source_exports = 2;
     mz_storage.controller.ProtoCollectionMetadata ingestion_metadata = 3;
     ProtoSourceDesc desc = 4;
+    mz_storage.types.hosts.ProtoStorageHostConfig host_config = 5;
 }

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -15,11 +15,11 @@
 name          type           size
 ----------------------------------
 demo          load-generator 1
-accounts      subsource      1
-auctions      subsource      1
-bids          subsource      1
-organizations subsource      1
-users         subsource      1
+accounts      subsource      <null>
+auctions      subsource      <null>
+bids          subsource      <null>
+organizations subsource      <null>
+users         subsource      <null>
 
 > SHOW COLUMNS FROM auctions
 end_time false "timestamp with time zone"

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -10,12 +10,12 @@
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
 > SHOW SOURCES
-accounts      subsource      1
+accounts      subsource      <null>
 auction_house load-generator 1
-auctions      subsource      1
-bids          subsource      1
-organizations subsource      1
-users         subsource      1
+auctions      subsource      <null>
+bids          subsource      <null>
+organizations subsource      <null>
+users         subsource      <null>
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';


### PR DESCRIPTION
`StorageManagedTable`s are unnecessary because we can instead model them as `Source`s.

### Motivation

This PR refactors existing code.

Closes #15222

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
