### PR TITLE
Fix some issues in `ColumnKnowledge`

### DIFF
--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -479,7 +479,7 @@ pub fn optimize(
                 } => {
                     let knowledge2 = knowledge_stack.pop().unwrap();
                     let knowledge1 = knowledge_stack.pop().unwrap();
-                    if knowledge1.value.is_some() && knowledge2.value.is_some() {
+                    if knowledge1.value.is_some() || knowledge2.value.is_some() {
                         e.reduce(column_types);
                     }
                     DatumKnowledge::from(&*e)
@@ -490,9 +490,9 @@ pub fn optimize(
                     for _ in exprs {
                         knows.push(knowledge_stack.pop().unwrap());
                     }
-                    // Note that `all` is short-circuiting, so it has to be done separately from the
+                    // Note that `any` is short-circuiting, so it has to be done separately from the
                     // above popping.
-                    if knows.iter().all(|k| k.value.is_some()) {
+                    if knows.iter().any(|k| k.value.is_some()) {
                         e.reduce(column_types);
                     }
                     DatumKnowledge::from(&*e)


### PR DESCRIPTION
This PR fixes two issues in `ColumnKnowledge`. 

The first commit fixes a bug that might lead to wrong query results: In `column_knowledge.rs::optimize`, the `CallVariadic` case doesn’t always pop for every input, because `all` is short-circuiting. The extra elements that were not popped might be mistaken for the knowledge results of the left sibling of the `CallVariadic` when processing some multi-input node that is just above the `CallVariadic`.

The second commit fixes a smaller issue: I changed the `all` to `any` and the `&&` to `||`, because nowadays `MirScalarExpr::reduce` has many reductions that kick in even when just some of the arguments to a function call are literals. (Maybe at the time when this code was written only that simple case existed which simply calls the function if all arguments are literals.)

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - For the first commit, I added two asserts that fail on main. (If both asserts are present, then the second assert fails. If only the first assert is present, then that assert fails.) These asserts codify the assumption written in the doc comment of `optimize`.
  - It’s hard to write a test case for the second commit, because `reduce` is called in a gazillion places, and some of those are inside the same fixpoint loop as `ColumnKnowledge`, so many `reduce` opportunities that `ColumnKnowledge` missed are being performed by `reduce` calls from other places. It might even be possible that all the `reduce` opportunities that `ColumnKnowledge` missed somehow ended up being performed in the end, but I wouldn’t bet on it.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No (minor bugfix)
