### PR TITLE
adapter: consistentize a few more catalog tables

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -18,7 +18,7 @@ The `mz_array_types` table contains a row for each array type in the system.
 
 Field          | Type       | Meaning
 ---------------|------------|--------
-`type_id`      | [`text`]   | The ID of the array type.
+`id`           | [`text`]   | The ID of the array type.
 `element_id`   | [`text`]   | The ID of the array's element type.
 
 ### `mz_audit_events`
@@ -28,9 +28,9 @@ other objects in the system catalog.
 
 Field           | Type                         | Meaning
 ----------------|------------------------------|--------
-`id  `          | [`bigint`]                   | The ordered id of the event.
+`id  `          | [`uint8`]                    | Materialize's unique, monotonically increasing ID for the event.
 `event_type`    | [`text`]                     | The type of the event: `create`, `drop`, `alter`, or `rename`.
-`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `index`, `materialized-view`, `sink`, `source`, or `view`.
+`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `connection`, `index`, `materialized-view`, `sink`, `source`, `table`, or `view`.
 `event_details` | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
 `user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
@@ -41,7 +41,28 @@ The `mz_base_types` table contains a row for each base type in the system.
 
 Field          | Type       | Meaning
 ---------------|------------|----------
-`type_id`      | [`text`]   | The ID of the type.
+`id`           | [`text`]   | The ID of the type.
+
+### `mz_cluster_replicas`
+
+The `mz_cluster_replicas` table contains a row for each cluster replica in the system.
+
+Field               | Type       | Meaning
+--------------------|------------|--------
+`id`                | [`uint8`]  | Materialize's unique ID for the cluster replica.
+`name`              | [`text`]   | The name of the cluster replica.
+`cluster_id`        | [`uint8`]  | The ID of the cluster to which the replica belongs.
+`size`              | [`text`]   | The cluster replica's size, selected during creation.
+`availability_zone` | [`text`]   | The availability zone in which the cluster is running.
+
+### `mz_clusters`
+
+The `mz_clusters` table contains a row for each cluster in the system.
+
+Field          | Type       | Meaning
+---------------|------------|--------
+`id`           | [`uint8`]  | Materialize's unique ID for the cluster.
+`name`         | [`text`]   | The name of the cluster.
 
 ### `mz_columns`
 
@@ -50,34 +71,25 @@ in the system.
 
 Field            | Type        | Meaning
 -----------------|-------------|--------
-`id`             | [`bigint`]  | The unique ID of the table, source, or view containing the column.
+`id`             | [`uint8`]   | The unique ID of the table, source, or view containing the column.
 `name`           | [`text`]    | The name of the column.
-`position`       | [`bigint`]  | The 1-indexed position of the column in its containing table, source, or view.
+`position`       | [`uint8`]   | The 1-indexed position of the column in its containing table, source, or view.
 `nullable`       | [`boolean`] | Can the column contain a `NULL` value?
 `type`           | [`text`]    | The data type of the column.
 `default`        | [`text`]    | The default expression of the column.
 `type_oid`       | [`oid`]     | The OID of the type of the column (references `mz_types`).
 
-### `mz_clusters`
+### `mz_connections`
 
-The `mz_clusters` table contains a row for each cluster in the system.
+The `mz_connections` table contains a row for each connection in the system.
 
-Field          | Type       | Meaning
----------------|------------|--------
-`id`           | [`bigint`] | Materialize's unique ID for the cluster.
-`name`         | [`text`]   | The name of the cluster.
-
-### `mz_cluster_replicas`
-
-The `mz_cluster_replicas` table contains a row for each cluster replica in the system.
-
-Field               | Type       | Meaning
---------------------|------------|--------
-`id`                | [`bigint`] | Materialize's unique ID for the cluster replica.
-`name`              | [`text`]   | The name of the cluster replica.
-`cluster_id`        | [`bigint`] | The ID of the cluster to which the replica belongs.
-`size`              | [`text`]   | The cluster replica's size, selected during creation.
-`availability_zone` | [`text`]   | The cluster replica's target availability zone, selected during creation. This value is `NULL` if no availability zone was specified when the replica was created.
+Field            | Type        | Meaning
+-----------------|-------------|--------
+`id`             | [`text`]    | The unique ID of the connection.
+`oid`            | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the connection.
+`schema_id`      | [`uint8`]   | The ID of the schema to which the connection belongs.
+`name`           | [`text`]    | The name of the connection.
+`type`           | [`text`]    | The type of the connection: `confluent-schema-registry`, `kafka`, `postgres`, or `ssh-tunnel`.
 
 ### `mz_databases`
 
@@ -85,7 +97,7 @@ The `mz_databases` table contains a row for each database in the system.
 
 Field  | Type       | Meaning
 -------|------------|--------
-`id`   | [`bigint`] | Materialize's unique ID for the database.
+`id`   | [`uint8`]  | Materialize's unique ID for the database.
 `oid`  | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the database.
 `name` | [`text`]   | The name of the database.
 
@@ -93,16 +105,16 @@ Field  | Type       | Meaning
 
 The `mz_functions` table contains a row for each function in the system.
 
-Field         | Type           | Meaning
---------------|----------------|--------
-`id`          | [`text`]       | Materialize's unique ID for the function.
-`oid`         | [`oid`]        | A [PostgreSQL-compatible OID][oid] for the function.
-`schema_id`   | [`bigint`]     | The ID of the schema to which the function belongs.
-`name`        | [`text`]       | The name of the function.
-`arg_ids`     | [`text array`] | The function's arguments' types. Elements refers to `mz_types.id`.
-`variadic_id` | [`text`]       | The variadic array parameter's elements, or `NULL` if the function does not have a variadic parameter. Refers to `mz_types.id`.
-`ret_id`      | [`text`]       | The returned value's type, or `NULL` if the function does not return a value. Refers to `mz_types.id`. Note that for table functions with > 1 column, this type corresponds to [`record`].
-`ret_set`     | [`boolean`]       | Whether the returned value is a set, i.e. the function is a table function.
+Field                       | Type              | Meaning
+----------------------------|-------------------|--------
+`id`                        | [`text`]          | Materialize's unique ID for the function.
+`oid`                       | [`oid`]           | A [PostgreSQL-compatible OID][oid] for the function.
+`schema_id`                 | [`uint8`]         | The ID of the schema to which the function belongs.
+`name`                      | [`text`]          | The name of the function.
+`argument_type_ids`         | [`text array`]    | The ID of each argument's type. Each entry refers to `mz_types.id`.
+`variadic_argument_type_id` | [`text`]          | The ID of the variadic argument's type, or `NULL` if the function does not have a variadic argument. Refers to `mz_types.id`.
+`return_type_id`            | [`text`]          | The returned value's type, or `NULL` if the function does not return a value. Refers to `mz_types.id`. Note that for table functions with > 1 column, this type corresponds to [`record`].
+`returns_set`               | [`boolean`]       | Whether the function returns a set, i.e. the function is a table function.
 
 ### `mz_indexes`
 
@@ -127,8 +139,8 @@ vice-versa.
 Field            | Type        | Meaning
 -----------------|-------------|--------
 `index_id`       | [`text`]    | The ID of the index which contains this column.
-`index_position` | [`bigint`]  | The 1-indexed position of this column within the index. (The order of columns in an index does not necessarily match the order of columns in the relation on which the index is built.)
-`on_position`    | [`bigint`]  | If not `NULL`, specifies the 1-indexed position of a column in the relation on which this index is built that determines the value of this index column.
+`index_position` | [`uint8`]   | The 1-indexed position of this column within the index. (The order of columns in an index does not necessarily match the order of columns in the relation on which the index is built.)
+`on_position`    | [`uint8`]   | If not `NULL`, specifies the 1-indexed position of a column in the relation on which this index is built that determines the value of this index column.
 `on_expression`  | [`text`]    | If not `NULL`, specifies a SQL expression that is evaluated to compute the value of this index column. The expression may contain references to any of the columns of the relation.
 `nullable`       | [`boolean`] | Can this column of the index evaluate to `NULL`?
 
@@ -158,8 +170,18 @@ The `mz_list_types` table contains a row for each list type in the system.
 
 Field        | Type     | Meaning
 -------------|----------|--------
-`type_id`    | [`text`] | The ID of the list type.
+`id`         | [`text`] | The ID of the list type.
 `element_id` | [`text`] | The IID of the list's element type.
+
+### `mz_map_types`
+
+The `mz_map_types` table contains a row for each map type in the system.
+
+Field          | Type       | Meaning
+---------------|------------|----------
+`id`           | [`text`]   | The ID of the map type.
+`key_id `      | [`text`]   | The ID of the map's key type.
+`value_id`     | [`text`]   | The ID of the map's value type.
 
 ### `mz_materialized_views`
 
@@ -169,20 +191,10 @@ Field          | Type        | Meaning
 ---------------|-------------|----------
 `id`           | [`text`]    | Materialize's unique ID for the materialized view.
 `oid`          | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the materialized view.
-`schema_id`    | [`bigint`]  | The ID of the schema to which the materialized view belongs.
+`schema_id`    | [`uint8`]   | The ID of the schema to which the materialized view belongs.
 `name`         | [`text`]    | The name of the materialized view.
-`cluster_id`   | [`bigint`]  | The ID of the cluster maintaining the materialized view.
+`cluster_id`   | [`uint8`]   | The ID of the cluster maintaining the materialized view.
 `definition`   | [`text`]    | The materialized view definition (a `SELECT` query).
-
-### `mz_map_types`
-
-The `mz_map_types` table contains a row for each map type in the system.
-
-Field          | Type       | Meaning
----------------|------------|----------
-`type_id`      | [`text`]   | The ID of the map type.
-`key_id `      | [`text`]   | The ID of the map's key type.
-`value_id`     | [`text`]   | The ID of the map's value type.
 
 ### `mz_objects`
 
@@ -197,7 +209,7 @@ Field       | Type       | Meaning
 ------------|------------|--------
 `id`        | [`text`]   | Materialize's unique ID for the object.
 `oid`       | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the object.
-`schema_id` | [`bigint`] | The ID of the schema to which the object belongs.
+`schema_id` | [`uint8`]  | The ID of the schema to which the object belongs.
 `name`      | [`text`]   | The name of the object.
 `type`      | [`text`]   | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`.
 
@@ -207,7 +219,7 @@ The `mz_pseudo_types` table contains a row for each pseudo type in the system.
 
 Field          | Type       | Meaning
 ---------------|------------|----------
-`type_id`      | [`text`]   | The ID of the type.
+`id`           | [`text`]   | The ID of the type.
 
 ### `mz_relations`
 
@@ -218,7 +230,7 @@ Field       | Type       | Meaning
 ------------|------------|--------
 `id`        | [`text`]   | Materialize's unique ID for the relation.
 `oid`       | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the relation.
-`schema_id` | [`bigint`] | The ID of the schema to which the relation belongs.
+`schema_id` | [`uint8`]  | The ID of the schema to which the relation belongs.
 `name`      | [`text`]   | The name of the relation.
 `type`      | [`text`]   | The type of the relation: either `table`, `source`, `view`, or `materialized view`.
 
@@ -228,7 +240,7 @@ The `mz_roles` table contains a row for each role in the system.
 
 Field  | Type       | Meaning
 -------|------------|--------
-`id`   | [`bigint`] | Materialize's unique ID for the role.
+`id`   | [`text`]   | Materialize's unique ID for the role.
 `oid`  | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the role.
 `name` | [`text`]   | The name of the role.
 
@@ -238,10 +250,31 @@ The `mz_schemas` table contains a row for each schema in the system.
 
 Field         | Type       | Meaning
 --------------|------------|--------
-`id`          | [`bigint`] | Materialize's unique ID for the schema.
+`id`          | [`uint8`]  | Materialize's unique ID for the schema.
 `oid`         | [`oid`]    | A [PostgreSQL-compatible oid][oid] for the schema.
-`database_id` | [`bigint`] | The ID of the database containing the schema.
+`database_id` | [`uint8`]  | The ID of the database containing the schema.
 `name`        | [`text`]   | The name of the schema.
+
+### `mz_secrets`
+
+The `mz_secrets` table contains a row for each connection in the system.
+
+Field            | Type        | Meaning
+-----------------|-------------|--------
+`id`             | [`text`]    | The unique ID of the secret.
+`schema_id`      | [`uint8`]   | The ID of the schema to which the secret belongs.
+`name`           | [`text`]    | The name of the secret.
+
+### `mz_ssh_tunnel_connections`
+
+The `mz_ssh_tunnel_connections` table contains a row for each SSH tunnel
+connection in the system.
+
+Field                 | Type           | Meaning
+----------------------|----------------|--------
+`id`                  | [`text`]       | The ID of the connection.
+`public_key_1`        | [`text`]       | The first public key associated with the SSH tunnel.
+`public_key_2`        | [`text`]       | The second public key associated with the SSH tunnel.
 
 ### `mz_sinks`
 
@@ -251,7 +284,7 @@ Field            | Type        | Meaning
 -----------------|-------------|--------
 `id`             | [`text`]    | Materialize's unique ID for the sink.
 `oid`            | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the sink.
-`schema_id`      | [`bigint`]  | The ID of the schema to which the sink belongs.
+`schema_id`      | [`uint8`]   | The ID of the schema to which the sink belongs.
 `name`           | [`text`]    | The name of the sink.
 `type`           | [`text`]    | The type of the sink: `kafka`.
 `connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any.
@@ -265,7 +298,7 @@ Field            | Type       | Meaning
 -----------------|------------|----------
 `id`             | [`text`]   | Materialize's unique ID for the source.
 `oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the source.
-`schema_id`      | [`bigint`] | The ID of the schema to which the source belongs.
+`schema_id`      | [`uint8`]  | The ID of the schema to which the source belongs.
 `name`           | [`text`]   | The name of the source.
 `type`           | [`text`]   | The type of the source: `kafka`, `postgres`, or `load-generator`.
 `connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
@@ -280,7 +313,7 @@ assessed approximately every hour.
 Field                  | Type                         | Meaning
 ---------------------- | ---------------------------- | -----------------------------------------------------------
 `object_id`            | [`text`]                     | The ID of the table, source, or materialized view.
-`size_bytes`           | [`bigint`]                   | The number of storage bytes used by the object.
+`size_bytes`           | [`uint8`]                    | The number of storage bytes used by the object.
 `collection_timestamp` | [`timestamp with time zone`] | The time at which storage usage of the object was assessed.
 
 ### `mz_tables`
@@ -291,9 +324,8 @@ Field            | Type       | Meaning
 -----------------|------------|----------
 `id`             | [`text`]   | Materialize's unique ID for the table.
 `oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the table.
-`schema_id`      | [`bigint`] | The ID of the schema to which the table belongs.
+`schema_id`      | [`uint8`]  | The ID of the schema to which the table belongs.
 `name`           | [`text`]   | The name of the table.
-`persisted_name` | [`text`]   | The name of the table's persisted materialization, or `NULL` if the table is not being persisted.
 
 ### `mz_types`
 
@@ -303,7 +335,7 @@ Field          | Type       | Meaning
 ---------------|------------|----------
 `id`           | [`text`]   | Materialize's unique ID for the type.
 `oid`          | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the type.
-`schema_id`    | [`bigint`] | The ID of the schema to which the type belongs.
+`schema_id`    | [`uint8`]  | The ID of the schema to which the type belongs.
 `name`         | [`text`]   | The name of the type.
 
 ### `mz_views`
@@ -314,7 +346,7 @@ Field          | Type        | Meaning
 ---------------|-------------|----------
 `id`           | [`text`]    | Materialize's unique ID for the view.
 `oid`          | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the view.
-`schema_id`    | [`bigint`]  | The ID of the schema to which the view belongs.
+`schema_id`    | [`uint8`]   | The ID of the schema to which the view belongs.
 `name`         | [`text`]    | The name of the view.
 `definition`   | [`text`]    | The view definition (a `SELECT` query).
 
@@ -327,3 +359,4 @@ Field          | Type        | Meaning
 [oid]: /sql/types/oid
 [`text array`]: /sql/types/array
 [`record`]: /sql/types/record
+[`uint8`]: /sql/types/uint8

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4082,18 +4082,15 @@ impl<S: Append> Catalog<S> {
                     new_public_keypair,
                 } => {
                     let entry = state.get_entry(&id);
-                    let name = &entry.name().item;
                     // Retract old keys
                     builtin_table_updates.extend(state.pack_ssh_tunnel_connection_update(
                         id,
-                        name,
                         &previous_public_keypair,
                         -1,
                     ));
-                    // Assert the new rotated keys
+                    // Insert the new rotated keys
                     builtin_table_updates.extend(state.pack_ssh_tunnel_connection_update(
                         id,
-                        name,
                         &new_public_keypair,
                         1,
                     ));

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -10,8 +10,8 @@
 # Test SSH key generation and management for SSH connections
 
 > SELECT * FROM mz_ssh_tunnel_connections;
-id name public_key_1 public_key_2
----------------------------------
+id public_key_1 public_key_2
+----------------------------
 
 > CREATE CONNECTION louisoix
   FOR SSH TUNNEL
@@ -20,7 +20,9 @@ id name public_key_1 public_key_2
     PORT 22;
 
 # mz_ssh_tunnel_connections is properly populated, and SSH public keys look like keys
-> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2 FROM mz_ssh_tunnel_connections;
+> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2
+  FROM mz_ssh_tunnel_connections
+  JOIN mz_connections USING (id);
 name     pkey1 pkey2
 --------------------
 louisoix true  true
@@ -31,7 +33,9 @@ louisoix true  true
     USER 'omega',
     PORT 22;
 
-> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2 FROM mz_ssh_tunnel_connections;
+> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2
+  FROM mz_ssh_tunnel_connections
+  JOIN mz_connections USING (id);
 name     pkey1 pkey2
 --------------------
 louisoix true  true
@@ -40,7 +44,9 @@ omega    true  true
 > DROP CONNECTION louisoix;
 
 # SSH connections can be normally dropped
-> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2 FROM mz_ssh_tunnel_connections;
+> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2
+  FROM mz_ssh_tunnel_connections
+  JOIN mz_connections USING (id);
 name     pkey1 pkey2
 --------------------
 omega    true  true
@@ -48,7 +54,9 @@ omega    true  true
 # Key rotation doesn't fail
 > ALTER CONNECTION omega ROTATE KEYS;
 
-> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2 FROM mz_ssh_tunnel_connections;
+> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2
+  FROM mz_ssh_tunnel_connections
+  JOIN mz_connections USING (id);
 name     pkey1 pkey2
 --------------------
 omega    true  true
@@ -56,7 +64,9 @@ omega    true  true
 > DROP CONNECTION omega;
 
 # Connections can still be dropped after rotating keys
-> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2 FROM mz_ssh_tunnel_connections;
+> SELECT name, public_key_1 LIKE 'ssh-ed25519%' pkey1, public_key_2 LIKE 'ssh-ed25519%' pkey2
+  FROM mz_ssh_tunnel_connections
+  JOIN mz_connections USING (id);
 name     pkey1 pkey2
 --------------------
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -270,7 +270,9 @@ importee1  importee2
     USER 'user',
     PORT 1
 
-> SELECT name, public_key_1 LIKE 'ssh-ed25519%' public_key_1 from mz_ssh_tunnel_connections
+> SELECT name, public_key_1 LIKE 'ssh-ed25519%' public_key_1
+  FROM mz_ssh_tunnel_connections
+  JOIN mz_connections USING (id)
 name public_key_1
 -----------
 ssh_conn true

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -18,7 +18,7 @@
 $ set-regex match=^s\d*$ replacement=<GID>
 # Without qualifiers, should default to builtin bool.
 > SELECT element_id
-  FROM mz_list_types JOIN mz_types ON mz_list_types.type_id = mz_types.id
+  FROM mz_list_types JOIN mz_types ON mz_list_types.id = mz_types.id
   WHERE name = 'custom'
 <GID>
 
@@ -27,7 +27,7 @@ $ set-regex match=^s\d*$ replacement=<GID>
 $ set-regex match=^u\d*$ replacement=<GID>
 # Qualified name should point to user-defined bool.
 > SELECT element_id
-  FROM mz_list_types JOIN mz_types ON mz_list_types.type_id = mz_types.id
+  FROM mz_list_types JOIN mz_types ON mz_list_types.id = mz_types.id
   WHERE name = 'another_custom'
 <GID>
 

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -18,7 +18,7 @@
 $ set-regex match=^s\d*$ replacement=<GID>
 # Without qualifiers, should default to builtin bool.
 > SELECT value_id
-  FROM mz_map_types JOIN mz_types ON mz_map_types.type_id = mz_types.id
+  FROM mz_map_types JOIN mz_types ON mz_map_types.id = mz_types.id
   WHERE name = 'custom'
 <GID>
 
@@ -27,7 +27,7 @@ $ set-regex match=^s\d*$ replacement=<GID>
 $ set-regex match=^u\d*$ replacement=<GID>
 # Qualified name should point to user-defined bool.
 > SELECT value_id
-  FROM mz_map_types JOIN mz_types ON mz_map_types.type_id = mz_types.id
+  FROM mz_map_types JOIN mz_types ON mz_map_types.id = mz_types.id
   WHERE name = 'another_custom'
 <GID>
 


### PR DESCRIPTION
Correct a few last inconsistencies in the system catalog:

  * Rename `type_id` to `id` in all `mz_$FOO_types` tables, to match how the `mz_$FOO_connections` tables work.

  * Remove `name` from `mz_ssh_tunnel_connections` for proper normalization, since the name is available in `mz_connections`. This matches `mz_kafka_connections`.

  * Avoid abbreviations in the column names for the `mz_functions` table, for consistency with other tables.

And also correct a number of errors in the documentation, including filling in a few tables that were missing from the documentation entirely.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
