### PR TITLE
adapter: robustify references to arranged log sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,6 +3027,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools",
+ "maplit",
  "mz-audit-log",
  "mz-build-info",
  "mz-ccsr",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,6 +19,7 @@ fail = { version = "0.5.0", features = ["failpoints"] }
 futures = "0.3.24"
 itertools = "0.10.4"
 once_cell = "1.14.0"
+maplit = "1.0.2"
 mz-audit-log = { path = "../audit-log" }
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -3458,7 +3458,6 @@ where
         return Ok(());
     }
 
-
     // Peeking from log sources on replicated compute instances is only
     // allowed if a target replica is selected. Otherwise, we have no
     // way of knowing which replica we read the introspection data from.

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -173,6 +173,10 @@ pub enum AdapterError {
     UntargetedLogRead {
         log_names: Vec<String>,
     },
+    /// Attempted to subscribe to a log source.
+    TargetedSubscribe {
+        log_names: Vec<String>,
+    },
     /// The transaction is in write-only mode.
     WriteOnlyTransaction,
     /// The transaction only supports single table writes
@@ -214,7 +218,8 @@ impl AdapterError {
                     .into(),
             ),
             AdapterError::IntrospectionDisabled { log_names }
-            | AdapterError::UntargetedLogRead { log_names } => Some(format!(
+            | AdapterError::UntargetedLogRead { log_names }
+            | AdapterError::TargetedSubscribe { log_names } => Some(format!(
                 "The query references the following log sources:\n    {}",
                 log_names.join("\n    "),
             )),
@@ -443,6 +448,9 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::UntargetedLogRead { .. } => {
                 f.write_str("log source reads must target a replica")
+            }
+            AdapterError::TargetedSubscribe { .. } => {
+                f.write_str("SUBSCRIBE cannot reference a log source")
             }
             AdapterError::MultiTableWriteTransaction => {
                 f.write_str("write transactions only support writes to a single table")

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -421,6 +421,7 @@ impl ErrorResponse {
             AdapterError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Unstructured(_) => SqlState::INTERNAL_ERROR,
             AdapterError::UntargetedLogRead { .. } => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::TargetedSubscribe { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             // It's not immediately clear which error code to use here because a
             // "write-only transaction" and "single table write transaction" are
             // not things in Postgres. This error code is the generic "bad txn thing"

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -97,8 +97,19 @@ CREATE CLUSTER test
 statement ok
 SET cluster_replica = replica_a
 
+# A query that has introspection views in its time domain but does not
+# specifically reference those introspection views should work even on a replica
+# with introspection disabled. This query would crash in v0.27.0-alpha.24.
+query I
+SELECT 1 FROM mz_sources LIMIT 1
+----
+1
+
 query error cannot read log sources of replica with disabled introspection
 SELECT * FROM mz_internal.mz_compute_exports
+
+statement error SUBSCRIBE cannot reference a log source
+SUBSCRIBE TO mz_internal.mz_compute_exports
 
 statement ok
 SET cluster_replica = replica_b


### PR DESCRIPTION
Make the adapter more robust to references to arranged log sources. Two commits within; see their messages for details.

### Motivation

  * This PR fixes a bug experienced by a prospect and diagnosed on Slack.

### Tips for reviewer

I'm not psyched about the complexity caused by these log sources—and it's a bummer that we have to eat the complexity twice, in two slightly different ways, for arranged vs. persisted sources.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
