### PR TITLE
sql: better error for SHOW CREATE SOURCE on system sources

### DIFF
--- a/test/sqllogictest/github-15357.slt
+++ b/test/sqllogictest/github-15357.slt
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/15357.
+
+mode cockroach
+
+statement error mz_internal.mz_dataflow_channels is a system source
+SHOW CREATE SOURCE mz_internal.mz_dataflow_channels
+
+statement error mz_internal.mz_dataflow_channels_1 is a system source
+SHOW CREATE SOURCE mz_internal.mz_dataflow_channels_1
+
+statement error mz_internal.mz_storage_shards is a system source
+SHOW CREATE SOURCE mz_internal.mz_storage_shards


### PR DESCRIPTION
System sources (sources created by the system instead of the user) don't contain valid SQL in `create_sql` and therefore yield cryptic error messages when one tries to `SHOW CREATE SOURCE` them:

```
materialize=> show create source mz_internal.mz_dataflow_channels;
ERROR:  Expected a keyword at the beginning of a statement, found operator "<"
materialize=> show create source mz_internal.mz_dataflow_channels_1;
ERROR:  Expected a keyword at the beginning of a statement, found operator "<"
materialize=> show create source mz_internal.mz_storage_shards;
ERROR:  Expected a keyword at the beginning of a statement, found identifier "todo"
```

This PR fixes that by adding a check based on the source's ID, and returning a useful error for sources that are created by the system.

### Motivation

  * This PR fixes a recognized bug.

Fixes #15357.

### Tips for reviewer

I think we should consider making `create_sql` an `Option`, instead of using dummy strings like "\<builtin\>" or "todo" as placeholders. Then the type system would help us avoid such issues in the future. This probably requires a larger refactoring though. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
