### PR TITLE
sql: Prevent SHOW CREATE statement for system obj

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -118,6 +118,12 @@ pub fn plan_show_create_table(
     ShowCreateTableStatement { table_name }: ShowCreateTableStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
     let table = scx.get_item_by_resolved_name(&table_name)?;
+    if table.id().is_system() {
+        sql_bail!(
+            "cannot show create for system object {}",
+            table_name.full_name_str()
+        );
+    }
     if let CatalogItemType::Table = table.item_type() {
         let name = table_name.full_name_str();
         let create_sql = simplify_names(scx.catalog, table.create_sql())?;
@@ -148,6 +154,12 @@ pub fn plan_show_create_source(
     ShowCreateSourceStatement { source_name }: ShowCreateSourceStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
     let source = scx.get_item_by_resolved_name(&source_name)?;
+    if source.id().is_system() {
+        sql_bail!(
+            "cannot show create for system object {}",
+            source_name.full_name_str()
+        );
+    }
     if let CatalogItemType::Source = source.item_type() {
         let name = source_name.full_name_str();
         let create_sql = simplify_names(scx.catalog, source.create_sql())?;

--- a/test/sqllogictest/show_create_system_objects.slt
+++ b/test/sqllogictest/show_create_system_objects.slt
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Tests for the bytea type.
-
 mode cockroach
 
 query error cannot show create for system object mz_internal.mz_dataflow_channels

--- a/test/sqllogictest/show_create_system_objects.slt
+++ b/test/sqllogictest/show_create_system_objects.slt
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for the bytea type.
+
+mode cockroach
+
+query error cannot show create for system object mz_internal.mz_dataflow_channels
+SHOW CREATE SOURCE mz_internal.mz_dataflow_channels
+
+query error cannot show create for system object mz_internal.mz_dataflow_channels_1
+SHOW CREATE SOURCE mz_internal.mz_dataflow_channels_1
+
+query error cannot show create for system object mz_internal.mz_storage_shards
+SHOW CREATE SOURCE mz_internal.mz_storage_shards
+
+query error cannot show create for system object mz_catalog.mz_tables
+SHOW CREATE TABLE mz_tables


### PR DESCRIPTION
System objects do not have a create SQL statement. Therefore, there is nothing to show when running SHOW CREATE. This commit returns an meaningful error message instead of the current confusing one.

Works towards resolving #15357

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
