### PR TITLE
test: Fix merge skew with defualt replica

### DIFF
--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -14,7 +14,7 @@ $ skip-if
 SELECT ${arg.replica-size} > 1
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 > CREATE TABLE t (a int)
 

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -20,7 +20,7 @@ $ skip-if
 SELECT ${arg.replica-size} > 1
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 > CREATE TABLE t (a int)
 

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -11,7 +11,7 @@
 # have any specific output.
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 $ set-regex match=s\d+ replacement=SID
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -85,9 +85,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if args.replicas > 1 or args.replica_size > 1:
             c.sql("DROP CLUSTER default CASCADE")
-            # Make sure a replica named 'default_replica' always exists
+            # Make sure a replica named 'r1' always exists
             replica_names = [
-                "default_replica" if replica_id == 0 else f"replica{replica_id}"
+                "r1" if replica_id == 0 else f"replica{replica_id}"
                 for replica_id in range(0, args.replicas)
             ]
             replica_string = ",".join(

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -45,7 +45,7 @@ count
 # workers.
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 > SELECT
     sum(sent) as sent

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -154,7 +154,7 @@ $ kafka-ingest format=avro topic=data partition=15 schema=${schema}
 # Make sure that none of the 'EXCEPT ALL' views above has ever produced any records.
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 > SELECT COUNT(*) FROM mz_internal.mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
 0

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -115,7 +115,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 # unable to select a timestamp.
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 > SELECT * FROM t CROSS JOIN mz_internal.mz_dataflow_operators LIMIT 0
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -158,7 +158,7 @@ contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM mz_relations, input_values_view, mz_views;
 
 # In case the environment has other replicas
-> SET cluster_replica = default_replica
+> SET cluster_replica = r1
 
 > SELECT count(*) FROM (SELECT count(*) FROM input_values_view, mz_internal.mz_dataflow_operators);
 1


### PR DESCRIPTION
This commit fixes a merge skew to rename all usages of 'default_replica' with 'r1'.


### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
