### PR TITLE
sql: Fix SHOW INDEXES for empty columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "postgres_array"
 version = "0.11.0"
-source = "git+https://github.com/MaterializeInc/rust-postgres-array#cbf48cd674ded4b6e7648fab253807c055c8ec10"
+source = "git+https://github.com/MaterializeInc/rust-postgres-array#f58d0101e5198e04e8692629018d9b58f8543534"
 dependencies = [
  "bytes",
  "fallible-iterator",

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -484,12 +484,15 @@ pub fn show_indexes<'a>(
             objs.name AS on,
             clusters.name AS cluster,
             (SELECT
-                ARRAY_AGG(
-                    CASE
-                        WHEN idx_cols.on_expression IS NULL THEN obj_cols.name
-                        ELSE idx_cols.on_expression
-                    END
-                    ORDER BY idx_cols.index_position ASC
+                COALESCE(
+                    ARRAY_AGG(
+                        CASE
+                            WHEN idx_cols.on_expression IS NULL THEN obj_cols.name
+                            ELSE idx_cols.on_expression
+                        END
+                        ORDER BY idx_cols.index_position ASC
+                    ),
+                    '{{}}'::_text
                 )
             FROM
                 mz_catalog.mz_index_columns AS idx_cols

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -500,7 +500,7 @@ pub fn show_indexes<'a>(
                     ) AS key
                 FROM
                     mz_indexes AS idxs
-                    JOIN mz_index_columns idx_cols ON idxs.id = idx_cols.index_id 
+                    JOIN mz_index_columns idx_cols ON idxs.id = idx_cols.index_id
                     LEFT JOIN mz_columns obj_cols ON
                         idxs.on_id = obj_cols.id AND idx_cols.on_position = obj_cols.position
                 GROUP BY idxs.id) AS keys

--- a/test/testdrive/empty-array.td
+++ b/test/testdrive/empty-array.td
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#$ postgres-execute connection=postgres://postgres:postgres@postgres
+#SELECT '{}'::_text;
+
+> SELECT '{}'::_text;
+{}

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -194,8 +194,17 @@ foo_primary_idx1    foo clstr   {a,b,z}
 > SHOW INDEXES FROM public WHERE name = 'foo_primary_idx1'
 foo_primary_idx1    foo clstr   {a,b,z}
 
+> DROP TABLE foo CASCADE
+> DROP SOURCE data CASCADE
+
 ! SHOW INDEXES FROM public ON foo
 contains:Cannot specify both FROM and ON
 
 ! SHOW INDEXES FROM nonexistent
 contains:unknown schema 'nonexistent'
+
+> CREATE TABLE bar ();
+> CREATE INDEX bar_ind ON bar ();
+
+> SHOW INDEXES
+bar_ind bar <VARIABLE_OUTPUT> <null>

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -207,7 +207,7 @@ contains:unknown schema 'nonexistent'
 > CREATE INDEX bar_ind ON bar ();
 
 > SHOW INDEXES
-bar_ind bar <VARIABLE_OUTPUT> <null>
+bar_ind bar <VARIABLE_OUTPUT> {}
 
 > DROP TABLE bar CASCADE
 > CREATE SCHEMA foo


### PR DESCRIPTION
Previously SHOW INDEXES would omit any indexes that had 0 columns. This commit fixes that so all INDEXES are shown, regardless of the number of columns.

### Motivation
This PR fixes a previously unreported bug.


### Tips for reviewer
  * Know SQL (the new query is a bit cursed)

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
