### PR TITLE
storage: add the connection id to the kafka group id

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -414,6 +414,16 @@ $ set schema={
     }
 ```
 
+#### `$ set-from-sql var=NAME`
+
+Sets the variable to the result of a SQL query that returns one row containing
+one string column:
+
+```
+$ set-from-sql var=environment-id
+SELECT mz_environment_id()
+```
+
 ## Referencing variables
 
 #### `${variable_name}`

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -735,10 +735,10 @@ Obtains the data from the specified `sink` or `topic` and compares it to the exp
 
 If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The records do not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
 
-#### `kafka-verify-commit source=... topic=... partition=...
+#### `kafka-verify-commit consumer-group-id=... topic=... partition=...
 
-Verifies that the provided offset (the input data) matches the committed offset for
-_the sources consumer id_
+Verifies that the provided offset (the input data) matches the committed offset
+for the specified consumer group, topic, and partition.
 
 
 #### `headers=<list or object>`

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -106,6 +106,7 @@ impl SourceReader for KafkaSourceReader {
     ) -> Result<(Self, Self::OffsetCommitter), anyhow::Error> {
         let KafkaSourceConnection {
             connection,
+            connection_id,
             options,
             topic,
             group_id_prefix,
@@ -113,7 +114,8 @@ impl SourceReader for KafkaSourceReader {
             ..
         } = kc;
         let kafka_config = TokioHandle::current().block_on(create_kafka_config(
-            &source_name,
+            connection_id,
+            source_id,
             group_id_prefix,
             environment_id,
             &connection,
@@ -509,12 +511,12 @@ impl KafkaSourceReader {
                     .expect("partition known to be installed");
 
                 error!(
-                        "kafka error consuming from source: {} topic: {}: partition: {} last processed offset: {} : {}",
-                        self.source_name,
-                        self.topic_name,
-                        pid,
-                        last_offset,
-                        e
+                    "kafka error consuming from source: {} topic: {}: partition: {} last processed offset: {} : {}",
+                    self.source_name,
+                    self.topic_name,
+                    pid,
+                    last_offset,
+                    e
                     );
                 None
             }
@@ -591,7 +593,8 @@ impl KafkaSourceReader {
 /// look arbitrary, other layers of the system tightly control which
 /// configuration options are allowable.
 async fn create_kafka_config(
-    name: &str,
+    connection_id: GlobalId,
+    source_id: GlobalId,
     group_id_prefix: Option<String>,
     environment_id: String,
     kafka_connection: &KafkaConnection,
@@ -646,10 +649,11 @@ async fn create_kafka_config(
     kafka_config.set(
         "group.id",
         &format!(
-            "{}materialize-{}-{}",
+            "{}materialize-{}-{}-{}",
             group_id_prefix.unwrap_or_else(String::new),
             environment_id,
-            name
+            connection_id,
+            source_id,
         ),
     );
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -740,6 +740,7 @@ impl Run for PosCommand {
                         sleep::run_sleep(builtin)
                     }
                     "set" => set::set_vars(builtin, state),
+                    "set-from-sql" => set::run_set_from_sql(builtin, state).await,
                     // "verify-timestamp-compaction" => Box::new(
                     //     verify_timestamp_compaction::run_verify_timestamp_compaction_action(
                     //         builtin,

--- a/src/testdrive/src/action/kafka/commit.rs
+++ b/src/testdrive/src/action/kafka/commit.rs
@@ -7,67 +7,46 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use anyhow::{anyhow, Context};
+use std::time::Duration;
+
+use anyhow::{bail, Context};
 use rdkafka::consumer::{Consumer, StreamConsumer};
-use rdkafka::topic_partition_list::Offset;
+use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 
 use mz_ore::retry::Retry;
+use mz_ore::str::StrExt;
 
 use crate::action::{ControlFlow, State};
 use crate::parser::BuiltinCommand;
-
-async fn get_env_id(state: &mut State) -> Result<String, anyhow::Error> {
-    let query = "select mz_environment_id();".to_string();
-    let result = state
-        .pgclient
-        .query_one(query.as_str(), &[])
-        .await
-        .context("retrieving env id")?
-        .get(0);
-    Ok(result)
-}
-
-async fn get_id(table: &str, name: &str, state: &mut State) -> Result<String, anyhow::Error> {
-    let query = format!("select id from {table} where name = $1");
-    let result = state
-        .pgclient
-        .query_one(query.as_str(), &[&name])
-        .await
-        .context("retrieving source id")?
-        .get(0);
-    Ok(result)
-}
 
 pub async fn run_verify_commit(
     mut cmd: BuiltinCommand,
     state: &mut State,
 ) -> Result<ControlFlow, anyhow::Error> {
-    let source = cmd.args.string("source")?;
-    let conn = cmd.args.string("conn")?;
+    let consumer_group_id = cmd.args.string("consumer-group-id")?;
     let topic = cmd.args.string("topic")?;
     let partition = cmd.args.parse("partition")?;
-    let expected_offset = Offset::Offset(cmd.input[0].parse()?);
+    cmd.args.done()?;
 
-    let env_id = get_env_id(state).await?;
-    let source_id = get_id("mz_sources", &source, state).await?;
-    let conn_id = get_id("mz_connections", &conn, state).await?;
     let topic = format!("testdrive-{}-{}", topic, state.seed);
+    let expected_offset = match &cmd.input[..] {
+        [line] => Offset::Offset(line.parse().context("parsing expected offset")?),
+        _ => bail!("kafka-verify-commit requires a single expected offset as input"),
+    };
+
+    println!(
+        "Verifying committed Kafka offset for topic {} and consumer group {}...",
+        topic.quoted(),
+        consumer_group_id.quoted(),
+    );
 
     let mut config = state.kafka_config.clone();
-    config.set(
-        "group.id",
-        format!("materialize-{}-{}-{}", env_id, conn_id, source_id),
-    );
-    println!(
-        "Verifying committed kafka offset for topic ({}) and consumer group ({})",
-        topic,
-        config.get("group.id").unwrap()
-    );
+    config.set("group.id", &consumer_group_id);
     Retry::default()
         .max_duration(state.default_timeout)
         .retry_async_canceling(|_| async {
             let config = config.clone();
-            let mut tpl = rdkafka::topic_partition_list::TopicPartitionList::new();
+            let mut tpl = TopicPartitionList::new();
             tpl.add_partition(&topic, partition);
             let committed_tpl = mz_ore::task::spawn_blocking(
                 || "kakfa_committed_offsets".to_string(),
@@ -76,7 +55,7 @@ pub async fn run_verify_commit(
                         config.create().context("creating kafka consumer")?;
 
                     Ok::<_, anyhow::Error>(
-                        consumer.committed_offsets(tpl, std::time::Duration::from_secs(10))?,
+                        consumer.committed_offsets(tpl, Duration::from_secs(10))?,
                     )
                 },
             )
@@ -85,14 +64,13 @@ pub async fn run_verify_commit(
 
             let found_offset = committed_tpl.elements_for_topic(&topic)[0].offset();
             if found_offset != expected_offset {
-                Err(anyhow!(
-                    "Found committed offset `{:?}` does not match expected offset `{:?}`",
+                bail!(
+                    "found committed offset `{:?}` does not match expected offset `{:?}`",
                     found_offset,
                     expected_offset
-                ))
-            } else {
-                Ok(())
+                );
             }
+            Ok(())
         })
         .await?;
     Ok(ControlFlow::Continue)

--- a/src/testdrive/src/action/set.rs
+++ b/src/testdrive/src/action/set.rs
@@ -9,7 +9,7 @@
 
 use std::cmp;
 
-use anyhow::Context;
+use anyhow::{bail, Context};
 use regex::Regex;
 
 use crate::action::{ControlFlow, State};
@@ -82,6 +82,31 @@ pub fn set_vars(cmd: BuiltinCommand, state: &mut State) -> Result<ControlFlow, a
             state.cmd_vars.insert(key, val);
         }
     }
+
+    Ok(ControlFlow::Continue)
+}
+
+pub async fn run_set_from_sql(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let var = cmd.args.string("var")?;
+    cmd.args.done()?;
+
+    let row = state
+        .pgclient
+        .query_one(&cmd.input.join("\n"), &[])
+        .await
+        .context("running query")?;
+    if row.columns().len() != 1 {
+        bail!(
+            "set-from-sql query must return exactly one column, but it returned {}",
+            row.columns().len()
+        );
+    }
+    let value: String = row.try_get(0).context("deserializing value as string")?;
+
+    state.cmd_vars.insert(var, value);
 
     Ok(ControlFlow::Continue)
 }

--- a/test/testdrive/kafka-commit.td
+++ b/test/testdrive/kafka-commit.td
@@ -34,5 +34,5 @@ one          0
 two          1
 three        2
 
-$ kafka-verify-commit source=topic topic=topic partition=0
+$ kafka-verify-commit source=topic conn=conn topic=topic partition=0
 3

--- a/test/testdrive/kafka-commit.td
+++ b/test/testdrive/kafka-commit.td
@@ -7,10 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test that committing kafka offsets works
+# Test that the source ingestion pipeline commits offsets back to Kafka with
+# the expected group ID.
+
+# Initial setup.
 
 $ kafka-create-topic topic=topic partitions=1
-
 $ kafka-ingest format=bytes topic=topic
 one
 two
@@ -19,20 +21,52 @@ three
 > CREATE CONNECTION conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
+# Test that the default consumer group ID is
+# `materialize-$ENVIRONMENTID-$CONNECTIONID-$SOURCEID`.
+
 > CREATE SOURCE topic
   FROM KAFKA CONNECTION conn (
     TOPIC 'testdrive-topic-${testdrive.seed}'
   )
   FORMAT BYTES
-  INCLUDE OFFSET
-  ENVELOPE NONE
 
 > SELECT * from topic
-data         offset
------------------------------------
-one          0
-two          1
-three        2
+one
+two
+three
 
-$ kafka-verify-commit source=topic conn=conn topic=topic partition=0
+$ set-from-sql var=consumer-group-id
+SELECT
+  'materialize-' || mz_environment_id() || '-' || c.id || '-' || s.id
+FROM mz_sources s
+JOIN mz_connections c ON c.id = s.connection_id
+WHERE s.name = 'topic'
+
+$ kafka-verify-commit consumer-group-id=${consumer-group-id} topic=topic partition=0
+3
+
+> DROP SOURCE topic
+
+# Test than an arbitrary prefix can be prepended to the consumer group.
+
+> CREATE SOURCE topic
+  FROM KAFKA CONNECTION conn (
+    TOPIC 'testdrive-topic-${testdrive.seed}',
+    GROUP ID PREFIX 'OVERRIDE-'
+  )
+  FORMAT BYTES
+
+> SELECT * from topic
+one
+two
+three
+
+$ set-from-sql var=consumer-group-id
+SELECT
+  'OVERRIDE-materialize-' || mz_environment_id() || '-' || c.id || '-' || s.id
+FROM mz_sources s
+JOIN mz_connections c ON c.id = s.connection_id
+WHERE s.name = 'topic'
+
+$ kafka-verify-commit consumer-group-id=${consumer-group-id} topic=topic partition=0
 3


### PR DESCRIPTION
As discussed on slack. One of the final (non-QA) changes required by https://github.com/MaterializeInc/materialize/issues/13534

cc @morsapaes this will need to be documented when we document the kafka commit behavior

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

