### PR TITLE
allow telling environmentd about egress ips

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -101,6 +101,15 @@ Field  | Type       | Meaning
 `oid`  | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the database.
 `name` | [`text`]   | The name of the database.
 
+### `mz_egress_ips`
+
+The `mz_egress_ips` table contains a row for each potential IP address that the
+system may connect to external systems from.
+
+Field       | Type     | Meaning
+------------|----------|--------
+`egress_ip` | [`text`] | The IP address.
+
 ### `mz_functions`
 
 The `mz_functions` table contains a row for each function in the system.

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -100,6 +100,8 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 "--storage-stash-url=postgres://postgres@postgres.default?options=--search_path=storage",
                 "--internal-sql-listen-addr=0.0.0.0:6877",
                 "--unsafe-mode",
+                "--announce-egress-ip=1.2.3.4",
+                "--announce-egress-ip=88.77.66.55",
             ],
             env=env,
             ports=ports,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1417,6 +1417,12 @@ pub static MZ_STORAGE_USAGE_BY_SHARD: Lazy<BuiltinTable> = Lazy::new(|| BuiltinT
         ),
 });
 
+pub static MZ_EGRESS_IPS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_egress_ips",
+    schema: MZ_CATALOG_SCHEMA,
+    desc: RelationDesc::empty().with_column("egress_ip", ScalarType::String.nullable(false)),
+});
+
 pub static MZ_STORAGE_SHARDS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_storage_shards",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2431,6 +2437,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
         Builtin::Table(&MZ_AUDIT_EVENTS),
         Builtin::Table(&MZ_STORAGE_USAGE_BY_SHARD),
+        Builtin::Table(&MZ_EGRESS_IPS),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_ARRANGEMENT_SHARING),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::net::Ipv4Addr;
+
 use chrono::{DateTime, Utc};
 
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
@@ -31,10 +33,10 @@ use mz_storage::types::sinks::{KafkaSinkConnection, StorageSinkConnection};
 use crate::catalog::builtin::{
     MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS,
     MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS,
-    MZ_DATABASES, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS,
-    MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS,
-    MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD,
-    MZ_TABLES, MZ_TYPES, MZ_VIEWS,
+    MZ_DATABASES, MZ_EGRESS_IPS, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS,
+    MZ_KAFKA_SINKS, MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES,
+    MZ_SCHEMAS, MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS,
+    MZ_STORAGE_USAGE_BY_SHARD, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
     CatalogItem, CatalogState, Connection, Database, Error, ErrorKind, Func, Index,
@@ -815,6 +817,12 @@ impl CatalogState {
                     .expect("must fit"),
             ),
         ]);
+        Ok(BuiltinTableUpdate { id, row, diff: 1 })
+    }
+
+    pub fn pack_egress_ip_update(&self, ip: &Ipv4Addr) -> Result<BuiltinTableUpdate, Error> {
+        let id = self.resolve_builtin_table(&MZ_EGRESS_IPS);
+        let row = Row::pack_slice(&[Datum::String(&ip.to_string())]);
         Ok(BuiltinTableUpdate { id, row, diff: 1 })
     }
 }

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -48,6 +49,8 @@ pub struct Config<'a, S> {
     pub availability_zones: Vec<String>,
     /// A handle to a secrets manager that can only read secrets.
     pub secrets_reader: Arc<dyn SecretsReader>,
+    /// IP Addresses which will be used for egress.
+    pub egress_ips: Vec<Ipv4Addr>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -67,6 +67,7 @@
 //!
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 use std::ops::Neg;
 use std::sync::Arc;
@@ -241,6 +242,7 @@ pub struct Config<S> {
     pub storage_usage_client: StorageUsageClient,
     pub storage_usage_collection_interval: Duration,
     pub segment_api_key: Option<String>,
+    pub egress_ips: Vec<Ipv4Addr>,
 }
 
 /// Soft-state metadata about a compute replica
@@ -871,6 +873,7 @@ pub async fn serve<S: Append + 'static>(
         storage_usage_client,
         storage_usage_collection_interval,
         segment_api_key,
+        egress_ips,
     }: Config<S>,
 ) -> Result<(Handle, Client), AdapterError> {
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -906,6 +909,7 @@ pub async fn serve<S: Append + 'static>(
             default_storage_host_size,
             availability_zones,
             secrets_reader: secrets_controller.reader(),
+            egress_ips,
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -16,7 +16,7 @@ use std::cmp;
 use std::env;
 use std::ffi::CStr;
 use std::iter;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -383,6 +383,10 @@ pub struct Args {
     /// An API key for Segment. Enables export of audit events to Segment.
     #[clap(long, env = "SEGMENT_API_KEY")]
     segment_api_key: Option<String>,
+    /// Public IP addresses which the cloud environment has configured for
+    /// egress
+    #[clap(long)]
+    announce_egress_ip: Vec<Ipv4Addr>,
 
     // === Tracing options. ===
     #[clap(flatten)]
@@ -713,6 +717,7 @@ max log level: {max_log_level}",
         tracing_target_callbacks,
         storage_usage_collection_interval: args.storage_usage_collection_interval_sec,
         segment_api_key: args.segment_api_key,
+        egress_ips: args.announce_egress_ip,
     }))?;
 
     println!(

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -14,7 +14,7 @@
 //! [timely dataflow]: ../timely/index.html
 
 use std::env;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -107,6 +107,8 @@ pub struct Config {
     pub storage_usage_collection_interval: Duration,
     /// An API key for Segment. Enables export of audit events to Segment.
     pub segment_api_key: Option<String>,
+    /// IP Addresses which will be used for egress.
+    pub egress_ips: Vec<Ipv4Addr>,
 
     // === Tracing options. ===
     /// The metrics registry to use.
@@ -279,6 +281,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         storage_usage_client,
         storage_usage_collection_interval: config.storage_usage_collection_interval,
         segment_api_key: config.segment_api_key,
+        egress_ips: config.egress_ips,
     })
     .await?;
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -219,6 +219,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         tracing_target_callbacks: mz_ore::tracing::TracingTargetCallbacks::default(),
         storage_usage_collection_interval: config.storage_usage_collection_interval,
         segment_api_key: None,
+        egress_ips: vec![],
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -698,6 +698,7 @@ impl Runner {
             tracing_target_callbacks: mz_ore::tracing::TracingTargetCallbacks::default(),
             storage_usage_collection_interval: Duration::from_secs(3600),
             segment_api_key: None,
+            egress_ips: vec![],
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/test/cloudtest/test_egress_ips.py
+++ b/test/cloudtest/test_egress_ips.py
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.cloudtest.application import MaterializeApplication
+
+
+def test_egress_ips(mz: MaterializeApplication) -> None:
+    egress_ips = mz.environmentd.sql_query(
+        "SELECT egress_ip FROM mz_catalog.mz_egress_ips"
+    )
+    assert egress_ips == (["1.2.3.4"], ["88.77.66.55"])

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -463,6 +463,7 @@ mz_cluster_replicas
 mz_columns
 mz_connections
 mz_databases
+mz_egress_ips
 mz_functions
 mz_index_columns
 mz_indexes
@@ -668,7 +669,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-31
+32
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
this allows the orchestrator to populate the mz_egress_ips system catalog table by passing --announce-egress-ip when launching environmentd.

### Motivation

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/cloud/issues/4277

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - no behavior changes
