### PR TITLE
environmentd: use correct query param name

### DIFF
--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -14,7 +14,7 @@ const hpccWasm = window['@hpcc-js/wasm'];
 async function query(sql) {
   const response = await fetch('/api/sql', {
     method: 'POST',
-    body: JSON.stringify({ sql: sql }),
+    body: JSON.stringify({ query: sql }),
     headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -14,7 +14,7 @@ const hpccWasm = window['@hpcc-js/wasm'];
 async function query(sql) {
   const response = await fetch('/api/sql', {
     method: 'POST',
-    body: JSON.stringify({ sql: sql }),
+    body: JSON.stringify({ query: sql }),
     headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {


### PR DESCRIPTION
This was missed in #15136.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a