### PR TITLE
cloudtest: Run S3/Kinesis tests against AWS not Minio

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -233,7 +233,7 @@ steps:
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [-m=long, test/cloudtest/test_full_testdrive.py]
+          args: [-m=long, --aws-region=us-east-2, test/cloudtest/test_full_testdrive.py]
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"
@@ -413,8 +413,9 @@ steps:
       queue: linux-x86_64
     artifact_paths: junit_cloudtest_*.xml
     plugins:
+      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [-m=long, test/cloudtest/test_upgrade.py]
+          args: [-m=long,  --aws-region=us-east-2, test/cloudtest/test_upgrade.py]
 
   - id: persist-maelstrom-single-node
     label: Long single-node Maelstrom coverage of persist

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -538,8 +538,9 @@ steps:
     artifact_paths: junit_cloudtest_*.xml
     inputs: [test/cloudtest]
     plugins:
+      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [-m, "not long", test/cloudtest/]
+          args: [-m, "not long", --aws-region=us-east-2, test/cloudtest/]
 
   - id: checks-restart-redpanda
     label: "Checks + restart Redpanda"

--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -15,6 +15,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import random
+
 from materialize.cloudtest.application import MaterializeApplication
 from materialize.mzcompose import Composition
 
@@ -48,9 +50,10 @@ class MzcomposeExecutor(Executor):
 class CloudtestExecutor(Executor):
     def __init__(self, application: MaterializeApplication) -> None:
         self.application = application
+        self.seed = random.getrandbits(32)
 
     def cloudtest_application(self) -> MaterializeApplication:
         return self.application
 
     def testdrive(self, input: str) -> None:
-        self.application.testdrive.run(input=input, no_reset=True, seed=1)
+        self.application.testdrive.run(input=input, no_reset=True, seed=self.seed)

--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -31,6 +31,7 @@ class Application:
     resources: List[K8sResource]
     images: List[str]
     release_mode: bool
+    aws_region: Optional[str]
 
     def __init__(self) -> None:
         self.create()
@@ -65,10 +66,16 @@ class Application:
 
 
 class MaterializeApplication(Application):
-    def __init__(self, release_mode: bool = True, tag: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        release_mode: bool = True,
+        tag: Optional[str] = None,
+        aws_region: Optional[str] = None,
+    ) -> None:
         self.environmentd = EnvironmentdService()
-        self.testdrive = Testdrive(release_mode=release_mode)
+        self.testdrive = Testdrive(release_mode=release_mode, aws_region=aws_region)
         self.release_mode = release_mode
+        self.aws_region = aws_region
 
         self.resources = [
             *POSTGRES_RESOURCES,

--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from _pytest.config import Config
@@ -26,8 +26,22 @@ def pytest_configure(config: "Config") -> None:
 
 @pytest.fixture(scope="session")
 def mz(pytestconfig: pytest.Config) -> MaterializeApplication:
-    return MaterializeApplication(release_mode=(not pytestconfig.getoption("dev")))
+    return MaterializeApplication(
+        release_mode=(not pytestconfig.getoption("dev")),
+        aws_region=pytestconfig.getoption("aws_region"),
+    )
+
+
+@pytest.fixture(scope="session")
+def aws_region(pytestconfig: pytest.Config) -> Any:
+    return pytestconfig.getoption("aws_region")
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--dev", action="store_true")
+    parser.addoption(
+        "--aws-region",
+        action="store",
+        default=None,
+        help="AWS region to pass to testdrive",
+    )

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -77,11 +77,11 @@ class CloudtestUpgrade(Scenario):
 
 
 @pytest.mark.long
-def test_upgrade() -> None:
+def test_upgrade(aws_region: Optional[str]) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
     last_released_version = f"v{util.released_materialize_versions()[0]}"
 
-    mz = MaterializeApplication(tag=last_released_version)
+    mz = MaterializeApplication(tag=last_released_version, aws_region=aws_region)
     wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-1-0")
 
     executor = CloudtestExecutor(application=mz)


### PR DESCRIPTION
```
Author: Philip Stoev <pstoev@materialize.com>
Date:   Thu Oct 13 12:02:03 2022 +0200

    cloudtest: Use AWS S3 instead of Minio for S3 testdrive tests
    
    Unfortuniately Minio does not seem compatible with S3 sources,
    so pass through AWS credentials from the host to testdrive if
    S3 testdrive tests are to be run.
    
    The AWS credentials are generated by the scratch-aws-access Buikdkite
    plugin in the form of environment variables that we copy over into
    the testdrive container.
    
    An --aws-region option can be passed to pytest which in turn
    passes it to testdrive.
    
    To avoid conflicts between concurrent tests that use S3, an actual
    random seed must be used by the Platform Checks in a cloudtest environment.

```

### Motivation

The Nightly "testdrive-in-cloudtest" CI job was failing because the S3/Kinesis tests were failing trying to work with Minio. 