### PR TITLE
zippy: Add Postgres CDC sources in Zippy

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -37,6 +37,7 @@ steps:
           - { value: zippy-kafka-sources }
           - { value: zippy-user-tables }
           - { value: zippy-debezium-postgres }
+          - { value: zippy-postgres-cdc }
           - { value: zippy-cluster-replicas }
           - { value: secrets }
           - { value: checks-oneatatime-drop-create-default-replica }
@@ -291,6 +292,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=UserTables, --actions=1000]
+
+  - id: zippy-postgres-cdc
+    label: "Zippy Postgres CDC"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=PostgresCdc, --actions=1000]
 
   - id: zippy-debezium-postgres
     label: "Zippy Debezium Postgres"

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -1,0 +1,80 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import random
+from textwrap import dedent
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
+from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
+
+
+class CreatePostgresCdcTable(Action):
+    """Creates a Postgres CDC source in Materialized."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, PostgresRunning, PostgresTableExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        postgres_table = random.choice(capabilities.get(PostgresTableExists))
+        postgres_pg_cdc_name = f"postgres_{postgres_table.name}"
+        this_postgres_cdc_table = PostgresCdcTableExists(name=postgres_pg_cdc_name)
+
+        existing_postgres_cdc_tables = [
+            s
+            for s in capabilities.get(PostgresCdcTableExists)
+            if s.name == this_postgres_cdc_table.name
+        ]
+
+        if len(existing_postgres_cdc_tables) == 0:
+            self.new_postgres_cdc_table = True
+
+            self.postgres_cdc_table = this_postgres_cdc_table
+            self.postgres_cdc_table.postgres_table = postgres_table
+        elif len(existing_postgres_cdc_tables) == 1:
+            self.new_postgres_cdc_table = False
+
+            self.postgres_cdc_table = existing_postgres_cdc_tables[0]
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if self.new_postgres_cdc_table:
+            assert self.postgres_cdc_table is not None
+            assert self.postgres_cdc_table.postgres_table is not None
+            name = self.postgres_cdc_table.name
+            c.testdrive(
+                dedent(
+                    f"""
+                    $ postgres-execute connection=postgres://postgres:postgres@postgres
+
+                    CREATE PUBLICATION {name}_publication FOR TABLE {self.postgres_cdc_table.postgres_table.name};
+
+
+                    > CREATE SECRET {name}_password AS 'postgres';
+                    > CREATE CONNECTION {name}_connection FOR POSTGRES
+                      HOST postgres,
+                      DATABASE postgres,
+                      USER postgres,
+                      PASSWORD SECRET {name}_password
+
+                    > CREATE SOURCE {name}_source
+                      FROM POSTGRES CONNECTION {name}_connection (PUBLICATION '{name}_publication')
+                      FOR TABLES ({self.postgres_cdc_table.postgres_table.name} AS {name})
+                    """
+                )
+            )
+
+    def provides(self) -> List[Capability]:
+        return [self.postgres_cdc_table] if self.new_postgres_cdc_table else []

--- a/misc/python/materialize/zippy/pg_cdc_capabilities.py
+++ b/misc/python/materialize/zippy/pg_cdc_capabilities.py
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Optional
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.postgres_capabilities import PostgresTableExists
+from materialize.zippy.watermarks import Watermarks
+
+
+class PostgresCdcTableExists(Capability):
+    """A Postgres CDC table exists in Materialize."""
+
+    def __init__(
+        self, name: str, postgres_table: Optional[PostgresTableExists] = None
+    ) -> None:
+        self.name = name
+        self.postgres_table = postgres_table
+
+    def get_watermarks(self) -> Watermarks:
+        assert self.postgres_table is not None
+        return self.postgres_table.watermarks

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -25,6 +25,7 @@ class PostgresStart(Action):
 
     def run(self, c: Composition) -> None:
         c.start_and_wait_for_tcp(services=["postgres"])
+        c.wait_for_postgres()
 
 
 class PostgresStop(Action):
@@ -39,6 +40,15 @@ class PostgresStop(Action):
 
     def run(self, c: Composition) -> None:
         c.kill("postgres")
+
+
+class PostgresRestart(Action):
+    """Restart the Postgres instance."""
+
+    def run(self, c: Composition) -> None:
+        c.kill("postgres")
+        c.start_and_wait_for_tcp(services=["postgres"])
+        c.wait_for_postgres()
 
 
 class CreatePostgresTable(Action):

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -13,9 +13,11 @@ from materialize.zippy.debezium_actions import CreateDebeziumSource, DebeziumSta
 from materialize.zippy.framework import Action, Scenario
 from materialize.zippy.kafka_actions import CreateTopic, Ingest, KafkaStart
 from materialize.zippy.mz_actions import KillComputed, KillStoraged, MzStart, MzStop
+from materialize.zippy.pg_cdc_actions import CreatePostgresCdcTable
 from materialize.zippy.postgres_actions import (
     CreatePostgresTable,
     PostgresDML,
+    PostgresRestart,
     PostgresStart,
 )
 from materialize.zippy.replica_actions import (
@@ -82,6 +84,25 @@ class DebeziumPostgres(Scenario):
             CreateDebeziumSource: 10,
             KillStoraged: 15,
             KillComputed: 15,
+            CreateView: 10,
+            ValidateView: 20,
+            PostgresDML: 30,
+        }
+
+
+class PostgresCdc(Scenario):
+    """A Zippy test using Postgres CDC exclusively."""
+
+    def bootstrap(self) -> List[Type[Action]]:
+        return [PostgresStart, MzStart]
+
+    def config(self) -> Dict[Type[Action], float]:
+        return {
+            CreatePostgresTable: 10,
+            CreatePostgresCdcTable: 10,
+            KillStoraged: 15,
+            KillComputed: 15,
+            PostgresRestart: 10,
             CreateView: 10,
             ValidateView: 20,
             PostgresDML: 30,

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -14,11 +14,14 @@ from materialize.mzcompose import Composition
 from materialize.zippy.debezium_capabilities import DebeziumSourceExists
 from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.source_capabilities import SourceExists
 from materialize.zippy.table_capabilities import TableExists
 from materialize.zippy.view_capabilities import ViewExists
 
-WatermarkedObjects = List[Union[TableExists, SourceExists, DebeziumSourceExists]]
+WatermarkedObjects = List[
+    Union[TableExists, SourceExists, DebeziumSourceExists, PostgresCdcTableExists]
+]
 
 
 class CreateView(Action):
@@ -30,6 +33,7 @@ class CreateView(Action):
             {MzIsRunning, SourceExists},
             {MzIsRunning, TableExists},
             {MzIsRunning, DebeziumSourceExists},
+            {MzIsRunning, PostgresCdcTableExists},
         ]
 
     def __init__(self, capabilities: Capabilities) -> None:
@@ -48,8 +52,9 @@ class CreateView(Action):
             debezium_sources: WatermarkedObjects = capabilities.get(
                 DebeziumSourceExists
             )
+            pg_cdc_tables: WatermarkedObjects = capabilities.get(PostgresCdcTableExists)
 
-            potential_froms = sources + tables + debezium_sources
+            potential_froms = sources + tables + debezium_sources + pg_cdc_tables
             this_view.froms = random.sample(
                 potential_froms, min(len(potential_froms), random.randint(1, 5))
             )

--- a/misc/python/materialize/zippy/view_capabilities.py
+++ b/misc/python/materialize/zippy/view_capabilities.py
@@ -11,12 +11,19 @@ from typing import List, Optional, Union
 
 from materialize.zippy.debezium_capabilities import DebeziumSourceExists
 from materialize.zippy.framework import Capability
+from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.source_capabilities import SourceExists
 from materialize.zippy.table_capabilities import TableExists
 from materialize.zippy.watermarks import Watermarks
 
 WatermarkedObjects = List[
-    Union[TableExists, SourceExists, "ViewExists", DebeziumSourceExists]
+    Union[
+        TableExists,
+        SourceExists,
+        "ViewExists",
+        DebeziumSourceExists,
+        PostgresCdcTableExists,
+    ]
 ]
 
 


### PR DESCRIPTION
- reuse existing Postgres tables but replicate them to Mz via Postgres CDC
- each table gets its own publication and Pg-cdc source
- a Nightly CI job is also added to run the test

Relates to #12856

### Motivation

  * This PR adds a known-desirable feature.
#12856 needs Zippy tests for sign-off