### PR TITLE
doc/user: add `https://` prepend to CSR connection examples

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -101,7 +101,7 @@ CREATE SECRET csr_password AS '<CSR_PASSWORD>';
 
 CREATE CONNECTION csr_ssl
   FOR CONFLUENT SCHEMA REGISTRY
-    URL 'rp-f00000bar.data.vectorized.cloud:30993',
+    URL 'https://rp-f00000bar.data.vectorized.cloud:30993',
     SSL KEY = SECRET csr_ssl_key,
     SSL CERTIFICATE = SECRET csr_ssl_crt,
     USERNAME = 'foo',

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -307,7 +307,7 @@ CREATE SECRET csr_password AS '<CSR_PASSWORD>';
 
 CREATE CONNECTION csr_ssl
   FOR CONFLUENT SCHEMA REGISTRY
-    URL 'rp-f00000bar.data.vectorized.cloud:30993',
+    URL 'https://rp-f00000bar.data.vectorized.cloud:30993',
     SSL KEY = SECRET csr_ssl_key,
     SSL CERTIFICATE = SECRET csr_ssl_crt,
     USERNAME = 'foo',


### PR DESCRIPTION
Confluent Schema Registry connections require that the URL is prepended with the `http://` bit, which isn't straightforward from the documentation. 

Reported in [this Slack thread](https://materializeinc.slack.com/archives/C02LJ9EJP9S/p1665431089458329?thread_ts=1665430661.824689&cid=C02LJ9EJP9S).