### PR TITLE
adapter: use mz_timestamp type in SUBSCRIBE

### DIFF
--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -64,7 +64,7 @@ with several additional columns that describe the nature of the update:
 <tbody>
   <tr>
     <td><code>mz_timestamp</code></td>
-    <td><code>numeric</code></td>
+    <td><code>mz_timestamp</code></td>
     <td>
       Materialize's internal logical timestamp. This will never be less than any
       timestamp previously emitted by the same <code>SUBSCRIBE</code> operation.

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -12,7 +12,6 @@
 use tokio::sync::mpsc;
 
 use mz_compute_client::response::{SubscribeBatch, SubscribeResponse};
-use mz_repr::adt::numeric;
 use mz_repr::{Datum, Row};
 
 use crate::coord::peek::PeekResponseUnary;
@@ -66,8 +65,7 @@ impl PendingSubscribe {
                     .into_iter()
                     .map(|(time, row, diff)| {
                         let mut packer = row_buf.packer();
-                        // TODO: Change to MzTimestamp.
-                        packer.push(Datum::from(numeric::Numeric::from(time)));
+                        packer.push(Datum::from(time));
                         if self.emit_progress {
                             // When sinking with PROGRESS, the output
                             // includes an additional column that
@@ -99,7 +97,7 @@ impl PendingSubscribe {
                         "SUBSCRIBE only supports single-dimensional timestamps"
                     );
                     let mut packer = row_buf.packer();
-                    packer.push(Datum::from(numeric::Numeric::from(upper[0])));
+                    packer.push(Datum::from(upper[0]));
                     packer.push(Datum::True);
                     // Fill in the diff column and all table columns with NULL.
                     for _ in 0..(self.arity + 1) {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -18,7 +18,6 @@ use std::collections::{HashMap, HashSet};
 use mz_expr::MirRelationExpr;
 use mz_ore::collections::CollectionExt;
 use mz_pgcopy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams};
-use mz_repr::adt::numeric::NumericMaxScale;
 use mz_repr::explain_new::{ExplainConfig, ExplainFormat};
 use mz_repr::{RelationDesc, ScalarType};
 
@@ -537,13 +536,8 @@ pub fn describe_subscribe(
     };
     let SubscribeOptionExtracted { progress, .. } = stmt.options.try_into()?;
     let progress = progress.unwrap_or(false);
-    let mut desc = RelationDesc::empty().with_column(
-        "mz_timestamp",
-        ScalarType::Numeric {
-            max_scale: Some(NumericMaxScale::ZERO),
-        }
-        .nullable(false),
-    );
+    let mut desc =
+        RelationDesc::empty().with_column("mz_timestamp", ScalarType::MzTimestamp.nullable(false));
     if progress {
         desc = desc.with_column("mz_progressed", ScalarType::Bool.nullable(false));
     }


### PR DESCRIPTION
This should have gotten done earlier but was missed.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - **Breaking change.** Change the `mz_timestamp` column of `SUBSCRIBE` to be of type `mz_timestamp` instead of `numeric`.