### PR TITLE
testdrive: remove vestiges of action building

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -25,249 +25,233 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
 use mz_pgrepr::{Interval, Jsonb, Numeric};
-use mz_sql_parser::ast::{Raw, Statement};
+use mz_sql_parser::ast::Statement;
 
 use crate::action::{ControlFlow, State};
 use crate::parser::{FailSqlCommand, SqlCommand, SqlExpectedError, SqlOutput};
 
-pub struct SqlAction {
-    cmd: SqlCommand,
-    stmt: Statement<Raw>,
-}
+pub async fn run_sql(mut cmd: SqlCommand, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
+    use Statement::*;
 
-pub async fn run_sql(cmd: SqlCommand, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
-    build_sql(cmd)?.run(state).await
-}
-
-fn build_sql(mut cmd: SqlCommand) -> Result<SqlAction, anyhow::Error> {
     let stmts = mz_sql_parser::parser::parse_statements(&cmd.query)
         .with_context(|| format!("unable to parse SQL: {}", cmd.query))?;
     if stmts.len() != 1 {
         bail!("expected one statement, but got {}", stmts.len());
     }
+    let stmt = stmts.into_element();
     if let SqlOutput::Full { expected_rows, .. } = &mut cmd.expected_output {
         // TODO(benesch): one day we'll support SQL queries where order matters.
         expected_rows.sort();
     }
-    Ok(SqlAction {
-        cmd,
-        stmt: stmts.into_element(),
+
+    let query = &cmd.query;
+    print_query(query);
+
+    let should_retry = match &stmt {
+        // Do not retry FETCH statements as subsequent executions are likely
+        // to return an empty result. The original result would thus be lost.
+        Fetch(_) => false,
+        // DDL statements should always provide the expected result on the first try
+        CreateConnection(_)
+        | CreateCluster(_)
+        | CreateClusterReplica(_)
+        | CreateDatabase(_)
+        | CreateSchema(_)
+        | CreateSource(_)
+        | CreateSink(_)
+        | CreateMaterializedView(_)
+        | CreateView(_)
+        | CreateTable(_)
+        | CreateIndex(_)
+        | CreateType(_)
+        | CreateRole(_)
+        | AlterObjectRename(_)
+        | AlterIndex(_)
+        | Discard(_)
+        | DropDatabase(_)
+        | DropObjects(_)
+        | SetVariable(_)
+        | Show(_) => false,
+        _ => true,
+    };
+
+    let state = &state;
+    let expected_output = &cmd.expected_output;
+    let res = match should_retry {
+        true => Retry::default()
+            .initial_backoff(state.initial_backoff)
+            .factor(state.backoff_factor)
+            .max_duration(state.timeout)
+            .max_tries(state.max_tries),
+        false => Retry::default().max_duration(state.timeout).max_tries(1),
+    }
+    .retry_async_canceling(|retry_state| async move {
+        match try_run_sql(state, query, expected_output).await {
+            Ok(()) => {
+                if retry_state.i != 0 {
+                    println!();
+                }
+                println!(
+                    "rows match; continuing at ts {}",
+                    SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs_f64()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                if retry_state.i == 0 && should_retry {
+                    print!("rows didn't match; sleeping to see if dataflow catches up");
+                }
+                if let Some(backoff) = retry_state.next_backoff {
+                    if !backoff.is_zero() {
+                        print!(" {:.0?}", backoff);
+                        io::stdout().flush().unwrap();
+                    }
+                }
+                Err(e)
+            }
+        }
     })
-}
+    .await;
+    if let Err(e) = res {
+        println!();
+        return Err(e);
+    }
 
-impl SqlAction {
-    async fn run(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
-        use Statement::*;
-
-        let query = &self.cmd.query;
-        print_query(query);
-
-        let should_retry = match &self.stmt {
-            // Do not retry FETCH statements as subsequent executions are likely
-            // to return an empty result. The original result would thus be lost.
-            Fetch(_) => false,
-            // DDL statements should always provide the expected result on the first try
-            CreateConnection(_)
-            | CreateCluster(_)
-            | CreateClusterReplica(_)
-            | CreateDatabase(_)
-            | CreateSchema(_)
-            | CreateSource(_)
-            | CreateSink(_)
-            | CreateMaterializedView(_)
-            | CreateView(_)
-            | CreateTable(_)
-            | CreateIndex(_)
-            | CreateType(_)
-            | CreateRole(_)
-            | AlterObjectRename(_)
-            | AlterIndex(_)
-            | Discard(_)
-            | DropDatabase(_)
-            | DropObjects(_)
-            | SetVariable(_)
-            | Show(_) => false,
-            _ => true,
-        };
-
-        let state = &state;
-        let res = match should_retry {
-            true => Retry::default()
-                .initial_backoff(state.initial_backoff)
-                .factor(state.backoff_factor)
-                .max_duration(state.timeout)
-                .max_tries(state.max_tries),
-            false => Retry::default().max_duration(state.timeout).max_tries(1),
-        }
-        .retry_async_canceling(|retry_state| async move {
-            match self.try_run(state, query).await {
-                Ok(()) => {
-                    if retry_state.i != 0 {
-                        println!();
-                    }
-                    println!(
-                        "rows match; continuing at ts {}",
-                        SystemTime::now()
-                            .duration_since(SystemTime::UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs_f64()
+    match stmt {
+        Statement::CreateDatabase { .. }
+        | Statement::CreateIndex { .. }
+        | Statement::CreateSchema { .. }
+        | Statement::CreateSource { .. }
+        | Statement::CreateTable { .. }
+        | Statement::CreateView { .. }
+        | Statement::DropDatabase { .. }
+        | Statement::DropObjects { .. } => {
+            let disk_state = state
+                .with_catalog_copy(|catalog| catalog.state().dump())
+                .await?;
+            if let Some(disk_state) = disk_state {
+                let mem_state = reqwest::get(&format!(
+                    "http://{}/api/catalog",
+                    state.materialize_internal_http_addr,
+                ))
+                .await?
+                .text()
+                .await?;
+                if disk_state != mem_state {
+                    bail!(
+                        "the on-disk state of the catalog does not match its in-memory state\n\
+                     disk:{}\n\
+                     mem:{}",
+                        disk_state,
+                        mem_state
                     );
-                    Ok(())
-                }
-                Err(e) => {
-                    if retry_state.i == 0 && should_retry {
-                        print!("rows didn't match; sleeping to see if dataflow catches up");
-                    }
-                    if let Some(backoff) = retry_state.next_backoff {
-                        if !backoff.is_zero() {
-                            print!(" {:.0?}", backoff);
-                            io::stdout().flush().unwrap();
-                        }
-                    }
-                    Err(e)
                 }
             }
-        })
-        .await;
-        if let Err(e) = res {
-            println!();
-            return Err(e);
         }
-
-        match self.stmt {
-            Statement::CreateDatabase { .. }
-            | Statement::CreateIndex { .. }
-            | Statement::CreateSchema { .. }
-            | Statement::CreateSource { .. }
-            | Statement::CreateTable { .. }
-            | Statement::CreateView { .. }
-            | Statement::DropDatabase { .. }
-            | Statement::DropObjects { .. } => {
-                let disk_state = state
-                    .with_catalog_copy(|catalog| catalog.state().dump())
-                    .await?;
-                if let Some(disk_state) = disk_state {
-                    let mem_state = reqwest::get(&format!(
-                        "http://{}/api/catalog",
-                        state.materialize_internal_http_addr,
-                    ))
-                    .await?
-                    .text()
-                    .await?;
-                    if disk_state != mem_state {
-                        bail!(
-                            "the on-disk state of the catalog does not match its in-memory state\n\
-                         disk:{}\n\
-                         mem:{}",
-                            disk_state,
-                            mem_state
-                        );
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        Ok(ControlFlow::Continue)
+        _ => {}
     }
-    async fn try_run(&self, state: &State, query: &str) -> Result<(), anyhow::Error> {
-        let stmt = state
-            .pgclient
-            .prepare(query)
-            .await
-            .context("preparing query failed")?;
-        let mut actual: Vec<_> = state
-            .pgclient
-            .query(&stmt, &[])
-            .await
-            .context("executing query failed")?
-            .into_iter()
-            .map(|row| decode_row(state, row))
-            .collect::<Result<_, _>>()?;
-        actual.sort();
 
-        match &self.cmd.expected_output {
-            SqlOutput::Full {
-                expected_rows,
-                column_names,
-            } => {
-                if let Some(column_names) = column_names {
-                    let actual_columns: Vec<_> = stmt.columns().iter().map(|c| c.name()).collect();
-                    if actual_columns.iter().ne(column_names) {
-                        bail!(
-                            "column name mismatch\nexpected: {:?}\nactual:   {:?}",
-                            column_names,
-                            actual_columns
-                        );
-                    }
-                }
-                if &actual == expected_rows {
-                    Ok(())
-                } else {
-                    let (mut left, mut right) = (0, 0);
-                    let mut buf = String::new();
-                    while let (Some(e), Some(a)) = (expected_rows.get(left), actual.get(right)) {
-                        match e.cmp(a) {
-                            std::cmp::Ordering::Less => {
-                                writeln!(buf, "- {}", TestdriveRow(e)).unwrap();
-                                left += 1;
-                            }
-                            std::cmp::Ordering::Equal => {
-                                left += 1;
-                                right += 1;
-                            }
-                            std::cmp::Ordering::Greater => {
-                                writeln!(buf, "+ {}", TestdriveRow(a)).unwrap();
-                                right += 1;
-                            }
-                        }
-                    }
-                    while let Some(e) = expected_rows.get(left) {
-                        writeln!(buf, "- {}", TestdriveRow(e)).unwrap();
-                        left += 1;
-                    }
-                    while let Some(a) = actual.get(right) {
-                        writeln!(buf, "+ {}", TestdriveRow(a)).unwrap();
-                        right += 1;
-                    }
-                    bail!(
-                        "non-matching rows: expected:\n{:?}\ngot:\n{:?}\nPoor diff:\n{}",
-                        expected_rows,
-                        actual,
-                        buf
-                    )
-                }
-            }
-            SqlOutput::Hashed { num_values, md5 } => {
-                if &actual.len() != num_values {
-                    bail!(
-                        "wrong row count: expected:\n{:?}\ngot:\n{:?}\n",
-                        actual.len(),
-                        num_values,
-                    )
-                } else {
-                    let mut hasher = Md5::new();
-                    for row in &actual {
-                        for entry in row {
-                            hasher.update(entry);
-                        }
-                    }
-                    let actual = format!("{:x}", hasher.finalize());
-                    if &actual != md5 {
-                        bail!("wrong hash value: expected:{:?} got:{:?}", md5, actual)
-                    } else {
-                        Ok(())
-                    }
-                }
-            }
-        }
-    }
+    Ok(ControlFlow::Continue)
 }
 
-pub struct FailSqlAction {
-    query: String,
-    expected_error: ErrorMatcher,
-    stmt: Option<Statement<Raw>>,
+async fn try_run_sql(
+    state: &State,
+    query: &str,
+    expected_output: &SqlOutput,
+) -> Result<(), anyhow::Error> {
+    let stmt = state
+        .pgclient
+        .prepare(query)
+        .await
+        .context("preparing query failed")?;
+    let mut actual: Vec<_> = state
+        .pgclient
+        .query(&stmt, &[])
+        .await
+        .context("executing query failed")?
+        .into_iter()
+        .map(|row| decode_row(state, row))
+        .collect::<Result<_, _>>()?;
+    actual.sort();
+
+    match expected_output {
+        SqlOutput::Full {
+            expected_rows,
+            column_names,
+        } => {
+            if let Some(column_names) = column_names {
+                let actual_columns: Vec<_> = stmt.columns().iter().map(|c| c.name()).collect();
+                if actual_columns.iter().ne(column_names) {
+                    bail!(
+                        "column name mismatch\nexpected: {:?}\nactual:   {:?}",
+                        column_names,
+                        actual_columns
+                    );
+                }
+            }
+            if &actual == expected_rows {
+                Ok(())
+            } else {
+                let (mut left, mut right) = (0, 0);
+                let mut buf = String::new();
+                while let (Some(e), Some(a)) = (expected_rows.get(left), actual.get(right)) {
+                    match e.cmp(a) {
+                        std::cmp::Ordering::Less => {
+                            writeln!(buf, "- {}", TestdriveRow(e)).unwrap();
+                            left += 1;
+                        }
+                        std::cmp::Ordering::Equal => {
+                            left += 1;
+                            right += 1;
+                        }
+                        std::cmp::Ordering::Greater => {
+                            writeln!(buf, "+ {}", TestdriveRow(a)).unwrap();
+                            right += 1;
+                        }
+                    }
+                }
+                while let Some(e) = expected_rows.get(left) {
+                    writeln!(buf, "- {}", TestdriveRow(e)).unwrap();
+                    left += 1;
+                }
+                while let Some(a) = actual.get(right) {
+                    writeln!(buf, "+ {}", TestdriveRow(a)).unwrap();
+                    right += 1;
+                }
+                bail!(
+                    "non-matching rows: expected:\n{:?}\ngot:\n{:?}\nPoor diff:\n{}",
+                    expected_rows,
+                    actual,
+                    buf
+                )
+            }
+        }
+        SqlOutput::Hashed { num_values, md5 } => {
+            if &actual.len() != num_values {
+                bail!(
+                    "wrong row count: expected:\n{:?}\ngot:\n{:?}\n",
+                    actual.len(),
+                    num_values,
+                )
+            } else {
+                let mut hasher = Md5::new();
+                for row in &actual {
+                    for entry in row {
+                        hasher.update(entry);
+                    }
+                }
+                let actual = format!("{:x}", hasher.finalize());
+                if &actual != md5 {
+                    bail!("wrong hash value: expected:{:?} got:{:?}", md5, actual)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
 }
 
 enum ErrorMatcher {
@@ -306,6 +290,8 @@ pub async fn run_fail_sql(
     cmd: FailSqlCommand,
     state: &mut State,
 ) -> Result<ControlFlow, anyhow::Error> {
+    use Statement::{Commit, Rollback};
+
     let stmts = mz_sql_parser::parser::parse_statements(&cmd.query)
         .map_err(|e| format!("unable to parse SQL: {}: {}", cmd.query, e));
 
@@ -328,42 +314,31 @@ pub async fn run_fail_sql(
         SqlExpectedError::Timeout => ErrorMatcher::Timeout,
     };
 
-    FailSqlAction {
-        query: cmd.query,
-        expected_error,
-        stmt,
-    }
-    .run(state)
-    .await
-}
+    let query = &cmd.query;
+    print_query(query);
 
-impl FailSqlAction {
-    async fn run(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
-        use Statement::{Commit, Rollback};
+    let should_retry = match &stmt {
+        // Do not retry statements that could not be parsed
+        None => false,
+        // Do not retry COMMIT and ROLLBACK. Once the transaction has errored out and has
+        // been aborted, retrying COMMIT or ROLLBACK will actually start succeeding, which
+        // causes testdrive to emit a confusing "query succeded but expected error" message.
+        Some(Commit(_)) | Some(Rollback(_)) => false,
+        Some(_) => true,
+    };
 
-        let query = &self.query;
-        print_query(query);
-
-        let should_retry = match &self.stmt {
-            // Do not retry statements that could not be parsed
-            None => false,
-            // Do not retry COMMIT and ROLLBACK. Once the transaction has errored out and has
-            // been aborted, retrying COMMIT or ROLLBACK will actually start succeeding, which
-            // causes testdrive to emit a confusing "query succeded but expected error" message.
-            Some(Commit(_)) | Some(Rollback(_)) => false,
-            Some(_) => true,
-        };
-
-        let state = &state;
-        let res = match should_retry {
-            true => Retry::default()
-                .initial_backoff(state.initial_backoff)
-                .factor(state.backoff_factor)
-                .max_duration(state.timeout)
-                .max_tries(state.max_tries),
-            false => Retry::default().max_duration(state.timeout).max_tries(1),
-        }.retry_async_canceling(|retry_state| async move {
-            match self.try_run(state, query).await {
+    let state = &state;
+    let res = match should_retry {
+        true => Retry::default()
+            .initial_backoff(state.initial_backoff)
+            .factor(state.backoff_factor)
+            .max_duration(state.timeout)
+            .max_tries(state.max_tries),
+        false => Retry::default().max_duration(state.timeout).max_tries(1),
+    }.retry_async_canceling(|retry_state| {
+        let expected_error = &expected_error;
+        async move {
+            match try_run_fail_sql(state, query, expected_error).await {
                 Ok(()) => {
                     if retry_state.i != 0 {
                         println!();
@@ -384,51 +359,49 @@ impl FailSqlAction {
                     Err(e)
                 }
             }
-        }).await;
+        }
+    }).await;
 
-        // If a timeout was expected, check whether the retry operation timed
-        // out, which indicates that the test passed.
-        if let ErrorMatcher::Timeout = self.expected_error {
-            if let Err(e) = &res {
-                if e.is::<tokio::time::error::Elapsed>() {
-                    println!("query timed out as expected");
-                    return Ok(ControlFlow::Continue);
-                }
+    // If a timeout was expected, check whether the retry operation timed
+    // out, which indicates that the test passed.
+    if let ErrorMatcher::Timeout = expected_error {
+        if let Err(e) = &res {
+            if e.is::<tokio::time::error::Elapsed>() {
+                println!("query timed out as expected");
+                return Ok(ControlFlow::Continue);
             }
         }
-
-        // Otherwise, return the error if any. Note that this is the error
-        // returned by the retry operation (e.g., "expected timeout, but query
-        // succeeded"), *not* an error returned from Materialize itself.
-        res?;
-        Ok(ControlFlow::Continue)
     }
+
+    // Otherwise, return the error if any. Note that this is the error
+    // returned by the retry operation (e.g., "expected timeout, but query
+    // succeeded"), *not* an error returned from Materialize itself.
+    res?;
+    Ok(ControlFlow::Continue)
 }
 
-impl FailSqlAction {
-    async fn try_run(&self, state: &State, query: &str) -> Result<(), anyhow::Error> {
-        match state.pgclient.query(query, &[]).await {
-            Ok(_) => bail!("query succeeded, but expected {}", self.expected_error),
-            Err(err) => match err.source().and_then(|err| err.downcast_ref::<DbError>()) {
-                Some(err) => {
-                    let mut err_string = err.message().to_string();
-                    if let Some(regex) = &state.regex {
-                        err_string = regex
-                            .replace_all(&err_string, state.regex_replacement.as_str())
-                            .to_string();
-                    }
-                    if !self.expected_error.is_match(&err_string) {
-                        bail!(
-                            "expected {}, got {}",
-                            self.expected_error,
-                            err_string.quoted()
-                        );
-                    }
-                    Ok(())
+async fn try_run_fail_sql(
+    state: &State,
+    query: &str,
+    expected_error: &ErrorMatcher,
+) -> Result<(), anyhow::Error> {
+    match state.pgclient.query(query, &[]).await {
+        Ok(_) => bail!("query succeeded, but expected {}", expected_error),
+        Err(err) => match err.source().and_then(|err| err.downcast_ref::<DbError>()) {
+            Some(err) => {
+                let mut err_string = err.message().to_string();
+                if let Some(regex) = &state.regex {
+                    err_string = regex
+                        .replace_all(&err_string, state.regex_replacement.as_str())
+                        .to_string();
                 }
-                None => Err(err.into()),
-            },
-        }
+                if !expected_error.is_match(&err_string) {
+                    bail!("expected {}, got {}", expected_error, err_string.quoted());
+                }
+                Ok(())
+            }
+            None => Err(err.into()),
+        },
     }
 }
 

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -28,12 +28,6 @@ use crate::action::{ControlFlow, State};
 use crate::parser::BuiltinCommand;
 use crate::util::mz_data::mzdata_copy;
 
-pub struct VerifyTimestampCompactionAction {
-    source: String,
-    max_size: usize,
-    permit_progress: bool,
-}
-
 async fn run_verify_timestamp_compaction_action(
     mut cmd: BuiltinCommand,
     state: &mut State,


### PR DESCRIPTION
Additional fallout from fc407b9. Testdrive actions are now built and run in one shot, so they no longer need to separate the build phase from the run phase.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
