### PR TITLE
persist: re-enable fast path for apply_merge_res in apply_diffs

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -552,9 +552,7 @@ where
                 let diff = StateDiff::from_diff(&self.state, &new_state);
                 // Sanity check that our diff logic roundtrips and adds back up
                 // correctly.
-                //
-                // TODO: Re-enable this #14490.
-                #[cfg(all(TODO, any(test, debug_assertions)))]
+                #[cfg(any(test, debug_assertions))]
                 {
                     if let Err(err) =
                         StateDiff::validate_roundtrip(&self.metrics, &self.state, &diff, &new_state)

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -26,7 +26,7 @@ use crate::internal::state::{
     HollowBatch, ProtoStateField, ProtoStateFieldDiffType, ProtoStateFieldDiffs, ReaderState,
     State, StateCollections, WriterState,
 };
-use crate::internal::trace::Trace;
+use crate::internal::trace::{FueledMergeRes, Trace};
 use crate::read::ReaderId;
 use crate::write::WriterId;
 use crate::{Metrics, PersistConfig};
@@ -515,15 +515,6 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
     }
 
     // Fast-path: compaction
-    //
-    // TODO: This seems to tickle some existing bugs that we haven't been
-    // hitting because, before incremental state, we were reconstructing Spine
-    // from scratch whenever we deserialized a new version of state. Losing it
-    // is unfortunate, but no worse than where we were before and we're getting
-    // down to the wire with getting inc state (and its backward
-    // incompatibility) into the desired release. Revisit as time permits to
-    // shake out the bugs (they repro readily in CI) and re-enable.
-    #[cfg(TODO)]
     if let Some((_inputs, output)) = sniff_compaction(&diffs) {
         let res = FueledMergeRes { output };
         // We can't predict how spine will arrange the batches when it's


### PR DESCRIPTION
Without this, we reconstruct the spine from scratch every time a compaction result is merged. This is (1) wasteful, (2) may not match a spine constructed incrementally and so may cause later merge responses to not apply, and (3) prevents us from running a strict debug check that a newly generated diff roundtrips.

Closes #14490.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
