### PR TITLE
adapter: set compute read policies for persisted logs

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -383,7 +383,9 @@ impl<S: Append + 'static> Coordinator<S> {
         builtin_migration_metadata: BuiltinMigrationMetadata,
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
     ) -> Result<(), AdapterError> {
-        let mut persisted_source_ids = HashMap::new();
+        // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
+        let mut policies_to_set: CollectionIdBundle = Default::default();
+
         for instance in self.catalog.compute_instances() {
             self.controller.compute.create_instance(
                 instance.id,
@@ -407,10 +409,14 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
 
-                persisted_source_ids.insert(
-                    instance.id,
-                    replica.config.logging.source_ids().collect_vec(),
-                );
+                policies_to_set
+                    .compute_ids
+                    .entry(instance.id)
+                    .or_insert_with(BTreeSet::new)
+                    .extend(replica.config.logging.source_ids());
+                policies_to_set
+                    .storage_ids
+                    .extend(replica.config.logging.source_ids());
 
                 self.controller
                     .active_compute()
@@ -418,20 +424,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
             }
-        }
-
-        for (instance_id, collection_ids) in persisted_source_ids {
-            self.initialize_compute_read_policies(
-                collection_ids.clone(),
-                instance_id,
-                DEFAULT_LOGICAL_COMPACTION_WINDOW_MS,
-            )
-            .await;
-            self.initialize_storage_read_policies(
-                collection_ids,
-                DEFAULT_LOGICAL_COMPACTION_WINDOW_MS,
-            )
-            .await;
         }
 
         // Migrate builtin objects.
@@ -464,9 +456,6 @@ impl<S: Append + 'static> Coordinator<S> {
         let logs: HashSet<_> = BUILTINS::logs()
             .map(|log| self.catalog.resolve_builtin_log(log))
             .collect();
-
-        // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
-        let mut policies_to_set: CollectionIdBundle = Default::default();
 
         // This is disabled for the moment because it has unusual upper
         // advancement behavior.


### PR DESCRIPTION
This PR makes adapter initialize compute read policies for the persisted log collections. Previously, only storage read policies would be initialized for those, which meant that in the compute controller persisted log collections would always have a read frontier of 0, and consequently, no `AllowCompaction` commands would be sent for these collections.

This didn't lead to issues because the storage controller is responsible for managing the read frontier of storage collections. But for consistency with other persist sinks in compute (materialized views), we should still track the read frontier of log collections correctly in the compute controller.

### Motivation

  * This PR fixes a previously unreported bug.

The compute controller's known read frontier for persisted introspection collections is always 0.

[Slack thread for context.](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1665501175355969)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
