### PR TITLE
persist: automatically heartbeat handles in background tasks (for now)

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -18,7 +18,9 @@ use std::time::{Duration, SystemTime};
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::cast::CastFrom;
+use mz_ore::task::spawn;
 use timely::progress::{Antichain, Timestamp};
+use tokio::task::JoinHandle;
 use tracing::{debug, info};
 
 #[allow(unused_imports)] // False positive.
@@ -336,28 +338,60 @@ where
         &mut self,
         reader_id: &ReaderId,
         heartbeat_timestamp_ms: u64,
-    ) -> (SeqNo, RoutineMaintenance) {
+    ) -> (SeqNo, bool, RoutineMaintenance) {
         let metrics = Arc::clone(&self.metrics);
-        let (seqno, _existed, maintenance) = self
+        let (seqno, existed, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.heartbeat_reader, |_, state| {
                 state.heartbeat_reader(reader_id, heartbeat_timestamp_ms)
             })
             .await;
-        (seqno, maintenance)
+        (seqno, existed, maintenance)
+    }
+
+    pub async fn start_reader_heartbeat_task(self, reader_id: ReaderId) -> JoinHandle<()> {
+        let mut machine = self;
+        spawn(|| "persist::heartbeat_read", async move {
+            let sleep_duration = machine.cfg.reader_lease_duration / 2;
+            loop {
+                tokio::time::sleep(sleep_duration).await;
+                let (_seqno, existed, _maintenance) = machine
+                    .heartbeat_reader(&reader_id, (machine.cfg.now)())
+                    .await;
+                if !existed {
+                    return;
+                }
+            }
+        })
     }
 
     pub async fn heartbeat_writer(
         &mut self,
         writer_id: &WriterId,
         heartbeat_timestamp_ms: u64,
-    ) -> (SeqNo, RoutineMaintenance) {
+    ) -> (SeqNo, bool, RoutineMaintenance) {
         let metrics = Arc::clone(&self.metrics);
-        let (seqno, _existed, maintenance) = self
+        let (seqno, existed, maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.heartbeat_writer, |_, state| {
                 state.heartbeat_writer(writer_id, heartbeat_timestamp_ms)
             })
             .await;
-        (seqno, maintenance)
+        (seqno, existed, maintenance)
+    }
+
+    pub async fn start_writer_heartbeat_task(self, writer_id: WriterId) -> JoinHandle<()> {
+        let mut machine = self;
+        spawn(|| "persist::heartbeat_write", async move {
+            let sleep_duration = machine.cfg.writer_lease_duration / 2;
+            loop {
+                tokio::time::sleep(sleep_duration).await;
+                let (_seqno, existed, _maintenance) = machine
+                    .heartbeat_writer(&writer_id, (machine.cfg.now)())
+                    .await;
+                if !existed {
+                    return;
+                }
+            }
+        })
     }
 
     pub async fn expire_reader(&mut self, reader_id: &ReaderId) -> SeqNo {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -17,7 +17,6 @@
     clippy::cast_sign_loss
 )]
 
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -415,21 +414,21 @@ impl PersistClient {
         let gc = GarbageCollector::new(machine.clone());
 
         let reader_id = ReaderId::new();
+        let heartbeat_ts = (self.cfg.now)();
         let (_, read_cap) = machine
-            .register_reader(&reader_id, self.cfg.reader_lease_duration, (self.cfg.now)())
+            .register_reader(&reader_id, self.cfg.reader_lease_duration, heartbeat_ts)
             .await;
-        let reader = ReadHandle {
-            cfg: self.cfg.clone(),
-            metrics: Arc::clone(&self.metrics),
-            reader_id,
+        let reader = ReadHandle::new(
+            self.cfg.clone(),
+            Arc::clone(&self.metrics),
             machine,
             gc,
-            blob: Arc::clone(&self.blob),
-            since: read_cap.since,
-            last_heartbeat: (self.cfg.now)(),
-            explicitly_expired: false,
-            leased_seqnos: BTreeMap::new(),
-        };
+            Arc::clone(&self.blob),
+            reader_id,
+            read_cap.since,
+            heartbeat_ts,
+        )
+        .await;
 
         Ok(reader)
     }
@@ -471,22 +470,23 @@ impl PersistClient {
                 writer_id.clone(),
             )
         });
+        let heartbeat_ts = (self.cfg.now)();
         let (shard_upper, _) = machine
-            .register_writer(&writer_id, self.cfg.writer_lease_duration, (self.cfg.now)())
+            .register_writer(&writer_id, self.cfg.writer_lease_duration, heartbeat_ts)
             .await;
-        let writer = WriteHandle {
-            cfg: self.cfg.clone(),
-            metrics: Arc::clone(&self.metrics),
-            writer_id,
+        let writer = WriteHandle::new(
+            self.cfg.clone(),
+            Arc::clone(&self.metrics),
             machine,
             gc,
             compact,
-            blob: Arc::clone(&self.blob),
-            cpu_heavy_runtime: Arc::clone(&self.cpu_heavy_runtime),
-            upper: shard_upper.0,
-            last_heartbeat: (self.cfg.now)(),
-            explicitly_expired: false,
-        };
+            Arc::clone(&self.blob),
+            Arc::clone(&self.cpu_heavy_runtime),
+            writer_id,
+            shard_upper.0,
+            heartbeat_ts,
+        )
+        .await;
         Ok(writer)
     }
 
@@ -1406,7 +1406,7 @@ mod tests {
             .expect_open::<String, String, u64, i64>(shard_id)
             .await;
 
-        let (_, maintenance) = read
+        let (_, _, maintenance) = read
             .machine
             .heartbeat_reader(&read.reader_id, now.load(Ordering::SeqCst))
             .await;
@@ -1665,6 +1665,40 @@ mod tests {
 
         // Read the snapshot and check that it got all the appropriate data.
         assert_eq!(snap.await, all_ok(&data[..], 3));
+    }
+
+    #[tokio::test]
+    async fn heartbeat_task_shutdown() {
+        // Verify that the ReadHandle and WriteHandle background heartbeat tasks
+        // shut down cleanly after the handle is expired.
+        let mut cache = new_test_client_cache();
+        cache.cfg.reader_lease_duration = Duration::from_millis(1);
+        cache.cfg.writer_lease_duration = Duration::from_millis(1);
+        let (mut write, mut read) = cache
+            .open(PersistLocation {
+                blob_uri: "mem://".to_owned(),
+                consensus_uri: "mem://".to_owned(),
+            })
+            .await
+            .expect("client construction failed")
+            .expect_open::<(), (), u64, i64>(ShardId::new())
+            .await;
+        let read_heartbeat_task = read
+            .heartbeat_task
+            .take()
+            .expect("handle should have heartbeat task");
+        let write_heartbeat_task = write
+            .heartbeat_task
+            .take()
+            .expect("handle should have heartbeat task");
+        write.expire().await;
+        let () = write_heartbeat_task
+            .await
+            .expect("task should shutdown cleanly");
+        read.expire().await;
+        let () = read_heartbeat_task
+            .await
+            .expect("task should shutdown cleanly");
     }
 
     proptest! {


### PR DESCRIPTION
Ideally, users of persist read and write handles will do their own explicit heartbeat-ing. In each place they've been used so far, there's some nice place to hook a maybe_heartbeat call into.

However, we fixed a bunch of these in the release that just went out and a set of new ones popped up in their place. The "correct" fix would be to continue to track each of these down and address them individually, but we've got enough fires as it is right now. Plus, until we figure out a way to shake these out in CI, we'll continue to see them pop up in production in new persist usages.

For now, introduce a background task for each read and each write handle that automatically heartbeats it. The plan is to rip these back out at some nebulous future point (probably not soon, to be honest), so intentionally don't document this. Instead,  keep the other heartbeat codepaths hooked up.

To make this more obvious, create ReadHandle::new and WriteHandle::new methods (instead of creating them directly in lib.rs). We probably should have done this a while ago, anyway.

Touches #15397

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
