### PR TITLE
storage: in sources, track max-seen-offset and offset frontier separately

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -89,7 +89,12 @@ pub fn render<G>(
             // to. Data from the source not beyond this time will be dropped, as it has already
             // been persisted.
             // In the future, sources will avoid passing through data not beyond this upper
-            *current_upper.borrow_mut() = write.upper().clone();
+            if active_write_worker {
+                // VERY IMPORTANT: Only the active write worker must change the
+                // shared upper. All other workers have already cleared this
+                // upper above.
+                current_upper.borrow_mut().clone_from(write.upper());
+            }
 
             while scheduler.notified().await {
                 let input_upper = frontiers.borrow()[0].clone();

--- a/src/storage/src/source/antichain.rs
+++ b/src/storage/src/source/antichain.rs
@@ -74,11 +74,8 @@ impl OffsetAntichain {
 
     // Data apis
 
-    /// Advance the frontier represented by this `OffsetAntichain` for `pid`
-    /// to a value that contains `offset`.
-    pub fn insert_data_up_to(&mut self, pid: PartitionId, offset: MzOffset) {
-        *self.inner.entry(pid).or_default() = offset + 1;
-    }
+    // TODO(aljoscha): These "data" APIs might be more confusing than they are
+    // worth.
 
     /// Produce offsets for all partitions in this `OffsetAntichain` that
     /// were at one point given by `insert_data_up_to`.

--- a/src/storage/src/source/antichain.rs
+++ b/src/storage/src/source/antichain.rs
@@ -106,6 +106,16 @@ impl OffsetAntichain {
     pub fn insert(&mut self, pid: PartitionId, m: MzOffset) -> Option<MzOffset> {
         self.inner.insert(pid, m)
     }
+
+    /// Insert a new `MzOffset` frontier value for `pid` if it is larger than
+    /// the previously stored value.
+    pub fn maybe_insert(&mut self, pid: PartitionId, offset: MzOffset) {
+        self.inner
+            .entry(pid)
+            .and_modify(|prev| *prev = std::cmp::max(*prev, offset))
+            .or_insert(offset);
+    }
+
     /// The same as `insert`, but for many values.
     pub fn extend<T: IntoIterator<Item = (PartitionId, MzOffset)>>(&mut self, iter: T) {
         self.inner.extend(iter)

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1252,8 +1252,10 @@ where
                 if !cap_set.is_empty() {
                     trace!(
                         "reclock({id}) {worker_id}/{worker_count}: \
-                        downgrading to {:?}",
-                        new_ts_upper
+                        downgrading to {:?} \
+                        global_source_upper {:?}",
+                        new_ts_upper,
+                        global_source_upper
                     );
 
                     cap_set

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -115,8 +115,8 @@ pub struct RawSourceCreationConfig {
     pub persist_clients: Arc<Mutex<PersistClientCache>>,
 }
 
-/// A batch of messages from a source reader, along with the current upper and
-/// any errors that occurred while reading that batch.
+/// A batch of messages from a source reader, along with the batch upper, the
+/// current source upper, and any errors that occurred while reading that batch.
 struct SourceMessageBatch<Key, Value, Diff> {
     messages: HashMap<PartitionId, Vec<(SourceMessage<Key, Value, Diff>, MzOffset)>>,
     /// Any errors that occurred while obtaining this batch. TODO: These
@@ -126,17 +126,19 @@ struct SourceMessageBatch<Key, Value, Diff> {
     /// behaviour.
     non_definite_errors: Vec<SourceError>,
     /// The current upper of the `SourceReader`, at the time this batch was
-    /// emitted. Source uppers of emitted batches must never regress.
+    /// emitted. Source uppers emitted via batches must never regress.
     source_upper: OffsetAntichain,
+    /// The timestamp/offset upper of messages contained in _this_ batch.
+    batch_upper: OffsetAntichain,
 }
 
-/// The source upper at the time of emitting a batch. This contains only the
-/// partitions that a given source reader operator is responsible for, so a
+/// The batch upper of the most recently emitted batch batch. This contains only
+/// the partitions that a given source reader operator is responsible for, so a
 /// downstream consumer needs summaries of all source reader operators in order
 /// to form a full view of the upper.
 #[derive(Clone, Serialize, Deserialize)]
-struct SourceUpperSummary {
-    source_upper: OffsetAntichain,
+struct BatchUpperSummary {
+    batch_upper: OffsetAntichain,
 }
 
 /// Creates a source dataflow operator graph from a connection that has a
@@ -176,7 +178,7 @@ where
         ReclockFollower::new(as_of)
     };
 
-    let ((batches, source_upper_summaries, resumption_feedback_stream), source_reader_token) =
+    let ((batches, batch_upper_summaries, resumption_feedback_stream), source_reader_token) =
         source_reader_operator::<G, S>(
             scope,
             config.clone(),
@@ -187,12 +189,8 @@ where
         );
     resumption_feedback_stream.connect_loop(source_reader_feedback_handle);
 
-    let (remap_stream, remap_token) = remap_operator::<G, S>(
-        scope,
-        config.clone(),
-        source_upper_summaries,
-        &resume_stream,
-    );
+    let (remap_stream, remap_token) =
+        remap_operator::<G, S>(scope, config.clone(), batch_upper_summaries, &resume_stream);
 
     let ((reclocked_stream, reclocked_err_stream), _reclock_token) =
         reclock_operator::<G, S>(scope, config, reclock_follower, batches, remap_stream);
@@ -224,10 +222,8 @@ struct SourceReaderOperatorOutput<S: SourceReader> {
     unconsumed_partitions: Vec<PartitionId>,
     /// See `SourceMessageBatch`.
     source_upper: OffsetAntichain,
-    /// Marks whether or not this batch contains
-    /// a `Finalized` message, or if its empty.
-    /// Used to downgrade the `batch_counter` frontier.
-    is_final: bool,
+    /// See `SourceMessageBatch`.
+    batch_upper: OffsetAntichain,
 }
 
 fn build_source_reader_stream<G, S>(
@@ -287,6 +283,11 @@ where
             None
         };
 
+        // Most recent batch upper frontier, does not regress.
+        // TODO(aljoscha): We track this as we go, but we could also derive it
+        // by iterating over all messages in a batch when we emit it.
+        let mut batch_upper = OffsetAntichain::new();
+
         // Send along an empty batch, so that the reclock operator knows
         // about the current frontier. Otherwise, if there are no new
         // messages after a restart, the reclock operator would be stuck and
@@ -296,7 +297,7 @@ where
             non_definite_errors: Vec::new(),
             unconsumed_partitions: Vec::new(),
             source_upper: initial_source_upper,
-            is_final: true,
+            batch_upper: batch_upper.clone(),
         });
 
         let source_stream = source_reader.into_stream(timestamp_interval).fuse();
@@ -312,8 +313,6 @@ where
         let mut untimestamped_messages = HashMap::<_, Vec<_>>::new();
         let mut unconsumed_partitions = Vec::new();
         let mut non_definite_errors = vec![];
-        // `None` is the default value, reset after we have sent a `Finalized` batch.
-        let mut is_final = None;
         loop {
             // TODO(guswyn): move lots of this out of the macro so rustfmt works better
             tokio::select! {
@@ -330,12 +329,8 @@ where
                             //    `InProgress` messages NEVER produces
                             //    messages at offsets below the most recent
                             //    `Finalized` message.
-                            if matches!(message, SourceMessageType::Finalized(_)) {
-                                is_final = Some(true);
-                            }
-                            if matches!(message, SourceMessageType::InProgress(_)) {
-                                is_final = Some(false);
-                            }
+                            let is_final = matches!(message, SourceMessageType::Finalized(_));
+
                             match message {
                                 SourceMessageType::DropPartitionCapabilities(mut pids) => {
                                     unconsumed_partitions.append(&mut pids);
@@ -343,13 +338,28 @@ where
                                 SourceMessageType::Finalized(message) | SourceMessageType::InProgress(message) => {
                                     let pid = message.partition.clone();
                                     let offset = message.offset;
-                                    // advance the _offset_ frontier if this the final message for that offset
+                                    // Advance the _overall_ frontier of the
+                                    // source if this the final message for that
+                                    // offset. We know that we won't see more
+                                    // messages of this offset so the frontier
+                                    // is now "that offset + 1".
+                                    if is_final {
+                                        source_upper.insert(pid.clone(), offset + 1);
+                                    }
+
+                                    // Always update our latest-offset tracking.
                                     //
-                                    // TODO(guswynn): when we remove this, we can simplify some of
-                                    // the code in the reclock operator (probably), but using
-                                    // subtraction/addition on the upper we pass through.
-                                    if let Some(true) = is_final {
-                                        source_upper.insert_data_up_to(pid.clone(), offset);
+                                    // We convert the "max seen offset" to a
+                                    // frontier, assuming that the frontier is
+                                    // always `1` beyond the max seen timestamp.
+                                    // We do this because the reclock operator
+                                    // "thinks" in terms of (timely-style)
+                                    // frontiers and not maximum seen
+                                    // timestamps.
+                                    let offset_frontier = offset + 1;
+                                    let prev_offset = batch_upper.insert(pid.clone(), offset_frontier);
+                                    if let Some(prev_offset) = prev_offset {
+                                        assert!(offset_frontier >= prev_offset, "offset regressed");
                                     }
                                     untimestamped_messages.entry(pid).or_default().push((message, offset));
                                 }
@@ -373,7 +383,7 @@ where
                                     non_definite_errors: non_definite_errors.drain(..).collect_vec(),
                                     unconsumed_partitions,
                                     source_upper: source_upper.clone(),
-                                    is_final: true
+                                    batch_upper: batch_upper.clone(),
                                 }
                             );
 
@@ -392,10 +402,12 @@ where
                               emitting new batch. \
                               untimestamped_messages.len(): {} \
                               unconsumed_partitions: {:?} \
-                              source_upper: {:?}",
+                              source_upper: {:?} \
+                              batch_upper: {:?}",
                               untimestamped_messages.len(),
                               unconsumed_partitions.clone(),
-                              source_upper);
+                              source_upper,
+                              batch_upper);
                     }
 
                     // Emit empty batches as well. Just to keep downstream
@@ -407,18 +419,9 @@ where
                             non_definite_errors: non_definite_errors.drain(..).collect_vec(),
                             unconsumed_partitions: unconsumed_partitions.clone(),
                             source_upper: source_upper.clone(),
-                            // Consider empty batches that do not fall in the middle of
-                            // InProgress and Finalized messages to be final.
-                            is_final: is_final.unwrap_or(true),
+                            batch_upper: batch_upper.clone(),
                         }
                     );
-                    if let Some(true) = is_final {
-                        // reset is_final so empty batches between sets of messages with
-                        // the same offset can be considered final.
-                        is_final = None;
-                    } else {
-                        is_final = Some(false);
-                    }
                 }
             }
         }
@@ -445,7 +448,7 @@ fn source_reader_operator<G, S: 'static>(
             G,
             Rc<RefCell<Option<SourceMessageBatch<S::Key, S::Value, S::Diff>>>>,
         >,
-        timely::dataflow::Stream<G, SourceUpperSummary>,
+        timely::dataflow::Stream<G, BatchUpperSummary>,
         timely::dataflow::Stream<G, ()>,
     ),
     Option<AsyncSourceToken>,
@@ -616,7 +619,7 @@ where
                         non_definite_errors,
                         unconsumed_partitions,
                         source_upper,
-                        is_final,
+                        batch_upper,
                     } = match update {
                         Some(update) => update,
                         None => {
@@ -640,8 +643,8 @@ where
 
                     // We forward only the partitions that we are responsible for to
                     // the remap operator.
-                    let source_upper_summary = SourceUpperSummary {
-                        source_upper: source_upper.clone(),
+                    let batch_upper_summary = BatchUpperSummary {
+                        batch_upper: batch_upper.clone(),
                     };
 
                     // Pull the upper to `max` for partitions that we are not
@@ -669,6 +672,7 @@ where
                         messages,
                         non_definite_errors,
                         source_upper: extended_source_upper,
+                        batch_upper: batch_upper.clone(),
                     };
                     // Wrap in an Rc to avoid cloning when sending it on.
                     let message_batch = Rc::new(RefCell::new(Some(message_batch)));
@@ -678,18 +682,17 @@ where
                         let mut output = output.activate();
                         let mut session = output.session(&cap);
 
-                        session.give((message_batch, source_upper_summary));
-                    }
-                    if is_final {
-                        trace!(
-                            "create_source_raw({id}) {worker_id}/{worker_count}: \
-                            downgrading to: {:?}",
-                            emit_ts
-                        );
-                        cap_set.downgrade(&[emit_ts]);
+                        session.give((message_batch, batch_upper_summary));
                     }
 
-                    emit_ts = Timestamp::from((*now_fn)());
+                    trace!(
+                        "create_source_raw({id}) {worker_id}/{worker_count}: \
+                        downgrading to: {:?}",
+                        emit_ts
+                    );
+                    cap_set.downgrade(&[emit_ts]);
+
+                    emit_ts = std::cmp::max(Timestamp::from((*now_fn)()), emit_ts.step_forward());
 
                     if timer.elapsed() > YIELD_INTERVAL {
                         timer = Instant::now();
@@ -746,7 +749,7 @@ where
 fn remap_operator<G, S: 'static>(
     scope: &G,
     config: RawSourceCreationConfig,
-    source_upper_summaries: timely::dataflow::Stream<G, SourceUpperSummary>,
+    batch_upper_summaries: timely::dataflow::Stream<G, BatchUpperSummary>,
     resume_stream: &timely::dataflow::Stream<G, ()>,
 ) -> (
     timely::dataflow::Stream<G, HashMap<PartitionId, Vec<(Timestamp, MzOffset)>>>,
@@ -780,7 +783,7 @@ where
     let (mut remap_output, remap_stream) = remap_op.new_output();
 
     let mut input = remap_op.new_input_connection(
-        &source_upper_summaries,
+        &batch_upper_summaries,
         Exchange::new(move |_x| chosen_worker as u64),
         // We don't want frontier information to flow from the input to the
         // output. This operator is it's own "root source" of capabilities for
@@ -911,10 +914,9 @@ where
                 input.for_each(|_cap, data| {
                     data.swap(&mut buffer);
 
-                    for source_upper_summary in buffer.drain(..) {
-                        for (pid, offset) in source_upper_summary.source_upper.iter() {
-                            let previous_offset =
-                                global_source_upper.insert(pid.clone(), offset.clone());
+                    for batch_upper_summary in buffer.drain(..) {
+                        for (pid, offset) in batch_upper_summary.batch_upper.iter() {
+                            let previous_offset = global_source_upper.insert(pid.clone(), *offset);
 
                             // TODO(guswynn&aljoscha&petrosagg): ensure this operator does not
                             // require ordered input.
@@ -1155,9 +1157,9 @@ where
                         None => {
                             trace!(
                                 "reclock({id}) {worker_id}/{worker_count}: \
-                                cannot yet reclock batch with source frontier {:?} \
+                                cannot yet reclock batch with batch_upper {:?} \
                                 reclock.source_frontier: {:?}",
-                                untimestamped_batch.source_upper,
+                                untimestamped_batch.batch_upper,
                                 timestamper.source_upper()
                             );
                             // We keep batches in the order they arrive from the

--- a/test/cluster/storaged/03-while-storaged-down.td
+++ b/test/cluster/storaged/03-while-storaged-down.td
@@ -10,6 +10,9 @@
 # Verify that the data ingested before `storaged` crashed is still present but
 # that newly ingested data does not appear.
 
+# Increased from the default because of CI flakiness.
+$ set-sql-timeout duration=180s
+
 # With storaged down, the upper of remote1 and remote2 will not advance. However, the global timestamp will advance.
 # In strict serializable mode we may select a timestamp that is ahead of on of the sources uppers and hang forever.
 > SET transaction_isolation = serializable

--- a/test/cluster/storaged/04-after-storaged-restart.td
+++ b/test/cluster/storaged/04-after-storaged-restart.td
@@ -10,6 +10,9 @@
 # Verify that the data ingested while `storaged` was down eventually appears,
 # then try ingesting new data.
 
+# Increased from the default because of CI flakiness.
+$ set-sql-timeout duration=180s
+
 > SELECT * from remote1
 one
 two


### PR DESCRIPTION
This, together with the previous commit that uses wall-clock time to
drive timestamps within the ingestion pipeline fixes a subtle bug.
Together, these two also fix the pipeline to work with multi-worker
setups again.

Before a recent change that made the ingestino pipeline multi-worker
aware, `ReclockOperator::reclock()` would always succeed, and it would
mint a binding for `max_seen_offset + 1` (that is, the upper implied
by the batch of updates that we’re seeing). The `source_upper` , which
was updated to either `offset` or `offset + 1`, depending on if the
message is a “final” message or not, was only used to drive forward the
reclocked frontier.

After this recent change, but before the changes in this commit,
`source_upper` was sent to `remap_operator`, which uses `mint()` to mint
new bindings. It took the upper as is, there was no +1 applied. The
`reclock_operator` was at the mercy of `remap_operator` to provide it
with the bindings it needs for reclocking batches of messages.
`source_upper` was also used to drive forward the frontier that in the
end will drive forward the reclock upper.

The solution, implemented in this change:
 - we track the `source_upper` and `max_seen_offset` separately (before,
   max seen timestamp was implied by the batch of messages that was
   being reclocked)
 - we send `max_seen_offset` to the `remap_operator`, we translate that
   to a "frontier" by adding `1`, which basically restores the old
   behavior and we don’t have to wait before we can reclock batches of
   messages
 - we use `source_upper` purely to track the upper, meaning we update it
   correctly based on `is_final` or not
 - we get rid of most of the complicated `is_final` logic in the source
   reader operator. We needed it because we tried to shoehorn
   `source_upper` into this dual use

Fixes https://github.com/MaterializeInc/materialize/issues/15300 (together with previous commit)

### Tips for reviewer

I decided to put the `+1` translation (from max offsets to frontier) in the `remap_operator`, but this might just as well live in `reclock.rs` itself. This seemed like the smaller diff, though.

Also, this removes the `is_final` dance, which I'm not sure anyone understands, and makes things much more straightforward.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
