### PR TITLE
sql: require SIZE option for sources and sinks

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -65,6 +65,7 @@ Field                | Value  | Description
 Field                | Value  | Description
 ---------------------|--------|------------
 `SNAPSHOT`           | `bool` | Default: `true`. Whether to emit the consolidated results of the query before the sink was created at the start of the sink. To see only results after the sink is created, specify `WITH (SNAPSHOT = false)`.
+`SIZE`               | `text`    | **Required.** The [size](#sizing-a-sink) for the sink. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Detail
 
@@ -138,6 +139,15 @@ You can find the topic name and other metadata for each Kafka sink by querying [
 {{</ note >}}
 
 To achieve its exactly-once processing guarantees, Materialize needs to store some internal metadata in an additional *progress topic*. This topic is shared among all sinks that use a particular Kafka connection. The name of this progress topic can be specified when [creating a connection](/sql/create-connection); otherwise, a default is chosen based on the Materialize environment `id` and the connection `id`. In either case, Materialize will attempt to create the topic if it does not exist. The contents of this topic are not user-specified.
+
+## Best practices
+
+### Sizing a sink
+
+Some sinks are low traffic and require relatively few resources, while others
+are high traffic and require hefty resource allocations. You choose the amount
+of CPU and memory available to a sink using the `SIZE` option. You cannot yet
+change the size of a sink after creation.
 
 ## Examples
 

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -221,9 +221,9 @@ Debezium may produce duplicate records if the connector is interrupted. Material
 
 ### Sizing a source
 
-Some sources are low traffic and require relatively few resources to handle data ingestion, while others are high traffic and require hefty resource allocations. You can provision a specific amount of CPU and memory to a source using the `SIZE` option, and adjust the provisioned size after source creation using the [`ALTER SOURCE`](/sql/alter-source) command.
+Some sources are low traffic and require relatively few resources to handle data ingestion, while others are high traffic and require hefty resource allocations. You choose the amount of CPU and memory available to a source using the `SIZE` option, and adjust the provisioned size after source creation using the [`ALTER SOURCE`](/sql/alter-source) command.
 
-By default, Materialize provisions sources using the smallest size (`3xsmall`). It's a good idea to increase the size of a source when:
+It's a good idea to use a larger source size source when:
 
   * You want to **increase throughput**. Larger sources will typically ingest data
     faster, as there is more CPU available to read and decode data from the

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -63,7 +63,7 @@ Field                                | Value     | Description
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | Default: `3xsmall`. The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Supported formats
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -33,7 +33,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | Default: `3xsmall`. The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Features
 

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -87,6 +87,9 @@ pub enum AdapterError {
         size: String,
         expected: Vec<String>,
     },
+    StorageHostSizeRequired {
+        expected: Vec<String>,
+    },
     /// The selection value for a table mutation operation refers to an invalid object.
     InvalidTableMutationSelection,
     /// Expression violated a column's constraint
@@ -270,8 +273,12 @@ impl AdapterError {
                 expected.join(", ")
             )),
             AdapterError::InvalidStorageHostSize { expected, .. } => {
-                Some(format!("Valid source sizes are: {}", expected.join(", ")))
+                Some(format!("Valid sizes are: {}", expected.join(", ")))
             }
+            Self::StorageHostSizeRequired { expected } => Some(format!(
+                "Try choosing one of the smaller sizes to start. Available sizes: {}",
+                expected.join(", ")
+            )),
             AdapterError::NoClusterReplicasAvailable(_) => {
                 Some("You can create cluster replicas using CREATE CLUSTER REPLICA".into())
             }
@@ -349,6 +356,9 @@ impl fmt::Display for AdapterError {
             }
             AdapterError::InvalidStorageHostSize { size, .. } => {
                 write!(f, "unknown source size {size}")
+            }
+            Self::StorageHostSizeRequired { .. } => {
+                write!(f, "size option is required")
             }
             AdapterError::InvalidTableMutationSelection => {
                 f.write_str("invalid selection: operation may only refer to user-defined tables")

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -360,6 +360,7 @@ impl ErrorResponse {
             AdapterError::InvalidClusterReplicaAz { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidClusterReplicaSize { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidStorageHostSize { .. } => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::StorageHostSizeRequired { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             AdapterError::NoClusterReplicasAvailable(_) => SqlState::FEATURE_NOT_SUPPORTED,


### PR DESCRIPTION
As discussed on Slack [0], requiring `SIZE`s with sources and sinks leaves the door open to improved UX in the future, where sources without an explicit `SIZE` get scheduled onto the active cluster.

The behavior in unsafe mode is unchanged, to avoid a massive rewrite of all test files.

[0]: https://materializeinc.slack.com/archives/CU7ELJ6E9/p1665379489997259?thread_ts=1664551051.353139&cid=CU7ELJ6E9

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR avoids a future backwards compatibility issue.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
