### PR TITLE
adapter: notify on replica changes during peeks

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -26,7 +26,7 @@ from kubernetes.client import (
 )
 from kubernetes.client.exceptions import ApiException
 from kubernetes.config import new_client_from_config  # type: ignore
-from pg8000 import Cursor
+from pg8000 import Connection, Cursor
 
 from materialize import ROOT, mzbuild
 
@@ -123,11 +123,15 @@ class K8sService(K8sResource):
 
         return node_port
 
-    def sql_cursor(self) -> Cursor:
-        """Get a cursor to run SQL queries against the service"""
-        conn = pg8000.connect(
+    def sql_conn(self) -> Connection:
+        """Get a connection to run SQL queries against the service"""
+        return pg8000.connect(
             host="localhost", port=self.node_port(), user="materialize"
         )
+
+    def sql_cursor(self) -> Cursor:
+        """Get a cursor to run SQL queries against the service"""
+        conn = self.sql_conn()
         conn.autocommit = True
         return conn.cursor()
 

--- a/misc/python/stubs/pg8000/__init__.pyi
+++ b/misc/python/stubs/pg8000/__init__.pyi
@@ -8,11 +8,14 @@
 # by the Apache License, Version 2.0.
 
 from types import TracebackType
-from typing import Any, ContextManager, Optional, Sequence
+from typing import IO, Any, AnyStr, ContextManager, Deque, Optional, Sequence
 
 class Connection:
     autocommit: bool
+    notices: Deque
     def cursor(self) -> Cursor: ...
+    def close(self) -> None: ...
+    def run(self, sql: str, stream: Optional[IO[AnyStr]]) -> None: ...
 
 class Cursor(ContextManager):
     rowcount: int

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -127,6 +127,7 @@ use crate::error::AdapterError;
 use crate::session::{EndTransactionAction, Session};
 use crate::subscribe::PendingSubscribe;
 use crate::util::{ClientTransmitter, CompletedClientTransmitter};
+use crate::AdapterNotice;
 
 pub(crate) mod id_bundle;
 pub(crate) mod peek;
@@ -266,6 +267,9 @@ struct ConnMeta {
     /// requests are required to authenticate with the secret of the connection
     /// that they are targeting.
     secret_key: u32,
+
+    /// Channel on which to send notices to a session.
+    notice_tx: mpsc::UnboundedSender<AdapterNotice>,
 }
 
 struct TxnReads {

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -207,6 +207,7 @@ impl<S: Append + 'static> Coordinator<S> {
             ConnMeta {
                 cancel_tx,
                 secret_key,
+                notice_tx: session.retain_notice_transmitter(),
             },
         );
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use chrono::DurationRound;
 use tracing::{event, warn, Level};
 
-use mz_compute_client::controller::ComputeInstanceEvent;
+use mz_compute_client::controller::{ComputeInstanceEvent, ComputeInstanceStatus};
 use mz_controller::ControllerResponse;
 use mz_ore::now::EpochMillis;
 use mz_ore::task;
@@ -25,9 +25,9 @@ use mz_sql::ast::Statement;
 use mz_sql::plan::{Plan, SendDiffsPlan};
 use mz_stash::Append;
 
-use crate::catalog;
 use crate::command::{Command, ExecuteResponse};
 use crate::coord::appends::{BuiltinTableUpdateSource, Deferred};
+use crate::{catalog, AdapterNotice};
 
 use crate::coord::{
     Coordinator, CreateSourceStatementReady, Message, PendingTxn, ReplicaMetadata, SendDiffs,
@@ -427,6 +427,31 @@ impl<S: Append + 'static> Coordinator<S> {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn message_compute_instance_status(&mut self, event: ComputeInstanceEvent) {
         event!(Level::TRACE, event = format!("{:?}", event));
+
+        let (instance_name, replica_name) = self
+            .catalog
+            .compute_instances()
+            .find(|i| i.id == event.instance_id)
+            .map(|i| {
+                let mut replica = event.replica_id.to_string();
+                for (name, id) in &i.replica_id_by_name {
+                    if *id == event.replica_id {
+                        replica = name.clone();
+                        break;
+                    }
+                }
+                (i.name.clone(), replica)
+            })
+            .unwrap_or_else(|| (event.instance_id.to_string(), event.replica_id.to_string()));
+
+        if matches!(event.status, ComputeInstanceStatus::NotReady) {
+            self.broadcast_notice(AdapterNotice::ClusterReplicaStatusChanged {
+                cluster: instance_name,
+                replica: replica_name,
+                status: event.status,
+            });
+        }
+
         self.catalog_transact(
             None,
             vec![catalog::Op::UpdateComputeInstanceStatus { event }],

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -9,6 +9,7 @@
 
 use std::fmt;
 
+use mz_compute_client::controller::ComputeInstanceStatus;
 use mz_ore::str::StrExt;
 use mz_sql::ast::NoticeSeverity;
 
@@ -16,15 +17,31 @@ use mz_sql::ast::NoticeSeverity;
 ///
 /// These are diagnostic warnings or informational messages that are not
 /// severe enough to warrant failing a query entirely.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AdapterNotice {
-    DatabaseAlreadyExists { name: String },
-    SchemaAlreadyExists { name: String },
-    TableAlreadyExists { name: String },
-    ObjectAlreadyExists { name: String, ty: &'static str },
+    DatabaseAlreadyExists {
+        name: String,
+    },
+    SchemaAlreadyExists {
+        name: String,
+    },
+    TableAlreadyExists {
+        name: String,
+    },
+    ObjectAlreadyExists {
+        name: String,
+        ty: &'static str,
+    },
     ExistingTransactionInProgress,
     ExplicitTransactionControlInImplicitTransaction,
-    UserRequested { severity: NoticeSeverity },
+    UserRequested {
+        severity: NoticeSeverity,
+    },
+    ClusterReplicaStatusChanged {
+        cluster: String,
+        replica: String,
+        status: ComputeInstanceStatus,
+    },
 }
 
 impl AdapterNotice {
@@ -62,6 +79,17 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::UserRequested { severity } => {
                 write!(f, "raised a test {}", severity.to_string().to_lowercase())
+            }
+            AdapterNotice::ClusterReplicaStatusChanged {
+                cluster,
+                replica,
+                status,
+            } => {
+                write!(
+                    f,
+                    "cluster replica {}.{} changed status to: {:?}",
+                    cluster, replica, status,
+                )
             }
         }
     }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -421,6 +421,7 @@ fn make_notices(client: &mut SessionClient) -> Vec<Notice> {
     client
         .session()
         .drain_notices()
+        .into_iter()
         .map(|notice| Notice {
             message: notice.to_string(),
             severity: Severity::for_adapter_notice(&notice)

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -79,7 +79,7 @@ pub struct ServiceEvent {
 }
 
 /// Describes the status of an orchestrated service.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 pub enum ServiceStatus {
     /// Service is ready to accept requests.
     Ready,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -423,6 +423,7 @@ impl ErrorResponse {
                 SqlState::NO_ACTIVE_SQL_TRANSACTION
             }
             AdapterNotice::UserRequested { .. } => SqlState::WARNING,
+            AdapterNotice::ClusterReplicaStatusChanged { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -569,6 +570,7 @@ impl Severity {
                 NoticeSeverity::Notice => Severity::Notice,
                 NoticeSeverity::Warning => Severity::Warning,
             },
+            AdapterNotice::ClusterReplicaStatusChanged { .. } => Severity::Notice,
         }
     }
 }

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -1,0 +1,119 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import threading
+import time
+from io import StringIO
+
+from pg8000 import Connection
+
+from materialize.cloudtest.application import MaterializeApplication
+
+
+def query(conn: Connection, sql: str) -> None:
+    # Wrap all exceptions so that when the connection is closed from the other
+    # thread we don't panic the test.
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(sql)
+    except:
+        pass
+
+
+def copy(conn: Connection, sql: str) -> None:
+    try:
+        conn.run(sql, stream=StringIO())
+    except:
+        pass
+
+
+# Returns and consumes notices on conn until one contains `contains`.
+def assert_notice(conn: Connection, contains: bytes) -> None:
+    while True:
+        try:
+            notice = conn.notices.pop()
+            if contains in notice[b"M"]:
+                return
+        except IndexError:
+            pass
+        time.sleep(0.2)
+
+
+# Test that a crashed (and restarted) computed replica generates expected notice
+# events.
+def test_crash_computed(mz: MaterializeApplication) -> None:
+    mz.environmentd.sql("DROP TABLE IF EXISTS t1 CASCADE")
+    mz.environmentd.sql("CREATE TABLE t1 (f1 TEXT)")
+
+    # For various query contexts, create a connection, run a query that'll never
+    # finish in another thread, and examine its notices from this thread since
+    # the queries block forever. The contexts here (SELECT stuck in pending,
+    # direct SUBSCRIBE, SUBSCRIBE via COPY) are all separately implemented, so
+    # need to be separately tested.
+    c_select = mz.environmentd.sql_conn()
+    t_select = threading.Thread(
+        target=query,
+        args=(
+            c_select,
+            "SELECT * FROM t1 AS OF 18446744073709551615",
+        ),
+    )
+    t_select.start()
+
+    c_subscribe = mz.environmentd.sql_conn()
+    t_subscribe = threading.Thread(
+        target=query,
+        args=(
+            c_subscribe,
+            "SUBSCRIBE t1",
+        ),
+    )
+    t_subscribe.start()
+
+    c_copy = mz.environmentd.sql_conn()
+    t_copy = threading.Thread(
+        target=copy,
+        args=(
+            c_copy,
+            "COPY (SUBSCRIBE t1) TO STDOUT",
+        ),
+    )
+    t_copy.start()
+
+    # Wait a teeny bit for the queries to be receiving notices.
+    time.sleep(1)
+
+    c_select.notices.clear()
+    c_subscribe.notices.clear()
+    c_copy.notices.clear()
+
+    # Simulate an unexpected computed crash.
+    pods = mz.kubectl("get", "pods", "-o", "custom-columns=:metadata.name")
+    podcount = 0
+    for pod in pods.splitlines():
+        if "compute-cluster" in pod:
+            mz.kubectl("delete", "pod", pod)
+            podcount += 1
+    assert podcount > 0
+
+    # Wait for expected notices on all connections.
+    msg = b"cluster replica default.r1 changed status to: NotReady"
+    assert_notice(c_select, msg)
+    assert_notice(c_subscribe, msg)
+    assert_notice(c_copy, msg)
+
+    # Cleanup for other tests.
+    mz.environmentd.sql("DROP TABLE t1")
+
+    # We need all the above threads to finish for the test to succeed.Close the
+    # connections from this thread because pg8000 doesn't support cancellation
+    # and dropping the table in mz doesn't complete the queries either.
+    c_select.close()
+    c_subscribe.close()
+    c_copy.close()


### PR DESCRIPTION
When a replica state changes during the time a peek or subscribe is pending or in progress, send pgwire NOTICE messages informing the users of the state change. This is useful in observing that replicas are OOMing or in a restart loop which sometimes presents as a slow query. The slow query gives us an opportunity to say something to a psql console that will hopefully make it easier for users to figure out how to fix the slow query problem.

See #15196

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a