### PR TITLE
Disable persisted introspection sources

### DIFF
--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -30,27 +30,10 @@ is issued, all subsequent `SELECT` queries, for introspection sources or not, wi
 be directed to the targeted replica. The latter selection can be cancelled by
 issuing the command `RESET cluster_replica`.
 
-Materialize also directly exposes replica-specific introspection sources by
-suffixing the respective catalog relation names with a replica ID that is unique
-across clusters. For example, `mz_internal.mz_compute_frontiers_1` corresponds to
-the introspection source `mz_internal.mz_compute_frontiers` in the replica with
-the unique ID of `1`. A mapping of replica IDs to clusters and replica names is
-provided by the [`mz_cluster_replicas`] system table.
-
 As a consequence of the above, you should expect the answers to the queries below
 to vary dependending on which cluster you are working in. In particular, indexes
 and dataflows are local to a cluster, so their introspection information will
 vary across clusters.
-
-It is often useful to monitor changes in the output to the below queries
-via [`SUBSCRIBE`](/sql/subscribe), e.g. via
-`COPY (SUBSCRIBE (<query>)) TO stdout`. Be mindful of the following two caveats:
-
-  * The `SUBSCRIBE` query itself may affect performance.
-  * `SUBSCRIBE` can only be used with replica-specific introspection sources
-    (i.e., the relations that are suffixed with replica IDs). You'll need to
-    rewrite the queries below to use the suffixed relations for the particular
-    replica you wish to target.
 
 ## How fast are my sources loading data?
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1970,6 +1970,7 @@ impl<S: Append> Catalog<S> {
                     start_instant: Instant::now(),
                     nonce: rand::random(),
                     unsafe_mode: config.unsafe_mode,
+                    persisted_introspection: config.persisted_introspection,
                     environment_id: config.environment_id,
                     session_id: Uuid::new_v4(),
                     build_info: config.build_info,
@@ -2851,6 +2852,7 @@ impl<S: Append> Catalog<S> {
         let (catalog, _, _) = Catalog::open(Config {
             storage,
             unsafe_mode: true,
+            persisted_introspection: true,
             build_info: &DUMMY_BUILD_INFO,
             environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
             now,
@@ -5001,6 +5003,10 @@ impl<S: Append> Catalog<S> {
 
     /// Allocate ids for persisted introspection views. Called once per compute replica creation
     pub async fn allocate_persisted_introspection_views(&mut self) -> Vec<(LogView, GlobalId)> {
+        if !self.state.config.persisted_introspection {
+            return Vec::new();
+        }
+
         let log_amount = DEFAULT_LOG_VIEWS
             .len()
             .try_into()
@@ -5024,6 +5030,10 @@ impl<S: Append> Catalog<S> {
     pub async fn allocate_persisted_introspection_sources(
         &mut self,
     ) -> Vec<(LogVariant, GlobalId)> {
+        if !self.state.config.persisted_introspection {
+            return Vec::new();
+        }
+
         let log_amount = DEFAULT_LOG_VARIANTS
             .len()
             .try_into()

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -29,6 +29,8 @@ pub struct Config<'a, S> {
     pub storage: storage::Connection<S>,
     /// Whether to enable unsafe mode.
     pub unsafe_mode: bool,
+    /// Whether to enable persisted introspection sources.
+    pub persisted_introspection: bool,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// A persistent ID associated with the environment.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -229,6 +229,7 @@ pub struct Config<S> {
     pub dataflow_client: mz_controller::Controller,
     pub storage: storage::Connection<S>,
     pub unsafe_mode: bool,
+    pub persisted_introspection: bool,
     pub build_info: &'static BuildInfo,
     pub environment_id: String,
     pub metrics_registry: MetricsRegistry,
@@ -860,6 +861,7 @@ pub async fn serve<S: Append + 'static>(
         dataflow_client,
         storage,
         unsafe_mode,
+        persisted_introspection,
         build_info,
         environment_id,
         metrics_registry,
@@ -899,6 +901,7 @@ pub async fn serve<S: Append + 'static>(
         Catalog::open(catalog::Config {
             storage,
             unsafe_mode,
+            persisted_introspection,
             build_info,
             environment_id,
             now: now.clone(),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -101,6 +101,17 @@ pub struct Args {
     ///     legitimate security risk if used in Materialize Cloud.
     #[clap(long, env = "UNSAFE_MODE")]
     unsafe_mode: bool,
+    /// Enable persisted introspection sources.
+    ///
+    /// These sources are temporarily disabled because they put significant
+    /// pressure on persist compaction, which is currently affected by some
+    /// known bugs. Once these are resolved, the plan is to enable persisted
+    /// introspection sources by default again.
+    ///
+    /// See <https://github.com/MaterializeInc/materialize/issues/15415>
+    /// for context.
+    #[clap(long, env = "PERSISTED_INTROSPECTION")]
+    persisted_introspection: bool,
 
     // === Connection options. ===
     /// The address on which to listen for untrusted SQL connections.
@@ -701,6 +712,7 @@ max log level: {max_log_level}",
         controller,
         secrets_controller,
         unsafe_mode: args.unsafe_mode,
+        persisted_introspection: args.persisted_introspection,
         metrics_registry,
         now,
         environment_id: args.environment_id,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -52,6 +52,8 @@ pub struct Config {
     // === Special modes. ===
     /// Whether to permit usage of unsafe features.
     pub unsafe_mode: bool,
+    /// Whether to enable persisted introspection sources.
+    pub persisted_introspection: bool,
 
     // === Connection options. ===
     /// The IP address and port to listen for pgwire connections on.
@@ -268,6 +270,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         dataflow_client: controller,
         storage: adapter_storage,
         unsafe_mode: config.unsafe_mode,
+        persisted_introspection: config.persisted_introspection,
         build_info: &BUILD_INFO,
         environment_id: config.environment_id,
         metrics_registry: config.metrics_registry.clone(),

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -203,6 +203,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         tls: config.tls,
         frontegg: config.frontegg,
         unsafe_mode: config.unsafe_mode,
+        persisted_introspection: true,
         metrics_registry: metrics_registry.clone(),
         now: config.now,
         environment_id: format!("environment-{}-0", Uuid::from_u128(0)),

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -212,6 +212,8 @@ pub struct CatalogConfig {
     pub session_id: Uuid,
     /// Whether the server is running in unsafe mode.
     pub unsafe_mode: bool,
+    /// Whether persisted introspection sources are enabled.
+    pub persisted_introspection: bool,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// Default timestamp interval.
@@ -619,6 +621,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
     session_id: Uuid::from_u128(0),
     unsafe_mode: true,
+    persisted_introspection: true,
     build_info: &DUMMY_BUILD_INFO,
     timestamp_interval: Duration::from_secs(1),
     now: NOW_ZERO.clone(),

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -46,6 +46,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
     session_id: Uuid::from_u128(0),
     unsafe_mode: false,
+    persisted_introspection: false,
     build_info: &DUMMY_BUILD_INFO,
     timestamp_interval: Duration::from_secs(1),
     now: NOW_ZERO.clone(),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -683,6 +683,7 @@ impl Runner {
             frontegg: None,
             cors_allowed_origin: AllowOrigin::list([]),
             unsafe_mode: true,
+            persisted_introspection: true,
             metrics_registry,
             now,
             environment_id: format!("environment-{}-0", Uuid::from_u128(0)),


### PR DESCRIPTION
This PR disables the creation, and consequently maintenance, of the persisted compute introspection sources by default. They can still be switched on through the `--persisted-introspection` command line flag.

This is meant to be a temporary measure to give persist some room to breathe until the current compaction issues are resolved.

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/materialize/issues/15415.

### Tips for reviewer

The persisted introspection sources are only disabled for new replicas, already existing ones still have them. I think it would be possible to write a catalog migration to disable them for old replicas too.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Disable persisted compute introspection sources.
