### PR TITLE
[DONOTMERGE] backport http server changes to alpha-24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "mz-compute"
-version = "0.27.0-alpha.23.post"
+version = "0.27.0-alpha.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.27.0-alpha.23.post"
+version = "0.27.0-alpha.24"
 dependencies = [
  "anyhow",
  "askama",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "mz-storaged"
-version = "0.27.0-alpha.23.post"
+version = "0.27.0-alpha.24"
 dependencies = [
  "anyhow",
  "axum",

--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 20221004
+Licensed Work:             Materialize Version v0.27.0-alpha.24
                            The Licensed Work is © 2022 Materialize, Inc.
 
 Additional Use Grant:      Within a single installation of Materialize, you

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-compute"
 description = "Materialize's compute layer."
-version = "0.27.0-alpha.23.post"
+version = "0.27.0-alpha.24"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.27.0-alpha.23.post"
+version = "0.27.0-alpha.24"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -98,16 +98,7 @@ impl HttpServer {
         adapter_client_tx
             .send(adapter_client)
             .expect("rx known to be live");
-        let router = Router::new()
-            .route("/", routing::get(root::handle_home))
-            .route("/api/sql", routing::post(sql::handle_sql))
-            .route("/memory", routing::get(memory::handle_memory))
-            .route(
-                "/hierarchical-memory",
-                routing::get(memory::handle_hierarchical_memory),
-            )
-            .nest("/prof/", mz_prof::http::router(&BUILD_INFO))
-            .route("/static/*path", routing::get(root::handle_static))
+        let router = base_router(BaseRouterConfig { profiling: false })
             .layer(middleware::from_fn(move |req, next| {
                 let frontegg = Arc::clone(&frontegg);
                 async move { auth(req, next, tls_mode, &frontegg).await }
@@ -181,7 +172,7 @@ impl InternalHttpServer {
             adapter_client_rx,
         }: InternalHttpConfig,
     ) -> InternalHttpServer {
-        let router = Router::new()
+        let router = base_router(BaseRouterConfig { profiling: true })
             .route(
                 "/metrics",
                 routing::get(move || async move {
@@ -412,4 +403,31 @@ async fn auth<B>(
 
     // Run the request.
     Ok(next.run(req).await)
+}
+
+/// Configuration for [`base_router`].
+struct BaseRouterConfig {
+    /// Whether to enable the profiling routes.
+    profiling: bool,
+}
+
+/// Returns the router for routes that are shared between the internal and
+/// external HTTP servers.
+fn base_router(BaseRouterConfig { profiling }: BaseRouterConfig) -> Router {
+    let mut router = Router::new()
+        .route(
+            "/",
+            routing::get(move || async move { root::handle_home(profiling).await }),
+        )
+        .route("/api/sql", routing::post(sql::handle_sql))
+        .route("/memory", routing::get(memory::handle_memory))
+        .route(
+            "/hierarchical-memory",
+            routing::get(memory::handle_hierarchical_memory),
+        )
+        .route("/static/*path", routing::get(root::handle_static));
+    if profiling {
+        router = router.nest("/prof/", mz_prof::http::router(&BUILD_INFO));
+    }
+    router
 }

--- a/src/environmentd/src/http/root.rs
+++ b/src/environmentd/src/http/root.rs
@@ -20,13 +20,15 @@ struct HomeTemplate<'a> {
     version: &'a str,
     build_time: &'a str,
     build_sha: &'static str,
+    profiling: bool,
 }
 
-pub async fn handle_home() -> impl IntoResponse {
+pub async fn handle_home(profiling: bool) -> impl IntoResponse {
     mz_http_util::template_response(HomeTemplate {
         version: BUILD_INFO.version,
         build_time: BUILD_INFO.time,
         build_sha: BUILD_INFO.sha,
+        profiling,
     })
 }
 

--- a/src/environmentd/src/http/templates/home.html
+++ b/src/environmentd/src/http/templates/home.html
@@ -5,7 +5,9 @@
 {% block content %}
 <p>environmentd {{ version }} (built at {{ build_time }} from <code>{{ build_sha }}</code>)</p>
 <ul>
-    <li><a href="/prof/">profiling functions</a></li>
+    {% if profiling %}
+        <li><a href="/prof/">profiling functions</a></li>
+    {% endif %}
     <li><a href="/memory">memory visualization</a></li>
     <li><a href="/hierarchical-memory">hierarchical memory visualization</a></li>
 </ul>

--- a/src/storaged/Cargo.toml
+++ b/src/storaged/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-storaged"
 description = "Materialize's storage server."
-version = "0.27.0-alpha.23.post"
+version = "0.27.0-alpha.24"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
