### PR TITLE
persist: set a timeout on compaction requests

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -600,6 +600,7 @@ pub struct CompactionMetrics {
     pub(crate) noop: IntCounter,
     pub(crate) seconds: Counter,
     pub(crate) concurrency_waits: IntCounter,
+    pub(crate) very_slow_requests: IntCounter,
     pub(crate) memory_violations: IntCounter,
     pub(crate) runs_compacted: IntCounter,
     pub(crate) chunks_compacted: IntCounter,
@@ -653,6 +654,10 @@ impl CompactionMetrics {
             concurrency_waits: registry.register(metric!(
                 name: "mz_persist_compaction_concurrency_waits",
                 help: "count of compaction requests that ever blocked due to concurrency limit",
+            )),
+            very_slow_requests: registry.register(metric!(
+                name: "mz_persist_compaction_very_slow_requests",
+                help: "count of very slow compaction requests",
             )),
             memory_violations: registry.register(metric!(
                 name: "mz_persist_compaction_memory_violations",

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -596,11 +596,11 @@ pub struct CompactionMetrics {
     pub(crate) skipped: IntCounter,
     pub(crate) started: IntCounter,
     pub(crate) applied: IntCounter,
+    pub(crate) timed_out: IntCounter,
     pub(crate) failed: IntCounter,
     pub(crate) noop: IntCounter,
     pub(crate) seconds: Counter,
     pub(crate) concurrency_waits: IntCounter,
-    pub(crate) very_slow_requests: IntCounter,
     pub(crate) memory_violations: IntCounter,
     pub(crate) runs_compacted: IntCounter,
     pub(crate) chunks_compacted: IntCounter,
@@ -643,6 +643,10 @@ impl CompactionMetrics {
                 name: "mz_persist_compaction_applied",
                 help: "count of compactions applied to state",
             )),
+            timed_out: registry.register(metric!(
+                name: "mz_persist_compaction_timed_out",
+                help: "count of compactions that timed out",
+            )),
             noop: registry.register(metric!(
                 name: "mz_persist_compaction_noop",
                 help: "count of compactions discarded (obsolete)",
@@ -654,10 +658,6 @@ impl CompactionMetrics {
             concurrency_waits: registry.register(metric!(
                 name: "mz_persist_compaction_concurrency_waits",
                 help: "count of compaction requests that ever blocked due to concurrency limit",
-            )),
-            very_slow_requests: registry.register(metric!(
-                name: "mz_persist_compaction_very_slow_requests",
-                help: "count of very slow compaction requests",
             )),
             memory_violations: registry.register(metric!(
                 name: "mz_persist_compaction_memory_violations",


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

I'll fill in more details on Monday, but it seems like we're seeing compaction requests occasionally start but never complete. This causes compaction for a shard to jam indefinitely, leading to a domino chain of greater problems, like `environmentd` crash looping. 

Inferring from what data points we do have, but lacking hard evidence, my best guess right now is some S3 calls got stuck indefinitely. We don't currently set any client timeouts on our calls, so it seems possible that a call could be made to an unreachable destination and never complete. We could add timeouts directly to the S3 client, but https://github.com/awslabs/smithy-rs/pull/1740 is upcoming and completely overhauls the timeout structure, and seems much improved over what we could do on today's SDK version.

This PR puts a hard timeout on compaction, so that requests over 10 minutes will be dropped. This should prevent us from getting stuck indefinitely on a long request, at the risk of dropping/spinning on requests that really do need 10 minutes. In practice, the mean compaction time is under a second, but, just want to highlight the potential risk here. 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
