### PR TITLE
[sources] Revive source status history collection

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1412,8 +1412,8 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
         .with_column("timestamp", ScalarType::Timestamp.nullable(false))
         .with_column("source_name", ScalarType::String.nullable(false))
         .with_column("source_id", ScalarType::String.nullable(false))
-        .with_column("worker_id", ScalarType::Int64.nullable(false))
-        .with_column("worker_count", ScalarType::Int64.nullable(false))
+        .with_column("worker_id", ScalarType::Int64.nullable(true))
+        .with_column("worker_count", ScalarType::Int64.nullable(true))
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("error", ScalarType::String.nullable(true))
         .with_column("metadata", ScalarType::Jsonb.nullable(true)),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1411,8 +1411,6 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     desc: RelationDesc::empty()
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
         .with_column("source_id", ScalarType::String.nullable(false))
-        .with_column("worker_id", ScalarType::Int64.nullable(true))
-        .with_column("worker_count", ScalarType::Int64.nullable(true))
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("error", ScalarType::String.nullable(true))
         .with_column("details", ScalarType::Jsonb.nullable(true)),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1409,13 +1409,13 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::SourceStatusHistory),
     desc: RelationDesc::empty()
-        .with_column("timestamp", ScalarType::Timestamp.nullable(false))
+        .with_column("occurred_at", ScalarType::Timestamp.nullable(false))
         .with_column("source_id", ScalarType::String.nullable(false))
         .with_column("worker_id", ScalarType::Int64.nullable(true))
         .with_column("worker_count", ScalarType::Int64.nullable(true))
         .with_column("status", ScalarType::String.nullable(false))
         .with_column("error", ScalarType::String.nullable(true))
-        .with_column("metadata", ScalarType::Jsonb.nullable(true)),
+        .with_column("details", ScalarType::Jsonb.nullable(true)),
 });
 
 pub static MZ_STORAGE_USAGE_BY_SHARD: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1410,7 +1410,6 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     data_source: Some(IntrospectionType::SourceStatusHistory),
     desc: RelationDesc::empty()
         .with_column("timestamp", ScalarType::Timestamp.nullable(false))
-        .with_column("source_name", ScalarType::String.nullable(false))
         .with_column("source_id", ScalarType::String.nullable(false))
         .with_column("worker_id", ScalarType::Int64.nullable(true))
         .with_column("worker_count", ScalarType::Int64.nullable(true))

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1406,14 +1406,12 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 
 pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_source_status_history",
-    schema: MZ_CATALOG_SCHEMA,
-    data_source: None,
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::SourceStatusHistory),
     desc: RelationDesc::empty()
         .with_column("timestamp", ScalarType::Timestamp.nullable(false))
         .with_column("source_name", ScalarType::String.nullable(false))
         .with_column("source_id", ScalarType::String.nullable(false))
-        .with_column("source_type", ScalarType::String.nullable(false))
-        .with_column("upstream_name", ScalarType::String.nullable(true))
         .with_column("worker_id", ScalarType::Int64.nullable(false))
         .with_column("worker_count", ScalarType::Int64.nullable(false))
         .with_column("status", ScalarType::String.nullable(false))
@@ -2682,10 +2680,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_INHERITS),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
-        // This is disabled for the moment because it has unusual upper
-        // advancement behavior.
-        // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
-        // Builtin::Source(&MZ_SOURCE_STATUS_HISTORY),
+        Builtin::Source(&MZ_SOURCE_STATUS_HISTORY),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::View(&MZ_STORAGE_USAGE),
         Builtin::Index(&MZ_SHOW_DATABASES_IND),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1409,7 +1409,7 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::SourceStatusHistory),
     desc: RelationDesc::empty()
-        .with_column("occurred_at", ScalarType::Timestamp.nullable(false))
+        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
         .with_column("source_id", ScalarType::String.nullable(false))
         .with_column("worker_id", ScalarType::Int64.nullable(true))
         .with_column("worker_count", ScalarType::Int64.nullable(true))

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -89,7 +89,6 @@ where
     let source_name = format!("{}-{}", connection.name(), id);
     let base_source_config = RawSourceCreationConfig {
         name: source_name,
-        upstream_name: connection.upstream_name().map(ToOwned::to_owned),
         id,
         num_outputs: description.desc.num_outputs(),
         timestamp_interval: description.desc.timestamp_interval.clone(),

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -227,8 +227,8 @@ impl Healthchecker {
                 .expect("status collection should not have errors");
             let row_vec = row.unpack();
             let row_source_id = row_vec[2].unwrap_str();
-            let row_worker_id = row_vec[5].unwrap_int64();
-            let row_status = row_vec[7].unwrap_str();
+            let row_worker_id = row_vec[3].unwrap_int64();
+            let row_status = row_vec[5].unwrap_str();
 
             if self.source_id.to_string() == row_source_id
                 && self.worker_id == row_worker_id as usize
@@ -556,7 +556,7 @@ mod tests {
             .await
             .into_iter()
             .find_map(|row| {
-                let error = row.unpack()[8];
+                let error = row.unpack()[6];
                 if !error.is_null() {
                     Some(error.unwrap_str().to_string())
                 } else {

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -33,8 +33,6 @@ pub struct Healthchecker {
     source_name: String,
     /// Internal ID of the source (e.g. s1)
     source_id: GlobalId,
-    /// Type of the source, from SourceConnection::name
-    source_type: &'static str,
     /// The ID of the Timely worker on which this operator is executing
     worker_id: usize,
     /// The total count of Timely workers
@@ -59,7 +57,6 @@ impl Healthchecker {
     pub async fn new(
         source_name: String,
         source_id: GlobalId,
-        source_type: &'static str,
         worker_id: usize,
         worker_count: usize,
         active: bool,
@@ -93,7 +90,6 @@ impl Healthchecker {
         let mut healthchecker = Self {
             worker_id,
             worker_count,
-            source_type,
             source_name,
             source_id,
             current_status: SourceStatus::Starting,
@@ -260,7 +256,6 @@ impl Healthchecker {
         let source_id = self.source_id.to_string();
         let source_name = Datum::String(&self.source_name);
         let source_id = Datum::String(&source_id);
-        let source_type: Datum = self.source_type.into();
         let worker_id =
             Datum::Int64(i64::try_from(self.worker_id).expect("worker_id does not fit into i64"));
         let worker_count = Datum::Int64(
@@ -273,7 +268,6 @@ impl Healthchecker {
             timestamp,
             source_name,
             source_id,
-            source_type,
             worker_id,
             worker_count,
             status,
@@ -681,7 +675,6 @@ mod tests {
         status_shard_id: ShardId,
         source_name: String,
         source_id: GlobalId,
-        source_type: &'static str,
         worker_id: usize,
         worker_count: usize,
         active: bool,
@@ -700,7 +693,6 @@ mod tests {
         Healthchecker::new(
             source_name,
             source_id,
-            source_type,
             worker_id,
             worker_count,
             active,

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -9,7 +9,7 @@
 
 //! Healthchecks for sources
 use anyhow::Context;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use std::fmt::Display;
 use std::sync::Arc;
 use timely::progress::{Antichain, Timestamp as _};
@@ -246,9 +246,12 @@ impl Healthchecker {
             (ts % 1000 * 1_000_000)
                 .try_into()
                 .expect("timestamp millis does not fit into a u32"),
-        )
-        .try_into()
-        .expect("timestamp does not fit");
+        );
+        let timestamp = Datum::TimestampTz(
+            DateTime::from_utc(timestamp, Utc)
+                .try_into()
+                .expect("must fit"),
+        );
         let source_id = self.source_id.to_string();
         let source_id = Datum::String(&source_id);
         let worker_id =

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -31,8 +31,6 @@ use crate::types::sources::SourceData;
 pub struct Healthchecker {
     /// Name of the source (e.g. kafka-s1)
     source_name: String,
-    /// Name of the upstream resource, if any (e.g. Kafka topic, file path)
-    upstream_name: Option<String>,
     /// Internal ID of the source (e.g. s1)
     source_id: GlobalId,
     /// Type of the source, from SourceConnection::name
@@ -60,7 +58,6 @@ pub struct Healthchecker {
 impl Healthchecker {
     pub async fn new(
         source_name: String,
-        upstream_name: Option<String>,
         source_id: GlobalId,
         source_type: &'static str,
         worker_id: usize,
@@ -99,7 +96,6 @@ impl Healthchecker {
             source_type,
             source_name,
             source_id,
-            upstream_name,
             current_status: SourceStatus::Starting,
             active,
             upper: Antichain::from_elem(Timestamp::minimum()),
@@ -265,7 +261,6 @@ impl Healthchecker {
         let source_name = Datum::String(&self.source_name);
         let source_id = Datum::String(&source_id);
         let source_type: Datum = self.source_type.into();
-        let upstream_name: Datum = self.upstream_name.as_deref().into();
         let worker_id =
             Datum::Int64(i64::try_from(self.worker_id).expect("worker_id does not fit into i64"));
         let worker_count = Datum::Int64(
@@ -279,7 +274,6 @@ impl Healthchecker {
             source_name,
             source_id,
             source_type,
-            upstream_name,
             worker_id,
             worker_count,
             status,
@@ -688,7 +682,6 @@ mod tests {
         source_name: String,
         source_id: GlobalId,
         source_type: &'static str,
-        upstream_name: Option<String>,
         worker_id: usize,
         worker_count: usize,
         active: bool,
@@ -706,7 +699,6 @@ mod tests {
 
         Healthchecker::new(
             source_name,
-            upstream_name,
             source_id,
             source_type,
             worker_id,
@@ -729,8 +721,6 @@ mod tests {
             status_shard_id,
             "source".to_string(),
             GlobalId::User(source_id),
-            "kafka",
-            Some("sample-topic".to_string()),
             1,
             1,
             true,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1063,9 +1063,8 @@ where
     reclock_op.build(move |mut capabilities| {
         capabilities.clear();
 
-        let metrics_name = name.clone();
         let mut source_metrics =
-            SourceMetrics::new(&base_metrics, &metrics_name, id, &worker_id.to_string());
+            SourceMetrics::new(&base_metrics, &name, id, &worker_id.to_string());
 
         source_metrics
             .resume_upper

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -253,7 +253,6 @@ where
     Box::pin(async_stream::stream!({
         let mut healthchecker = if storage_metadata.status_shard.is_some() {
             match Healthchecker::new(
-                name.clone(),
                 id,
                 worker_id,
                 worker_count,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -11,7 +11,7 @@
 //!
 //! Raw sources are streams (currently, Timely streams) of data directly produced by the
 //! upstream service. The main export of this module is [`create_raw_source`],
-//! which turns [`RawSourceCreationConfig`]s, [`SourceConnection`]s,
+//! which turns [`RawSourceCreationConfig`]s, [`SourceReader::Connection`]s,
 //! and [`SourceReader`] implementations into the aforementioned streams.
 //!
 //! The full source, which is the _differential_ stream that represents the actual object
@@ -66,7 +66,6 @@ use crate::source::healthcheck::Healthchecker;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::ReclockFollower;
 use crate::source::reclock::ReclockOperator;
-use crate::source::types::SourceConnection;
 use crate::source::types::SourceOutput;
 use crate::source::types::SourceReaderError;
 use crate::source::types::{
@@ -227,7 +226,6 @@ struct SourceReaderOperatorOutput<S: SourceReader> {
 fn build_source_reader_stream<G, S>(
     source_reader: S,
     config: RawSourceCreationConfig,
-    source_connection: S::Connection,
     initial_source_upper: OffsetAntichain,
     mut source_upper: OffsetAntichain,
 ) -> Pin<
@@ -257,7 +255,6 @@ where
             match Healthchecker::new(
                 name.clone(),
                 id,
-                source_connection.name(),
                 worker_id,
                 worker_count,
                 true,
@@ -537,7 +534,6 @@ where
                 let mut source_reader = build_source_reader_stream::<G, S>(
                     source_reader,
                     sub_config,
-                    source_connection,
                     initial_source_upper,
                     source_upper,
                 );

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -88,9 +88,6 @@ const YIELD_INTERVAL: Duration = Duration::from_millis(10);
 pub struct RawSourceCreationConfig {
     /// The name to attach to the underlying timely operator.
     pub name: String,
-    /// The name of the upstream resource this source corresponds to
-    /// (For example, a Kafka topic)
-    pub upstream_name: Option<String>,
     /// The ID of this instantiation of this source.
     pub id: GlobalId,
     /// The number of expected outputs from this ingestion
@@ -243,7 +240,6 @@ where
 {
     let RawSourceCreationConfig {
         name,
-        upstream_name,
         id,
         num_outputs: _,
         worker_id,
@@ -260,7 +256,6 @@ where
         let mut healthchecker = if storage_metadata.status_shard.is_some() {
             match Healthchecker::new(
                 name.clone(),
-                upstream_name,
                 id,
                 source_connection.name(),
                 worker_id,
@@ -465,7 +460,6 @@ where
     let sub_config = config.clone();
     let RawSourceCreationConfig {
         name,
-        upstream_name: _,
         id,
         num_outputs: _,
         worker_id,
@@ -783,7 +777,6 @@ where
 {
     let RawSourceCreationConfig {
         name,
-        upstream_name: _,
         id,
         num_outputs: _,
         worker_id,
@@ -1049,7 +1042,6 @@ where
 {
     let RawSourceCreationConfig {
         name,
-        upstream_name,
         id,
         num_outputs,
         worker_id,
@@ -1084,7 +1076,7 @@ where
     reclock_op.build(move |mut capabilities| {
         capabilities.clear();
 
-        let metrics_name = upstream_name.clone().unwrap_or_else(|| name.clone());
+        let metrics_name = name.clone();
         let mut source_metrics =
             SourceMetrics::new(&base_metrics, &metrics_name, id, &worker_id.to_string());
 

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -252,16 +252,8 @@ where
     } = config;
     Box::pin(async_stream::stream!({
         let mut healthchecker = if storage_metadata.status_shard.is_some() {
-            match Healthchecker::new(
-                id,
-                worker_id,
-                worker_count,
-                true,
-                &persist_clients,
-                &storage_metadata,
-                now.clone(),
-            )
-            .await
+            match Healthchecker::new(id, true, &persist_clients, &storage_metadata, now.clone())
+                .await
             {
                 Ok(h) => Some(h),
                 Err(e) => {

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -21,7 +21,7 @@ mode cockroach
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name LIKE '%_1');
 ----
-1
+2
 
 # This test checks if the views in mz_catalog are also present in a postfixed
 # way. If this test fails and you added new view that uses introspection

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -567,6 +567,7 @@ mz_scheduling_parks_internal                    log   <null>
 mz_scheduling_parks_internal_1                  log   <null>
 mz_scheduling_parks_internal_2                  log   <null>
 mz_scheduling_parks_internal_3                  log   <null>
+mz_source_status_history                        source <null>
 mz_storage_shards                               source <null>
 mz_worker_compute_frontiers                     log   <null>
 mz_worker_compute_frontiers_1                   log   <null>

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Specify the behaviour of the status history tables
+
+# History starts out empty when there are no sources
+> select * from mz_internal.mz_source_status_history


### PR DESCRIPTION
This PR adapts the schema of the collection to match the design doc, adds it to the mz_internal schema, and sets it to have its write frontier automatically bumped.

### Motivation

Known-desirable feature: #15162.

### Tips for reviewer

I'd like to do this before adding the other writers to the collection, since that lets me make smaller PRs. However, it's a bit weird to have this collection that nobody's updating yet.

This is the ideal time to suggest any further changes to the collection schema, if you want. I'm a bit split on the worker id etc... it's hard to choose meaningful values in the storage controller for these, but not including them would force a rearchitecture of the healthchecker, which I'm not ready to think about yet.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None. (Exposes a new relation in the mz_internal schema... but that's private.)
