### PR TITLE
[sinks] Add pending interface to storage exports

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -596,7 +596,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     let create_export_token = self
                         .controller
                         .storage
-                        .pending_export(entry.id(), sink.from)
+                        .prepare_export(entry.id(), sink.from)
                         .await
                         .unwrap();
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -355,7 +355,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 let () = self
                     .controller
                     .storage
-                    .pending_export_cancel(create_export_token)
+                    .cancel_prepare_export(create_export_token)
                     .await;
                 tx.send(Err(e), session);
             }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -303,6 +303,7 @@ impl<S: Append + 'static> Coordinator<S> {
             tx,
             id,
             oid,
+            create_export_token,
             result,
         }: SinkConnectionReady,
     ) {
@@ -317,11 +318,17 @@ impl<S: Append + 'static> Coordinator<S> {
                     // no better solution presents itself. Possibly sinks should
                     // have an error bit, and an error here would set the error
                     // bit on the sink.
-                    self.handle_sink_connection_ready(id, oid, connection, Some(&session))
-                        .await
-                        // XXX(chae): I really don't like this -- especially as we're now doing cross
-                        // process calls to start a sink.
-                        .expect("sinks should be validated by sequence_create_sink");
+                    self.handle_sink_connection_ready(
+                        id,
+                        oid,
+                        connection,
+                        create_export_token,
+                        Some(&session),
+                    )
+                    .await
+                    // XXX(chae): I really don't like this -- especially as we're now doing cross
+                    // process calls to start a sink.
+                    .expect("sinks should be validated by sequence_create_sink");
                 } else {
                     // Another session dropped the sink while we were
                     // creating the connection. Report to the client that
@@ -344,6 +351,12 @@ impl<S: Append + 'static> Coordinator<S> {
                     // attempting to create the connection, in which case we don't need to do
                     // anything.
                 }
+                // Drop the placeholder sink in the storage controller
+                let () = self
+                    .controller
+                    .storage
+                    .pending_export_cancel(create_export_token)
+                    .await;
                 tx.send(Err(e), session);
             }
         }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1227,6 +1227,19 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
 
+        let create_export_token = match self
+            .controller
+            .storage
+            .pending_export(id, catalog_sink.from)
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                tx.send(Err(e.into()), session);
+                return;
+            }
+        };
+
         // Now we're ready to create the sink connection. Arrange to notify the
         // main coordinator thread when the future completes.
         let connection_builder = sink.connection_builder;
@@ -1242,6 +1255,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         tx,
                         id,
                         oid,
+                        create_export_token,
                         result: mz_storage::sink::build_sink_connection(
                             connection_builder,
                             connection_context,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1230,7 +1230,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let create_export_token = match self
             .controller
             .storage
-            .pending_export(id, catalog_sink.from)
+            .prepare_export(id, catalog_sink.from)
             .await
         {
             Ok(t) => t,

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1439,6 +1439,8 @@ where
                     .exports
                     .get(&export_id)
                     .map(|state| state.write_frontier.clone())
+                    // If sink has not been fully initialized (only `prepare_export` but not
+                    // `create_export` has been called), hold back compaction completely.
                     .unwrap_or_else(|| Antichain::from_elem(Timestamp::minimum())),
             );
         }


### PR DESCRIPTION
Compaction of storage collections is partially held back by the storage controller's list of exported collections.  The coordinator / adapter provides some guidance, on top of which the storage controller layers its own logic based on the output progress of sinks.  This is the logic which keeps sinks / tables / materialized views held back far enough so that the sink may write everything out.

However, before this PR, we didn't actually install this dependency until the export (sink) was created in the storage layer.  This behavior is incorrect in at least two situations:
- `CREATE SINK` command comes in.  We determine an acceptable AS OF and then we instruct the storage layer to create the export, installing the dependency.  This dependency should be made known to the storage controller before selecting the AS OF -- it the storage controller can ensure the AS OF stays valid until the usual sink logic takes over.
- bootstraping.  #15228 adds logic to retry sink connections on startup.  However, while this retrying occurs, the storage controller does not know about the dependency and can allow the source to be compacted.  In this case, when the sink does finally start up, the AS OF is invalid and we enter a crash loop.  We avoid that by telling the storage controller immediately -- during the bootstrap process when no frontiers are adjusted.

We use an opaque `CreateExportToken` to ensure that the `pending_export` function is called before `create_export`.  It replaces the `id` argument to `create_export`.  The only other field contained is the `from_id` which needs to be passed around the coordinator _anyway_ so that we could properly cancel the pending export on error.

I'm not convinced that this is the ideal way to solve the issue (perhaps the logic should live elsewhere?) but I am convinced this is correct -- and so it feels less risky to extend the current behavior than move it around altogether.

### Motivation
Necessary to unblock #15228 and re-merging #15146 -- which each close one of the last two issues in the kafka sink epic #11503 .

### Tips for reviewer
I've rebased the two PRs mentioned above on top of this to help make it easier to envision what the change will look like.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
