### PR TITLE
backport: mark postgres and pubnub sources as non-monotonic

### DIFF
--- a/doc/developer/design/20210401_volatile_sources.md
+++ b/doc/developer/design/20210401_volatile_sources.md
@@ -144,7 +144,7 @@ the following:
 
 ```sql
 CREATE SOURCE market_orders_raw FROM PUBNUB
-SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
 CHANNEL 'pubnub-market-orders';
 
 CREATE MATERIALIZED VIEW market_orders_1 AS
@@ -293,7 +293,7 @@ expect to be very common in demos is to only materialize the last _n_ seconds
 of data, which requires both an unmaterialized source and a materialized view:
 
 ```sql
-CREATE SOURCE market_orders_raw FROM PUBNUB SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe' CHANNEL 'pubnub-market-orders';
+CREATE SOURCE market_orders_raw FROM PUBNUB SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8' CHANNEL 'pubnub-market-orders';
 
 CREATE MATERIALIZED VIEW market_orders AS
   SELECT *
@@ -317,7 +317,7 @@ could be used in exactly one materialized view:
 ```
 CREATE MATERIALIZED VIEW market_orders AS
  WITH market_orders_raw AS SOURCE (
-     PUBNUB SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe' CHANNEL 'pubnub-market-orders';
+     PUBNUB SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8' CHANNEL 'pubnub-market-orders';
   )
   SELECT *
   FROM (

--- a/doc/user/content/cloud/get-started-with-cloud.md
+++ b/doc/user/content/cloud/get-started-with-cloud.md
@@ -61,7 +61,7 @@ We'll start with some sample real-time data from a [PubNub stream](https://www.p
     ```sql
     CREATE SOURCE market_orders_raw
     FROM PUBNUB
-    SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+    SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
     CHANNEL 'pubnub-market-orders';
     ```
 

--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -114,7 +114,7 @@ We'll start with some sample real-time data from a [PubNub stream](https://www.p
     ```sql
     CREATE SOURCE market_orders_raw
     FROM PUBNUB
-    SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+    SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
     CHANNEL 'pubnub-market-orders';
     ```
 

--- a/doc/user/content/guides/dbt.md
+++ b/doc/user/content/guides/dbt.md
@@ -137,7 +137,7 @@ When you use dbt with Materialize, **your models stay up-to-date** without manua
 
     CREATE SOURCE {{ source_name }}
     FROM PUBNUB
-    SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+    SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
     CHANNEL 'pubnub-market-orders'
     ```
 

--- a/doc/user/content/guides/golang.md
+++ b/doc/user/content/guides/golang.md
@@ -179,7 +179,7 @@ Typically, you create sources, views, and indexes when deploying Materialize, al
 
 ```go
 createSourceSQL := `CREATE SOURCE market_orders_raw FROM PUBNUB
-                SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe
+                SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8
                 CHANNEL 'pubnub-market-orders'`
 
 _, err = conn.Exec(ctx, createSourceSQL)

--- a/doc/user/content/guides/node-js.md
+++ b/doc/user/content/guides/node-js.md
@@ -193,7 +193,7 @@ async function main() {
     await client.connect();
     const res = await client.query(
         `CREATE SOURCE market_orders_raw_2 FROM PUBNUB
-            SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+            SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
             CHANNEL 'pubnub-market-orders'`
         );
     console.log(res);

--- a/doc/user/content/guides/php-pdo.md
+++ b/doc/user/content/guides/php-pdo.md
@@ -186,7 +186,7 @@ Typically, you create sources, views, and indexes when deploying Materialize, al
 require 'connect.php';
 
 $sql = "CREATE SOURCE market_orders_raw_2 FROM PUBNUB
-            SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+            SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
             CHANNEL 'pubnub-market-orders'";
 
 $statement = $connection->prepare($sql);

--- a/doc/user/content/guides/python.md
+++ b/doc/user/content/guides/python.md
@@ -177,7 +177,7 @@ cur = conn.cursor()
 
 with conn.cursor() as cur:
     cur.execute("CREATE SOURCE market_orders_raw_2 FROM PUBNUB " \
-            "SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe' " \
+            "SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8' " \
             "CHANNEL 'pubnub-market-orders'")
 
 with conn.cursor() as cur:

--- a/doc/user/content/sql/create-source/json-pubnub.md
+++ b/doc/user/content/sql/create-source/json-pubnub.md
@@ -29,7 +29,7 @@ This document details how to connect Materialize to a JSON–formatted
 
 ```sql
 CREATE SOURCE market_orders_raw FROM PUBNUB
-SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
 CHANNEL 'pubnub-market-orders';
 ```
 

--- a/doc/user/content/sql/create-source/text-pubnub.md
+++ b/doc/user/content/sql/create-source/text-pubnub.md
@@ -29,7 +29,7 @@ This document details how to connect Materialize to a text–formatted
 
 ```sql
 CREATE MATERIALIZED SOURCE market_orders_raw FROM PUBNUB
-SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
 CHANNEL 'pubnub-market-orders';
 ```
 

--- a/play/materialize-cloud-dbt/models/example/market_orders_raw.sql
+++ b/play/materialize-cloud-dbt/models/example/market_orders_raw.sql
@@ -20,5 +20,5 @@
 {% endset %}
 
 CREATE MATERIALIZED SOURCE {{ source_name }} FROM PUBNUB
-SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
 CHANNEL 'pubnub-market-orders'

--- a/test/testdrive/esoteric/pubnub.td
+++ b/test/testdrive/esoteric/pubnub.td
@@ -11,7 +11,7 @@
 # The raw source that brings in data as a single text column containing JSON
 > CREATE SOURCE market_orders_raw
   FROM PUBNUB
-  SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+  SUBSCRIBE KEY 'sub-c-99084bc5-1844-4e1c-82ca-a01b18166ca8'
   CHANNEL 'pubnub-market-orders';
 
 # Extract a couple JSON fields


### PR DESCRIPTION
Fixes #12783
