### PR TITLE
sql: don't crash on EXPLAIN (SHOW ...)

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -650,13 +650,7 @@ impl<'a> ShowSelect<'a> {
 
     /// Converts this `ShowSelect` into a [`(HirRelationExpr, Scope)`].
     pub fn plan_hir(self, qcx: &QueryContext) -> Result<(HirRelationExpr, Scope), PlanError> {
-        let query::PlannedQuery {
-            expr,
-            desc,
-            finishing: _,
-        } = query::plan_root_query(self.scx, self.stmt.query, qcx.lifetime)?;
-        let scope = Scope::from_source(None, desc.iter_names());
-        Ok((expr, scope))
+        query::plan_nested_query(&mut qcx.clone(), &self.stmt.query)
     }
 }
 

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -570,3 +570,20 @@ EXPLAIN PLAN FOR MATERIALIZED VIEW mv
 | Constant (1)
 
 EOF
+
+# Regression test for #15151.
+query T multiline
+EXPLAIN PLAN FOR (SHOW VIEWS)
+----
+Source mz_catalog.mz_views (s275):
+| Map dummy, dummy, dummy
+| Filter (3 = uint8_to_double(#2))
+| Project (#5, #6, #2, #3, #7)
+
+Query:
+%0 =
+| Get mz_catalog.mz_views (s275)
+| Filter (3 = uint8_to_double(#2))
+| Project (#3)
+
+EOF


### PR DESCRIPTION
ShowSelect::plan_hir was incorrectly ignoring the row finishing returned by plan_root_query. Instead, use plan_nested_query, which knows how to apply the finishing to a MirRelationExpr.

Fix #15151.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
