### PR TITLE
web,upgrade: Handle unreleased Mz versions

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -13,6 +13,7 @@ colored==1.4.3
 docker==6.0.0
 ec2instanceconnectcli==1.0.2
 flake8==5.0.4
+python-frontmatter==1.0.0
 humanize==4.4.0
 isort==5.10.1
 junit-xml==1.9
@@ -39,6 +40,7 @@ shtab==1.5.5
 sqlparse==0.4.3
 toml==0.10.2
 twine==4.0.1
+types-Markdown==3.4.1
 types-pkg-resources==0.1.3
 types-prettytable==3.4.2
 types-psutil==5.9.5.1

--- a/doc/user/content/releases/v0.27.0.md
+++ b/doc/user/content/releases/v0.27.0.md
@@ -1,6 +1,7 @@
 ---
 title: "Materialize v0.27.0"
 date: 2022-10-12
+released: true
 ---
 
 v0.27.0 is the first cloud-native release of Materialize. It contains

--- a/doc/user/content/releases/v0.28.0.md
+++ b/doc/user/content/releases/v0.28.0.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.28.0"
+date: 2022-10-19
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## Changes
+
+* No documented changes yet.

--- a/doc/user/layouts/shortcodes/version-list.html
+++ b/doc/user/layouts/shortcodes/version-list.html
@@ -15,7 +15,10 @@
               </a>
             </strong>
           </td>
-          <td>{{$page.Date.Format "January 2, 2006"}}</td>
+          <td>
+            {{$page.Date.Format "January 2, 2006"}}
+            {{if not $page.Params.released}}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<em>Not yet released.</em>{{end}}
+          </td>
         </tr>
       {{end}}
     </tbody>

--- a/misc/python/stubs/frontmatter.pyi
+++ b/misc/python/stubs/frontmatter.pyi
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+from typing import Any, Dict
+
+def load(path: Path) -> Dict[Any, Any]: ...

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -29,7 +29,7 @@ from materialize.mzcompose.services import (
 )
 
 # All released Materialize versions, in order from most to least recent.
-all_versions = util.known_materialize_versions()
+all_versions = util.released_materialize_versions()
 
 mz_options: Dict[Version, str] = {}
 


### PR DESCRIPTION
- When processing the .md files in doc/user/content/releases in order to compile a list of Mz releases, skip those that are explicitly marked as released: false in their Markdown metadata.

- Label such versions in the list of versions on the web site as well.

### Motivation
  * This PR adds a feature that has not yet been specified.

The upgrade tests obtain the list of versions to upgrade from from the md files in the `doc/user/content/releases` directory. However, that list would contain both released and unreleased versions, whereas upgrade needs to operate only against released versions. Therefore the need arose to somehow distinguish the two and @benesch thought metadata should be embedded in the .md file itself.

### Tips for reviewer

The PR is written defensively in a sense that unless a release is explicitly tagged with `released: false` , it will be considered as released and subject to upgrade testing.

@benesch do I need to add a checklist item somewhere so that the `released: false` tag is removed from the `md` file of the release? In `./.github/ISSUE_TEMPLATE/08-release.md` I see no mention of those md files whatsoever.