### PR TITLE
adapter: Add system compute instances

### DIFF
--- a/doc/developer/platform-checks.md
+++ b/doc/developer/platform-checks.md
@@ -149,8 +149,8 @@ class DropCreateDefaultReplica(Action):
     def execute(self, c: Composition) -> None:
         c.sql(
             """
-           DROP CLUSTER REPLICA default.default_replica;
-           CREATE CLUSTER REPLICA default.default_replica SIZE '1';
+           DROP CLUSTER REPLICA default.r1;
+           CREATE CLUSTER REPLICA default.r1 SIZE '1';
         """
         )
 ```

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -7,7 +7,7 @@ menu:
 
 ---
 
-`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `default_replica` will exist in every environment; this cluster can be dropped at any time.
+`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time.
 
 ## Syntax
 
@@ -20,10 +20,10 @@ SHOW CLUSTER REPLICAS;
 ```
 
 ```nofmt
-    cluster    |     replica     |  size  |
----------------+-----------------|--------|
- auction_house | bigger          | xlarge |
- default       | default_replica | xsmall |
+    cluster    | replica |  size  |
+---------------+---------|--------|
+ auction_house | bigger  | xlarge |
+ default       | r1      | xsmall |
 ```
 
 ```sql
@@ -31,9 +31,9 @@ SHOW CLUSTER REPLICAS WHERE cluster='default';
 ```
 
 ```nofmt
-    cluster    |     replica     |  size  |
----------------+-----------------|--------|
- default       | default_replica | xsmall |
+    cluster    | replica |  size  |
+---------------+---------|--------|
+ default       | r1      | xsmall |
 ```
 
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -7,7 +7,7 @@ menu:
 
 ---
 
-`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `default_replica` will exist in every environment; this cluster can be dropped at any time.
+`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time.
 
 ## Syntax
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -47,13 +47,13 @@ Field          | Type       | Meaning
 
 The `mz_cluster_replicas` table contains a row for each cluster replica in the system.
 
-Field               | Type       | Meaning
---------------------|------------|--------
-`id`                | [`uint8`]  | Materialize's unique ID for the cluster replica.
-`name`              | [`text`]   | The name of the cluster replica.
-`cluster_id`        | [`uint8`]  | The ID of the cluster to which the replica belongs.
-`size`              | [`text`]   | The cluster replica's size, selected during creation.
-`availability_zone` | [`text`]   | The availability zone in which the cluster is running.
+Field               | Type      | Meaning
+--------------------|-----------|--------
+`id`                | [`uint8`] | Materialize's unique ID for the cluster replica.
+`name`              | [`text`]  | The name of the cluster replica.
+`cluster_id`        | [`text`]  | The ID of the cluster to which the replica belongs.
+`size`              | [`text`]  | The cluster replica's size, selected during creation.
+`availability_zone` | [`text`]  | The availability zone in which the cluster is running.
 
 ### `mz_clusters`
 
@@ -187,14 +187,14 @@ Field          | Type       | Meaning
 
 The `mz_materialized_views` table contains a row for each materialized view in the system.
 
-Field          | Type        | Meaning
----------------|-------------|----------
-`id`           | [`text`]    | Materialize's unique ID for the materialized view.
-`oid`          | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the materialized view.
-`schema_id`    | [`uint8`]   | The ID of the schema to which the materialized view belongs.
-`name`         | [`text`]    | The name of the materialized view.
-`cluster_id`   | [`uint8`]   | The ID of the cluster maintaining the materialized view.
-`definition`   | [`text`]    | The materialized view definition (a `SELECT` query).
+Field          | Type      | Meaning
+---------------|-----------|----------
+`id`           | [`text`]  | Materialize's unique ID for the materialized view.
+`oid`          | [`oid`]   | A [PostgreSQL-compatible OID][oid] for the materialized view.
+`schema_id`    | [`uint8`] | The ID of the schema to which the materialized view belongs.
+`name`         | [`text`]  | The name of the materialized view.
+`cluster_id`   | [`text`]  | The ID of the cluster maintaining the materialized view.
+`definition`   | [`text`]  | The materialized view definition (a `SELECT` query).
 
 ### `mz_objects`
 

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -70,8 +70,8 @@ class UseComputed(MzcomposeAction):
 
         c.sql(
             """
-            DROP CLUSTER REPLICA default.default_replica;
-            CREATE CLUSTER REPLICA default.default_replica
+            DROP CLUSTER REPLICA default.r1;
+            CREATE CLUSTER REPLICA default.r1
                 REMOTE ['computed_1:2100'],
                 COMPUTE ['computed_1:2102'],
                 WORKERS 1;
@@ -137,7 +137,7 @@ class DropCreateDefaultReplica(MzcomposeAction):
 
         c.sql(
             """
-           DROP CLUSTER REPLICA default.default_replica;
-           CREATE CLUSTER REPLICA default.default_replica SIZE '1';
+           DROP CLUSTER REPLICA default.r1;
+           CREATE CLUSTER REPLICA default.r1 SIZE '1';
         """
         )

--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -103,4 +103,4 @@ class MaterializeApplication(Application):
 
     def create(self) -> None:
         super().create()
-        wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+        wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-1-0")

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -24,7 +24,7 @@ class DropDefaultReplica(Action):
         return {MzIsRunning}
 
     def run(self, c: Composition) -> None:
-        c.testdrive("> DROP CLUSTER REPLICA default.default_replica;")
+        c.testdrive("> DROP CLUSTER REPLICA default.r1;")
 
 
 class CreateReplica(Action):

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -69,7 +69,7 @@ use mz_transform::Optimizer;
 
 use crate::catalog::builtin::{
     Builtin, BuiltinLog, BuiltinStorageManagedTable, BuiltinTable, BuiltinType, Fingerprint,
-    BUILTINS, BUILTIN_ROLE_PREFIXES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA,
+    BUILTINS, BUILTIN_PREFIXES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA,
     MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
@@ -103,6 +103,8 @@ pub static HTTP_DEFAULT_USER: Lazy<User> = Lazy::new(|| User {
 });
 
 const CREATE_SQL_TODO: &str = "TODO";
+
+pub const DEFAULT_CLUSTER_REPLICA_NAME: &str = "r1";
 
 /// A `Catalog` keeps track of the SQL objects known to the planner.
 ///
@@ -1690,6 +1692,23 @@ impl CatalogItem {
             CatalogItem::StorageManagedTable(i) => Ok(CatalogItem::StorageManagedTable(i)),
         }
     }
+
+    fn compute_instance_id(&self) -> Option<ComputeInstanceId> {
+        match self {
+            CatalogItem::MaterializedView(mv) => Some(mv.compute_instance),
+            CatalogItem::Index(index) => Some(index.compute_instance),
+            CatalogItem::Table(_)
+            | CatalogItem::Source(_)
+            | CatalogItem::Log(_)
+            | CatalogItem::View(_)
+            | CatalogItem::Sink(_)
+            | CatalogItem::Type(_)
+            | CatalogItem::Func(_)
+            | CatalogItem::Secret(_)
+            | CatalogItem::Connection(_)
+            | CatalogItem::StorageManagedTable(_) => None,
+        }
+    }
 }
 
 impl CatalogEntry {
@@ -2770,6 +2789,7 @@ impl<S: Append> Catalog<S> {
             &BootstrapArgs {
                 now: (now)(),
                 default_cluster_replica_size: "1".into(),
+                builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
             },
         )
@@ -3012,6 +3032,22 @@ impl<S: Append> Catalog<S> {
         name: &str,
     ) -> Result<&ComputeInstance, SqlCatalogError> {
         self.state.resolve_compute_instance(name)
+    }
+
+    pub fn active_compute_instance(
+        &self,
+        session: &Session,
+    ) -> Result<&ComputeInstance, AdapterError> {
+        // TODO(benesch): this check here is not sufficiently protective. It'd
+        // be very easy for a code path to accidentally avoid this check by
+        // calling `resolve_compute_instance(session.vars().cluster()`.
+        if session.user().name != SYSTEM_USER.name && session.vars().cluster() == SYSTEM_USER.name {
+            coord_bail!(
+                "system cluster '{}' cannot execute user queries",
+                SYSTEM_USER.name
+            );
+        }
+        Ok(self.resolve_compute_instance(session.vars().cluster())?)
     }
 
     pub fn state(&self) -> &CatalogState {
@@ -3630,7 +3666,8 @@ impl<S: Append> Catalog<S> {
                             ErrorKind::ReservedClusterName(name),
                         )));
                     }
-                    let id = tx.insert_compute_instance(&name, &arranged_introspection_sources)?;
+                    let id =
+                        tx.insert_user_compute_instance(&name, &arranged_introspection_sources)?;
                     state.add_to_audit_log(
                         session,
                         tx,
@@ -3639,7 +3676,7 @@ impl<S: Append> Catalog<S> {
                         EventType::Create,
                         ObjectType::Cluster,
                         EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
-                            id,
+                            id: id.to_string(),
                             name: name.clone(),
                         }),
                     )?;
@@ -3663,12 +3700,12 @@ impl<S: Append> Catalog<S> {
                             ErrorKind::ReservedReplicaName(name),
                         )));
                     }
-                    let id =
+                    let (replica_id, compute_instance_id) =
                         tx.insert_compute_replica(&on_cluster_name, &name, &config.clone().into())?;
                     if let ComputeReplicaLocation::Managed { size, .. } = &config.location {
                         let details = EventDetails::CreateComputeReplicaV1(
                             mz_audit_log::CreateComputeReplicaV1 {
-                                cluster_id: id,
+                                cluster_id: compute_instance_id.to_string(),
                                 cluster_name: on_cluster_name.clone(),
                                 replica_name: name.clone(),
                                 logical_size: size.clone(),
@@ -3688,7 +3725,7 @@ impl<S: Append> Catalog<S> {
                         state,
                         builtin_table_updates,
                         Action::CreateComputeReplica {
-                            id,
+                            id: replica_id,
                             name,
                             on_cluster_name,
                             config,
@@ -3702,6 +3739,13 @@ impl<S: Append> Catalog<S> {
                     item,
                 } => {
                     state.ensure_no_unstable_uses(&item)?;
+
+                    if let Some(id @ ComputeInstanceId::System(_)) = item.compute_instance_id() {
+                        let compute_instance_name = state.compute_instances_by_id[&id].name.clone();
+                        return Err(AdapterError::Catalog(Error::new(
+                            ErrorKind::ReadOnlyComputeInstance(compute_instance_name),
+                        )));
+                    }
 
                     if item.is_temporary() {
                         if name.qualifiers.database_spec != ResolvedDatabaseSpecifier::Ambient
@@ -3800,6 +3844,11 @@ impl<S: Append> Catalog<S> {
                     catalog_action(state, builtin_table_updates, Action::DropRole { name })?;
                 }
                 Op::DropComputeInstance { name } => {
+                    if is_reserved_name(&name) {
+                        return Err(AdapterError::Catalog(Error::new(
+                            ErrorKind::ReservedClusterName(name),
+                        )));
+                    }
                     let (instance_id, introspection_source_index_ids) =
                         tx.remove_compute_instance(&name)?;
                     builtin_table_updates.push(state.pack_compute_instance_update(&name, -1));
@@ -3814,7 +3863,7 @@ impl<S: Append> Catalog<S> {
                         EventType::Drop,
                         ObjectType::Cluster,
                         EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
-                            id: instance_id,
+                            id: instance_id.to_string(),
                             name: name.clone(),
                         }),
                     )?;
@@ -3828,6 +3877,11 @@ impl<S: Append> Catalog<S> {
                     )?;
                 }
                 Op::DropComputeReplica { name, compute_name } => {
+                    if is_reserved_name(&name) {
+                        return Err(AdapterError::Catalog(Error::new(
+                            ErrorKind::ReservedReplicaName(name),
+                        )));
+                    }
                     let instance = state.resolve_compute_instance(&compute_name)?;
                     tx.remove_compute_replica(&name, instance.id)?;
 
@@ -3851,7 +3905,7 @@ impl<S: Append> Catalog<S> {
 
                     let details =
                         EventDetails::DropComputeReplicaV1(mz_audit_log::DropComputeReplicaV1 {
-                            cluster_id: instance.id,
+                            cluster_id: instance.id.to_string(),
                             cluster_name: instance.name.clone(),
                             replica_name: name.clone(),
                         });
@@ -4576,6 +4630,11 @@ impl<S: Append> Catalog<S> {
         self.state.compute_instances_by_id.values()
     }
 
+    pub fn user_compute_instances(&self) -> impl Iterator<Item = &ComputeInstance> {
+        self.compute_instances()
+            .filter(|compute_instance| compute_instance.id.is_user())
+    }
+
     pub fn databases(&self) -> impl Iterator<Item = &Database> {
         self.state.database_by_id.values()
     }
@@ -4665,7 +4724,7 @@ impl<S: Append> Catalog<S> {
 }
 
 pub fn is_reserved_name(name: &str) -> bool {
-    BUILTIN_ROLE_PREFIXES
+    BUILTIN_PREFIXES
         .iter()
         .any(|prefix| name.starts_with(prefix))
 }
@@ -5309,6 +5368,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
+    use mz_compute_client::controller::ComputeInstanceId;
     use std::collections::HashMap;
     use std::error::Error;
 
@@ -5604,7 +5664,7 @@ mod tests {
                                 .with_column("a", ScalarType::Int32.nullable(true))
                                 .with_key(vec![0]),
                             depends_on,
-                            compute_instance: 1,
+                            compute_instance: ComputeInstanceId::User(1),
                         })
                     }
                 };

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -113,7 +113,7 @@ impl CatalogState {
         let id = self.compute_instances_by_name[name];
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTERS),
-            row: Row::pack_slice(&[Datum::UInt64(id), Datum::String(name)]),
+            row: Row::pack_slice(&[Datum::String(&id.to_string()), Datum::String(name)]),
             diff,
         }
     }
@@ -143,7 +143,7 @@ impl CatalogState {
             row: Row::pack_slice(&[
                 Datum::UInt64(id),
                 Datum::String(name),
-                Datum::UInt64(compute_instance_id),
+                Datum::String(&compute_instance_id.to_string()),
                 Datum::from(size),
                 Datum::from(az),
             ]),
@@ -477,7 +477,7 @@ impl CatalogState {
                 Datum::UInt32(oid),
                 Datum::UInt64(schema_id.into()),
                 Datum::String(name),
-                Datum::UInt64(mview.compute_instance),
+                Datum::String(&mview.compute_instance.to_string()),
                 Datum::String(&query_string),
             ]),
             diff,
@@ -559,7 +559,7 @@ impl CatalogState {
                 Datum::UInt32(oid),
                 Datum::String(name),
                 Datum::String(&index.on.to_string()),
-                Datum::UInt64(index.compute_instance),
+                Datum::String(&index.compute_instance.to_string()),
             ]),
             diff,
         });

--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -50,6 +50,8 @@ pub enum ErrorKind {
     ReservedClusterName(String),
     #[error("replica name {} is reserved", .0.quoted())]
     ReservedReplicaName(String),
+    #[error("system cluster '{0}' cannot be modified")]
+    ReadOnlyComputeInstance(String),
     #[error("system schema '{0}' cannot be modified")]
     ReadOnlySystemSchema(String),
     #[error("system item '{0}' cannot be modified")]

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -709,7 +709,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
         // An arbitrary compute instance ID to satisfy the function calls below. Note that
         // this only works because this function will never run.
-        let compute_instance: ComputeInstanceId = 1;
+        let compute_instance = ComputeInstanceId::User(1);
 
         let df = DataflowDesc::new("".into());
         let _: () = self.ship_dataflow(df.clone(), compute_instance).await;

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -658,7 +658,7 @@ impl<S: Append + 'static> Coordinator<S> {
             "Materialized view",
         )?;
         self.validate_resource_limit(
-            self.catalog.compute_instances().count(),
+            self.catalog.user_compute_instances().count(),
             new_clusters,
             SystemVars::max_clusters,
             "Cluster",

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1982,9 +1982,7 @@ impl<S: Append + 'static> Coordinator<S> {
             copy_to,
         } = plan;
 
-        let compute_instance = self
-            .catalog
-            .resolve_compute_instance(session.vars().cluster())?;
+        let compute_instance = self.catalog.active_compute_instance(session)?;
 
         let target_replica_name = session.vars().cluster_replica();
         let mut target_replica = target_replica_name
@@ -2234,9 +2232,7 @@ impl<S: Append + 'static> Coordinator<S> {
             emit_progress,
         } = plan;
 
-        let compute_instance = self
-            .catalog
-            .resolve_compute_instance(session.vars().cluster())?;
+        let compute_instance = self.catalog.active_compute_instance(session)?;
         let compute_instance_id = compute_instance.id;
 
         // SUBSCRIBE AS OF, similar to peeks, doesn't need to worry about transaction
@@ -2352,10 +2348,7 @@ impl<S: Append + 'static> Coordinator<S> {
         use mz_repr::explain_new::trace_plan;
         use ExplainStageNew::*;
 
-        let compute_instance = self
-            .catalog
-            .resolve_compute_instance(session.vars().cluster())?
-            .id;
+        let compute_instance = self.catalog.active_compute_instance(session)?.id;
 
         let ExplainPlanNew {
             raw_plan,
@@ -2520,10 +2513,7 @@ impl<S: Append + 'static> Coordinator<S> {
         session: &Session,
         plan: ExplainPlanOld,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let compute_instance = self
-            .catalog
-            .resolve_compute_instance(session.vars().cluster())?
-            .id;
+        let compute_instance = self.catalog.active_compute_instance(session)?.id;
 
         let ExplainPlanOld {
             raw_plan,

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -156,7 +156,7 @@ pub struct NameV1 {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct IdNameV1 {
-    pub id: u64,
+    pub id: String,
     pub name: String,
 }
 
@@ -168,14 +168,14 @@ pub struct RenameItemV1 {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct DropComputeReplicaV1 {
-    pub cluster_id: u64,
+    pub cluster_id: String,
     pub cluster_name: String,
     pub replica_name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct CreateComputeReplicaV1 {
-    pub cluster_id: u64,
+    pub cluster_id: String,
     pub cluster_name: String,
     pub replica_name: String,
     pub logical_size: String,
@@ -253,13 +253,13 @@ fn test_audit_log() -> Result<(), anyhow::Error> {
                 EventType::Drop,
                 ObjectType::ClusterReplica,
                 EventDetails::IdNameV1(IdNameV1 {
-                    id: 0,
+                    id: "u1".to_string(),
                     name: "name".into(),
                 }),
                 None,
                 2,
             )),
-            r#"{"V1":{"id":2,"event_type":"drop","object_type":"cluster-replica","event_details":{"IdNameV1":{"id":0,"name":"name"}},"user":null,"occurred_at":2}}"#,
+            r#"{"V1":{"id":2,"event_type":"drop","object_type":"cluster-replica","event_details":{"IdNameV1":{"id":"u1","name":"name"}},"user":null,"occurred_at":2}}"#,
         ),
     ];
 

--- a/src/compute-client/src/controller/orchestrator.rs
+++ b/src/compute-client/src/controller/orchestrator.rs
@@ -174,7 +174,7 @@ fn parse_replica_service_name(
     service_name: &str,
 ) -> Result<(ComputeInstanceId, ReplicaId), anyhow::Error> {
     static SERVICE_NAME_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?-u)^cluster-(\d+)-replica-(\d+)$").unwrap());
+        Lazy::new(|| Regex::new(r"(?-u)^cluster-([us]\d+)-replica-(\d+)$").unwrap());
 
     let caps = SERVICE_NAME_RE
         .captures(service_name)

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -355,6 +355,13 @@ pub struct Args {
         default_value = "1"
     )]
     bootstrap_default_cluster_replica_size: String,
+    /// The size of the builtin cluster replicas if bootstrapping.
+    #[clap(
+        long,
+        env = "BOOTSTRAP_BUILTIN_CLUSTER_REPLICA_SIZE",
+        default_value = "1"
+    )]
+    bootstrap_builtin_cluster_replica_size: String,
     /// A map from size name to resource allocations for storage hosts.
     #[clap(long, env = "STORAGE_HOST_SIZES")]
     storage_host_sizes: Option<String>,
@@ -694,6 +701,7 @@ max log level: {max_log_level}",
         environment_id: args.environment_id,
         cluster_replica_sizes,
         bootstrap_default_cluster_replica_size: args.bootstrap_default_cluster_replica_size,
+        bootstrap_builtin_cluster_replica_size: args.bootstrap_builtin_cluster_replica_size,
         storage_host_sizes,
         default_storage_host_size: args.default_storage_host_size,
         availability_zones: args.availability_zone,

--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -63,9 +63,9 @@ function ClusterReplicaView() {
         setSqlResponse(results);
         if (!replicaName && results.length > 0) {
           if(results.some(
-            result => ('default' == result[0]) && ('default_replica' == result[1]))) {
+            result => ('default' == result[0]) && ('r1' == result[1]))) {
             setCurrentClusterName('default');
-            setCurrentReplicaName('default_replica');
+            setCurrentReplicaName('r1');
           } else {
             setCurrentClusterName(results[0][0]);
             setCurrentReplicaName(results[0][1]);

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -64,9 +64,9 @@ function ClusterReplicaView() {
         setSqlResponse(results);
         if (!replicaName && results.length > 0) {
           if(results.some(
-            result => ('default' == result[0]) && ('default_replica' == result[1]))) {
+            result => ('default' == result[0]) && ('r1' == result[1]))) {
             setCurrentClusterName('default');
-            setCurrentReplicaName('default_replica');
+            setCurrentReplicaName('r1');
           } else {
             setCurrentClusterName(results[0][0]);
             setCurrentReplicaName(results[0][1]);

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -97,6 +97,8 @@ pub struct Config {
     pub cluster_replica_sizes: ClusterReplicaSizeMap,
     /// The size of the default cluster replica if bootstrapping.
     pub bootstrap_default_cluster_replica_size: String,
+    /// The size of the builtin cluster replicas if bootstrapping.
+    pub bootstrap_builtin_cluster_replica_size: String,
     /// A map from size name to resource allocations for storage hosts.
     pub storage_host_sizes: StorageHostSizeMap,
     /// Default storage host size, should be a key from storage_host_sizes.
@@ -235,6 +237,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         &BootstrapArgs {
             now: (config.now)(),
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size,
+            builtin_cluster_replica_size: config.bootstrap_builtin_cluster_replica_size,
             // TODO(benesch, brennan): remove this after v0.27.0-alpha.4 has
             // shipped to cloud since all clusters will have had a default
             // availability zone installed.

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -47,7 +47,7 @@ pub static KAFKA_ADDRS: Lazy<mz_kafka_util::KafkaAddrs> =
     });
 // Port 2181 is used by ZooKeeper.
 static PORT_ALLOCATOR: Lazy<Arc<PortAllocator>> =
-    Lazy::new(|| Arc::new(PortAllocator::new_with_filter(2100, 2200, &[2181])));
+    Lazy::new(|| Arc::new(PortAllocator::new_with_filter(2100, 2600, &[2181])));
 
 #[derive(Clone)]
 pub struct Config {
@@ -209,6 +209,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         cors_allowed_origin: AllowOrigin::list([]),
         cluster_replica_sizes: Default::default(),
         bootstrap_default_cluster_replica_size: "1".into(),
+        bootstrap_builtin_cluster_replica_size: "1".into(),
         storage_host_sizes: Default::default(),
         default_storage_host_size: None,
         availability_zones: Default::default(),

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1027,7 +1027,8 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     Err(e) => {
                         self.status = Err(e.into());
                         ResolvedClusterName {
-                            id: 0,
+                            // The id is arbitrary here, we just need some dummy value to return.
+                            id: ComputeInstanceId::System(0),
                             print_name: None,
                         }
                     }
@@ -1041,7 +1042,8 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 Err(e) => {
                     self.status = Err(e.into());
                     ResolvedClusterName {
-                        id: 0,
+                        // The id is arbitrary here, we just need some dummy value to return.
+                        id: ComputeInstanceId::System(0),
                         print_name: None,
                     }
                 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -376,7 +376,7 @@ fn show_materialized_views<'a>(
     let mut where_clause = format!("schema_id = {schema_spec}");
 
     if let Some(cluster) = in_cluster {
-        write!(where_clause, " AND cluster_id = {}", cluster.id)
+        write!(where_clause, " AND cluster_id = '{}'", cluster.id)
             .expect("write on string cannot fail");
     }
 
@@ -475,7 +475,7 @@ pub fn show_indexes<'a>(
     }
 
     if let Some(cluster) = in_cluster {
-        query_filter.push(format!("clusters.id = {}", cluster.id))
+        query_filter.push(format!("clusters.id = '{}'", cluster.id))
     };
 
     let query = format!(

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -688,6 +688,7 @@ impl Runner {
             environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
             cluster_replica_sizes: Default::default(),
             bootstrap_default_cluster_replica_size: "1".into(),
+            bootstrap_builtin_cluster_replica_size: "1".into(),
             storage_host_sizes: Default::default(),
             default_storage_host_size: None,
             availability_zones: Default::default(),

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -14,7 +14,7 @@ from materialize.cloudtest.wait import wait
 
 
 def test_wait(mz: MaterializeApplication) -> None:
-    wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+    wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-1-0")
 
 
 def test_sql(mz: MaterializeApplication) -> None:

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -84,7 +84,7 @@ def test_upgrade() -> None:
     """Test upgrade from LAST_RELEASED_VERSION to the current source by running all the Platform Checks"""
 
     mz = MaterializeApplication(tag=LAST_RELEASED_VERSION)
-    wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+    wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)
     scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -154,7 +154,7 @@ def start_services(
                 + f"], WORKERS {workers};"
             )
 
-            c.sql("DROP CLUSTER REPLICA default.default_replica")
+            c.sql("DROP CLUSTER REPLICA default.r1")
 
     c.up("testdrive", persistent=True)
 

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1350,7 +1350,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
         for replica_id in range(0, args.replicas):
             nodes = []
             for node_id in range(0, args.nodes):
-                node_name = f"computed_{cluster_id}_{replica_id}_{node_id}"
+                node_name = f"computed_u{cluster_id}_{replica_id}_{node_id}"
                 nodes.append(node_name)
 
             for node_id in range(0, args.nodes):
@@ -1405,10 +1405,10 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                 for replica_id in range(0, args.replicas):
                     nodes = []
                     for node_id in range(0, args.nodes):
-                        node_name = f"computed_{cluster_id}_{replica_id}_{node_id}"
+                        node_name = f"computed_u{cluster_id}_{replica_id}_{node_id}"
                         nodes.append(node_name)
 
-                    replica_name = f"replica_{cluster_id}_{replica_id}"
+                    replica_name = f"replica_u{cluster_id}_{replica_id}"
 
                     replica_definitions.append(
                         f"{replica_name} (REMOTE ["
@@ -1419,14 +1419,14 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     )
 
                 c.sql(
-                    f"CREATE CLUSTER cluster_{cluster_id} REPLICAS ("
+                    f"CREATE CLUSTER cluster_u{cluster_id} REPLICAS ("
                     + ",".join(replica_definitions)
                     + ")"
                 )
 
             # Construct some dataflows in each cluster
             for cluster_id in range(0, args.clusters):
-                cluster_name = f"cluster_{cluster_id}"
+                cluster_name = f"cluster_u{cluster_id}"
 
                 c.testdrive(
                     dedent(
@@ -1456,7 +1456,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
 
             # Validate that each individual cluster is operating properly
             for cluster_id in range(0, args.clusters):
-                cluster_name = f"cluster_{cluster_id}"
+                cluster_name = f"cluster_u{cluster_id}"
 
                 c.testdrive(
                     dedent(

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -50,10 +50,10 @@ DROP CLUSTER foo;
 query ITTTT
 SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORDER BY id
 ----
-1  create  cluster  {"id":1,"name":"default"}  NULL
-2  create  cluster-replica  {"cluster_id":1,"cluster_name":"default","logical_size":"1","replica_name":"default_replica"}  NULL
-3  create  cluster  {"id":2,"name":"foo"}  materialize
-4  create  cluster-replica  {"cluster_id":2,"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+1  create  cluster  {"id":"u1","name":"default"}  NULL
+2  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_name":"r1"}  NULL
+3  create  cluster  {"id":"u2","name":"foo"}  materialize
+4  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
 5  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
 6  create  view  {"database":"materialize","item":"unmat","schema":"public"}  materialize
 7  create  table  {"database":"materialize","item":"t","schema":"public"}  materialize
@@ -65,5 +65,5 @@ SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORD
 13  drop  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
 14  drop  view  {"database":"materialize","item":"renamed","schema":"public"}  materialize
 15  create  source  {"database":"materialize","item":"s","schema":"public"}  materialize
-16  drop  cluster-replica  {"cluster_id":2,"cluster_name":"foo","replica_name":"r"}  materialize
-17  drop  cluster  {"id":2,"name":"foo"}  materialize
+16  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
+17  drop  cluster  {"id":"u2","name":"foo"}  materialize

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -43,13 +43,17 @@ CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235']), r2 (REMOTE ['localh
 query TT rowsort
 SELECT * FROM mz_clusters
 ----
-1 default
-3 foo
-4 bar
+s1 mz_system
+s2 mz_introspection
+u1 default
+u3 foo
+u4 bar
 
 query T rowsort
 SHOW CLUSTERS
 ----
+mz_system
+mz_introspection
 bar
 default
 foo
@@ -141,57 +145,57 @@ FROM
 WHERE clusters.name = 'bar'
 ORDER BY on_name, seq_in_index ASC;
 ----
-bar  mz_active_peeks  mz_active_peeks_4_primary_idx  1  id  NULL  false
-bar  mz_active_peeks  mz_active_peeks_4_primary_idx  2  worker_id  NULL  false
-bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_4_primary_idx  1  operator_id  NULL  false
-bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_4_primary_idx  2  worker_id  NULL  false
-bar  mz_arrangement_records_internal  mz_arrangement_records_internal_4_primary_idx  1  operator_id  NULL  false
-bar  mz_arrangement_records_internal  mz_arrangement_records_internal_4_primary_idx  2  worker_id  NULL  false
-bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_4_primary_idx  1  operator_id  NULL  false
-bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_4_primary_idx  2  worker_id  NULL  false
-bar  mz_compute_exports  mz_compute_exports_4_primary_idx  1  export_id  NULL  false
-bar  mz_compute_exports  mz_compute_exports_4_primary_idx  2  worker_id  NULL  false
-bar  mz_dataflow_addresses  mz_dataflow_addresses_4_primary_idx  1  id  NULL  false
-bar  mz_dataflow_addresses  mz_dataflow_addresses_4_primary_idx  2  worker_id  NULL  false
-bar  mz_dataflow_channels  mz_dataflow_channels_4_primary_idx  1  id  NULL  false
-bar  mz_dataflow_channels  mz_dataflow_channels_4_primary_idx  2  worker_id  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_4_primary_idx  1  address  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_4_primary_idx  2  port  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_4_primary_idx  3  worker_id  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_4_primary_idx  4  update_type  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_4_primary_idx  5  timestamp  NULL  true
-bar  mz_dataflow_operators  mz_dataflow_operators_4_primary_idx  1  id  NULL  false
-bar  mz_dataflow_operators  mz_dataflow_operators_4_primary_idx  2  worker_id  NULL  false
-bar  mz_message_counts_received_internal  mz_message_counts_received_internal_4_primary_idx  1  channel_id  NULL  false
-bar  mz_message_counts_received_internal  mz_message_counts_received_internal_4_primary_idx  2  from_worker_id  NULL  false
-bar  mz_message_counts_received_internal  mz_message_counts_received_internal_4_primary_idx  3  to_worker_id  NULL  false
-bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_4_primary_idx  1  channel_id  NULL  false
-bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_4_primary_idx  2  from_worker_id  NULL  false
-bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_4_primary_idx  3  to_worker_id  NULL  false
-bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_4_primary_idx  1  id  NULL  false
-bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_4_primary_idx  2  worker_id  NULL  false
-bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_4_primary_idx  3  duration_ns  NULL  false
-bar  mz_raw_peek_durations  mz_raw_peek_durations_4_primary_idx  1  worker_id  NULL  false
-bar  mz_raw_peek_durations  mz_raw_peek_durations_4_primary_idx  2  duration_ns  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_4_primary_idx  1  export_id  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_4_primary_idx  2  import_id  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_4_primary_idx  3  worker_id  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_4_primary_idx  4  delay_ns  NULL  false
-bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_4_primary_idx  1  id  NULL  false
-bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_4_primary_idx  2  worker_id  NULL  false
-bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_4_primary_idx  1  worker_id  NULL  false
-bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_4_primary_idx  2  slept_for  NULL  false
-bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_4_primary_idx  3  requested  NULL  false
-bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_4_primary_idx  1  export_id  NULL  false
-bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_4_primary_idx  2  import_id  NULL  false
-bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_4_primary_idx  3  worker_id  NULL  false
-bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_4_primary_idx  1  export_id  NULL  false
-bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_4_primary_idx  2  worker_id  NULL  false
-bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_4_primary_idx  3  time  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_4_primary_idx  1  export_id  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_4_primary_idx  2  import_id  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_4_primary_idx  3  worker_id  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_4_primary_idx  4  time  NULL  false
+bar  mz_active_peeks  mz_active_peeks_u4_primary_idx  1  id  NULL  false
+bar  mz_active_peeks  mz_active_peeks_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_u4_primary_idx  1  operator_id  NULL  false
+bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_arrangement_records_internal  mz_arrangement_records_internal_u4_primary_idx  1  operator_id  NULL  false
+bar  mz_arrangement_records_internal  mz_arrangement_records_internal_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_u4_primary_idx  1  operator_id  NULL  false
+bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_compute_exports  mz_compute_exports_u4_primary_idx  1  export_id  NULL  false
+bar  mz_compute_exports  mz_compute_exports_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_dataflow_addresses  mz_dataflow_addresses_u4_primary_idx  1  id  NULL  false
+bar  mz_dataflow_addresses  mz_dataflow_addresses_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_dataflow_channels  mz_dataflow_channels_u4_primary_idx  1  id  NULL  false
+bar  mz_dataflow_channels  mz_dataflow_channels_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  1  address  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  2  port  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  3  worker_id  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  4  update_type  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  5  timestamp  NULL  true
+bar  mz_dataflow_operators  mz_dataflow_operators_u4_primary_idx  1  id  NULL  false
+bar  mz_dataflow_operators  mz_dataflow_operators_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u4_primary_idx  1  channel_id  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u4_primary_idx  2  from_worker_id  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u4_primary_idx  3  to_worker_id  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u4_primary_idx  1  channel_id  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u4_primary_idx  2  from_worker_id  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u4_primary_idx  3  to_worker_id  NULL  false
+bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u4_primary_idx  1  id  NULL  false
+bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u4_primary_idx  3  duration_ns  NULL  false
+bar  mz_raw_peek_durations  mz_raw_peek_durations_u4_primary_idx  1  worker_id  NULL  false
+bar  mz_raw_peek_durations  mz_raw_peek_durations_u4_primary_idx  2  duration_ns  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  1  export_id  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  2  import_id  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  3  worker_id  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  4  delay_ns  NULL  false
+bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_u4_primary_idx  1  id  NULL  false
+bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u4_primary_idx  1  worker_id  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u4_primary_idx  2  slept_for  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u4_primary_idx  3  requested  NULL  false
+bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u4_primary_idx  1  export_id  NULL  false
+bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u4_primary_idx  2  import_id  NULL  false
+bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u4_primary_idx  3  worker_id  NULL  false
+bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u4_primary_idx  1  export_id  NULL  false
+bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u4_primary_idx  2  worker_id  NULL  false
+bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u4_primary_idx  3  time  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  1  export_id  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  2  import_id  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  3  worker_id  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  4  time  NULL  false
 bar  v  v_primary_idx  1  ?column?  NULL  false
 
 query TTTT
@@ -333,12 +337,12 @@ DROP CLUSTER foo, foo2, foo3 CASCADE
 
 # There are 19 introspection sources
 query I
-SELECT COUNT(name) FROM mz_indexes WHERE cluster_id = 1;
+SELECT COUNT(name) FROM mz_indexes WHERE cluster_id = 'u1';
 ----
 19
 
 query I
-SELECT COUNT(name) FROM mz_indexes WHERE cluster_id <> 1;
+SELECT COUNT(name) FROM mz_indexes WHERE cluster_id <> 'u1' AND cluster_id NOT LIKE 's%';
 ----
 0
 
@@ -348,7 +352,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-38
+76
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -356,7 +360,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-19
+57
 
 statement error nvalid SIZE: must provide a string value
 CREATE CLUSTER REPLICA default.size_1 SIZE;
@@ -367,8 +371,10 @@ CREATE CLUSTER REPLICA default.size_1 SIZE '1';
 query TT
 SHOW CLUSTER REPLICAS
 ----
-default default_replica
+default r1
 default size_1
+mz_introspection r1
+mz_system r1
 
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
@@ -376,10 +382,12 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 query TT
 SHOW CLUSTER REPLICAS
 ----
-default default_replica
+default r1
 default size_1
 foo size_1
 foo size_2
+mz_introspection r1
+mz_system r1
 
 statement ok
 DROP CLUSTER REPLICA IF EXISTS default.bar
@@ -402,7 +410,9 @@ DROP CLUSTER REPLICA foo.size_1, foo.size_2
 query TT
 SHOW CLUSTER REPLICAS
 ----
-default default_replica
+default r1
+mz_introspection r1
+mz_system r1
 
 statement ok
 CREATE CLUSTER REPLICA default.foo_bar SIZE '1'
@@ -519,7 +529,9 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_32 (SIZE '32'), size_2_2 (S
 query TT
 SELECT name, size FROM mz_cluster_replicas ORDER BY name
 ----
-default_replica  1
+r1               1
+r1               1
+r1               1
 size_1           1
 size_2_2         2-2
 size_32          32

--- a/test/sqllogictest/cluster_log_compaction.slt
+++ b/test/sqllogictest/cluster_log_compaction.slt
@@ -21,8 +21,8 @@ statement ok
 BEGIN
 
 # Transaction will force a read hold on this index.
-query T rowsort
-SELECT * FROM mz_internal.mz_arrangement_batches_internal_2;
+query TT rowsort
+SELECT * FROM mz_internal.mz_arrangement_batches_internal_4;
 ----
 
 statement ok

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -19,7 +19,7 @@ mode cockroach
 # this automatically. If the new source does not use per replica data,
 # increment the counter.
 query T rowsort
-SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1') - (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name LIKE '%_1');
+SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name LIKE '%_1');
 ----
 1
 
@@ -28,22 +28,22 @@ SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1') - 
 # sources: also add it in a per replica postfixed way, see DEFAULT_LOG_VIEWS.
 # If your view does not involve introspection data, increment this counter.
 query T rowsort
-SELECT (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name NOT LIKE '%_1') - (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name LIKE '%_1');
+SELECT (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name LIKE '%_1');
 ----
 27
 
 
-# The default cluster also has log sources, thus we should have one set active at boot.
+# The default and system clusters also have log sources, thus we should have 3 set active at boot.
 # Check the presence of one source and one view
 query T rowsort
 select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-1
+3
 
 query T rowsort
 select COUNT(*) from mz_catalog.mz_views WHERE name LIKE 'mz_compute_frontiers_%';
 ----
-1
+3
 
 statement ok
 CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '2'));
@@ -51,12 +51,12 @@ CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '2'));
 query T rowsort
 select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-3
+5
 
 query T rowsort
 select COUNT(*) from mz_catalog.mz_views WHERE name LIKE 'mz_compute_frontiers_%';
 ----
-3
+5
 
 statement ok
 DROP CLUSTER REPLICA c1.r1;
@@ -64,12 +64,12 @@ DROP CLUSTER REPLICA c1.r1;
 query T rowsort
 select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-2
+4
 
 query T rowsort
 select COUNT(*) from mz_catalog.mz_views WHERE name LIKE 'mz_compute_frontiers_%';
 ----
-2
+4
 
 statement ok
 DROP CLUSTER c1;
@@ -77,9 +77,9 @@ DROP CLUSTER c1;
 query T rowsort
 select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-1
+3
 
 query T rowsort
 select COUNT(*) from mz_catalog.mz_views WHERE name LIKE 'mz_compute_frontiers_%';
 ----
-1
+3

--- a/test/sqllogictest/cluster_log_sinks.slt
+++ b/test/sqllogictest/cluster_log_sinks.slt
@@ -74,7 +74,7 @@
 ### query T
 ### SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ### ----
-### 1
+### 3
 ### """)
 ###
 ### print(stmt_ok("CREATE CLUSTER c1 REPLICAS (r (SIZE '1'))"))
@@ -82,7 +82,7 @@
 ### query T
 ### SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ### ----
-### 2
+### 4
 ### """)
 ### print(stmt_ok("CREATE TABLE t1(f1 int, f2 int)"))
 ### print(stmt_ok("INSERT INTO t1 VALUES (1,1),(2,3),(4,5)"))
@@ -91,26 +91,26 @@
 ###
 ### print(stmt_ok("SET CLUSTER TO c1"))
 ### print(stmt_ok("CREATE MATERIALIZED VIEW ma2 AS SELECT COUNT(*) FROM t1"))
-### print(equal("2"))
+### print(equal("4"))
 ###
 ### print(stmt_ok("CREATE CLUSTER c2 REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'))"))
 ### print("""
 ### query T
 ### SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ### ----
-### 4
+### 6
 ### """)
 ###
 ### print(stmt_ok("set cluster = c2"))
 ### print(stmt_ok("set cluster_replica = r1"))
-### print(equal("3"))
+### print(equal("5"))
 
 
 # Check that no log source has been created initially
 query T
 SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-1
+3
 
 statement ok
 CREATE CLUSTER c1 REPLICAS (r (SIZE '1'));
@@ -120,7 +120,7 @@ CREATE CLUSTER c1 REPLICAS (r (SIZE '1'));
 query T
 SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-2
+4
 
 statement ok
 CREATE TABLE t1(f1 int, f2 int);
@@ -432,291 +432,291 @@ CREATE MATERIALIZED VIEW ma2 AS SELECT COUNT(*) FROM t1;
 
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_4) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_2));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_4));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_2) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_4) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_2));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_4));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_2) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_4) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_4) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports_2) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports_4) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies_4) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks_2) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks_4) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations_2) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations_4) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_2) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_4) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_4) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays_2) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays_4) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays_4) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers_4) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_4) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_4) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_4) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_4) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_4) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_2));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_4));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_2) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_4) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers_4) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers_4) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_2) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_4) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_2) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_4) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_2) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_4) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_2) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_4) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_4) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_2) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_4) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_4));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_4) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
 ----
 
 
@@ -728,7 +728,7 @@ CREATE CLUSTER c2 REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'));
 query T
 SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_active_peeks_%';
 ----
-4
+6
 
 statement ok
 set cluster = c2;
@@ -739,289 +739,289 @@ set cluster_replica = r1;
 
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_5) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_3));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_5));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_3) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_5) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_3));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_5));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_3) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_5) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_5) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports_3) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_exports_5) EXCEPT (SELECT * FROM mz_internal.mz_compute_exports));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_dependencies_5) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_dependencies));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks_3) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_active_peeks_5) EXCEPT (SELECT * FROM mz_internal.mz_active_peeks));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations_3) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_peek_durations_5) EXCEPT (SELECT * FROM mz_internal.mz_raw_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_3) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_5) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_5) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays_3) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_worker_compute_delays_5) EXCEPT (SELECT * FROM mz_internal.mz_raw_worker_compute_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_delays_5) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_frontiers_5) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_compute_import_frontiers_5) EXCEPT (SELECT * FROM mz_internal.mz_worker_compute_import_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_5) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_5) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_5) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_5) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_3));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_5));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_3) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_5) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_frontiers_5) EXCEPT (SELECT * FROM mz_internal.mz_compute_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_compute_import_frontiers_5) EXCEPT (SELECT * FROM mz_internal.mz_compute_import_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_3) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_5) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_3) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_5) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_3) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_5) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_3) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_5) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_5) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_3) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_raw_compute_operator_durations_5) EXCEPT (SELECT * FROM mz_internal.mz_raw_compute_operator_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_5));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_5) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
 ----

--- a/test/sqllogictest/id_reuse.slt
+++ b/test/sqllogictest/id_reuse.slt
@@ -87,11 +87,13 @@ u3 bar
 statement ok
 CREATE CLUSTER foo REPLICAS (r1 (size '1'))
 
-query IT rowsort
+query TT rowsort
 SELECT id, name FROM mz_clusters
 ----
-1 default
-2 foo
+s1 mz_system
+s2 mz_introspection
+u1 default
+u2 foo
 
 statement ok
 DROP CLUSTER foo CASCADE
@@ -99,8 +101,10 @@ DROP CLUSTER foo CASCADE
 statement ok
 CREATE CLUSTER bar REPLICAS (r1 (size '1'))
 
-query IT rowsort
+query TT rowsort
 SELECT id, name FROM mz_clusters
 ----
-1 default
-3 bar
+s1 mz_system
+s2 mz_introspection
+u1 default
+u3 bar

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -500,43 +500,81 @@ name                                           type   size
 ------------------------------------------------------------
 mz_arrangement_batches_internal                 log   <null>
 mz_arrangement_batches_internal_1               log   <null>
+mz_arrangement_batches_internal_2               log   <null>
+mz_arrangement_batches_internal_3               log   <null>
 mz_arrangement_records_internal                 log   <null>
 mz_arrangement_records_internal_1               log   <null>
+mz_arrangement_records_internal_2               log   <null>
+mz_arrangement_records_internal_3               log   <null>
 mz_arrangement_sharing_internal                 log   <null>
 mz_arrangement_sharing_internal_1               log   <null>
+mz_arrangement_sharing_internal_2               log   <null>
+mz_arrangement_sharing_internal_3               log   <null>
 mz_dataflow_channels                            log   <null>
 mz_dataflow_channels_1                          log   <null>
+mz_dataflow_channels_2                          log   <null>
+mz_dataflow_channels_3                          log   <null>
 mz_dataflow_addresses                           log   <null>
 mz_dataflow_addresses_1                         log   <null>
+mz_dataflow_addresses_2                         log   <null>
+mz_dataflow_addresses_3                         log   <null>
 mz_dataflow_operator_reachability_internal      log   <null>
 mz_dataflow_operator_reachability_internal_1    log   <null>
+mz_dataflow_operator_reachability_internal_2    log   <null>
+mz_dataflow_operator_reachability_internal_3    log   <null>
 mz_dataflow_operators                           log   <null>
 mz_dataflow_operators_1                         log   <null>
+mz_dataflow_operators_2                         log   <null>
+mz_dataflow_operators_3                         log   <null>
 mz_worker_compute_dependencies                  log   <null>
 mz_worker_compute_dependencies_1                log   <null>
+mz_worker_compute_dependencies_2                log   <null>
+mz_worker_compute_dependencies_3                log   <null>
 mz_compute_exports                              log   <null>
 mz_compute_exports_1                            log   <null>
+mz_compute_exports_2                            log   <null>
+mz_compute_exports_3                            log   <null>
 mz_message_counts_received_internal             log   <null>
 mz_message_counts_received_internal_1           log   <null>
+mz_message_counts_received_internal_2           log   <null>
+mz_message_counts_received_internal_3           log   <null>
 mz_message_counts_sent_internal                 log   <null>
 mz_message_counts_sent_internal_1               log   <null>
+mz_message_counts_sent_internal_2               log   <null>
+mz_message_counts_sent_internal_3               log   <null>
 mz_raw_peek_durations                           log   <null>
 mz_raw_peek_durations_1                         log   <null>
+mz_raw_peek_durations_2                         log   <null>
+mz_raw_peek_durations_3                         log   <null>
 mz_raw_worker_compute_delays                    log   <null>
 mz_raw_worker_compute_delays_1                  log   <null>
+mz_raw_worker_compute_delays_2                  log   <null>
+mz_raw_worker_compute_delays_3                  log   <null>
 mz_active_peeks                                 log   <null>
 mz_active_peeks_1                               log   <null>
+mz_active_peeks_2                               log   <null>
+mz_active_peeks_3                               log   <null>
 mz_scheduling_elapsed_internal                  log   <null>
 mz_scheduling_elapsed_internal_1                log   <null>
+mz_scheduling_elapsed_internal_2                log   <null>
+mz_scheduling_elapsed_internal_3                log   <null>
 mz_raw_compute_operator_durations_internal      log   <null>
 mz_raw_compute_operator_durations_internal_1    log   <null>
+mz_raw_compute_operator_durations_internal_2    log   <null>
+mz_raw_compute_operator_durations_internal_3    log   <null>
 mz_scheduling_parks_internal                    log   <null>
 mz_scheduling_parks_internal_1                  log   <null>
+mz_scheduling_parks_internal_2                  log   <null>
+mz_scheduling_parks_internal_3                  log   <null>
 mz_storage_shards                               source <null>
 mz_worker_compute_frontiers                     log   <null>
 mz_worker_compute_frontiers_1                   log   <null>
+mz_worker_compute_frontiers_2                   log   <null>
+mz_worker_compute_frontiers_3                   log   <null>
 mz_worker_compute_import_frontiers              log   <null>
 mz_worker_compute_import_frontiers_1            log   <null>
+mz_worker_compute_import_frontiers_2            log   <null>
+mz_worker_compute_import_frontiers_3            log   <null>
 
 > SHOW TABLES FROM mz_internal
 name
@@ -552,38 +590,72 @@ name
 -------------------------------------
 mz_arrangement_sharing
 mz_arrangement_sharing_1
+mz_arrangement_sharing_2
+mz_arrangement_sharing_3
 mz_arrangement_sizes
 mz_arrangement_sizes_1
+mz_arrangement_sizes_2
+mz_arrangement_sizes_3
 mz_dataflows
 mz_dataflows_1
+mz_dataflows_2
+mz_dataflows_3
 mz_dataflow_operator_dataflows
 mz_dataflow_operator_dataflows_1
+mz_dataflow_operator_dataflows_2
+mz_dataflow_operator_dataflows_3
 mz_dataflow_operator_reachability
 mz_dataflow_operator_reachability_1
+mz_dataflow_operator_reachability_2
+mz_dataflow_operator_reachability_3
 mz_compute_frontiers
 mz_compute_frontiers_1
+mz_compute_frontiers_2
+mz_compute_frontiers_3
 mz_compute_import_frontiers
 mz_compute_import_frontiers_1
+mz_compute_import_frontiers_2
+mz_compute_import_frontiers_3
 mz_compute_operator_durations
 mz_compute_operator_durations_1
+mz_compute_operator_durations_2
+mz_compute_operator_durations_3
 mz_message_counts
 mz_message_counts_1
+mz_message_counts_2
+mz_message_counts_3
 mz_peek_durations
 mz_peek_durations_1
+mz_peek_durations_2
+mz_peek_durations_3
 mz_raw_compute_operator_durations
 mz_raw_compute_operator_durations_1
+mz_raw_compute_operator_durations_2
+mz_raw_compute_operator_durations_3
 mz_records_per_dataflow
 mz_records_per_dataflow_1
+mz_records_per_dataflow_2
+mz_records_per_dataflow_3
 mz_records_per_dataflow_global
 mz_records_per_dataflow_global_1
+mz_records_per_dataflow_global_2
+mz_records_per_dataflow_global_3
 mz_records_per_dataflow_operator
 mz_records_per_dataflow_operator_1
+mz_records_per_dataflow_operator_2
+mz_records_per_dataflow_operator_3
 mz_scheduling_elapsed
 mz_scheduling_elapsed_1
+mz_scheduling_elapsed_2
+mz_scheduling_elapsed_3
 mz_scheduling_parks
 mz_scheduling_parks_1
+mz_scheduling_parks_2
+mz_scheduling_parks_3
 mz_worker_compute_delays
 mz_worker_compute_delays_1
+mz_worker_compute_delays_2
+mz_worker_compute_delays_3
 
 > CREATE SCHEMA tester
 
@@ -600,7 +672,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-19
+57
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2


### PR DESCRIPTION
This commit adds the feature of system compute instances. Compute
instance IDs are now partitioned into two namespaces, User and System,
depending on what type of compute instance it is. We can now add
builtin compute instances and builtin compute instance replicas that
will be automatically added to the deployment on the next version
upgrade. The implementation is very similar to roles.

System compute instances will be used for system tasks such as
collecting billing information and serving simple common introspection
queries. Users will not be able to create anything in the system
compute instances or drop them.

Some parts of the role implementation was changed so that it would more
closely match the compute instance implementation.

### Motivation
This PR adds a feature that has not yet been specified. See https://www.notion.so/materialize/System-clusters-26b20f5ecb93457a8164f1bd59650f91

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds system clusters
