### PR TITLE
adapter: last-minute audit log updates

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -29,8 +29,8 @@ other objects in the system catalog.
 Field           | Type                         | Meaning
 ----------------|------------------------------|--------
 `id  `          | [`uint8`]                    | Materialize's unique, monotonically increasing ID for the event.
-`event_type`    | [`text`]                     | The type of the event: `create`, `drop`, `alter`, or `rename`.
-`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `connection`, `index`, `materialized-view`, `sink`, `source`, `table`, or `view`.
+`event_type`    | [`text`]                     | The type of the event: `create`, `drop`, or `alter`.
+`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `connection`, `database`, `function`, `index`, `materialized-view`, `role`, `schema`, `secret`, `sink`, `source`, `table`, `type`, or `view`.
 `event_details` | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
 `user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -31,7 +31,7 @@ Field           | Type                         | Meaning
 `id  `          | [`uint8`]                    | Materialize's unique, monotonically increasing ID for the event.
 `event_type`    | [`text`]                     | The type of the event: `create`, `drop`, or `alter`.
 `object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `connection`, `database`, `function`, `index`, `materialized-view`, `role`, `schema`, `secret`, `sink`, `source`, `table`, `type`, or `view`.
-`event_details` | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
+`details`       | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
 `user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1172,19 +1172,12 @@ impl CatalogState {
         audit_events: &mut Vec<VersionedEvent>,
         event_type: EventType,
         object_type: ObjectType,
-        event_details: EventDetails,
+        details: EventDetails,
     ) -> Result<(), Error> {
         let user = session.map(|session| session.user().name.to_string());
         let occurred_at = (self.config.now)();
         let id = tx.get_and_increment_id(storage::AUDIT_LOG_ID_ALLOC_KEY.to_string())?;
-        let event = VersionedEvent::new(
-            id,
-            event_type,
-            object_type,
-            event_details,
-            user,
-            occurred_at,
-        );
+        let event = VersionedEvent::new(id, event_type, object_type, details, user, occurred_at);
         builtin_table_updates.push(self.pack_audit_log_update(&event)?);
         audit_events.push(event.clone());
         tx.insert_audit_log_event(event);
@@ -1201,10 +1194,9 @@ impl CatalogState {
         let collection_timestamp = (self.config.now)();
         let id = tx.get_and_increment_id(storage::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
 
-        let event_details =
-            VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
-        builtin_table_updates.push(self.pack_storage_usage_update(&event_details)?);
-        tx.insert_storage_usage_event(event_details);
+        let details = VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
+        builtin_table_updates.push(self.pack_storage_usage_update(&details)?);
+        tx.insert_storage_usage_event(details);
         Ok(())
     }
 }

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1382,7 +1382,7 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("id", ScalarType::UInt64.nullable(false))
         .with_column("event_type", ScalarType::String.nullable(false))
         .with_column("object_type", ScalarType::String.nullable(false))
-        .with_column("event_details", ScalarType::Jsonb.nullable(false))
+        .with_column("details", ScalarType::Jsonb.nullable(false))
         .with_column("user", ScalarType::String.nullable(true))
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
 });

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -741,7 +741,7 @@ impl CatalogState {
         &self,
         event: &VersionedEvent,
     ) -> Result<BuiltinTableUpdate, Error> {
-        let (event_type, object_type, event_details, user, occurred_at): (
+        let (event_type, object_type, details, user, occurred_at): (
             &EventType,
             &ObjectType,
             &EventDetails,
@@ -751,12 +751,12 @@ impl CatalogState {
             VersionedEvent::V1(ev) => (
                 &ev.event_type,
                 &ev.object_type,
-                &ev.event_details,
+                &ev.details,
                 &ev.user,
                 ev.occurred_at,
             ),
         };
-        let event_details = Jsonb::from_serde_json(event_details.as_json())
+        let details = Jsonb::from_serde_json(details.as_json())
             .map_err(|e| {
                 Error::new(ErrorKind::Unstructured(format!(
                     "could not pack audit log update: {}",
@@ -764,7 +764,7 @@ impl CatalogState {
                 )))
             })?
             .into_row();
-        let event_details = event_details.iter().next().unwrap();
+        let details = details.iter().next().unwrap();
         let dt = mz_ore::now::to_datetime(occurred_at).naive_utc();
         let id = event.sortable_id();
         Ok(BuiltinTableUpdate {
@@ -773,7 +773,7 @@ impl CatalogState {
                 Datum::UInt64(id),
                 Datum::String(&format!("{}", event_type)),
                 Datum::String(&format!("{}", object_type)),
-                event_details,
+                details,
                 match user {
                     Some(user) => Datum::String(user),
                     None => Datum::Null,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -169,6 +169,24 @@ async fn migrate<S: Append>(
                     name: "materialize".into(),
                 },
             )?;
+            let id = txn.get_and_increment_id(AUDIT_LOG_ID_ALLOC_KEY.to_string())?;
+            txn.audit_log_updates.push((
+                AuditLogKey {
+                    event: VersionedEvent::new(
+                        id,
+                        EventType::Create,
+                        ObjectType::Database,
+                        EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                            id: MATERIALIZE_DATABASE_ID.to_string(),
+                            name: "materialize".into(),
+                        }),
+                        None,
+                        bootstrap_args.now,
+                    ),
+                },
+                (),
+                1,
+            ));
             txn.schemas.insert(
                 SchemaKey {
                     id: MZ_CATALOG_SCHEMA_ID,
@@ -196,6 +214,25 @@ async fn migrate<S: Append>(
                     name: "public".into(),
                 },
             )?;
+            let id = txn.get_and_increment_id(AUDIT_LOG_ID_ALLOC_KEY.to_string())?;
+            txn.audit_log_updates.push((
+                AuditLogKey {
+                    event: VersionedEvent::new(
+                        id,
+                        EventType::Create,
+                        ObjectType::Schema,
+                        EventDetails::SchemaV1(mz_audit_log::SchemaV1 {
+                            id: PUBLIC_SCHEMA_ID.to_string(),
+                            name: "public".into(),
+                            database_name: "materialize".into(),
+                        }),
+                        None,
+                        bootstrap_args.now,
+                    ),
+                },
+                (),
+                1,
+            ));
             txn.schemas.insert(
                 SchemaKey {
                     id: MZ_INTERNAL_SCHEMA_ID,
@@ -222,6 +259,24 @@ async fn migrate<S: Append>(
                     name: "materialize".into(),
                 },
             )?;
+            let id = txn.get_and_increment_id(AUDIT_LOG_ID_ALLOC_KEY.to_string())?;
+            txn.audit_log_updates.push((
+                AuditLogKey {
+                    event: VersionedEvent::new(
+                        id,
+                        EventType::Create,
+                        ObjectType::Role,
+                        EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                            id: MATERIALIZE_ROLE_ID.to_string(),
+                            name: "materialize".into(),
+                        }),
+                        None,
+                        bootstrap_args.now,
+                    ),
+                },
+                (),
+                1,
+            ));
             let default_instance = ComputeInstanceValue {
                 name: "default".into(),
             };

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -270,7 +270,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     event_type,
                     json!({
                         "event_source": "environmentd",
-                        "details": event.event_details.as_json(),
+                        "details": event.details.as_json(),
                     }),
                     Some(json!({
                         "groupId": user_metadata.group_id,

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -41,7 +41,7 @@ impl VersionedEvent {
         id: u64,
         event_type: EventType,
         object_type: ObjectType,
-        event_details: EventDetails,
+        details: EventDetails,
         user: Option<String>,
         occurred_at: EpochMillis,
     ) -> Self {
@@ -49,7 +49,7 @@ impl VersionedEvent {
             id,
             event_type,
             object_type,
-            event_details,
+            details,
             user,
             occurred_at,
         ))
@@ -219,7 +219,7 @@ pub struct EventV1 {
     pub id: u64,
     pub event_type: EventType,
     pub object_type: ObjectType,
-    pub event_details: EventDetails,
+    pub details: EventDetails,
     pub user: Option<String>,
     pub occurred_at: EpochMillis,
 }
@@ -229,7 +229,7 @@ impl EventV1 {
         id: u64,
         event_type: EventType,
         object_type: ObjectType,
-        event_details: EventDetails,
+        details: EventDetails,
         user: Option<String>,
         occurred_at: EpochMillis,
     ) -> EventV1 {
@@ -237,7 +237,7 @@ impl EventV1 {
             id,
             event_type,
             object_type,
-            event_details,
+            details,
             user,
             occurred_at,
         }
@@ -261,7 +261,7 @@ fn test_audit_log() -> Result<(), anyhow::Error> {
             None,
             2,
         )),
-        r#"{"V1":{"id":2,"event_type":"drop","object_type":"cluster-replica","event_details":{"IdNameV1":{"id":"u1","name":"name"}},"user":null,"occurred_at":2}}"#,
+        r#"{"V1":{"id":2,"event_type":"drop","object_type":"cluster-replica","details":{"IdNameV1":{"id":"u1","name":"name"}},"user":null,"occurred_at":2}}"#,
     )];
 
     for (event, expected_bytes) in cases {

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -100,10 +100,13 @@ pub enum ObjectType {
     Cluster,
     ClusterReplica,
     Connection,
+    Database,
     Func,
     Index,
     MaterializedView,
+    Role,
     Secret,
+    Schema,
     Sink,
     Source,
     Table,
@@ -117,9 +120,12 @@ impl ObjectType {
             ObjectType::Cluster => "Cluster",
             ObjectType::ClusterReplica => "Cluster Replica",
             ObjectType::Connection => "Connection",
+            ObjectType::Database => "Database",
             ObjectType::Func => "Function",
             ObjectType::Index => "Index",
             ObjectType::MaterializedView => "Materialized View",
+            ObjectType::Role => "Role",
+            ObjectType::Schema => "Schema",
             ObjectType::Secret => "Secret",
             ObjectType::Sink => "Sink",
             ObjectType::Source => "Source",
@@ -136,10 +142,17 @@ serde_plain::derive_display_from_serialize!(ObjectType);
 pub enum EventDetails {
     CreateComputeReplicaV1(CreateComputeReplicaV1),
     DropComputeReplicaV1(DropComputeReplicaV1),
-    FullNameV1(FullNameV1),
-    NameV1(NameV1),
+    IdFullNameV1(IdFullNameV1),
     RenameItemV1(RenameItemV1),
     IdNameV1(IdNameV1),
+    SchemaV1(SchemaV1),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
+pub struct IdFullNameV1 {
+    pub id: String,
+    #[serde(flatten)]
+    pub name: FullNameV1,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
@@ -150,11 +163,6 @@ pub struct FullNameV1 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
-pub struct NameV1 {
-    pub name: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct IdNameV1 {
     pub id: String,
     pub name: String,
@@ -162,8 +170,9 @@ pub struct IdNameV1 {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct RenameItemV1 {
-    pub previous_name: FullNameV1,
-    pub new_name: String,
+    pub id: String,
+    pub old_name: FullNameV1,
+    pub new_name: FullNameV1,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
@@ -181,6 +190,13 @@ pub struct CreateComputeReplicaV1 {
     pub logical_size: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
+pub struct SchemaV1 {
+    pub id: String,
+    pub name: String,
+    pub database_name: String,
+}
+
 impl EventDetails {
     pub fn as_json(&self) -> serde_json::Value {
         match self {
@@ -190,10 +206,10 @@ impl EventDetails {
             EventDetails::DropComputeReplicaV1(v) => {
                 serde_json::to_value(v).expect("must serialize")
             }
+            EventDetails::IdFullNameV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::RenameItemV1(v) => serde_json::to_value(v).expect("must serialize"),
-            EventDetails::NameV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::IdNameV1(v) => serde_json::to_value(v).expect("must serialize"),
-            EventDetails::FullNameV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::SchemaV1(v) => serde_json::to_value(v).expect("must serialize"),
         }
     }
 }
@@ -233,35 +249,20 @@ impl EventV1 {
 // failing. Instead of changing data structures, add new variants.
 #[test]
 fn test_audit_log() -> Result<(), anyhow::Error> {
-    let cases: Vec<(VersionedEvent, &'static str)> = vec![
-        (
-            VersionedEvent::V1(EventV1::new(
-                1,
-                EventType::Create,
-                ObjectType::View,
-                EventDetails::NameV1(NameV1 {
-                    name: "name".into(),
-                }),
-                Some("user".into()),
-                1,
-            )),
-            r#"{"V1":{"id":1,"event_type":"create","object_type":"view","event_details":{"NameV1":{"name":"name"}},"user":"user","occurred_at":1}}"#,
-        ),
-        (
-            VersionedEvent::V1(EventV1::new(
-                2,
-                EventType::Drop,
-                ObjectType::ClusterReplica,
-                EventDetails::IdNameV1(IdNameV1 {
-                    id: "u1".to_string(),
-                    name: "name".into(),
-                }),
-                None,
-                2,
-            )),
-            r#"{"V1":{"id":2,"event_type":"drop","object_type":"cluster-replica","event_details":{"IdNameV1":{"id":"u1","name":"name"}},"user":null,"occurred_at":2}}"#,
-        ),
-    ];
+    let cases: Vec<(VersionedEvent, &'static str)> = vec![(
+        VersionedEvent::V1(EventV1::new(
+            2,
+            EventType::Drop,
+            ObjectType::ClusterReplica,
+            EventDetails::IdNameV1(IdNameV1 {
+                id: "u1".to_string(),
+                name: "name".into(),
+            }),
+            None,
+            2,
+        )),
+        r#"{"V1":{"id":2,"event_type":"drop","object_type":"cluster-replica","event_details":{"IdNameV1":{"id":"u1","name":"name"}},"user":null,"occurred_at":2}}"#,
+    )];
 
     for (event, expected_bytes) in cases {
         let event_bytes = serde_json::to_vec(&event).unwrap();

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -142,6 +142,8 @@ serde_plain::derive_display_from_serialize!(ObjectType);
 pub enum EventDetails {
     CreateComputeReplicaV1(CreateComputeReplicaV1),
     DropComputeReplicaV1(DropComputeReplicaV1),
+    CreateSourceSinkV1(CreateSourceSinkV1),
+    AlterSourceSinkV1(AlterSourceSinkV1),
     IdFullNameV1(IdFullNameV1),
     RenameItemV1(RenameItemV1),
     IdNameV1(IdNameV1),
@@ -191,6 +193,23 @@ pub struct CreateComputeReplicaV1 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
+pub struct CreateSourceSinkV1 {
+    pub id: String,
+    #[serde(flatten)]
+    pub name: FullNameV1,
+    pub size: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
+pub struct AlterSourceSinkV1 {
+    pub id: String,
+    #[serde(flatten)]
+    pub name: FullNameV1,
+    pub old_size: Option<String>,
+    pub new_size: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct SchemaV1 {
     pub id: String,
     pub name: String,
@@ -210,6 +229,8 @@ impl EventDetails {
             EventDetails::RenameItemV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::IdNameV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::SchemaV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::CreateSourceSinkV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::AlterSourceSinkV1(v) => serde_json::to_value(v).expect("must serialize"),
         }
     }
 }

--- a/src/storage/src/types/hosts.rs
+++ b/src/storage/src/types/hosts.rs
@@ -48,3 +48,14 @@ pub enum StorageHostConfig {
         size: String,
     },
 }
+
+impl StorageHostConfig {
+    /// Returns the size specified by the storage host configuration, if
+    /// the storage host is a managed storage host.
+    pub fn size(&self) -> Option<&str> {
+        match self {
+            StorageHostConfig::Remote { .. } => None,
+            StorageHostConfig::Managed { size, .. } => Some(size),
+        }
+    }
+}

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -60,7 +60,13 @@ statement ok
 DROP VIEW renamed
 
 statement ok
-CREATE SOURCE s FROM LOAD GENERATOR COUNTER;
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+
+statement ok
+ALTER SOURCE s SET (SIZE '2');
+
+statement ok
+DROP SOURCE s;
 
 statement ok
 DROP CLUSTER REPLICA foo.r;
@@ -72,7 +78,7 @@ query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id
 ----
 1  create  database  {"id":"1","name":"materialize"}  NULL
-2  create  schema  {"id":"3","name":"public"}  NULL
+2  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
 3  create  role  {"id":"1","name":"materialize"}  NULL
 4  create  cluster  {"id":"u1","name":"default"}  NULL
 5  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_name":"r1"}  NULL
@@ -98,6 +104,8 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 25  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
 26  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
 27  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
-28  create  source  {"database":"materialize","id":"u7","item":"s","schema":"public"}  materialize
-29  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
-30  drop  cluster  {"id":"u2","name":"foo"}  materialize
+28  create  source  {"database":"materialize","id":"u7","item":"s","schema":"public","size":"1"}  materialize
+29  alter  source  {"database":"materialize","id":"u7","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
+30  drop  source  {"database":"materialize","id":"u7","item":"s","schema":"public"}  materialize
+31  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
+32  drop  cluster  {"id":"u2","name":"foo"}  materialize

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -69,7 +69,7 @@ statement ok
 DROP CLUSTER foo;
 
 query ITTTT
-SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORDER BY id
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id
 ----
 1  create  database  {"id":"1","name":"materialize"}  NULL
 2  create  schema  {"id":"3","name":"public"}  NULL

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -12,6 +12,27 @@
 mode cockroach
 
 statement ok
+CREATE DATABASE test
+
+statement ok
+CREATE SCHEMA test.sc1
+
+statement ok
+CREATE SCHEMA test.sc2
+
+statement ok
+DROP SCHEMA test.sc1
+
+statement ok
+DROP DATABASE test
+
+statement ok
+CREATE ROLE foo LOGIN SUPERUSER
+
+statement ok
+DROP ROLE foo
+
+statement ok
 CREATE CLUSTER foo REPLICAS (r (SIZE '1'));
 
 statement ok
@@ -50,20 +71,33 @@ DROP CLUSTER foo;
 query ITTTT
 SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORDER BY id
 ----
-1  create  cluster  {"id":"u1","name":"default"}  NULL
-2  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_name":"r1"}  NULL
-3  create  cluster  {"id":"u2","name":"foo"}  materialize
-4  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
-5  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
-6  create  view  {"database":"materialize","item":"unmat","schema":"public"}  materialize
-7  create  table  {"database":"materialize","item":"t","schema":"public"}  materialize
-8  create  index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
-9  alter  view  {"new_name":"renamed","previous_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
-10  drop  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
-11  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
-12  create  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
-13  drop  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
-14  drop  view  {"database":"materialize","item":"renamed","schema":"public"}  materialize
-15  create  source  {"database":"materialize","item":"s","schema":"public"}  materialize
-16  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
-17  drop  cluster  {"id":"u2","name":"foo"}  materialize
+1  create  database  {"id":"1","name":"materialize"}  NULL
+2  create  schema  {"id":"3","name":"public"}  NULL
+3  create  role  {"id":"1","name":"materialize"}  NULL
+4  create  cluster  {"id":"u1","name":"default"}  NULL
+5  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_name":"r1"}  NULL
+6  create  database  {"id":"2","name":"test"}  materialize
+7  create  schema  {"database_name":"test","id":"6","name":"public"}  materialize
+8  create  schema  {"database_name":"test","id":"7","name":"sc1"}  materialize
+9  create  schema  {"database_name":"test","id":"8","name":"sc2"}  materialize
+10  drop  schema  {"database_name":"test","id":"7","name":"sc1"}  materialize
+11  drop  schema  {"database_name":"test","id":"6","name":"public"}  materialize
+12  drop  schema  {"database_name":"test","id":"8","name":"sc2"}  materialize
+13  drop  database  {"id":"2","name":"test"}  materialize
+14  create  role  {"id":"u2","name":"foo"}  materialize
+15  drop  role  {"id":"u2","name":"foo"}  materialize
+16  create  cluster  {"id":"u2","name":"foo"}  materialize
+17  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+18  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
+19  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
+20  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
+21  create  index  {"database":"materialize","id":"u4","item":"t_primary_idx","schema":"public"}  materialize
+22  alter  view  {"id":"u2","new_name":{"database":"materialize","item":"renamed","schema":"public"},"old_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
+23  drop  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
+24  create  materialized-view  {"database":"materialize","id":"u5","item":"v2","schema":"public"}  materialize
+25  create  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
+26  drop  index  {"database":"materialize","id":"u6","item":"renamed_primary_idx","schema":"public"}  materialize
+27  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
+28  create  source  {"database":"materialize","id":"u7","item":"s","schema":"public"}  materialize
+29  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
+30  drop  cluster  {"id":"u2","name":"foo"}  materialize


### PR DESCRIPTION
  * Add database, schema, and role events to the audit log, including
    for the databses, schemas, and roles we create automatically when
    bootstrapping.

  * Add IDs to all event types, so that it's easy to match creation
    events with deletion events even when items change names.

  * Adjust the `new_name` field in the renamed event to include a new
    full name, for flexibility when we support cross-schema renames in
    the future.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a