### PR TITLE
persist: semaphore to increase/limit compaction concurrency

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -30,7 +30,8 @@ use mz_persist_types::{Codec, Codec64};
 use timely::progress::Timestamp;
 use timely::PartialOrder;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, TryAcquireError};
+use tracing::log::warn;
 use tracing::{debug, debug_span, info, Instrument, Span};
 
 use crate::async_runtime::CpuHeavyRuntime;
@@ -93,6 +94,9 @@ where
     {
         let (compact_req_sender, mut compact_req_receiver) =
             mpsc::unbounded_channel::<(CompactReq<T>, oneshot::Sender<()>)>();
+        let concurrency_limit = Arc::new(tokio::sync::Semaphore::new(
+            machine.cfg.compaction_concurrency_limit,
+        ));
         let metrics = Arc::clone(&machine.metrics);
         let cfg = machine.cfg.clone();
 
@@ -108,6 +112,27 @@ where
                 let cpu_heavy_runtime = Arc::clone(&cpu_heavy_runtime);
                 let mut machine = machine.clone();
                 let writer_id = writer_id.clone();
+                let permit = {
+                    let inner = Arc::clone(&concurrency_limit);
+                    // perform a non-blocking attempt to acquire a permit so we can
+                    // record how often we're ever blocked on the concurrency limit
+                    match inner.try_acquire_owned() {
+                        Ok(permit) => permit,
+                        Err(TryAcquireError::NoPermits) => {
+                            metrics.compaction.concurrency_waits.inc();
+                            Arc::clone(&concurrency_limit)
+                                .acquire_owned()
+                                .await
+                                .expect("semaphore is never closed")
+                        }
+                        Err(TryAcquireError::Closed) => {
+                            // should never happen in practice. the semaphore is
+                            // never explicitly closed, nor will it close on Drop
+                            warn!("semaphore for shard {} is closed", machine.shard_id());
+                            continue;
+                        }
+                    }
+                };
 
                 let compact_span =
                     debug_span!(parent: None, "compact::apply", shard_id=%machine.shard_id());
@@ -162,6 +187,9 @@ where
                             debug!("compaction for {} failed: {:#}", machine.shard_id(), err);
                         }
                     };
+
+                    // moves `permit` into async scope so it can be dropped upon completion
+                    drop(permit);
                 }
                 .instrument(compact_span)
                 .await;

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -599,6 +599,7 @@ pub struct CompactionMetrics {
     pub(crate) failed: IntCounter,
     pub(crate) noop: IntCounter,
     pub(crate) seconds: Counter,
+    pub(crate) concurrency_waits: IntCounter,
     pub(crate) memory_violations: IntCounter,
     pub(crate) runs_compacted: IntCounter,
     pub(crate) chunks_compacted: IntCounter,
@@ -645,6 +646,10 @@ impl CompactionMetrics {
             seconds: registry.register(metric!(
                 name: "mz_persist_compaction_seconds",
                 help: "time spent in compaction",
+            )),
+            concurrency_waits: registry.register(metric!(
+                name: "mz_persist_compaction_concurrency_waits",
+                help: "count of compaction requests that ever blocked due to concurrency limit",
             )),
             memory_violations: registry.register(metric!(
                 name: "mz_persist_compaction_memory_violations",

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -215,6 +215,9 @@ pub struct PersistConfig {
     /// if the number of updates is at least this many. Compaction is performed
     /// if any of the heuristic criteria are met (they are OR'd).
     pub compaction_heuristic_min_updates: usize,
+    /// In Compactor::compact_and_apply_background, the maximum number of concurrent
+    /// compaction requests that can execute for a given shard.
+    pub compaction_concurrency_limit: usize,
     /// The maximum size of the connection pool to Postgres/CRDB when performing
     /// consensus reads and writes.
     pub consensus_connection_pool_max_size: usize,
@@ -283,6 +286,7 @@ impl PersistConfig {
             compaction_memory_bound_bytes: 1024 * MB,
             compaction_heuristic_min_inputs: 8,
             compaction_heuristic_min_updates: 1024,
+            compaction_concurrency_limit: 5,
             consensus_connection_pool_max_size: 50,
             writer_lease_duration: Duration::from_secs(60 * 15),
             reader_lease_duration: Self::DEFAULT_READ_LEASE_DURATION,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The move to a background task for compaction was useful to bound the amount of work a shard could be doing at once, but for higher throughput shards, the zero-concurrency setup is insufficient to keep up. This reintroduces concurrent compaction requests, in bounded fashion, up to a particular limit. This should help us strike a balance between  requirements with throughput needs.

### Motivation

  * This PR fixes a recognized bug.

Compaction falls behind on some high-throughput prod shards

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
