### PR TITLE
environmentd: improve non-COPY http support

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -171,6 +171,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         server.inner.http_local_addr()
     ))?;
 
+    #[derive(Debug)]
     struct TestCaseSimple {
         query: &'static str,
         status: StatusCode,
@@ -367,6 +368,21 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             query: "subscribe (select * from t)",
             status: StatusCode::BAD_REQUEST,
             body: r#"unsupported via this API: SUBSCRIBE (SELECT * FROM t)"#,
+        },
+        TestCaseSimple {
+            query: "copy (select 1) to stdout",
+            status: StatusCode::BAD_REQUEST,
+            body: r#"unsupported via this API: COPY (SELECT 1) TO STDOUT"#,
+        },
+        TestCaseSimple {
+            query: "EXPLAIN SELECT 1",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[["%0 =\n| Constant (1)\n"]],"col_names":["Optimized Plan"],"notices":[]}]}"#,
+        },
+        TestCaseSimple {
+            query: "SHOW VIEWS",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[["v"]],"col_names":["name"],"notices":[]}]}"#,
         },
     ];
 


### PR DESCRIPTION
Previously we incorrectly disallowed EXPLAIN and SHOW statements, because we didn't explicitly check for those in the match. Instead of an allowlist, switch to a blocklist which should evolve better if we add more of those.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a