### PR TITLE
doc/user: polish v0.27.0 release notes

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -268,7 +268,7 @@ a {
     width: 80%;
   }
 
-  .warning {
+  .warning, .alpha {
     background: rgba(238, 134, 96, 0.05);
     border: 1px solid rgba(238, 134, 96, 0.2);
 
@@ -310,7 +310,7 @@ a {
     }
   }
 
-  .warning, .note, .beta {
+  .warning, .note, .alpha, .beta {
     box-sizing: border-box;
     margin: 1rem 0;
     padding: 1rem 1rem 1rem 6rem;

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -15,12 +15,6 @@ deployed.
 
 ## Release notes
 
-{{< warning >}}
-The v0.27.0 release notes describe the coalesced changes between v0.26 LTS
-and the currently released version of Materialize. We will begin publishing
-weekly release notes after general availability.
-{{< /warning >}}
-
 {{< version-list >}}
 
 For versions that predate cloud-native Materialize, see our
@@ -57,13 +51,13 @@ SELECT mz_version();
 ```
 
 Scheduled weekly releases increase the middle component of the version number
-(e.g., v0.27.0). Unscheduled releases increase the final component of the
-version number (e.g., v0.27.1).
+and reset the final component to zero (e.g., v0.26.2 -> v0.27.0). Unscheduled
+releases increase the final component of the version number (e.g., v0.27.0 -> v0.27.1).
 
 ## Backwards compatibility
 
-Materialize maintains backwards compatibility whenever possible. Applications
-that work with the current version of Materialize can expect to work with all
+Materialize maintains backwards compatibility whenever possible. You can expect
+applications that work with the current version of Materialize to work with all
 future versions of Materialize with only minor changes to the application's
 code.
 
@@ -76,8 +70,9 @@ notes](#release-notes).
 There are several aspects of the product that are not considered part of
 Materialize's stable interface:
 
-  * Features that are in beta (labeled as such in the documentation)
-  * Objects in the [system catalog](/sql/system-catalog)
+  * Features that are in alpha (labeled as such in the documentation)
+  * The [`EXPLAIN`](/sql/explain) statement
+  * Objects in the [`mz_internal` schema](/sql/system-catalog/mz_internal)
   * Any undocumented features or behavior
 
 These unstable interfaces are not subject to the backwards-compatibility policy.

--- a/doc/user/content/releases/v0.27.0.md
+++ b/doc/user/content/releases/v0.27.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Materialize v0.27.0"
-date: 2022-11-01
+date: 2022-10-12
 ---
 
 v0.27.0 is the first cloud-native release of Materialize. It contains
@@ -8,40 +8,125 @@ substantial breaking changes from [v0.26 LTS].
 
 ## Changes
 
-* Add [clusters](/sql/create-cluster) and [cluster
-  replicas](/sql/create-cluster-replica/).
+* Add [clusters](/sql/create-cluster) and [cluster replicas](/sql/create-cluster-replica/),
+  which together allocate isolated, highly available, and horizontally scalable
+  compute resources that incrementally maintain a "cluster" of indexes.
 
-* Require associating indexes with a cluster.
+* Add [materialized views](/sql/create-materialized-view), which are views that
+  are persisted in durable storage and incrementally updated as new data
+  arrives.
 
-* Remove the `MATERIALIZED` keyword as shorthand for `CREATE DEFAULT INDEX`.
+  A materialized view is created in a
+  [cluster](https://materialize.com/docs/overview/key-concepts/#clusters) that
+  is tasked with keeping its results up-to-date, but **can be referenced in any
+  cluster**.
 
-  * Remove `CREATE MATERIALIZED SOURCE` syntax.
-  * Remove the `materialized` column from the output of `SHOW FULL SOURCES`.
+  The result of a materialized view is not maintained in memory, unless you
+  create an [index](/sql/create-index) on it. However, intermediate state
+  necessary for efficient incremental updates of the materialized view may be
+  maintained in memory.
 
-* Add recorded views (which will be conflated with materialized views in an
-  upcoming release {{% gh 13663 %}}).
+* Add [connections](/sql/create-connection/), which describe how to connect to
+  and authenticate with external systems. Once created, a connection is reusable
+  across multiple [`CREATE SOURCE`](/sql/create-source) and
+  [`CREATE SINK`](/sql/create-sink) statements.
 
-* Add secrets.
+* Add [secrets](/sql/create-secret), which securely store sensitive credentials
+  (like passwords and SSL keys) for reference in connections.
 
-* Add connections.
+* Durably record data ingested from [sources](/sql/create-source).
 
-* Ingest and persist sources. This removes the single-materialization limitation
-  for sources. Sources can always be queried directly.
-
-* Require the use of connections with sources and sinks.
+  Once a source has acknowledged data upstream (e.g., via committing a Kafka
+  offset or advancing a PostgreSQL replication slot), it will never re-read that
+  data. As a result, PostgreSQL sources no longer have a "single
+  materialization" limitation. All sources are directly queryable via
+  [`SELECT`](/sql/select).
 
 * Allow provisioning the size of a source or sink.
 
-* Change sinks to have exactly-once behavior by default.
+  Each source and sink now runs with an isolated set of compute resources. You
+  can adjust the size of the resource allocation with the
+  [`SIZE`](/sql/create-source/#sizing-a-source) parameter.
 
-* Add [load generator sources](/sql/create-source/load-generator).
+* Add [load generator sources](/sql/create-source/load-generator), which
+  produce synthetic data for use in demos and performance tests.
 
-* Remove the `PUBNUB` source connector.
+* Add an [HTTP API](/integrations/http-api) which supports executing SQL queries
+  over HTTP.
 
-* Rename `TAIL` to [`SUBSCRIBE`](/sql/subscribe).
+* **Breaking change.** Require all [indexes](/sql/create-index) to be associated
+  with a cluster.
 
-* `CREATE SINK` no longer defaults to `ENVELOPE DEBEZIUM`. You must explicitly
-  specify the envelope to use.
+* **Breaking change.** Require the use of [connections](/sql/create-connection/)
+  with Kafka sources, PostgreSQL sources, and Kafka sinks.
+
+* **Breaking change.** Rename `TAIL` to [`SUBSCRIBE`](/sql/subscribe).
+
+* **Breaking change.** Change the meaning of `CREATE MATERIALIZED VIEW`.
+
+  `CREATE MATERIALIZED VIEW` now creates a new type of object called a
+  [materialized view](/sql/create-materialized-view), rather than providing a
+  shorthand for creating a view with a default index.
+
+  To emulate the old behavior, explicitly create a default index after creating
+  a view:
+
+  ```sql
+  CREATE VIEW <name> ...;
+  CREATE DEFAULT INDEX ON <name>;
+  ```
+
+* **Breaking change.** Remove the `MATERIALIZED` option from `CREATE SOURCE`.
+
+  `CREATE MATERIALIZED SOURCE` is no longer shorthand for creating a source with
+  a default index. Instead, you must explicitly create a default index after
+  creating a source:
+
+  ```sql
+  CREATE SOURCE <name> ...;
+  CREATE DEFAULT INDEX ON <name>;
+  ```
+
+* **Breaking change.** Remove support for the following source types:
+
+  * PubNub
+  * Kinesis
+  * S3
+
+  These source types may be restored in the future, depending on demand.
+
+* **Breaking change.** Remove the `reuse_topic` option from
+  [Kafka sinks](/sql/create-sink).
+
+  The exactly-once semantics enabled by `reuse_topic` are now on by default.
+
+* **Breaking change.** Remove the `consistency_topic` option from
+  [Kafka sinks](/sql/create-sink).
+
+  This option may be restored in the future, given sufficient demand.
+
+* **Breaking change.** Do not default to the [Debezium
+  envelope](/sql/create-sink#debezium-envelope-details) in `CREATE SINK`. You
+  must explicitly specify the envelope to use.
+
+* **Breaking change.** Remove the `CREATE VIEWS` statement, which was used to
+  separate the data in a PostgreSQL source into a single relation per upstream
+  table.
+
+  The PostgreSQL source now automatically creates a relation in Materialize
+  for each upstream table.
+
+* **Breaking change.** Overhaul the system catalog.
+
+  The relations in the [`mz_catalog`](/sql/system-catalog/mz_catalog) schema
+  have been adjusted substantially to support the above changes. Many column
+  and relation names were adjusted for consistency. The resulting relations
+  are now part of Materialize's stable interface and subject to our
+  [backwards compatibility policy](/releases/#backwards-compatibility).
+
+  Relations which were not ready for stabilization were moved to a new
+  [`mz_internal`](/sql/system-catalog/mz_internal) schema. Those relations are
+  not subject to the backwards compatibility policy.
 
 ## Upgrade guide
 
@@ -81,7 +166,7 @@ CREATE CONNECTION csr
     USERNAME = '<SCHEMA_REGISTRY_USERNAME>',
     PASSWORD = SECRET csr_password;
 CREATE SOURCE kafka_top_secret FROM
-    KAFKA CONNECTION kafka
+    KAFKA CONNECTION kafka TOPIC ('top-secret')
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr;
 ```
 
@@ -100,7 +185,7 @@ CREATE VIEW v AS SELECT ...
 CREATE DEFAULT INDEX ON v
 ```
 
-## Materialized source
+### Materialized source
 
 Change from:
 
@@ -119,6 +204,20 @@ index on `src` directly:
 
 ```
 CREATE INDEX on src (lookup_col1, lookup_col2)
+```
+
+### `TAIL`
+
+Change from:
+
+```sql
+COPY (TAIL t) TO STDOUT
+```
+
+to:
+
+```sql
+COPY (SUBSCRIBE t) TO STDOUT
 ```
 
 [v0.26 LTS]: https://materialize.com/docs/release-notes/#v0.26.4

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -8,7 +8,8 @@ menu:
 
 ---
 
-A connection describes how to connect and authenticate to an external system you want Materialize to read data from. Once created, a connection is **reusable** across multiple [`CREATE SOURCE`](/sql/create-source) statements.
+A connection describes how to connect and authenticate to an external system you want Materialize to read data from. Once created, a connection is **reusable** across multiple [`CREATE SOURCE`](/sql/create-source) and [`CREATE SINK`](/sql/create-sink)
+statements.
 
 To use credentials that contain sensitive information (like passwords and SSL keys) in a connection, you must first [create a secret](/sql/create-secret) to securely store them in Materialize's secret management system. Credentials that are generally not sensitive (like usernames and SSL certificates) can be specified as plain `text`, or also stored as secrets.
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -13,6 +13,9 @@ schema.
 {{< warning >}}
 The objects in the `mz_internal` schema are not part of Materialize's stable interface.
 Backwards-incompatible changes to these tables may be made at any time.
+
+`SELECT` statements may reference these objects, but creating views that
+reference these objects is not allowed.
 {{< /warning >}}
 
 {{< warning >}}

--- a/doc/user/layouts/shortcodes/alpha.html
+++ b/doc/user/layouts/shortcodes/alpha.html
@@ -1,0 +1,11 @@
+<div class="alpha">
+  <strong class="gutter">ALPHA!</strong>
+  {{ with .Inner}}{{.|$.Page.RenderString}}{{else}}This feature{{ end }}
+  is in alpha. It has known performance or stability issues and is under
+  active development. It is not subject to our backwards compatibility
+  guarantees.
+  <br><br>
+  You must
+  <a href="https://materialize.com/contact/">contact us</a>
+  to enable this feature in your Materialize Cloud region.
+</div>

--- a/doc/user/layouts/shortcodes/beta.html
+++ b/doc/user/layouts/shortcodes/beta.html
@@ -1,6 +1,5 @@
 <div class="beta">
     <strong class="gutter">BETA!</strong>
     {{ with .Inner}}{{.|$.Page.RenderString}}{{else}}This feature{{ end }}
-    is in beta. It may have performance or stability issues and is not subject
-    to our backwards compatibility guarantee.
+    is in beta. It may have performance or stability issues.
 </div>


### PR DESCRIPTION
Flesh out the v0.27.0 release notes. They look plausible now. Surely there are still some items that are missing, but this covers the highlights.

Also update some of the text around release mechanics (e.g., the backwards compatibility policy and the new meaning of alpha) to reflect the new reality.
