### PR TITLE
storage: in CollectionManager, ignore sender hanging up

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -2323,7 +2323,13 @@ mod collection_mgmt {
                             // uppers here is best-effort and only needs to
                             // succeed if no one else is advancing it;
                             // contention proves otherwise.
-                            let _ = write_handle.monotonic_append(updates).await.expect("sender hung up");
+                            match write_handle.monotonic_append(updates).await {
+                                Ok(_append_result) => (), // All good!
+                                Err(_recv_error) => {
+                                    // Sender hung up, this seems fine and can
+                                    // happen when shutting down.
+                                }
+                            }
                         },
                         cmd = rx.recv() => {
                             if let Some((id, updates)) = cmd {


### PR DESCRIPTION
This was causing ci to be flaky because it can happen when shutting down. We now ignore it properly, as the comment says.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
