### PR TITLE
Reconcile materialized views

### DIFF
--- a/src/compute-client/src/sinks.rs
+++ b/src/compute-client/src/sinks.rs
@@ -88,6 +88,15 @@ impl<S> ComputeSinkConnection<S> {
             ComputeSinkConnection::Persist(_) => "persist",
         }
     }
+
+    /// True if the sink is a subscribe, which is differently recoverable than other sinks.
+    pub fn is_subscribe(&self) -> bool {
+        if let ComputeSinkConnection::Subscribe(_) = self {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl RustType<ProtoComputeSinkConnection> for ComputeSinkConnection<CollectionMetadata> {

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -712,10 +712,13 @@ impl<'w, A: Allocate> Worker<'w, A> {
                                             dataflow.as_of.as_ref().unwrap(),
                                         )
                                     });
-                                // TODO: this can be improved to "subscribe with snapshot"-free, I believe.
-                                // There would need to be changes to clean-up, especially around `subscribe_response_buffer`.
-                                let sink_free = dataflow.sink_exports.is_empty();
-                                if compatible && uncompacted && sink_free {
+                                // We cannot reconcile subscriptions at the moment, because the response buffer is shared,
+                                // and to a first approximation must be completely reformed.
+                                let subscribe_free = dataflow
+                                    .sink_exports
+                                    .iter()
+                                    .all(|(_id, sink)| !sink.connection.is_subscribe());
+                                if compatible && uncompacted && subscribe_free {
                                     // Match found; remove the match from the deletion queue,
                                     // and compact its outputs to the dataflow's `as_of`.
                                     old_dataflows.remove(&export_ids);


### PR DESCRIPTION
This PR in principle will allow `computed` to reconcile materialized views, vs its current behavior which is to always restart dataflows that contain a `persist` sink. We still must restart any dataflow that contains a subscribe, on account of the shared state they have (we could attempt to un-share it, and then perhaps better reconcile them, but in future work).

I have no testing in place for this, as I'm not sure the best way to do so, but would be delighted to have @philip-stoev provide any guidance and maybe hand off that work if it ends up complicated. But for sure, the code is essentially untested.

### Motivation

  * This PR adds a feature that has not yet been specified.

Materialized view dataflows are often large and expensive, and we would prefer to reconcile them rather than restart them, should there be an `environmentd` or connection hiccup. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
