### PR TITLE
load generator: make `id` column a key

### DIFF
--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -79,21 +79,24 @@ impl Generator for Auction {
                 "organizations",
                 RelationDesc::empty()
                     .with_column("id", ScalarType::Int64.nullable(false))
-                    .with_column("name", ScalarType::String.nullable(false)),
+                    .with_column("name", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
             ),
             (
                 "users",
                 RelationDesc::empty()
                     .with_column("id", ScalarType::Int64.nullable(false))
                     .with_column("org_id", ScalarType::Int64.nullable(false))
-                    .with_column("name", ScalarType::String.nullable(false)),
+                    .with_column("name", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
             ),
             (
                 "accounts",
                 RelationDesc::empty()
                     .with_column("id", ScalarType::Int64.nullable(false))
                     .with_column("org_id", ScalarType::Int64.nullable(false))
-                    .with_column("balance", ScalarType::Int64.nullable(false)),
+                    .with_column("balance", ScalarType::Int64.nullable(false))
+                    .with_key(vec![0]),
             ),
             (
                 "auctions",
@@ -101,7 +104,8 @@ impl Generator for Auction {
                     .with_column("id", ScalarType::Int64.nullable(false))
                     .with_column("seller", ScalarType::Int64.nullable(false))
                     .with_column("item", ScalarType::String.nullable(false))
-                    .with_column("end_time", ScalarType::TimestampTz.nullable(false)),
+                    .with_column("end_time", ScalarType::TimestampTz.nullable(false))
+                    .with_key(vec![0]),
             ),
             (
                 "bids",
@@ -110,7 +114,8 @@ impl Generator for Auction {
                     .with_column("buyer", ScalarType::Int64.nullable(false))
                     .with_column("auction_id", ScalarType::Int64.nullable(false))
                     .with_column("amount", ScalarType::Int32.nullable(false))
-                    .with_column("bid_time", ScalarType::TimestampTz.nullable(false)),
+                    .with_column("bid_time", ScalarType::TimestampTz.nullable(false))
+                    .with_key(vec![0]),
             ),
         ]
     }

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
+
+> SHOW SOURCES
+accounts      subsource      1
+auction_house load-generator 1
+auctions      subsource      1
+bids          subsource      1
+organizations subsource      1
+users         subsource      1
+
+> CREATE CONNECTION IF NOT EXISTS kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+# Validate that the ID column of the load generator data is usable as a key.
+> CREATE SINK accounts_sink FROM accounts
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-accounts-${testdrive.seed}')
+  KEY (id)
+  FORMAT JSON
+  ENVELOPE UPSERT;


### PR DESCRIPTION
This isn't particularly meaningful for this data set, but we could express the auction tables' ID columns as a key and propagate that to the `RelationDesc`, which in turn lets us use this with the `UPSERT` envelope (or even just key the data on something in Kafka).

I'm punting on tests for this for the moment to see if this is desirable to do at all; will add them if this gets a nod.

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `LOAD GENERATOR AUCTION` sources' subsources now use their `id` column as a key in their relation, enabling the data to be e.g. used with the `UPSERT` envelope.
