### PR TITLE
doc/user: add basic reference docs about replica introspection

### DIFF
--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -32,17 +32,14 @@ machines.
 
 {{< diagram "create-cluster-replica.svg" >}}
 
-### `replica_option`
-
-{{< diagram "replica-option.svg" >}}
-
 Field | Use
 ------|-----
 _cluster_name_ | The cluster whose resources you want to create an additional computation of.
 _replica_name_ | A name for this replica.
-_replica_option_ | This replica's specified [options](#replica_option).
-_size_ | A "size" for a managed replica. For valid `size` values, see [Sizes](#sizes)
-_az_ | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
+
+### Options
+
+{{% replica-options %}}
 
 ## Details
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -86,7 +86,7 @@ Create a cluster with a single replica with introspection disabled:
 
 ```sql
 CREATE CLUSTER c REPLICAS (
-    r1 (SIZE = 'xsmall', INTROSPECTION GRANULARITY = 0)
+    r1 (SIZE = 'xsmall', INTROSPECTION INTERVAL = 0)
 );
 ```
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -46,35 +46,17 @@ this might require setting up more than one cluster.
 
 {{< diagram "cluster-replica-def.svg" >}}
 
-### `replica_option`
-
-{{< diagram "replica-option.svg" >}}
-
 Field | Use
 ------|-----
 _name_ | A name for the cluster.
 _inline_replica_ | Any [replicas](#replica_definition) you want to immediately provision.
 _replica_name_ | A name for a cluster replica.
-_replica_option_ | This replica's specified [options](#replica_option).
-_size_ | A "size" for a managed replica. For valid `size` values, see [Cluster replica sizes](#cluster-replica-sizes)
-_az_ | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
+
+### Replica options
+
+{{% replica-options %}}
 
 ## Details
-
-### Cluster replica sizes
-
-Valid `size` options are:
-
-- `xsmall`
-- `small`
-- `medium`
-- `large`
-- `xlarge`
-- `2xlarge`
-- `3xlarge`
-- `4xlarge`
-- `5xlarge`
-- `6xlarge`
 
 ### Deployment options
 
@@ -85,13 +67,42 @@ Action | Outcome
 Adding clusters + decreasing dataflow density | Reduced contention among dataflows, decoupled dataflow availability
 Adding replicas to clusters | See [Cluster replica scaling](/sql/create-cluster#deployment-options)
 
-## Example
+## Examples
+
+### Basic
+
+Create a cluster with two medium replicas:
 
 ```sql
-CREATE CLUSTER c1 REPLICAS (r1 (SIZE = 'medium'), r2 (SIZE = 'medium'));
+CREATE CLUSTER c1 REPLICAS (
+    r1 (SIZE = 'medium'),
+    r2 (SIZE = 'medium')
+);
+```
 
--- Create an empty cluster
+### Introspection disabled
+
+Create a cluster with a single replica with introspection disabled:
+
+```sql
+CREATE CLUSTER c REPLICAS (
+    r1 (SIZE = 'xsmall', INTROSPECTION GRANULARITY = 0)
+);
+```
+
+Disabling introspection can yield a small performance improvement, but you lose
+the ability to run [troubleshooting queries](/ops/troubleshooting/) against
+that cluster replica.
+
+### Empty
+
+Create a cluster with no replicas:
+
+```sql
 CREATE CLUSTER c1 REPLICAS ();
 ```
+
+You can later add replicas to this cluster with [`CREATE CLUSTER
+REPLICA`](../create-cluster-replica).
 
 [AWS availability zone ID]: https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html

--- a/doc/user/layouts/partials/sql-grammar/create-cluster-replica.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-cluster-replica.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="505" height="147">
+<svg xmlns="http://www.w3.org/2000/svg" width="505" height="163">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -36,22 +36,33 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="467" y="21">.</text>
-   <rect x="199" y="113" width="106" height="32"/>
-   <rect x="197" y="111" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="207" y="131">replica_name</text>
-   <rect x="345" y="113" width="112" height="32"/>
-   <rect x="343" y="111" width="112" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="353" y="131">replica_option</text>
-   <rect x="345" y="69" width="24" height="32" rx="10"/>
-   <rect x="343"
+   <rect x="87" y="113" width="106" height="32"/>
+   <rect x="85" y="111" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="95" y="131">replica_name</text>
+   <rect x="253" y="113" width="62" height="32"/>
+   <rect x="251" y="111" width="62" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="261" y="131">option</text>
+   <rect x="335" y="113" width="28" height="32" rx="10"/>
+   <rect x="333"
+         y="111"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="343" y="131">=</text>
+   <rect x="383" y="113" width="54" height="32"/>
+   <rect x="381" y="111" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="391" y="131">value</text>
+   <rect x="253" y="69" width="24" height="32" rx="10"/>
+   <rect x="251"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="87">,</text>
+   <text class="terminal" x="261" y="87">,</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-328 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m20 0 h10 m112 0 h10 m-152 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m132 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-132 0 h10 m24 0 h10 m0 0 h88 m23 44 h-3"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-440 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m106 0 h10 m40 0 h10 m62 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-224 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m204 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-204 0 h10 m24 0 h10 m0 0 h160 m-244 44 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v14 m264 0 v-14 m-264 14 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m0 0 h234 m23 -34 h-3"/>
    <polygon points="495 127 503 123 503 131"/>
    <polygon points="495 127 487 123 487 131"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/replica-option.svg
+++ b/doc/user/layouts/partials/sql-grammar/replica-option.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="349" height="81">
+<svg xmlns="http://www.w3.org/2000/svg" width="397" height="169">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="51" y="3" width="50" height="32" rx="10"/>
@@ -9,30 +9,35 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="59" y="21">SIZE</text>
-   <rect x="121" y="3" width="46" height="32"/>
-   <rect x="119" y="1" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="129" y="21">size</text>
-   <rect x="51" y="47" width="118" height="32" rx="10"/>
+   <rect x="51" y="47" width="162" height="32" rx="10"/>
    <rect x="49"
          y="45"
-         width="118"
+         width="162"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="65">AVAILABILITY</text>
-   <rect x="189" y="47" width="58" height="32" rx="10"/>
-   <rect x="187"
-         y="45"
-         width="58"
+   <text class="terminal" x="59" y="65">AVAILABILITY ZONE</text>
+   <rect x="51" y="91" width="210" height="32" rx="10"/>
+   <rect x="49"
+         y="89"
+         width="210"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="197" y="65">ZONE</text>
-   <rect x="267" y="47" width="34" height="32"/>
-   <rect x="265" y="45" width="34" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="275" y="65">az</text>
+   <text class="terminal" x="59" y="109">INTROSPECTION INTERVAL</text>
+   <rect x="51" y="135" width="224" height="32" rx="10"/>
+   <rect x="49"
+         y="133"
+         width="224"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="153">INTROSPECTION DEBUGGING</text>
+   <rect x="315" y="3" width="54" height="32"/>
+   <rect x="313" y="1" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="323" y="21">value</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m50 0 h10 m0 0 h10 m46 0 h10 m0 0 h134 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v24 m290 0 v-24 m-290 24 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m118 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m34 0 h10 m23 -44 h-3"/>
-   <polygon points="339 17 347 13 347 21"/>
-   <polygon points="339 17 331 13 331 21"/>
+         d="m17 17 h2 m20 0 h10 m50 0 h10 m0 0 h174 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m162 0 h10 m0 0 h62 m-254 -10 v20 m264 0 v-20 m-264 20 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m210 0 h10 m0 0 h14 m-254 -10 v20 m264 0 v-20 m-264 20 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m224 0 h10 m20 -132 h10 m54 0 h10 m3 0 h-3"/>
+   <polygon points="387 17 395 13 395 21"/>
+   <polygon points="387 17 379 13 379 21"/>
 </svg>

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -2,5 +2,5 @@ Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
 `SIZE`                              | `text`     | The size of the replica. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
 `AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
-`INTROSPECTION GRANULARITY`         | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data. Defaults to `1s`.
+`INTROSPECTION INTERVAL`         | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data. Defaults to `1s`.
 `INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data. Defaults to false.

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -1,0 +1,6 @@
+Field                               | Value      | Description
+------------------------------------|------------|-------------------------------------
+`SIZE`                              | `text`     | The size of the replica. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
+`AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
+`INTROSPECTION GRANULARITY`         | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data. Defaults to `1s`.
+`INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data. Defaults to false.

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -35,12 +35,9 @@ create_cluster ::=
     'REPLICAS' '(' (replica_definition (',' replica_definition)*)? ')'
   )?
 cluster_replica_def ::=
-  replica_name '(' replica_option ( ',' replica_option )* ')'
+  replica_name '(' replica_option = value ( ',' replica_option = value )* ')'
 create_cluster_replica ::=
-  'CREATE' 'CLUSTER' 'REPLICA' cluster_name '.' replica_name replica_option ( ',' replica_option )*
-replica_option ::=
-    'SIZE' size |
-    'AVAILABILITY' 'ZONE' az
+  'CREATE' 'CLUSTER' 'REPLICA' cluster_name '.' replica_name (option '=' value ( ',' option '=' value )*)?
 create_connection ::=
   'CREATE' 'CONNECTION' 'IF NOT EXISTS'? connection_name 'FOR'
   ( 'KAFKA' | 'CONFLUENT' 'SCHEMA' 'REGISTRY' | 'POSTGRES' | 'SSH' 'TUNNEL' )


### PR DESCRIPTION
And share the option definitions for cluster replicas across the pages for `CREATE CLUSTER` and `CREATE CLUSTER REPLICA`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR adds missing documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
