### PR TITLE
persist: add client timeouts to S3 API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,6 +3709,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-http",
+ "aws-smithy-types",
  "aws-types",
  "base64",
  "bytes",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = "0.1.57"
 aws-config = { version = "0.49.0", default-features = false, features = ["native-tls"] }
 aws-sdk-s3 = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"]  }
 aws-smithy-http = "0.49.0"
+aws-smithy-types = "0.49.0"
 aws-types = { version = "0.49.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
 bytes = "1.2.1"

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -23,7 +23,7 @@ use aws_sdk_s3::model::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::types::{ByteStream, SdkError};
 use aws_sdk_s3::Client as S3Client;
 use aws_smithy_http::endpoint::Endpoint;
-use aws_smithy_types::{timeout, tristate::TriState};
+use aws_smithy_types::tristate::TriState;
 use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use aws_types::Credentials;
@@ -97,7 +97,7 @@ impl S3BlobConfig {
         // TODO: our timeouts will all be redone when https://github.com/awslabs/smithy-rs/pull/1740
         // is released. it contains a much more straightforward and robust way of thinking about
         // AWS client timeouts.
-        loader.timeout_config(
+        loader = loader.timeout_config(
             timeout::Config::new().with_api_timeouts(
                 timeout::Api::new()
                     // maximum time allowed for a top-level S3 API call (including internal retries)

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -18,10 +18,12 @@ use async_trait::async_trait;
 use aws_config::default_provider::{credentials, region};
 use aws_config::meta::region::ProvideRegion;
 use aws_config::sts::AssumeRoleProvider;
+use aws_config::timeout;
 use aws_sdk_s3::model::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::types::{ByteStream, SdkError};
 use aws_sdk_s3::Client as S3Client;
 use aws_smithy_http::endpoint::Endpoint;
+use aws_smithy_types::{timeout, tristate::TriState};
 use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use aws_types::Credentials;
@@ -91,6 +93,19 @@ impl S3BlobConfig {
                 endpoint.parse().expect("valid S3 endpoint URI"),
             ))
         }
+
+        // TODO: our timeouts will all be redone when https://github.com/awslabs/smithy-rs/pull/1740
+        // is released. it contains a much more straightforward and robust way of thinking about
+        // AWS client timeouts.
+        loader.timeout_config(
+            timeout::Config::new().with_api_timeouts(
+                timeout::Api::new()
+                    // maximum time allowed for a top-level S3 API call (including internal retries)
+                    .with_call_timeout(TriState::Set(Duration::from_secs(180)))
+                    // maximum time allowed for a single network call
+                    .with_call_attempt_timeout(TriState::Set(Duration::from_secs(90))),
+            ),
+        );
 
         let client = aws_sdk_s3::Client::new(&loader.load().await);
         Ok(S3BlobConfig {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds client timeouts to our S3 calls. I'm not sure if we want to pursue this or https://github.com/MaterializeInc/materialize/pull/15260 or both, so I wrote up both to see how they look. Right now I believe it's possible for us to make a request to S3 that winds up being unrouteable for whatever network-y reasons, and never returns.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
