### PR TITLE
For SHOW commands, only support IN CLUSTER for materialized views and indexes

### DIFF
--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -138,6 +138,13 @@ SHOW TABLES FROM foo.bar
 Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
 
 parse-statement
+SHOW TABLES IN CLUSTER baz
+----
+error: Expected end of statement, found IN
+SHOW TABLES IN CLUSTER baz
+            ^
+
+parse-statement
 SHOW SINKS
 ----
 SHOW SINKS
@@ -154,9 +161,9 @@ Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(Unresolved
 parse-statement
 SHOW SINKS FROM foo.bar IN CLUSTER baz
 ----
+error: Expected end of statement, found IN
 SHOW SINKS FROM foo.bar IN CLUSTER baz
-=>
-Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), filter: None }))
+                        ^
 
 parse-statement
 SHOW TABLES LIKE '%foo%'


### PR DESCRIPTION
Only materialized views and indexes are associated with clusters. Therefore, it only makes sense to support the `IN CLUSTER` filter to SHOW commands on those object types. Remove parser support (it was not documented in the UI) for the `IN CLUSTER` filter for all other objects.

Added bonus that this cleans up the code nicely, too!

 This PR fixes a previously unreported bug, discussed in slack https://materializeinc.slack.com/archives/C02FWJ94HME/p1665429589756879 and https://materializeinc.slack.com/archives/C02FWJ94HME/p1665429737355069.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
