### PR TITLE
sql: refactor load gen ast -> storage calls

### DIFF
--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -34,7 +34,7 @@ use crate::plan::query;
 use crate::plan::{Params, Plan, PlanContext, PlanKind};
 use crate::{normalize, DEFAULT_SCHEMA};
 
-mod ddl;
+pub(crate) mod ddl;
 mod dml;
 mod raise;
 mod scl;


### PR DESCRIPTION
Only convert from the load gen ast to load gen storage enum in a single falliable function. This is needed by the upcoming TPCH load gen which must be allowed to fail on invalid scale factor which has to happen when converting from AST nodes, because afterward we don't have an error path.

Change the generator schema to be the string version of the ast node, future proofing it against new load generators.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

    * The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a