### PR TITLE
doc/user: fix documentation of sink SNAPSHOT option

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -49,22 +49,22 @@ _item&lowbar;name_ | The name of the source or view you want to send to the sink
 
 ### `CONNECTION` options
 
-Field                | Value type | Description
----------------------|------------|------------
-`TOPIC`              | `text`     | The prefix used to generate the Kafka topic name to create and write to.
+Field                | Value  | Description
+---------------------|--------|------------
+`TOPIC`              | `text` | The prefix used to generate the Kafka topic name to create and write to.
 
 ### CSR `CONNECTION` options
 
-Field                | Value type | Description
----------------------|------------|------------
-`AVRO KEY FULLNAME`  | `text`     | Sets the Avro fullname on the generated key schema, if a `KEY` is specified. When used, a value must be specified for `AVRO VALUE FULLNAME`. The default fullname is `row`.
-`AVRO VALUE FULLNAME`| `text`     | Default: `envelope`. Sets the Avro fullname on the generated value schema. When `KEY` is specified, `AVRO KEY FULLNAME` must additionally be specified.
+Field                | Value  | Description
+---------------------|--------|------------
+`AVRO KEY FULLNAME`  | `text` | Sets the Avro fullname on the generated key schema, if a `KEY` is specified. When used, a value must be specified for `AVRO VALUE FULLNAME`. The default fullname is `row`.
+`AVRO VALUE FULLNAME`| `text` | Default: `envelope`. Sets the Avro fullname on the generated value schema. When `KEY` is specified, `AVRO KEY FULLNAME` must additionally be specified.
 
-### `WITH SNAPSHOT` or `WITHOUT SNAPSHOT`
+### `WITH` options
 
-By default, each `SINK` is created with a `SNAPSHOT` which contains the consolidated results of the
-query before the sink was created. Any further updates to these results are produced at the time when
-they occur. To only see results after the sink is created, specify `WITHOUT SNAPSHOT`.
+Field                | Value  | Description
+---------------------|--------|------------
+`SNAPSHOT`           | `bool` | Default: `true`. Whether to emit the consolidated results of the query before the sink was created at the start of the sink. To see only results after the sink is created, specify `WITH (SNAPSHOT = false)`.
 
 ## Detail
 


### PR DESCRIPTION
This is now a normal WITH option. Update the documentation accordingly.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported docs bug.
