### PR TITLE
sql: Simplify SHOW command queries

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -315,9 +315,8 @@ fn show_connections<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let query = format!(
-        "SELECT t.name, t.type
-        FROM mz_catalog.mz_connections t
-        JOIN mz_catalog.mz_schemas s on t.schema_id = s.id
+        "SELECT name, type
+        FROM mz_catalog.mz_connections
         WHERE schema_id = {schema_spec}",
     );
     ShowSelect::new(scx, query, filter, None, None)
@@ -330,9 +329,8 @@ fn show_tables<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let query = format!(
-        "SELECT t.name
-        FROM mz_catalog.mz_tables t
-        JOIN mz_catalog.mz_schemas s ON t.schema_id = s.id
+        "SELECT name
+        FROM mz_catalog.mz_tables
         WHERE schema_id = {schema_spec}",
     );
     ShowSelect::new(scx, query, filter, None, None)
@@ -421,10 +419,9 @@ fn show_types<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let query = format!(
-        "SELECT t.name
-        FROM mz_catalog.mz_types t
-        JOIN mz_catalog.mz_schemas s ON t.schema_id = s.id
-        WHERE t.schema_id = {schema_spec}",
+        "SELECT name
+        FROM mz_catalog.mz_types
+        WHERE schema_id = {schema_spec}",
     );
     ShowSelect::new(scx, query, filter, None, None)
 }
@@ -436,10 +433,9 @@ fn show_all_objects<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let query = format!(
-        "SELECT o.name, o.type
-        FROM mz_catalog.mz_objects o
-        JOIN mz_catalog.mz_schemas s ON o.schema_id = s.id
-        WHERE o.schema_id = {schema_spec}",
+        "SELECT name, type
+        FROM mz_catalog.mz_objects
+        WHERE schema_id = {schema_spec}",
     );
     ShowSelect::new(scx, query, filter, None, None)
 }
@@ -534,7 +530,7 @@ pub fn show_columns<'a>(
             mz_columns.nullable,
             mz_columns.type,
             mz_columns.position
-         FROM mz_catalog.mz_columns AS mz_columns
+         FROM mz_catalog.mz_columns
          WHERE mz_columns.id = '{}'",
         entry.id(),
     );
@@ -583,8 +579,8 @@ pub fn show_secrets<'a>(
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let query = format!(
-        "SELECT sec.name FROM mz_catalog.mz_secrets sec
-        JOIN mz_catalog.mz_schemas s ON sec.schema_id = s.id
+        "SELECT name
+        FROM mz_catalog.mz_secrets
         WHERE schema_id = {schema_spec}",
     );
 


### PR DESCRIPTION
A lot of the SQL queries used to implement SHOW commands had unused joins in them. This commit removes all unused joins from these queries.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
