### PR TITLE
testdrive: drop clusters created during testing

### DIFF
--- a/test/testdrive/github-15095.td
+++ b/test/testdrive/github-15095.td
@@ -18,3 +18,5 @@
   FROM mz_cluster_replicas r, mz_internal.mz_cluster_replica_heartbeats h
   WHERE r.id = h.replica_id AND r.name = 'r'
 1
+
+> DROP CLUSTER c CASCADE;

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -209,3 +209,5 @@ contains:unknown schema 'nonexistent'
 
 > SHOW INDEXES ON foo.bar
 bar_ind bar <VARIABLE_OUTPUT> {a}
+
+> DROP CLUSTER clstr CASCADE;


### PR DESCRIPTION
Issue DROP CLUSTER at the end of tests that issue CREATE CLUSTER.

Otherwise the extra clusters show up in later tests that do SHOW CLUSTERS.

### Motivation

  * This PR fixes a previously unreported bug.
There were CI failures due to clusters left behind.