### PR TITLE
ci: Add missing dependency for the checks-restart-redpanda job

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -543,6 +543,7 @@ steps:
 
   - id: checks-restart-redpanda
     label: "Checks + restart Redpanda"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64


### PR DESCRIPTION
A dependency on build-x86_64 was missing, causing the checks-restart-redpanda job to needlessly compile everything from scratch.


### Motivation
  * This PR fixes a previously unreported bug.


The checks-restart-redpanda job was recompiling the containers from scratch