### PR TITLE
ci,testdrive: Add a Nightly CI job with SIZE 4

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -26,11 +26,9 @@ steps:
           - { value: limits }
           - { value: cluster-limits }
           - { value: limits-instance-size }
-          - { value: testdrive-workers-1 }
-          - { value: testdrive-workers-32 }
           - { value: testdrive-partitions-5 }
           - { value: testdrive-replicas-4}
-          - { value: testdrive-replica-size-4}
+          - { value: testdrive-size-4}
           - { value: testdrive-in-cloudtest}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
@@ -194,31 +192,6 @@ steps:
           run: instance-size
     timeout_in_minutes: 50
 
-  - id: testdrive-workers-1
-    label: ":racing_car: testdrive with --workers 1"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          # TODO(benesch): set --workers=1 again.
-          args: [--aws-region=us-east-2]
-
-  # TODO(benesch): reenable.
-  # - id: testdrive-workers-32
-  #   label: ":racing_car: testdrive with --workers 32"
-  #   depends_on: build-x86_64
-  #   timeout_in_minutes: 600
-  #   plugins:
-  #     - ./ci/plugins/scratch-aws-access: ~
-  #     - ./ci/plugins/mzcompose:
-  #         composition: testdrive
-  #         args: [--aws-region=us-east-2, --workers=32]
-  #   agents:
-  #     queue: linux-x86_64-large
-
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"
     timeout_in_minutes: 600
@@ -241,8 +214,8 @@ steps:
           composition: testdrive
           args: [--aws-region=us-east-2, --replicas=4]
 
-  - id: testdrive-replica-size-4
-    label: ":racing_car: testdrive replica SIZE 4"
+  - id: testdrive-size-4
+    label: ":racing_car: testdrive with SIZE 4"
     timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
@@ -250,7 +223,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --replica-size=4]
+          args: [--aws-region=us-east-2, --size=4]
 
   - id: testdrive-in-cloudtest
     label: Full Testdrive in Cloudtest (K8s)

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -55,6 +55,8 @@ class Testdrive(K8sPod):
                 "--aws-endpoint=http://minio-service.default:9000",
                 "--aws-access-key-id=minio",
                 "--aws-secret-access-key=minio123",
+                "--var=replicas=1",
+                "--var=size=1",
                 *(["--no-reset"] if no_reset else []),
                 *([f"--seed={seed}"] if seed else []),
                 *args,

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -44,6 +44,7 @@ class Materialized(Service):
         persist_blob_url: Optional[str] = None,
         data_directory: str = "/mzdata",
         workers: Optional[int] = None,
+        size: Optional[str] = None,
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         environment_extra: Optional[List[str]] = None,
@@ -83,6 +84,17 @@ class Materialized(Service):
                 "AWS_SESSION_TOKEN",
             ]
 
+        if size:
+            environment += [
+                f"MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE={size}",
+                f"MZ_DEFAULT_STORAGE_HOST_SIZE={size}",
+            ]
+
+        if workers:
+            environment += [
+                f"MZ_WORKERS={workers}",
+            ]
+
         if environment_extra:
             environment.extend(environment_extra)
 
@@ -104,9 +116,6 @@ class Materialized(Service):
                 config_ports.pop()
 
         command_list = []
-
-        if workers:
-            command_list.append(f"--workers {workers}")
 
         if options:
             if isinstance(options, str):
@@ -150,6 +159,7 @@ class Computed(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
+        workers: Optional[int] = None,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -365,12 +365,8 @@ pub struct Args {
     /// A map from size name to resource allocations for storage hosts.
     #[clap(long, env = "STORAGE_HOST_SIZES")]
     storage_host_sizes: Option<String>,
-    /// Default storage host size, should be a key from storage_host_sizes.
-    #[clap(
-        long,
-        env = "DEFAULT_STORAGE_HOST_SIZE",
-        requires = "storage-host-sizes"
-    )]
+    /// Default storage host size
+    #[clap(long, env = "DEFAULT_STORAGE_HOST_SIZE")]
     default_storage_host_size: Option<String>,
     /// The interval in seconds at which to collect storage usage information.
     #[clap(

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -152,7 +152,7 @@ id price
 
 # The ouput of SUBSCRIBE is dependent on the replica size
 $ skip-if
-SELECT ${arg.replica-size} > 1;
+SELECT ${arg.size} > 1;
 
 > BEGIN
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -493,7 +493,7 @@ mz_storage_usage
 
 # The sources in the catalog depend on the number of replicas and computeds
 $ skip-if
-SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
+SELECT ${arg.replicas} > 1 OR ${arg.size} > 1;
 
 > SHOW SOURCES FROM mz_internal
 name                                           type   size

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -11,15 +11,19 @@
 
 > CREATE SOURCE demo FROM LOAD GENERATOR AUCTION (TICK INTERVAL '50ms') FOR ALL TABLES
 
+$ set-regex match=\d replacement=<SIZE>
+
 > SHOW SOURCES
 name          type           size
 ----------------------------------
-demo          load-generator 1
+demo          load-generator <SIZE>
 accounts      subsource      <null>
 auctions      subsource      <null>
 bids          subsource      <null>
 organizations subsource      <null>
 users         subsource      <null>
+
+$ unset-regex
 
 > SHOW COLUMNS FROM auctions
 end_time false "timestamp with time zone"

--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -11,7 +11,7 @@
 
 # The contents of the introspection tables depend on the replica size
 $ skip-if
-SELECT ${arg.replica-size} > 1
+SELECT ${arg.size} > 1
 
 # In case the environment has other replicas
 > SET cluster_replica = r1

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -17,7 +17,7 @@
 
 # The contents of the introspection tables depend on the replica size
 $ skip-if
-SELECT ${arg.replica-size} > 1
+SELECT ${arg.size} > 1
 
 # In case the environment has other replicas
 > SET cluster_replica = r1

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -9,13 +9,17 @@
 
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
+$ set-regex match=\d replacement=<SIZE>
+
 > SHOW SOURCES
 accounts      subsource      <null>
-auction_house load-generator 1
+auction_house load-generator <SIZE>
 auctions      subsource      <null>
 bids          subsource      <null>
 organizations subsource      <null>
 users         subsource      <null>
+
+$ unset-regex
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -334,11 +334,15 @@ a  b
 3  4
 1  2
 
+$ set-regex match=\d replacement=<SIZE>
+
 > SHOW SOURCES
 name     type    size
 ---------------------
-data     kafka   1
-mat_data kafka   1
+data     kafka   <SIZE>
+mat_data kafka   <SIZE>
+
+$ unset-regex
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -50,7 +50,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="set the default number of kafka partitions per topic",
     )
     parser.add_argument(
-        "--replica-size", type=int, default=1, help="use REPLICA SIZE 'N'"
+        "--size", type=int, default=4, help="use SIZE 'N' for replicas and sources"
     )
 
     parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
@@ -79,11 +79,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         validate_postgres_stash=True,
     )
 
-    with c.override(testdrive):
+    materialized = Materialized(size=args.size) if args.size else Materialized()
+
+    with c.override(testdrive, materialized):
         c.start_and_wait_for_tcp(services=dependencies)
         c.wait_for_materialized("materialized")
 
-        if args.replicas > 1 or args.replica_size > 1:
+        if args.replicas > 1 or args.size > 1:
             c.sql("DROP CLUSTER default CASCADE")
             # Make sure a replica named 'r1' always exists
             replica_names = [
@@ -91,8 +93,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 for replica_id in range(0, args.replicas)
             ]
             replica_string = ",".join(
-                f"{replica_name} (SIZE '{args.replica_size}')"
-                for replica_name in replica_names
+                f"{replica_name} (SIZE '{args.size}')" for replica_name in replica_names
             )
             c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})")
 
@@ -102,7 +103,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 "testdrive",
                 f"--junit-report={junit_report}",
                 f"--var=replicas={args.replicas}",
-                f"--var=replica-size={args.replica_size}",
+                f"--var=size={args.size}",
                 *args.files,
             )
         finally:

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -162,17 +162,21 @@ renamed_sink
 # Clean up temp view
 > DROP VIEW public_objects;
 
+$ set-regex match=\d replacement=<SIZE>
+
 # Source was successfully renamed
 > SHOW SOURCES;
 name               type   size
 ------------------------------
-renamed_mz_data    kafka  1
+renamed_mz_data    kafka  <SIZE>
 
 # Sink was successfully renamed
 > SHOW SINKS
 name               type   size
 ------------------------------
-renamed_sink       kafka  1
+renamed_sink       kafka  <SIZE>
+
+$ set-regex match=u\d+|cluster1|default replacement=<VARIABLE_OUTPUT>
 
 # View was successfully renamed
 > SHOW VIEWS

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -106,12 +106,16 @@ name               type   size
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
+$ set-regex match=\d replacement=<D>
+
 > SHOW SINKS
 name               type   size
 ------------------------------
-snk1               kafka  1
-snk2               kafka  1
-snk3               kafka  1
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+
+$ unset-regex
 
 $ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
@@ -200,18 +204,22 @@ $ kafka-verify-data format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"column1": 2}}}
 {"before": null, "after": {"row":{"column1": 3}}}
 
+$ set-regex match=\d replacement=<D>
+
 > SHOW SINKS
 name               type   size
 ------------------------------
-snk1               kafka  1
-snk2               kafka  1
-snk3               kafka  1
-snk4               kafka  1
-snk5               kafka  1
-snk6               kafka  1
-snk7               kafka  1
-snk8               kafka  1
-snk_unsigned       kafka  1
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk<D>             kafka  <D>
+snk_unsigned       kafka  <D>
+
+$ unset-regex
 
 # test explicit partition count
 > CREATE SINK snk9 FROM foo
@@ -263,7 +271,10 @@ snk_unsigned       kafka  1
 
 # Including for sinks with default size
 > SELECT size FROM mz_sinks WHERE name = 'snk13'
-1
+"${arg.size}"
+
+$ skip-if
+SELECT ${arg.size} != 1
 
 # Check that SHOW SINKS shows the size correctly
 > SHOW SINKS


### PR DESCRIPTION
Various bugs prevent running the entire CI with SIZE > 1, so we are adding a separate dedicated CI job.

- modify environmentd so that --default-storage-host-size is not required to be an item from storage-host-sizes but can be an item from the built-in list as well.
- create a Nightly CI job that uses SIZE 4 for sources, sinks and clusters
- adjust tests to run properly regardless of the SIZE
- remove existing workers-1 and workers-32 CI jobs, as those were misleading or disabled

### Motivation

  * This PR adds a feature that has not yet been specified.
We urgently need some SIZE 4 coverage in CI before any new regressions are introduced.

Due to existing bugs it is not possible to run the entire CI with SIZE = 4, so a dedicated Nightly CI job is being defined instead.
### Tips for reviewer

@benesch there is a one-liner change in `src/environmentd/src/bin/environmentd/main.rs`, the rest if python and .td stuff.

This PR does not address the problem of auto-discovering the correct values for `size` and `replicas` so that testdrive can run out of the box without any `--var=` command-line arguments. This will come in a follow-up PR as soon as I have a solution.