### PR TITLE
Fix recursive calls in `extract_non_errors_from_expr`

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -348,17 +348,17 @@ impl MapFilterProject {
             MirRelationExpr::Map { input, scalars }
                 if scalars.iter().all(|s| !s.is_literal_err()) =>
             {
-                let (mfp, expr) = Self::extract_from_expression(input);
+                let (mfp, expr) = Self::extract_non_errors_from_expr(input);
                 (mfp.map(scalars.iter().cloned()), expr)
             }
             MirRelationExpr::Filter { input, predicates }
                 if predicates.iter().all(|p| !p.is_literal_err()) =>
             {
-                let (mfp, expr) = Self::extract_from_expression(input);
+                let (mfp, expr) = Self::extract_non_errors_from_expr(input);
                 (mfp.filter(predicates.iter().cloned()), expr)
             }
             MirRelationExpr::Project { input, outputs } => {
-                let (mfp, expr) = Self::extract_from_expression(input);
+                let (mfp, expr) = Self::extract_non_errors_from_expr(input);
                 (mfp.project(outputs.iter().cloned()), expr)
             }
             x => (Self::new(x.arity()), x),

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -863,15 +863,15 @@ query T multiline
 explain with(arity, join_impls) select * from t1 as a1 join t1 as a2 on (a2.f2 = (select 6 from t1)) where a2.f2 = 9;
 ----
 Explained Query:
-  Project (#0..=#3) // { arity: 4 }
-    CrossJoin type=differential // { arity: 5 }
-      implementation
-        %1 » %2[] » %0[]
-      ArrangeBy keys=[[]] // { arity: 2 }
-        Get materialize.public.t1 // { arity: 2 }
-      Filter (#1 = 9) // { arity: 2 }
-        Get materialize.public.t1 // { arity: 2 }
-      ArrangeBy keys=[[]] // { arity: 1 }
+  CrossJoin type=differential // { arity: 4 }
+    implementation
+      %1 » %2[] » %0[]
+    ArrangeBy keys=[[]] // { arity: 2 }
+      Get materialize.public.t1 // { arity: 2 }
+    Filter (#1 = 9) // { arity: 2 }
+      Get materialize.public.t1 // { arity: 2 }
+    ArrangeBy keys=[[]] // { arity: 0 }
+      Project () // { arity: 0 }
         Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
           Reduce aggregates=[count(true)] // { arity: 1 }
             Project () // { arity: 0 }


### PR DESCRIPTION
We have `extract_from_expression`, which calls itself recursively. Then we have `extract_non_errors_from_expr`, which really looks like it should be calling itself recursively, but instead it calls `extract_from_expression`. This PR modifies `extract_non_errors_from_expr` to call itself rather than `extract_from_expression`.

### Motivation

  * This PR fixes a previously unreported bug: `extract_non_errors_from_expr` should avoid extracting any maps, filters, or projects that have errors, but the current behavior is that it avoids extracting errors only from the root, and then if there are further maps, filters, or projects below the root, then it would happily crunch through them even if they have errors.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  - It's a bit hard to come up with a test that would exercise this, so I hope it's ok that I'm not adding a test.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No
