### PR TITLE
Remove some sketchy source error variants

### DIFF
--- a/doc/developer/platform/architecture-storage.md
+++ b/doc/developer/platform/architecture-storage.md
@@ -117,7 +117,7 @@ There may be other auxiliary information, like the reclocking collection, that f
 We want source ingestion to satisfy at least these three properties:
 
 1. Definiteness: this property is provided by `persist`.
-2. "Fault tolerance": The source pipeline should produce equivalent `persist` output when run when run with arbitrary unclean shutdowns and restarts, and arbitrary concurrent instances, as when it is run uninterrupted".
+2. "Fault tolerance": The source pipeline should produce equivalent `persist` output when run when run with arbitrary unclean shutdowns and restarts, and arbitrary concurrent instances, as when it is run uninterrupted.
 3. "Bounded input reliance": the raw input data we have to keep around to provide these properties should be as limited as possible.
 
 ## A recipe for source ingestion

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -61,8 +61,7 @@ enum SourceType<Delimited, ByteStream, RowSource> {
 /// alive as long as it is not dropped.
 ///
 /// This function is intended to implement the recipe described here:
-/// <https://github.com/MaterializeInc/materialize/pull/12109>
-// TODO(guswynn): Link to merged document
+/// <https://github.com/MaterializeInc/materialize/blob/main/doc/developer/platform/architecture-storage.md#source-ingestion>
 pub fn render_source<G>(
     scope: &mut G,
     dataflow_debug_name: &String,

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -157,7 +157,7 @@ impl Healthchecker {
                         }
                     }
                     Ok(Err(invalid_use)) => panic!("compare_and_append failed: {invalid_use}"),
-                    // An external error means that the operation might have suceeded or failed but we
+                    // An external error means that the operation might have succeeded or failed but we
                     // don't know. In either case it is safe to retry because:
                     // * If it succeeded, then on retry we'll get an `Upper(_)` error as if some other
                     //   process raced us. This is safe and will just cause the healthchecker to sync

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -436,7 +436,7 @@ async fn postgres_replication_loop_inner(
             }
             Err(ReplicationError::Fatal(e)) => {
                 return Err(SourceReaderError {
-                    inner: SourceErrorDetails::FileIO(e.to_string()),
+                    inner: SourceErrorDetails::Other(e.to_string()),
                 })
             }
             Ok(_) => {

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -440,7 +440,7 @@ async fn postgres_replication_loop_inner(
                 })
             }
             Ok(_) => {
-                // shutdown iniated elsewhere
+                // shutdown initiated elsewhere
                 return Ok(());
             }
         }

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -116,10 +116,10 @@ pub struct RawSourceCreationConfig {
 }
 
 /// A batch of messages from a source reader, along with the current upper and
-/// any errors that occured while reading that batch.
+/// any errors that occurred while reading that batch.
 struct SourceMessageBatch<Key, Value, Diff> {
     messages: HashMap<PartitionId, Vec<(SourceMessage<Key, Value, Diff>, MzOffset)>>,
-    /// Any errors that occured while obtaining this batch. TODO: These
+    /// Any errors that occurred while obtaining this batch. TODO: These
     /// non-definite errors should not show up in the dataflows/the persist
     /// shard but it's the current "correct" behaviour. We need to fix this as a
     /// follow-up issue because it's a bigger thing that breaks with the current

--- a/src/storage/src/types/errors.proto
+++ b/src/storage/src/types/errors.proto
@@ -29,8 +29,8 @@ message ProtoDecodeErrorKind {
 message ProtoSourceErrorDetails {
     oneof kind {
         string initialization = 1;
-        string file_io = 2;
-        string persistence = 3;
+        string deprecated_file_io = 2;
+        string deprecated_persistence = 3;
         string other = 4;
     }
 }

--- a/src/storage/src/types/errors.rs
+++ b/src/storage/src/types/errors.rs
@@ -21,6 +21,8 @@ use mz_repr::{GlobalId, Row};
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage.types.errors.rs"));
 
+/// The underlying data was not decodable in the format we expected: eg.
+/// invalid JSON or Avro data that doesn't match a schema.
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct DecodeError {
     pub kind: DecodeErrorKind,
@@ -254,6 +256,8 @@ impl Display for UpsertError {
     }
 }
 
+/// Source-wide durable errors; for example, a replication log being meaningless or corrupted.
+/// This should _not_ include transient source errors, like connection issues or misconfigurations.
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct SourceError {
     pub source_id: GlobalId,
@@ -345,6 +349,8 @@ impl Display for SourceErrorDetails {
     }
 }
 
+/// An error that's destined to be presented to the user in a differential dataflow collection.
+/// For example, a divide by zero will be visible in the error collection for a particular row.
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, Deserialize, Serialize, PartialEq, Hash)]
 pub enum DataflowError {
     DecodeError(DecodeError),


### PR DESCRIPTION
We've decided that we're going to keep having source errors for a while, but these variants will always be a bad idea. (They describe categories of errors that are ~transient by definition.) Let's clear things out.

### Motivation

Known-desirable improvement: #15061.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
