### PR TITLE
testdrive: Make sure 'default_replica' always exists

### DIFF
--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -9,9 +9,6 @@
 
 # Test support for Avro sources without using the Confluent Schema Registry.
 
-$ skip-if
-SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
-
 $ set schema=[
   {
     "type": "array",

--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -9,9 +9,12 @@
 
 # Regression test for https://github.com/MaterializeInc/materialize/issues/13790
 
-# The contents of the introspection tables depend on the replica size and number of replicas
+# The contents of the introspection tables depend on the replica size
 $ skip-if
-SELECT ${arg.replica-size} > 1 OR ${arg.replicas} > 1;
+SELECT ${arg.replica-size} > 1
+
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
 
 > CREATE TABLE t (a int)
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -15,9 +15,12 @@
 # Note that we count on the retry behavior of testdrive in this test
 # since introspection sources may take some time to catch up.
 
-# The contents of the introspection tables depend on the replica size and number of replicas
+# The contents of the introspection tables depend on the replica size
 $ skip-if
-SELECT ${arg.replica-size} > 1 OR ${arg.replicas} > 1;
+SELECT ${arg.replica-size} > 1
+
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
 
 > CREATE TABLE t (a int)
 

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -10,9 +10,8 @@
 # This test only verifies that the log relations are published, not that they
 # have any specific output.
 
-# log sources require a single replica
-$ skip-if
-SELECT ${arg.replicas} > 1
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
 
 $ set-regex match=s\d+ replacement=SID
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -85,9 +85,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if args.replicas > 1 or args.replica_size > 1:
             c.sql("DROP CLUSTER default CASCADE")
+            # Make sure a replica named 'default_replica' always exists
+            replica_names = [
+                "default_replica" if replica_id == 0 else f"replica{replica_id}"
+                for replica_id in range(0, args.replicas)
+            ]
             replica_string = ",".join(
-                f"replica{r} (SIZE '{args.replica_size}')"
-                for r in range(0, args.replicas)
+                f"{replica_name} (SIZE '{args.replica_size}')"
+                for replica_name in replica_names
             )
             c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})")
 

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -44,9 +44,8 @@ count
 # threshold since the actual number of messages sent depends on the number of
 # workers.
 
-# log sources require a single replica
-$ skip-if
-SELECT ${arg.replicas} > 1
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
 
 > SELECT
     sum(sent) as sent

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -153,9 +153,8 @@ $ kafka-ingest format=avro topic=data partition=15 schema=${schema}
 
 # Make sure that none of the 'EXCEPT ALL' views above has ever produced any records.
 
-# log sources require a single replica
-$ skip-if
-SELECT ${arg.replicas} > 1
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
 
 > SELECT COUNT(*) FROM mz_internal.mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
 0

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -114,9 +114,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 # rather than e.g. blocking forever, or producing an error about being
 # unable to select a timestamp.
 
-# log sources require a single replica
-$ skip-if
-SELECT ${arg.replicas} > 1
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
 
 > SELECT * FROM t CROSS JOIN mz_internal.mz_dataflow_operators LIMIT 0
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -157,6 +157,9 @@ contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW values_cdcv2_view AS SELECT * FROM input_values_view, source_cdcv2;
 > CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM mz_relations, input_values_view, mz_views;
 
+# In case the environment has other replicas
+> SET cluster_replica = default_replica
+
 > SELECT count(*) FROM (SELECT count(*) FROM input_values_view, mz_internal.mz_dataflow_operators);
 1
 


### PR DESCRIPTION
- Make sure 'default_replica' always exists even if we are running with --replicas > 1
- Use SET cluster_replica = default_replicas for tests that must be run in the context of a particular replica
### Motivation

  * This PR fixes a previously unreported bug.

The Nightly "4 replicas" CI job was failing because some tests required a default_replica to run properly.