### PR TITLE
sql: Fix SHOW INDEXES in non-active schemas

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -455,9 +455,6 @@ pub fn show_indexes<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let mut query_filter = vec!["idxs.on_id NOT LIKE 's%'".into()];
 
-    let schema_spec = scx.resolve_optional_schema(&from_schema)?;
-    query_filter.push(format!("objs.schema_id = {}", schema_spec));
-
     if let Some(on_object) = on_object {
         let on_item = scx.get_item_by_resolved_name(&on_object)?;
         if on_item.item_type() != CatalogItemType::View
@@ -472,6 +469,9 @@ pub fn show_indexes<'a>(
             );
         }
         query_filter.push(format!("objs.id = '{}'", on_item.id()));
+    } else {
+        let schema_spec = scx.resolve_optional_schema(&from_schema)?;
+        query_filter.push(format!("objs.schema_id = {}", schema_spec));
     }
 
     if let Some(cluster) = in_cluster {

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -194,8 +194,18 @@ foo_primary_idx1    foo clstr   {a,b,z}
 > SHOW INDEXES FROM public WHERE name = 'foo_primary_idx1'
 foo_primary_idx1    foo clstr   {a,b,z}
 
+> DROP TABLE foo CASCADE
+> DROP SOURCE data CASCADE
+
 ! SHOW INDEXES FROM public ON foo
 contains:Cannot specify both FROM and ON
 
 ! SHOW INDEXES FROM nonexistent
 contains:unknown schema 'nonexistent'
+
+> CREATE SCHEMA foo
+> CREATE TABLE foo.bar (a INT)
+> CREATE INDEX bar_ind ON foo.bar (a)
+
+> SHOW INDEXES ON foo.bar
+bar_ind bar <VARIABLE_OUTPUT> {a}


### PR DESCRIPTION
Previously if you ran SHOW INDEXES ON <object-in-non-active-schema> then it would not correctly display the existing indexes in the non-active schema. This commit fixes that issue so all indexes are correctly displayed in all schemas.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
