### PR TITLE
persist: special case compaction for a single nonempty batch in inputs

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -470,9 +470,9 @@ where
         //   is a subset of the description they are registered with. The since can
         //   be anything.
         let inline_desc = &part.desc;
-        let needs_truncation =
-            PartialOrder::less_than(inline_desc.lower(), registered_desc.lower())
-                || PartialOrder::less_than(registered_desc.upper(), inline_desc.upper());
+        // Technically we could truncate any batch where the since is less_than the
+        // output_desc's lower, but we're strict here so we don't get any surprises.
+        let needs_truncation = inline_desc.since() == &Antichain::from_elem(T::minimum());
         if needs_truncation {
             assert!(
                 PartialOrder::less_equal(inline_desc.lower(), registered_desc.lower()),
@@ -483,18 +483,6 @@ where
             );
             assert!(
                 PartialOrder::less_equal(registered_desc.upper(), inline_desc.upper()),
-                "key={} inline={:?} registered={:?}",
-                key,
-                inline_desc,
-                registered_desc
-            );
-            // As mentioned above, batches that needs truncation will always have a
-            // since of the minimum timestamp. Technically we could truncate any
-            // batch where the since is less_than the output_desc's lower, but we're
-            // strict here so we don't get any surprises.
-            assert_eq!(
-                inline_desc.since(),
-                &Antichain::from_elem(T::minimum()),
                 "key={} inline={:?} registered={:?}",
                 key,
                 inline_desc,

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -473,22 +473,7 @@ where
         // Technically we could truncate any batch where the since is less_than the
         // output_desc's lower, but we're strict here so we don't get any surprises.
         let needs_truncation = inline_desc.since() == &Antichain::from_elem(T::minimum());
-        if needs_truncation {
-            assert!(
-                PartialOrder::less_equal(inline_desc.lower(), registered_desc.lower()),
-                "key={} inline={:?} registered={:?}",
-                key,
-                inline_desc,
-                registered_desc
-            );
-            assert!(
-                PartialOrder::less_equal(registered_desc.upper(), inline_desc.upper()),
-                "key={} inline={:?} registered={:?}",
-                key,
-                inline_desc,
-                registered_desc
-            );
-        } else {
+        if !needs_truncation {
             assert!(
                 PartialOrder::less_equal(registered_desc.lower(), inline_desc.lower())
                     && PartialOrder::less_equal(inline_desc.upper(), registered_desc.upper()),

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -467,9 +467,8 @@ where
         //   truncated bounds must be ignored. Not every user batch is
         //   truncated.
         // - Batches written by compaction. These always have an inline desc that
-        //   exactly matches the lower they are registered with, and an upper that
-        //   is less_equal to the upper they are registered with. The since can be
-        //   anything.
+        //   is a subset of the description they are registered with. The since can
+        //   be anything.
         let inline_desc = &part.desc;
         let needs_truncation =
             PartialOrder::less_than(inline_desc.lower(), registered_desc.lower())
@@ -503,7 +502,7 @@ where
             );
         } else {
             assert!(
-                inline_desc.lower() == registered_desc.lower()
+                PartialOrder::less_equal(registered_desc.lower(), inline_desc.lower())
                     && PartialOrder::less_equal(inline_desc.upper(), registered_desc.upper()),
                 "key={} inline={:?} registered={:?}",
                 key,

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -28,7 +28,7 @@ use mz_persist::indexed::columnar::{
 };
 use mz_persist::location::Blob;
 use mz_persist_types::{Codec, Codec64};
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{mpsc, oneshot, TryAcquireError};
@@ -344,7 +344,13 @@ where
             }
         }
         if let Some(batch) = single_nonempty_batch {
-            if batch.runs.len() == 0 {
+            // if we have a single nonempty batch, we still want to compact if:
+            //   - it has >1 run, so its runs can be merged together
+            //   - it it has a since of the minimum antichain. this implies the batch was
+            //     produced by a writer's append (i.e. not from compaction), and it could
+            //     require truncation. rewriting the batch via compaction will trim out any
+            //     of the unneeded data.
+            if batch.runs.len() == 0 && batch.desc.since() != &Antichain::from_elem(T::minimum()) {
                 let mut output = batch.clone();
                 output.desc = req.desc;
                 metrics.compaction.single_batch_fast_path.inc();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -343,15 +343,17 @@ where
                 }
             }
         }
-        if let Some(batch) = single_nonempty_batch {
+        if let Some(single_nonempty_batch) = single_nonempty_batch {
             // if we have a single nonempty batch, we still want to compact if:
             //   - it has >1 run, so its runs can be merged together
             //   - it it has a since of the minimum antichain. this implies the batch was
             //     produced by a writer's append (i.e. not from compaction), and it could
             //     require truncation. rewriting the batch via compaction will trim out any
             //     of the unneeded data.
-            if batch.runs.len() == 0 && batch.desc.since() != &Antichain::from_elem(T::minimum()) {
-                let mut output = batch.clone();
+            if single_nonempty_batch.runs.len() == 0
+                && single_nonempty_batch.desc.since() != &Antichain::from_elem(T::minimum())
+            {
+                let mut output = single_nonempty_batch.clone();
                 output.desc = req.desc;
                 metrics.compaction.single_batch_fast_path.inc();
                 return Ok(CompactRes { output });

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -935,6 +935,11 @@ pub mod datadriven {
         let upper = args.expect_antichain("upper");
         let target_size = args.optional("target_size");
         let parts_size_override = args.optional("parts_size_override");
+        let runs = args.optional_str("runs").map(|x| {
+            x.split(',')
+                .map(|s| s.parse::<usize>().expect("invalid run"))
+                .collect()
+        });
         let updates = args.input.split('\n').flat_map(DirectiveArgs::parse_update);
 
         let mut cfg = datadriven.client.cfg.clone();
@@ -954,11 +959,15 @@ pub mod datadriven {
         for ((k, ()), t, d) in updates {
             builder.add(&k, &(), &t, &d).await.expect("invalid batch");
         }
-        let batch = builder
+        let mut batch = builder
             .finish(upper)
             .await
             .expect("invalid batch")
             .into_hollow_batch();
+
+        if let Some(runs) = runs {
+            batch.runs = runs;
+        }
 
         if let Some(size) = parts_size_override {
             let mut batch = batch.clone();
@@ -1036,13 +1045,18 @@ pub mod datadriven {
         let output = args.expect_str("output");
         let lower = args.expect_antichain("lower");
         let upper = args.expect_antichain("upper");
+        let since = args.optional_antichain("since");
 
         let mut batch = datadriven
             .batches
             .get(input)
             .expect("unknown batch")
             .clone();
-        let truncated_desc = Description::new(lower, upper, batch.desc.since().clone());
+        let truncated_desc = Description::new(
+            lower,
+            upper,
+            since.unwrap_or_else(|| batch.desc.since().clone()),
+        );
         let () = validate_truncate_batch(&batch.desc, &truncated_desc)?;
         batch.desc = truncated_desc;
         datadriven.batches.insert(output.to_owned(), batch.clone());

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -601,6 +601,7 @@ pub struct CompactionMetrics {
     pub(crate) noop: IntCounter,
     pub(crate) seconds: Counter,
     pub(crate) concurrency_waits: IntCounter,
+    pub(crate) single_batch_fast_path: IntCounter,
     pub(crate) memory_violations: IntCounter,
     pub(crate) runs_compacted: IntCounter,
     pub(crate) chunks_compacted: IntCounter,
@@ -659,6 +660,10 @@ impl CompactionMetrics {
             concurrency_waits: registry.register(metric!(
                 name: "mz_persist_compaction_concurrency_waits",
                 help: "count of compaction requests that ever blocked due to concurrency limit",
+            )),
+            single_batch_fast_path: registry.register(metric!(
+                name: "mz_persist_compaction_single_batch_fast_path",
+                help: "count of single nonempty batch fast path compactions",
             )),
             memory_violations: registry.register(metric!(
                 name: "mz_persist_compaction_memory_violations",

--- a/src/persist-client/tests/machine/compaction_single
+++ b/src/persist-client/tests/machine/compaction_single
@@ -27,6 +27,20 @@ zero 99 1
 <run 0>
 part 0
 
+# attempting to compact our just-compacted batch should hit our special case,
+# as it is the single nonempty batch with since in advance of [0]
+compact output=b_compacted_again inputs=(b_compacted) lower=1 upper=2 since=999
+----
+parts=1 len=1
+
+# (the since has not advanced, confirming we're reading the same contents referred by b_compacted)
+fetch-batch input=b_compacted_again
+----
+<part 0>
+zero 99 1
+<run 0>
+part 0
+
 # always compact if our only nonempty batch has >1 run, in order to consolidate across runs
 write-batch output=b lower=1 upper=2 target_size=0 runs=1
 zero 1 1
@@ -90,7 +104,7 @@ compact output=b1_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
 ----
 parts=1 len=1
 
-# (notably, the since has not advanced, confirming we're reading the same contents referred by b1)
+# (the since has not advanced, confirming we're reading the same contents referred by b1)
 fetch-batch input=b1_unchanged
 ----
 <part 0>

--- a/src/persist-client/tests/machine/compaction_single
+++ b/src/persist-client/tests/machine/compaction_single
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Compaction with a single nonempty input is special cased to
+# return the nonempty batch directly with a new description
+
+write-batch output=b0 lower=0 upper=1
+zero 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+----
+parts=0 len=0
+
+write-batch output=b2 lower=2 upper=3
+----
+parts=0 len=0
+
+write-batch output=b3 lower=3 upper=4
+----
+parts=0 len=0
+
+compact output=b0_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
+----
+parts=1 len=1
+
+# notably, the since has not advanced, confirming we're reading the same contents referred by b0
+fetch-batch input=b0_unchanged
+----
+<part 0>
+zero 0 1
+<run 0>
+part 0

--- a/src/persist-client/tests/machine/compaction_single
+++ b/src/persist-client/tests/machine/compaction_single
@@ -33,7 +33,7 @@ compact output=b_compacted_again inputs=(b_compacted) lower=1 upper=2 since=999
 ----
 parts=1 len=1
 
-# (the since has not advanced, confirming we're reading the same contents referred by b_compacted)
+# (the timestamp has not advanced, confirming we're reading the same contents referred by b_compacted)
 fetch-batch input=b_compacted_again
 ----
 <part 0>
@@ -104,7 +104,7 @@ compact output=b1_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
 ----
 parts=1 len=1
 
-# (the since has not advanced, confirming we're reading the same contents referred by b1)
+# (the timestamp has not advanced, confirming we're reading the same contents referred by b1)
 fetch-batch input=b1_unchanged
 ----
 <part 0>

--- a/src/persist-client/tests/machine/compaction_single
+++ b/src/persist-client/tests/machine/compaction_single
@@ -7,15 +7,73 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Compaction with a single nonempty input is special cased to
-# return the nonempty batch directly with a new description
+## Compaction with a single nonempty input is special cased to
+## return the nonempty batch directly with a new description
 
+# always compact if our only nonempty batch has a since of [0], in order to trim truncatable data
+write-batch output=b lower=1 upper=2
+zero 1 1
+----
+parts=1 len=1
+
+compact output=b_compacted inputs=(b) lower=1 upper=2 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b_compacted
+----
+<part 0>
+zero 99 1
+<run 0>
+part 0
+
+# always compact if our only nonempty batch has >1 run, in order to consolidate across runs
+write-batch output=b lower=1 upper=2 target_size=0 runs=1
+zero 1 1
+one 1 1
+----
+parts=2 len=2
+
+# (same lower/upper, but rewrite the since to be in advance of [0])
+truncate-batch-desc input=b output=b lower=1 upper=2 since=1
+----
+parts=2 len=2
+
+fetch-batch input=b
+----
+<part 0>
+zero 1 1
+<part 1>
+one 1 1
+<run 0>
+part 0
+<run 1>
+part 1
+
+compact output=b_compacted inputs=(b) lower=1 upper=2 since=99
+----
+parts=1 len=2
+
+fetch-batch input=b_compacted
+----
+<part 0>
+one 99 1
+zero 99 1
+<run 0>
+part 0
+
+
+# now let's cover cases where we skip compaction and send back the same batch with a new description
 write-batch output=b0 lower=0 upper=1
 ----
 parts=0 len=0
 
 write-batch output=b1 lower=1 upper=2
 zero 1 1
+----
+parts=1 len=1
+
+truncate-batch-desc input=b1 output=b1 lower=1 upper=2 since=1
 ----
 parts=1 len=1
 
@@ -27,11 +85,12 @@ write-batch output=b3 lower=3 upper=4
 ----
 parts=0 len=0
 
+# compacting b1 with empty batches will return a batch pointing to the same keys as b1, but with an updated desc
 compact output=b1_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
 ----
 parts=1 len=1
 
-# notably, the since has not advanced, confirming we're reading the same contents referred by b0
+# (notably, the since has not advanced, confirming we're reading the same contents referred by b1)
 fetch-batch input=b1_unchanged
 ----
 <part 0>
@@ -39,7 +98,7 @@ zero 1 1
 <run 0>
 part 0
 
-# and test edge cases of our non-empty batch being the lower and upper batch
+# and test edge cases of our non-empty batch being the lower / upper / only batch
 compact output=b1_unchanged inputs=(b1,b2) lower=1 upper=3 since=99
 ----
 parts=1 len=1
@@ -52,6 +111,17 @@ zero 1 1
 part 0
 
 compact output=b1_unchanged inputs=(b0,b1) lower=0 upper=2 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
+<run 0>
+part 0
+
+compact output=b1_unchanged inputs=(b1) lower=1 upper=2 since=99
 ----
 parts=1 len=1
 

--- a/src/persist-client/tests/machine/compaction_single
+++ b/src/persist-client/tests/machine/compaction_single
@@ -11,13 +11,13 @@
 # return the nonempty batch directly with a new description
 
 write-batch output=b0 lower=0 upper=1
-zero 0 1
-----
-parts=1 len=1
-
-write-batch output=b1 lower=1 upper=2
 ----
 parts=0 len=0
+
+write-batch output=b1 lower=1 upper=2
+zero 1 1
+----
+parts=1 len=1
 
 write-batch output=b2 lower=2 upper=3
 ----
@@ -27,14 +27,37 @@ write-batch output=b3 lower=3 upper=4
 ----
 parts=0 len=0
 
-compact output=b0_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
+compact output=b1_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
 ----
 parts=1 len=1
 
 # notably, the since has not advanced, confirming we're reading the same contents referred by b0
-fetch-batch input=b0_unchanged
+fetch-batch input=b1_unchanged
 ----
 <part 0>
-zero 0 1
+zero 1 1
+<run 0>
+part 0
+
+# and test edge cases of our non-empty batch being the lower and upper batch
+compact output=b1_unchanged inputs=(b1,b2) lower=1 upper=3 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
+<run 0>
+part 0
+
+compact output=b1_unchanged inputs=(b0,b1) lower=0 upper=2 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
 <run 0>
 part 0

--- a/src/persist-client/tests/machine/compaction_truncate
+++ b/src/persist-client/tests/machine/compaction_truncate
@@ -35,33 +35,57 @@ three 3 1
 ----
 parts=1 len=3
 
-# Compact b1 to advance the since and lose the distinctions of the original
-# data. The truncating logic relies on the data being original fidelity and this
-# ensures that it doesn't get applied too eagerly.
+## Compact b1 to advance the since and lose the distinctions of the original
+## data. The truncating logic relies on the data being original fidelity and this
+## ensures that it doesn't get applied too eagerly.
 
 truncate-batch-desc input=b1 output=b1trunc lower=2 upper=3
 ----
 parts=1 len=3
 
-compact output=b1advanced inputs=(b1trunc) lower=2 upper=3 since=6
+# introduce a new batch to compact with b1trunc, because compaction over
+# a single batch simply returns the input with an updated description
+write-batch output=b2 lower=3 upper=4
+four 3 1
 ----
 parts=1 len=1
+
+# advance since beyond the upper. if truncation (erroneously) applied, we would not see any results in the output
+compact output=b1advanced inputs=(b1trunc,b2) lower=2 upper=4 since=6
+----
+parts=1 len=2
 
 fetch-batch input=b1advanced
 ----
 <part 0>
+four 6 1
 two 6 1
 <run 0>
 part 0
 
-compact output=b0_1trunc inputs=(b0trunc,b1advanced) lower=1 upper=3 since=10
+compact output=b0_1trunc inputs=(b0trunc,b1advanced) lower=1 upper=4 since=10
 ----
-parts=1 len=2
+parts=1 len=3
 
 fetch-batch input=b0_1trunc
 ----
 <part 0>
+four 10 1
 one 10 1
 two 10 1
+<run 0>
+part 0
+
+## Verify that the special compaction case of a single input still receives truncation.
+## The compaction res should contain all the updates of b1trunc, but should only return
+## updates within the registered desc
+compact output=b1trunc_compacted inputs=(b1trunc) lower=2 upper=3 since=6
+----
+parts=1 len=3
+
+fetch-batch input=b1trunc_compacted
+----
+<part 0>
+two 2 1
 <run 0>
 part 0

--- a/src/persist-client/tests/machine/compaction_truncate
+++ b/src/persist-client/tests/machine/compaction_truncate
@@ -35,57 +35,33 @@ three 3 1
 ----
 parts=1 len=3
 
-## Compact b1 to advance the since and lose the distinctions of the original
-## data. The truncating logic relies on the data being original fidelity and this
-## ensures that it doesn't get applied too eagerly.
+# Compact b1 to advance the since and lose the distinctions of the original
+# data. The truncating logic relies on the data being original fidelity and this
+# ensures that it doesn't get applied too eagerly.
 
 truncate-batch-desc input=b1 output=b1trunc lower=2 upper=3
 ----
 parts=1 len=3
 
-# introduce a new batch to compact with b1trunc, because compaction over
-# a single batch simply returns the input with an updated description
-write-batch output=b2 lower=3 upper=4
-four 3 1
+compact output=b1advanced inputs=(b1trunc) lower=2 upper=3 since=6
 ----
 parts=1 len=1
-
-# advance since beyond the upper. if truncation (erroneously) applied, we would not see any results in the output
-compact output=b1advanced inputs=(b1trunc,b2) lower=2 upper=4 since=6
-----
-parts=1 len=2
 
 fetch-batch input=b1advanced
 ----
 <part 0>
-four 6 1
 two 6 1
 <run 0>
 part 0
 
-compact output=b0_1trunc inputs=(b0trunc,b1advanced) lower=1 upper=4 since=10
+compact output=b0_1trunc inputs=(b0trunc,b1advanced) lower=1 upper=3 since=10
 ----
-parts=1 len=3
+parts=1 len=2
 
 fetch-batch input=b0_1trunc
 ----
 <part 0>
-four 10 1
 one 10 1
 two 10 1
-<run 0>
-part 0
-
-## Verify that the special compaction case of a single input still receives truncation.
-## The compaction res should contain all the updates of b1trunc, but should only return
-## updates within the registered desc
-compact output=b1trunc_compacted inputs=(b1trunc) lower=2 upper=3 since=6
-----
-parts=1 len=3
-
-fetch-batch input=b1trunc_compacted
-----
-<part 0>
-two 2 1
 <run 0>
 part 0


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

We have constant compaction churn over system-table-like workloads where a batch with data is written, followed by many empty progress batches. This produces merge requests that contain only 1 batch with updates that we pull down, advance since for, and write back in full. One could imagine it be especially problematic if the 1 batch with updates is a  large snapshot.

This PR updates compaction to specially handle requests that contain only a single nonempty batch by returning a new batch pointing to the same keys, but with an updated description. This allows us to avoid the I/O and work of reading and writing the batch entirely. It does however change our expectations of compaction-produced batches, where their inline and registered descriptions are no longer guaranteed to match, and the registered upper can now be in advance of the inline upper. It also means that compaction will not periodically rewrite batches, potentially migration them to a new format/encoding.

### Motivation

  * This PR fixes a recognized bug.
Part of the story for https://github.com/MaterializeInc/materialize/issues/15149 and https://github.com/MaterializeInc/materialize/issues/15098


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
