### PR TITLE
doc/user: Make Key Concepts more prominent in Search

### DIFF
--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -1,6 +1,7 @@
 ---
 title: "Key concepts"
 description: "Understand Materialize's architecture."
+pagerank: 5
 menu:
   main:
     parent: 'overview'

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -25,9 +25,9 @@
   {{ range .functions }}
   <tr>
     {{/*  Extract the function's name from its signature and use it as the ID
-          to facilitate deeplinking. The `docsearch_l4` class is a special
+          to facilitate deeplinking. The `docsearch_l3` class is a special
           class that is scraped by our Algolia DocSearch configuration.  */}}
-    <td class="docsearch_l4" id="{{ index (split .signature "(") 0 | urlize }}">
+    <td class="docsearch_l3" id="{{ index (split .signature "(") 0 | urlize }}">
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}


### PR DESCRIPTION
### Motivation

If someone types "Cluster" or "Sink" I think it makes the most sense to show:

1. The Key Concept section
2. The CREATE [OBJECT] page
3. Other pages.

This PR attempts to set Algolia up to do that by marking the "Key Concepts" page with a PR of 5 (lower is better)

I also took the opportunity to fix a legacy issue where the class to manually flag something as "level 3" was called "level_4". 

### Tips for reviewer

Unfortunately we won't be able to test this until the change is deployed in production.

Fixes #15539 