### PR TITLE
persist: allow `apply_merge_res` to replace subset of fueled merge parts

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -39,7 +39,7 @@ use crate::internal::state::{
 };
 use crate::internal::state_diff::StateDiff;
 use crate::internal::state_versions::StateVersions;
-use crate::internal::trace::FueledMergeRes;
+use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
 use crate::read::ReaderId;
 use crate::write::WriterId;
 use crate::{PersistConfig, ShardId};
@@ -268,7 +268,7 @@ where
         }
     }
 
-    pub async fn merge_res(&mut self, res: &FueledMergeRes<T>) -> bool {
+    pub async fn merge_res(&mut self, res: &FueledMergeRes<T>) -> ApplyMergeResult {
         let metrics = Arc::clone(&self.metrics);
 
         // SUBTLE! If Machine::merge_res returns false, the blobs referenced in
@@ -299,17 +299,19 @@ where
         // false negative (a blob we can never recover referenced by state). We
         // anyway need a mechanism to clean up leaked blobs because of process
         // crashes.
-        let mut applied_ever_true = false;
-        let (_seqno, _applied, _maintenance) = self
+        let mut merge_result_ever_applied = ApplyMergeResult::NotApplied;
+        let (_seqno, _apply_merge_result, _maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.merge_res, |_, state| {
                 let ret = state.apply_merge_res(res);
-                if let Continue(applied) = ret {
-                    applied_ever_true = applied_ever_true || applied;
+                if let Continue(result) = ret {
+                    if result.applied() {
+                        merge_result_ever_applied = result;
+                    }
                 }
                 ret
             })
             .await;
-        applied_ever_true
+        merge_result_ever_applied
     }
 
     pub async fn downgrade_since(
@@ -1296,11 +1298,15 @@ pub mod datadriven {
             .get(input)
             .expect("unknown batch")
             .clone();
-        let applied = datadriven
+        let merge_res = datadriven
             .machine
             .merge_res(&FueledMergeRes { output: batch })
             .await;
-        Ok(format!("{} {}\n", datadriven.machine.seqno(), applied))
+        Ok(format!(
+            "{} {}\n",
+            datadriven.machine.seqno(),
+            merge_res.applied()
+        ))
     }
 
     pub async fn perform_maintenance(

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -604,6 +604,9 @@ pub struct CompactionMetrics {
     pub(crate) runs_compacted: IntCounter,
     pub(crate) chunks_compacted: IntCounter,
 
+    pub(crate) applied_exact_match: IntCounter,
+    pub(crate) applied_subset_match: IntCounter,
+
     pub(crate) batch: BatchWriteMetrics,
     pub(crate) steps: CompactionStepTimings,
 
@@ -662,6 +665,14 @@ impl CompactionMetrics {
             chunks_compacted: registry.register(metric!(
                 name: "mz_persist_compaction_chunks_compacted",
                 help: "count of run chunks compacted",
+            )),
+            applied_exact_match: registry.register(metric!(
+                name: "mz_persist_compaction_applied_exact_match",
+                help: "count of merge results that exactly replaced a SpineBatch",
+            )),
+            applied_subset_match: registry.register(metric!(
+                name: "mz_persist_compaction_applied_subset_match",
+                help: "count of merge results that replaced a subset of a SpineBatch",
             )),
             batch: BatchWriteMetrics::new(registry, "compaction"),
             steps: CompactionStepTimings::new(step_timings.clone()),

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -27,7 +27,7 @@ use timely::PartialOrder;
 use crate::error::{Determinacy, InvalidUsage};
 use crate::internal::gc::GcReq;
 use crate::internal::paths::{PartialBatchKey, PartialRollupKey};
-use crate::internal::trace::{FueledMergeReq, FueledMergeRes, Trace};
+use crate::internal::trace::{ApplyMergeResult, FueledMergeReq, FueledMergeRes, Trace};
 use crate::read::ReaderId;
 use crate::write::WriterId;
 use crate::{PersistConfig, ShardId};
@@ -277,9 +277,12 @@ where
         Continue(merge_reqs)
     }
 
-    pub fn apply_merge_res(&mut self, res: &FueledMergeRes<T>) -> ControlFlow<Infallible, bool> {
-        let applied = self.trace.apply_merge_res(res);
-        Continue(applied)
+    pub fn apply_merge_res(
+        &mut self,
+        res: &FueledMergeRes<T>,
+    ) -> ControlFlow<Infallible, ApplyMergeResult> {
+        let apply_merge_result = self.trace.apply_merge_res(res);
+        Continue(apply_merge_result)
     }
 
     pub fn downgrade_since(

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -527,7 +527,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
         // that was generated elsewhere. Most of the time we can, though, so
         // count the good ones and fall back to the slow path below when we
         // can't.
-        if trace.apply_merge_res(&res) {
+        if trace.apply_merge_res(&res).applied() {
             // Maybe return the replaced batches from apply_merge_res and verify
             // that they match _inputs?
             metrics.state.apply_spine_fast_path.inc();

--- a/src/persist-client/tests/trace/compaction
+++ b/src/persist-client/tests/trace/compaction
@@ -68,31 +68,11 @@ take-merge-reqs
 ----
 [0][8][0] k0 k1 k2 k3 k4 k5 k6 k7
 
-# Merge responses that we didn't generate are ignored.
-apply-merge-res
-[1][3][0] 0 nope
-----
-no-op
-
-# For now, we only apply a merge req if it exactly matches the bounds of some
-# SpineBatch. In practice, this means a merge req that is outdated when it
-# arrives will be a no-op.
-apply-merge-res
-[0][2][0] 2 nope
-----
-no-op
-
-# Verify that nothing has been changed by the no-op.
-spine-batches
-----
-[0][8][0] 8/8 k0 k1 k2 k3 k4 k5 k6 k7
-[8][9][0] 100 k8
-
 # Successfully apply a merge res
 apply-merge-res
 [0][8][0] 5 k0-7
 ----
-applied
+applied exact
 
 spine-batches
 ----

--- a/src/persist-client/tests/trace/compaction_apply_res
+++ b/src/persist-client/tests/trace/compaction_apply_res
@@ -1,0 +1,144 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+push-batch
+[0][2][0] 1 k0-2
+[2][4][0] 1 k2-4
+[4][6][0] 1 k4-6
+[6][8][0] 1 k6-8
+[8][10][0] 1 k8-10
+[10][12][0] 1 k10-12
+[12][14][0] 1 k12-14
+[14][16][0] 1 k14-16
+----
+ok
+
+push-batch
+[16][18][0] 100 k16-18
+----
+ok
+
+spine-batches
+----
+[0][16][0] 8/8 k0-2 k2-4 k4-6 k6-8 k8-10 k10-12 k12-14 k14-16
+[16][18][0] 100 k16-18
+
+# cannot apply batch that spans two spine batches exactly
+apply-merge-res
+[0][18][0] 2 nope
+----
+no-op
+
+# cannot apply batch that spans two spine batches with matching lower
+apply-merge-res
+[0][17][0] 2 nope
+----
+no-op
+
+# cannot apply batch that spans two spine batches with matching upper
+apply-merge-res
+[1][18][0] 2 nope
+----
+no-op
+
+# cannot apply batch that spans more than all spine batches
+apply-merge-res
+[0][20][0] 2 nope
+----
+no-op
+
+# cannot apply batch whose lower does not align with the lower of any parts of our fueled merge
+apply-merge-res
+[1][6][0] 2 nope
+----
+no-op
+
+# cannot apply batch whose upper does not align with the upper of any parts of our fueled merge
+apply-merge-res
+[2][7][0] 2 nope
+----
+no-op
+
+# cannot apply batch whose lower nor upper aligns with any parts of our fueled merge
+apply-merge-res
+[2][7][0] 2 nope
+----
+no-op
+
+# cannot apply batch into a merge spine batch
+apply-merge-res
+[16][17][0] 2 nope
+----
+no-op
+
+# perform a merge res at the start of the fueled merge
+apply-merge-res
+[0][4][0] 2 k0-4
+----
+applied subset
+
+spine-batches
+----
+[0][16][0] 7/8 k0-4 k4-6 k6-8 k8-10 k10-12 k12-14 k14-16
+[16][18][0] 100 k16-18
+
+# perform a merge res at the end of the fueled merge
+apply-merge-res
+[12][16][0] 2 k12-16
+----
+applied subset
+
+spine-batches
+----
+[0][16][0] 6/8 k0-4 k4-6 k6-8 k8-10 k10-12 k12-16
+[16][18][0] 100 k16-18
+
+# perform a merge res in the middle of the fueled merge
+apply-merge-res
+[6][10][0] 2 k6-10
+----
+applied subset
+
+spine-batches
+----
+[0][16][0] 5/8 k0-4 k4-6 k6-10 k10-12 k12-16
+[16][18][0] 100 k16-18
+
+# replace a single part within the fueled merge
+apply-merge-res
+[4][6][0] 1 k4-6-v2
+----
+applied subset
+
+spine-batches
+----
+[0][16][0] 5/8 k0-4 k4-6-v2 k6-10 k10-12 k12-16
+[16][18][0] 100 k16-18
+
+# replace a subset of parts, some of which have already been replaced
+apply-merge-res
+[4][12][0] 4 k4-12
+----
+applied subset
+
+spine-batches
+----
+[0][16][0] 3/8 k0-4 k4-12 k12-16
+[16][18][0] 100 k16-18
+
+# perform a merge res that replaces an entire spine batch
+apply-merge-res
+[0][16][0] 8 k0-16
+----
+applied exact
+
+spine-batches
+----
+[0][16][0] 8 k0-16
+[16][18][0] 100 k16-18

--- a/src/persist-client/tests/trace/compaction_apply_res_since
+++ b/src/persist-client/tests/trace/compaction_apply_res_since
@@ -49,7 +49,7 @@ no-op
 apply-merge-res
 [0][4][3] 2 k0-4
 ----
-applied
+applied exact
 
 spine-batches
 ----

--- a/src/persist-client/tests/trace/compaction_regression_size_reduction
+++ b/src/persist-client/tests/trace/compaction_regression_size_reduction
@@ -49,7 +49,7 @@ ok
 apply-merge-res
 [0][2][0] 1 k0-1
 ----
-applied
+applied exact
 
 # Insert a batch that would force FuelingMerge(0-2,2-3) to finish and move up a
 # few levels. In the regression, this would panic.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Currently compaction results only apply to spine if the description exactly matches a spine batch. However if the spine has been rebuilt, or if another merge for the batch occurred in the interim, this can prevent the merge from cleanly applying. [Depending on the access pattern](https://github.com/MaterializeInc/materialize/issues/15093#issuecomment-1273051321), this can result in unbounded state growth due to compaction failing to consolidate updates repeatedly over time.

This PR updates `apply_merge_res`/`maybe_replace` to allow merges over subsets of parts within a fueled merge, when there is a run of parts that begin with the compaction result's lower and ending with its upper.

cc @aljoscha 

### Motivation

  * This PR fixes a recognized bug.

Part of #15093 along with the constellation of issues noted in https://github.com/MaterializeInc/materialize/issues/15093#issuecomment-1273052887 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
