### PR TITLE
replicated: track frontiers of arranged logs

### DIFF
--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -128,3 +128,8 @@ true
         FROM
             mz_internal.mz_worker_compute_import_frontiers AS import_frontiers)
 0
+
+# Test that frontiers of introspection sources advance at all.
+
+! SELECT * FROM mz_internal.mz_active_peeks AS OF 0
+contains: Timestamp (0) is not valid for all inputs


### PR DESCRIPTION
This PR fixes an oversight in the `ActiveReplication` client, where frontiers of persisted logs would be correctly propagted but frontiers of arranged logs would be ignored.

Arranged logs are shared between all replicas (at least their IDs are) but might be disabled for some replicas, so to track their frontiers we need yet another special case.

### Motivation

  * This PR fixes a previously unreported bug.

`FrontierUppers` compute responses for arranged introspection sources never reach the compute controller.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
