### PR TITLE
coord: Optimize single statement read transaction

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2011,13 +2011,15 @@ impl<S: Append + 'static> Coordinator<S> {
         // Queries are independent of the logical timestamp iff there are no referenced
         // sources or indexes and there is no reference to `mz_now()`.
         let timestamp_independent = source_ids.is_empty() && !source.contains_temporal();
-        // For queries that do not use AS OF, get the
+        // For transactions that do not use AS OF, get the
         // timestamp of the in-progress transaction or create one. If this is an AS OF
-        // query, we don't care about any possible transaction timestamp. We do
-        // not do any optimization of the so-called single-statement transactions
-        // (TransactionStatus::Started) because multiple statements can actually be
-        // executed there in the extended protocol.
-        let timestamp = if when == QueryWhen::Immediately {
+        // query, we don't care about any possible transaction timestamp. If this is a
+        // single-statement transaction (TransactionStatus::Started), we don't need to
+        // worry about preventing compaction or choosing a valid timestamp for future
+        // queries.
+        let timestamp = if session.transaction().is_in_multi_statement_transaction()
+            && when == QueryWhen::Immediately
+        {
             // If all previous statements were timestamp-independent and the current one is
             // not, clear the transaction ops so it can get a new timestamp and timedomain.
             if let Some(read_txn) = self.txn_reads.get(&conn_id) {
@@ -2630,23 +2632,10 @@ impl<S: Append + 'static> Coordinator<S> {
                 let optimized_plan = self.view_optimizer.optimize(decorrelated_plan)?;
                 let timeline = self.validate_timeline(optimized_plan.depends_on())?;
                 let source_ids = optimized_plan.depends_on();
-                let id_bundle = if session.vars().transaction_isolation()
-                    == &IsolationLevel::StrictSerializable
-                    && timeline.is_some()
-                {
-                    self.index_oracle(compute_instance)
-                        .sufficient_collections(&source_ids)
-                } else {
-                    // Determine a timestamp that will be valid for anything in any schema
-                    // referenced by the query.
-                    self.timedomain_for(
-                        &source_ids,
-                        &timeline,
-                        session.conn_id(),
-                        compute_instance,
-                    )?
-                };
-                // TODO: determine_timestamp takes a mut self to track table linearizability,
+                let id_bundle = self
+                    .index_oracle(compute_instance)
+                    .sufficient_collections(&source_ids);
+                // TODO: determine_timestamp takes a mut self to track linearizability,
                 // so explaining a plan involving tables has side effects. Removing those side
                 // effects would be good.
                 let timestamp = self.determine_timestamp(

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -268,7 +268,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .collect::<Vec<_>>();
         format!(
             "Timestamp ({}) is not valid for all inputs: {:?}",
-            candidate, invalid
+            candidate, invalid,
         )
     }
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1743,7 +1743,7 @@ fn wait_for_view_population(
     let current_isolation = mz_client
         .query_one("SHOW transaction_isolation", &[])?
         .get::<_, String>(0);
-    mz_client.query_one("SET transaction_isolation = SERIALIZABLE", &[])?;
+    mz_client.batch_execute("SET transaction_isolation = SERIALIZABLE")?;
     Retry::default()
         .max_duration(Duration::from_secs(10))
         .retry(|_| {
@@ -1760,10 +1760,9 @@ fn wait_for_view_population(
             }
         })
         .unwrap();
-    let _ = mz_client.query_one(
-        &format!("SET transaction_isolation = '{current_isolation}'"),
-        &[],
-    );
+    mz_client.batch_execute(&format!(
+        "SET transaction_isolation = '{current_isolation}'"
+    ))?;
     Ok(())
 }
 

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1743,7 +1743,7 @@ fn wait_for_view_population(
     let current_isolation = mz_client
         .query_one("SHOW transaction_isolation", &[])?
         .get::<_, String>(0);
-    let _ = mz_client.query_one("SET transaction_isolation = SERIALIZABLE", &[]);
+    mz_client.query_one("SET transaction_isolation = SERIALIZABLE", &[])?;
     Retry::default()
         .max_duration(Duration::from_secs(10))
         .retry(|_| {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -360,15 +360,29 @@ where
                 let execute_root_span =
                     tracing::debug_span!(parent: None, "advance_ready", otel.name = message_name);
                 execute_root_span.follows_from(tracing::Span::current());
-                self.execute(
-                    portal_name,
-                    max_rows,
-                    portal_exec_message,
-                    None,
-                    ExecuteTimeout::None,
-                )
-                .instrument(execute_root_span)
-                .await?
+                let state = self
+                    .execute(
+                        portal_name,
+                        max_rows,
+                        portal_exec_message,
+                        None,
+                        ExecuteTimeout::None,
+                    )
+                    .instrument(execute_root_span)
+                    .await?;
+                // Close the current transaction if we are in an implicit transaction.
+                // In PostgreSQL, when using the extended query protocol, some statements may
+                // trigger an eager commit of the current implicit transaction,
+                // see: <https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137>.
+                // In Materialize however, we eagerly commit all statements outside of an explicit
+                // transaction when using the extended query protocol. This allows us to remove
+                // the ambiguity between multiple and single statement implicit transactions when
+                // using the extended query protocol and apply some optimizations to single
+                // statement transactions.
+                if self.adapter_client.session().transaction().is_implicit() {
+                    self.commit_transaction().await?;
+                }
+                state
             }
             Some(FrontendMessage::DescribeStatement { name }) => {
                 self.describe_statement(&name).await?

--- a/test/pgtest-mz/ddl-extended.pt
+++ b/test/pgtest-mz/ddl-extended.pt
@@ -1,0 +1,49 @@
+# Test that multiple DDL statements in the same extended request are supported
+send
+Parse {"query": "CREATE TABLE a (a int)"}
+Bind
+Execute
+Parse {"query": "CREATE TABLE b (a int)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO a VALUES (1)"}
+Bind
+Execute
+Parse {"query": "SELECT 1/0"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Parse {"query": "SELECT * FROM a"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/ddl-extended.pt
+++ b/test/pgtest-mz/ddl-extended.pt
@@ -13,9 +13,11 @@ Parse {"query": "SELECT 1/0"}
 Bind
 Execute
 Sync
+Query {"query": "SELECT * FROM a"}
 ----
 
 until
+ReadyForQuery
 ReadyForQuery
 ----
 ParseComplete
@@ -30,6 +32,9 @@ CommandComplete {"tag":"INSERT 0 1"}
 ParseComplete
 BindComplete
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"I"}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 
 send

--- a/test/pgtest-mz/ddl-extended.pt
+++ b/test/pgtest-mz/ddl-extended.pt
@@ -33,6 +33,7 @@ ParseComplete
 BindComplete
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/parse-started.pt
+++ b/test/pgtest-mz/parse-started.pt
@@ -27,8 +27,8 @@
 # fetching from the catalog tables. Our code previously made assumptions that
 # transactions in the TBLOCK_STARTED were always single statement, and would
 # thus skip some work. However it is possible that there are other stataments
-# issued in that block, so we should instead never perform those kinds of
-# optimizations because they are not in fact safe.
+# issued in that block, so we eagerly commit all statements after receiving an
+# Execute message.
 #
 # The bug motivating this test was caused by sequence_peek adding a
 # second transaction operation at a different timestamp to an existing

--- a/test/pgtest-mz/portals.pt
+++ b/test/pgtest-mz/portals.pt
@@ -27,7 +27,7 @@ Sync
 Query {"query": "FETCH c"}
 ----
 
-until err_field_typs=M
+until
 ReadyForQuery
 ReadyForQuery
 ----
@@ -36,5 +36,5 @@ BindComplete
 DataRow {"fields":["1"]}
 PortalSuspended
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"M","value":"cursor \"c\" does not exist"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/portals.pt
+++ b/test/pgtest-mz/portals.pt
@@ -1,0 +1,40 @@
+# In Materialize we eagerly commint implicit transactions after Execute
+# messages, causing portals to be destroyed.
+send
+Parse {"query": "VALUES (1), (2)"}
+Bind {"portal": "c"}
+Execute {"portal": "c", "max_rows": 1}
+Execute {"portal": "c", "max_rows": 1}
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+PortalSuspended
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+# Verify that portals (cursors) are destroyed on Execute.
+send
+Parse {"query": "VALUES (1), (2)"}
+Bind {"portal": "c"}
+Execute {"portal": "c", "max_rows": 1}
+Sync
+Query {"query": "FETCH c"}
+----
+
+until err_field_typs=M
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+PortalSuspended
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"M","value":"cursor \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/transactions.pt
+++ b/test/pgtest-mz/transactions.pt
@@ -25,22 +25,42 @@ ReadyForQuery {"status":"I"}
 # PG permits commits writes that are part of read-only txns, but
 # we do not if the read involves a timestamp
 send
+Query {"query": "INSERT INTO t VALUES (2); BEGIN READ ONLY; SELECT * FROM t;"}
+Query {"query": "COMMIT"}
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"INSERT 0 1"}
+CommandComplete {"tag":"BEGIN"}
+ErrorResponse {"fields":[{"typ":"M","value":"transaction in write-only mode"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+# Unlike PostgreSQL, we do not upgrade implicit transactions in the
+# extended protocol
+send
 Parse {"query": "INSERT INTO t VALUES (2)"}
 Bind
 Execute
-Parse {"query": "BEGIN READ ONLY"}
-Bind
-Execute
-Parse {"query": "SELECT * FROM t"}
+Parse {"query": "BEGIN"}
 Bind
 Execute
 Parse {"query": "COMMIT"}
 Bind
 Execute
 Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
 ----
 
 until err_field_typs=M ignore=RowDescription
+ReadyForQuery
 ReadyForQuery
 ----
 ParseComplete
@@ -51,5 +71,116 @@ BindComplete
 CommandComplete {"tag":"BEGIN"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"M","value":"transaction in write-only mode"}]}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 2"}
+ReadyForQuery {"status":"I"}
+
+send
+Parse {"query": "INSERT INTO t VALUES (3)"}
+Bind
+Execute
+Parse {"query": "BEGIN"}
+Bind
+Execute
+Parse {"query": "SELECT 0/0"}
+Bind
+Execute
+Sync
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"E"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+DataRow {"fields":["3"]}
+CommandComplete {"tag":"SELECT 3"}
+ReadyForQuery {"status":"I"}
+
+# Verify eager committing in implicit transactions for the extended protocol.
+# In Materialize we eagerly commit all statements in an implicit transaction
+# for the extended protocol. This differs from PostgreSQL, which only eagerly
+# commits certain statements.
+send
+Parse {"query": "INSERT INTO t VALUES (4)"}
+Bind
+Execute
+Parse {"query": "SELECT 1/(SELECT 0)"}
+Bind
+Execute
+Sync
+Query {"query": "SELECT * FROM t"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"}]}
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+DataRow {"fields":["3"]}
+DataRow {"fields":["4"]}
+CommandComplete {"tag":"SELECT 4"}
+ReadyForQuery {"status":"I"}
+
+# Verify that we don't eagerly commit in implicit transactions for the simple
+# protocol.
+send
+Query {"query": "INSERT INTO t VALUES (5); SELECT 1/(SELECT 0)"}
+Query {"query": "SELECT * FROM t"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"INSERT 0 1"}
+RowDescription {"fields":[{"name":"?column?"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"a"}]}
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+DataRow {"fields":["3"]}
+DataRow {"fields":["4"]}
+CommandComplete {"tag":"SELECT 4"}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest/ddl-extended.pt
+++ b/test/pgtest/ddl-extended.pt
@@ -6,9 +6,6 @@ Execute
 Parse {"query": "CREATE TABLE b (a int)"}
 Bind
 Execute
-Parse {"query": "INSERT INTO a VALUES (1)"}
-Bind
-Execute
 Parse {"query": "SELECT 1/0"}
 Bind
 Execute
@@ -24,9 +21,6 @@ CommandComplete {"tag":"CREATE TABLE"}
 ParseComplete
 BindComplete
 CommandComplete {"tag":"CREATE TABLE"}
-ParseComplete
-BindComplete
-CommandComplete {"tag":"INSERT 0 1"}
 ParseComplete
 BindComplete
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"division by zero"}]}

--- a/test/pgtest/portals.pt
+++ b/test/pgtest/portals.pt
@@ -73,27 +73,6 @@ ReadyForQuery
 ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}
 
-# Verify that portals (cursors) are destroyed on Sync.
-send
-Parse {"query": "VALUES (1), (2)"}
-Bind {"portal": "c"}
-Execute {"portal": "c", "max_rows": 1}
-Sync
-Query {"query": "FETCH c"}
-----
-
-until err_field_typs=M
-ReadyForQuery
-ReadyForQuery
-----
-ParseComplete
-BindComplete
-DataRow {"fields":["1"]}
-PortalSuspended
-ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"M","value":"cursor \"c\" does not exist"}]}
-ReadyForQuery {"status":"I"}
-
 # Verify portal reuse errors.
 
 send

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -477,16 +477,7 @@ ReadyForQuery {"status":"I"}
 # Verify implicit transactions are properly upgraded
 send
 Query {"query": "CREATE TABLE t (a INT)"}
-Parse {"query": "INSERT INTO t VALUES (1)"}
-Bind
-Execute
-Parse {"query": "BEGIN"}
-Bind
-Execute
-Parse {"query": "COMMIT"}
-Bind
-Execute
-Sync
+Query {"query": "INSERT INTO t VALUES (1); BEGIN; COMMIT;"}
 Parse {"query": "SELECT a FROM t"}
 Bind
 Execute
@@ -500,14 +491,8 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"CREATE TABLE"}
 ReadyForQuery {"status":"I"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"INSERT 0 1"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"BEGIN"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"COMMIT"}
 ReadyForQuery {"status":"I"}
 ParseComplete
@@ -519,16 +504,7 @@ ReadyForQuery {"status":"I"}
 # Verify implicit transactions are properly upgraded, and share fate
 # with upgraded txn; the insert of 2 should get discarded
 send
-Parse {"query": "INSERT INTO t VALUES (2)"}
-Bind
-Execute
-Parse {"query": "BEGIN"}
-Bind
-Execute
-Parse {"query": "SELECT 0/0"}
-Bind
-Execute
-Sync
+Query {"query": "INSERT INTO t VALUES (2); BEGIN; SELECT 0/0;"}
 Parse {"query": "COMMIT"}
 Bind
 Execute
@@ -544,14 +520,8 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-ParseComplete
-BindComplete
 CommandComplete {"tag":"INSERT 0 1"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"BEGIN"}
-ParseComplete
-BindComplete
 ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"E"}
 ParseComplete
@@ -567,16 +537,7 @@ ReadyForQuery {"status":"I"}
 # PG permits starting a read only txn with writes blended into its ops;
 # evidence of this behavior by an errored txn does not commit write.
 send
-Parse {"query": "INSERT INTO t VALUES (2)"}
-Bind
-Execute
-Parse {"query": "BEGIN READ ONLY"}
-Bind
-Execute
-Parse {"query": "SELECT 0/0"}
-Bind
-Execute
-Sync
+Query {"query": "INSERT INTO t VALUES (2); BEGIN READ ONLY; SELECT 0/0;"}
 Parse {"query": "COMMIT"}
 Bind
 Execute
@@ -592,14 +553,8 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-ParseComplete
-BindComplete
 CommandComplete {"tag":"INSERT 0 1"}
-ParseComplete
-BindComplete
 CommandComplete {"tag":"BEGIN"}
-ParseComplete
-BindComplete
 ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"E"}
 ParseComplete

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -10,19 +10,6 @@
 mode cockroach
 
 statement ok
-CREATE VIEW logical_timestamp_view AS SELECT mz_now()
-
-# Equivalent to running `SELECT mz_now()` directly IF AND ONLY IF
-# there are no other objects in the same time domain, and has the same somewhat
-# confusing output when there are no dependencies on any views. If there are
-# other objects in the same time domain as the view, they will dictate what is
-# returned.
-query T
-SELECT * FROM logical_timestamp_view
-----
-18446744073709551615
-
-statement ok
 CREATE TABLE dateish (
     a DATE
 )
@@ -772,6 +759,19 @@ query B
 SELECT current_timestamp > TIMESTAMP '2016-06-13 00:00:00'
 ----
 true
+
+statement ok
+CREATE VIEW logical_timestamp_view AS SELECT mz_now()
+
+# Equivalent to running `SELECT mz_now()` directly IF AND ONLY IF
+# there are no other objects in the same time domain, and has the same somewhat
+# confusing output when there are no dependencies on any views. If there are
+# other objects in the same time domain as the view, they will dictate what is
+# returned.
+query T
+SELECT * FROM logical_timestamp_view
+----
+18446744073709551615
 
 statement ok
 CREATE VIEW now_view AS SELECT now() AS ts

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -18,7 +18,7 @@ $ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
 "          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
 
-# Serializable does look at every object in the same time domain
+# Serializable also doesn't look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n\nsource materialize.public.t2 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"

--- a/test/testdrive/numeric.td
+++ b/test/testdrive/numeric.td
@@ -37,7 +37,7 @@ a
 # statement ok
 > CREATE OR REPLACE MATERIALIZED VIEW numeric_cast_ok AS
   SELECT 1
-  WHERE mz_now() < 18446744073709551615::numeric(38,0);
+  WHERE mz_now() > 1927418240000::numeric(38,0);
 
 > SELECT * FROM numeric_cast_ok;
 1

--- a/test/testdrive/temporal.td
+++ b/test/testdrive/temporal.td
@@ -277,7 +277,7 @@ contains:no overload for mz_timestamp + integer
 
 > CREATE OR REPLACE MATERIALIZED VIEW numeric_trunc AS
   SELECT 1
-  WHERE mz_now() <= 18446744073709551614.1;
+  WHERE mz_now() > 1927418240000.1;
 
 ! SELECT * FROM numeric_trunc;
 contains:Evaluation error: mz_timestamp out of range

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -191,6 +191,16 @@ b  sum
 ------
 1  10
 
+> SET transaction_isolation = serializable
+
+> SELECT * FROM bar;
+b  sum
+------
+1  10
+3  30
+
+> SET transaction_isolation = 'strict serializable'
+
 > SELECT * FROM join;
 b foo_sum bar_sum
 -----------------


### PR DESCRIPTION
coord: Optimize single statement read transaction

The PostgreSQL extended wire protocol
(https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY)
leaves it ambiguous as to whether or not the current statement will be
single statement implicit transaction or a multi statement implicit
transaction. Due to this ambiguity, we previously removed all of our
single statement read transactions in
a88775504bf263ecd212d4180c4c0bedf8904f54. This ended up negatively
impacting query freshness and latency in the Serializable isolation
level.

PostgreSQL will eagerly commit implicit transactions after executing
certain statements but before receiving a Sync message. See
https://www.postgresql.org/message-id/flat/17434-d9f7a064ce2a88a3%40postgresql.org
and
https://git.postgresql.org/gitweb/?p=postgresql.git&a=commitdiff&h=f92944137.

This commit will eagerly commit ALL statements in an implicit
transaction when using the extended protocol. This vastly simplifies
things and allows us to re-apply the optimizations we previously made
to single statement transactions.

Multi-statement implicit transactions using the extended protocol are
extremely rare and an edge case. They are not possible unless a client
uses pipelining in psql or a custom driver. The PostgreSQL BEGIN
documentation even wrongly implies that they don't exist
(https://www.postgresql.org/docs/14/sql-begin.html). Therefore,
it's much better to apply the optimizations in the common case than to
allow this edge case feature.

Much of this commit is reversing certain parts of
a88775504bf263ecd212d4180c4c0bedf8904f54.

Fixes #14696
Fixes #14038

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
 - Some of this commit is reversing certain parts of a88775504bf263ecd212d4180c4c0bedf8904f54.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Implicit transactions run using the extended query protocol will eagerly commit after one statement. If you want multi-statement transactions while using the extended query protocol, then use explicit transactions.
