### PR TITLE
storage: batch stash writes in create_collections

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -785,24 +785,33 @@ where
         }
 
         // Install collection state for each bound description.
-        for (id, description) in collections {
-            let durable_metadata = METADATA_COLLECTION
-                .insert_without_overwrite(
-                    &mut self.state.stash,
-                    &id,
-                    DurableCollectionMetadata {
-                        remap_shard: ShardId::new(),
-                        data_shard: ShardId::new(),
-                    },
-                )
-                .await?;
 
+        // Perform all stash writes in a single transaction, to minimize transaction overhead and
+        // the time spent waiting for stash.
+        METADATA_COLLECTION
+            .insert_without_overwrite(
+                &mut self.state.stash,
+                collections.iter().map(|(id, _)| {
+                    (
+                        *id,
+                        DurableCollectionMetadata {
+                            remap_shard: ShardId::new(),
+                            data_shard: ShardId::new(),
+                        },
+                    )
+                }),
+            )
+            .await?;
+
+        let mut durable_metadata = METADATA_COLLECTION.peek_one(&mut self.state.stash).await?;
+
+        for (id, description) in collections {
+            let collection_shards = durable_metadata.remove(&id).expect("inserted above");
             let status_shard = if let Some(status_collection_id) = description.status_collection_id
             {
                 Some(
-                    METADATA_COLLECTION
-                        .peek_key_one(&mut self.state.stash, &status_collection_id)
-                        .await?
+                    durable_metadata
+                        .remove(&status_collection_id)
                         .ok_or(StorageError::IdentifierMissing(status_collection_id))?
                         .data_shard,
                 )
@@ -812,8 +821,8 @@ where
 
             let metadata = CollectionMetadata {
                 persist_location: self.persist_location.clone(),
-                remap_shard: durable_metadata.remap_shard,
-                data_shard: durable_metadata.data_shard,
+                remap_shard: collection_shards.remap_shard,
+                data_shard: collection_shards.data_shard,
                 status_shard,
             };
 
@@ -997,7 +1006,7 @@ where
             let from_since = from_collection.implied_capability.clone();
 
             let as_of = MetadataExportFetcher::get_stash_collection()
-                .insert_without_overwrite(
+                .insert_key_without_overwrite(
                     &mut self.state.stash,
                     &id,
                     DurableExportMetadata {


### PR DESCRIPTION
This PR changes the storage controller's `create_collections` logic to batch all reads and writes on the `METADATA_COLLECTION` together, to reduce the transaction overhead experienced when a large number of collections is created.

This reduces the amount of time spent when creating a new compute replica (and its 15+ introspection collections) significantly (see https://github.com/MaterializeInc/materialize/issues/14729#issuecomment-1271584837 for traces).

There are still two invocations of stash `transact`s happening. I think the first appends the new data, and the second performs consolidation. We could skip consolidation, but I don't know if this is a good idea. And it would only save us ~160ms in any case. 

### Motivation

   * This PR refactors existing code.

Closes https://github.com/MaterializeInc/materialize/issues/15074.

### Tips for reviewer

In stash, I changed `insert_without_overwrite` to be able to deal with multiple key-value pairs at the same time and added `insert_key_without_overwrite` for the single-key case. This is consistent to the `upsert`/`upsert_key` implementations.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
