### PR TITLE
storage: remove connection_id from ingestion and sink

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1374,7 +1374,6 @@ pub struct Source {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Ingestion {
-    pub connection_id: Option<GlobalId>,
     // TODO(benesch): this field contains connection information that could be
     // derived from the connection ID. Too hard to fix at the moment.
     pub desc: SourceDesc,
@@ -4417,7 +4416,6 @@ impl<S: Append> Catalog<S> {
             }) => CatalogItem::Source(Source {
                 create_sql: source.create_sql,
                 ingestion: source.ingestion.map(|ingestion| Ingestion {
-                    connection_id: ingestion.connection_id,
                     desc: ingestion.desc,
                     source_imports: ingestion.source_imports,
                     subsource_exports: ingestion.subsource_exports,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -528,7 +528,7 @@ impl CatalogState {
                     Datum::UInt64(schema_id.into()),
                     Datum::String(name),
                     Datum::String(connection.name()),
-                    Datum::from(sink.connection_id.map(|id| id.to_string()).as_deref()),
+                    Datum::from(sink.connection_id().map(|id| id.to_string()).as_deref()),
                     size,
                 ]),
                 diff,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -206,7 +206,7 @@ impl CatalogState {
                 let connection_id = source
                     .ingestion
                     .as_ref()
-                    .and_then(|ingestion| ingestion.connection_id);
+                    .and_then(|ingestion| ingestion.desc.connection.connection_id());
                 self.pack_source_update(
                     id,
                     oid,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1168,7 +1168,6 @@ impl<S: Append + 'static> Coordinator<S> {
         let catalog_sink = catalog::Sink {
             create_sql: sink.create_sql,
             from: sink.from,
-            connection_id: sink.connection_id,
             connection: StorageSinkConnectionState::Pending(StorageSinkConnectionBuilder::Kafka(
                 connection_builder,
             )),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -441,7 +441,6 @@ impl<S: Append + 'static> Coordinator<S> {
             let source = catalog::Source {
                 create_sql: plan.source.create_sql,
                 ingestion: plan.source.ingestion.map(|ingestion| catalog::Ingestion {
-                    connection_id: ingestion.connection_id,
                     desc: ingestion.desc,
                     source_imports: ingestion.source_imports,
                     subsource_exports: ingestion.subsource_exports,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -653,7 +653,6 @@ pub struct Source {
 
 #[derive(Clone, Debug)]
 pub struct Ingestion {
-    pub connection_id: Option<GlobalId>,
     pub desc: SourceDesc,
     pub source_imports: HashSet<GlobalId>,
     pub subsource_exports: HashMap<GlobalId, usize>,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -674,7 +674,6 @@ pub struct Secret {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    pub connection_id: Option<GlobalId>,
     pub connection_builder: StorageSinkConnectionBuilder,
     pub envelope: SinkEnvelope,
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1641,7 +1641,7 @@ pub fn plan_create_sink(
         return Err(PlanError::UpsertSinkWithoutKey);
     }
 
-    let (connection_id, connection_builder) = match connection {
+    let connection_builder = match connection {
         CreateSinkConnection::Kafka { connection, .. } => kafka_sink_builder(
             scx,
             connection,
@@ -1669,7 +1669,6 @@ pub fn plan_create_sink(
         sink: Sink {
             create_sql,
             from: from.id(),
-            connection_id: Some(connection_id),
             connection_builder,
             envelope,
         },
@@ -1744,7 +1743,7 @@ fn kafka_sink_builder(
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     value_desc: RelationDesc,
     envelope: SinkEnvelope,
-) -> Result<(GlobalId, StorageSinkConnectionBuilder), PlanError> {
+) -> Result<StorageSinkConnectionBuilder, PlanError> {
     let item = scx.get_item_by_resolved_name(&connection)?;
     // Get Kafka connection
     let connection = match item.connection()? {
@@ -1885,9 +1884,8 @@ fn kafka_sink_builder(
         bytes: retention_bytes,
     };
 
-    Ok((
-        connection_id,
-        StorageSinkConnectionBuilder::Kafka(KafkaSinkConnectionBuilder {
+    Ok(StorageSinkConnectionBuilder::Kafka(
+        KafkaSinkConnectionBuilder {
             connection_id,
             connection,
             options: config_options,
@@ -1901,7 +1899,7 @@ fn kafka_sink_builder(
             key_desc_and_indices,
             value_desc,
             retention,
-        }),
+        },
     ))
 }
 

--- a/src/storage/src/sink/sink_connection.rs
+++ b/src/storage/src/sink/sink_connection.rs
@@ -256,6 +256,7 @@ async fn build_kafka(
 
     Ok(StorageSinkConnection::Kafka(KafkaSinkConnection {
         connection: builder.connection,
+        connection_id: builder.connection_id,
         options: builder.options,
         topic: builder.topic_name,
         relation_key_indices: builder.relation_key_indices,

--- a/src/storage/src/types/sinks.proto
+++ b/src/storage/src/types/sinks.proto
@@ -68,6 +68,7 @@ message ProtoKafkaSinkConnection {
     //  - repeated mz_repr.global_id.ProtoGlobalId transitive_source_dependencies = 10;
     reserved 3, 10;
 
+    mz_repr.global_id.ProtoGlobalId connection_id = 13;
     mz_storage.types.connections.ProtoKafkaConnection connection = 1;
     string topic = 2;
     optional ProtoKeyDescAndIndices key_desc_and_indices = 4;

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -145,6 +145,7 @@ message ProtoDebeziumSourceProjection {
 
 message ProtoKafkaSourceConnection {
     mz_storage.types.connections.ProtoKafkaConnection connection = 1;
+    mz_repr.global_id.ProtoGlobalId connection_id = 13;
     string topic = 2;
     map<int32, int64> start_offsets = 3;
     optional string group_id_prefix = 4;
@@ -185,6 +186,7 @@ message ProtoSourceData {
 }
 
 message ProtoKinesisSourceConnection {
+    mz_repr.global_id.ProtoGlobalId connection_id = 3;
     string stream_name = 1;
     mz_storage.types.connections.aws.ProtoAwsConfig aws = 2;
 }
@@ -194,6 +196,7 @@ message ProtoPostgresSourceConnection {
         repeated mz_expr.scalar.ProtoMirScalarExpr column_casts = 1;
     }
 
+    mz_repr.global_id.ProtoGlobalId connection_id = 6;
     mz_storage.types.connections.ProtoPostgresConnection connection = 1;
     string publication = 2;
     ProtoPostgresSourceDetails details = 4;
@@ -214,6 +217,7 @@ message ProtoLoadGeneratorSourceConnection {
 }
 
 message ProtoS3SourceConnection {
+    mz_repr.global_id.ProtoGlobalId connection_id = 5;
     repeated ProtoS3KeySource key_sources = 1;
     optional string pattern = 2;
     mz_storage.types.connections.aws.ProtoAwsConfig aws = 3;


### PR DESCRIPTION
As discussed on https://materializeinc.slack.com/archives/C01CFKM1QRF/p1664913763624729

This also adds the connection id to the sink and source objects so sink and source impls can access them. This basically just move fields in the catalog, so has to merge before the wipe.

### Motivation


  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

