### PR TITLE
[storage] Heartbeat writer in storage persist sink

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -105,13 +105,6 @@ pub fn render<G>(
                 }
 
                 // Make sure that our write handle lease does not expire!
-                //
-                // We don't write to _Consensus_ but instead only write batch
-                // data to _Blob_ so someone might eventually expire our lease.
-                // This could lead to the "leaked blob reaper" eventually
-                // removing blobs that have been written but not yet appended to
-                // the shard.
-                //
                 write.maybe_heartbeat_writer().await;
                 trace!(
                     "storage persist_sink {}/{}: writer heartbeating write handle",

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -11,6 +11,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use differential_dataflow::{Collection, Hashable};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
@@ -21,6 +22,7 @@ use timely::dataflow::Scope;
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp as _;
 use timely::PartialOrder;
+use tracing::trace;
 
 use crate::storage_state::StorageState;
 
@@ -51,6 +53,8 @@ pub fn render<G>(
     // shard.
     let hashed_id = src_id.hashed();
     let active_write_worker = (hashed_id as usize) % scope.peers() == scope.index();
+
+    let activator = scope.activator_for(&persist_op.operator_info().address[..]);
 
     let mut input = persist_op.new_input(&source_data.inner, Exchange::new(move |_| hashed_id));
 
@@ -99,6 +103,25 @@ pub fn render<G>(
                     // frontier from advancing for the one active write worker.
                     continue;
                 }
+
+                // Make sure that our write handle lease does not expire!
+                //
+                // We don't write to _Consensus_ but instead only write batch
+                // data to _Blob_ so someone might eventually expire our lease.
+                // This could lead to the "leaked blob reaper" eventually
+                // removing blobs that have been written but not yet appended to
+                // the shard.
+                //
+                write.maybe_heartbeat_writer().await;
+                trace!(
+                    "storage persist_sink {}/{}: writer heartbeating write handle",
+                    src_id,
+                    metadata.data_shard
+                );
+                // NOTE: We schedule ourselves to make sure that we keep
+                // heartbeating even in cases where there are no changes in our
+                // inputs (updates or frontier changes).
+                activator.activate_after(Duration::from_secs(60));
 
                 while let Some((_cap, data)) = input.next() {
                     data.swap(&mut buffer);


### PR DESCRIPTION
Do similar to #15198 (which touched up heartbeating in compute persist sinks).   I'm not sure how to test exactly since the bug report mentions it's quite difficult to repro

### Motivation
Fixes #15333.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
