### PR TITLE
zippy: Increase the timeout on MzStart

### DIFF
--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -20,7 +20,8 @@ class MzStart(Action):
 
     def run(self, c: Composition) -> None:
         c.up("materialized")
-        c.wait_for_materialized()
+        # Loaded Mz environments take a while to start up
+        c.wait_for_materialized(timeout_secs=300)
 
     def provides(self) -> List[Capability]:
         return [MzIsRunning()]


### PR DESCRIPTION
Starting a loaded Mz instance from scratch can take a long time.
### Motivation

  * This PR fixes a previously unreported bug.
Nightly Zippy User Tables was failing