### PR TITLE
cloudtest: Add Debezium to cloudtest

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 
 from materialize import ROOT, mzbuild
 from materialize.cloudtest.k8s import K8sResource
+from materialize.cloudtest.k8s.debezium import DEBEZIUM_RESOURCES
 from materialize.cloudtest.k8s.environmentd import (
     EnvironmentdService,
     EnvironmentdStatefulSet,
@@ -73,6 +74,7 @@ class MaterializeApplication(Application):
             *POSTGRES_RESOURCES,
             *POSTGRES_SOURCE_RESOURCES,
             *REDPANDA_RESOURCES,
+            *DEBEZIUM_RESOURCES,
             *SSH_RESOURCES,
             Minio(),
             AdminRoleBinding(),

--- a/misc/python/materialize/cloudtest/k8s/debezium.py
+++ b/misc/python/materialize/cloudtest/k8s/debezium.py
@@ -1,0 +1,93 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from kubernetes.client import (
+    V1Container,
+    V1ContainerPort,
+    V1Deployment,
+    V1DeploymentSpec,
+    V1EnvVar,
+    V1LabelSelector,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from materialize.cloudtest.k8s import K8sDeployment, K8sService
+
+
+class DebeziumDeployment(K8sDeployment):
+    def __init__(self) -> None:
+        ports = [V1ContainerPort(container_port=8083, name="debezium")]
+
+        env = [
+            V1EnvVar(name="BOOTSTRAP_SERVERS", value="redpanda:9092"),
+            V1EnvVar(name="CONFIG_STORAGE_TOPIC", value="connect_configs"),
+            V1EnvVar(name="OFFSET_STORAGE_TOPIC", value="connect_offsets"),
+            V1EnvVar(name="STATUS_STORAGE_TOPIC", value="connect_statuses"),
+            # We don't support JSON, so ensure that connect uses AVRO to encode messages and CSR to
+            # record the schema
+            V1EnvVar(
+                name="KEY_CONVERTER", value="io.confluent.connect.avro.AvroConverter"
+            ),
+            V1EnvVar(
+                name="VALUE_CONVERTER", value="io.confluent.connect.avro.AvroConverter"
+            ),
+            V1EnvVar(
+                name="CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL",
+                value="http://redpanda:8081",
+            ),
+            V1EnvVar(
+                name="CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL",
+                value="http://redpanda:8081",
+            ),
+            V1EnvVar(
+                name="CONNECT_OFFSET_COMMIT_POLICY", value="AlwaysCommitOffsetPolicy"
+            ),
+        ]
+
+        container = V1Container(
+            name="debezium", image="debezium/connect:1.9.5.Final", env=env, ports=ports
+        )
+
+        template = V1PodTemplateSpec(
+            metadata=V1ObjectMeta(labels={"app": "debezium"}),
+            spec=V1PodSpec(containers=[container]),
+        )
+
+        selector = V1LabelSelector(match_labels={"app": "debezium"})
+
+        spec = V1DeploymentSpec(replicas=1, template=template, selector=selector)
+
+        self.deployment = V1Deployment(
+            api_version="apps/v1",
+            kind="Deployment",
+            metadata=V1ObjectMeta(name="debezium"),
+            spec=spec,
+        )
+
+
+class DebeziumService(K8sService):
+    def __init__(self) -> None:
+        ports = [
+            V1ServicePort(name="debezium", port=8083),
+        ]
+
+        self.service = V1Service(
+            metadata=V1ObjectMeta(name="debezium", labels={"app": "debezium"}),
+            spec=V1ServiceSpec(
+                type="NodePort", ports=ports, selector={"app": "debezium"}
+            ),
+        )
+
+
+DEBEZIUM_RESOURCES = [DebeziumDeployment(), DebeziumService()]

--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -47,7 +47,7 @@ class RedpandaDeployment(K8sDeployment):
                 "--set",
                 "redpanda.enable_idempotence=true",
                 "--set",
-                "redpanda.auto_create_topics_enabled=false",
+                "redpanda.auto_create_topics_enabled=true",
                 "--advertise-kafka-addr",
                 "redpanda:9092",
             ],

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -25,9 +25,6 @@ from materialize.cloudtest.wait import wait
 # Once a stable release is out, we need to get its DockerHub tag in here
 LAST_RELEASED_VERSION = None
 
-# Debezium is not available in cloudtest yet
-DISABLED_CHECKS = [DebeziumPostgres]  # noqa: F405
-
 
 class ReplaceEnvironmentdStatefulSet(Action):
     """Change the image tag of the environmentd stateful set, re-create the definition and replace the existing one."""
@@ -85,11 +82,10 @@ class CloudtestUpgrade(Scenario):
 @pytest.mark.long
 def test_upgrade() -> None:
     """Test upgrade from LAST_RELEASED_VERSION to the current source by running all the Platform Checks"""
-    checks = [check for check in Check.__subclasses__() if check not in DISABLED_CHECKS]
 
     mz = MaterializeApplication(tag=LAST_RELEASED_VERSION)
     wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)
-    scenario = CloudtestUpgrade(checks=checks, executor=executor)
+    scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)
     scenario.run()


### PR DESCRIPTION
Add a Debezium pod to the K8s cluster and re-enable the Debezium platform check in the cloudtest upgrade tests

### Motivation

  * This PR fixes a previously unreported bug.
Debezium was missing from cloudtest