### PR TITLE
storage: add bare-bones UNITTEST source

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -652,6 +652,39 @@ Adjust the number of tries testdrive will perform while waiting for a SQL statem
 Set `max-tries` to `1` in order to ensure that statements are executed only once. If the desired result is not achieved on the first try, the test will fail. This is
 useful when testing operations that should return the right result immediately rather than eventually.
 
+## `TEST SCRIPT` sources
+`TEST SCRIPT` sources can be a useful to have a source that emits data in specific pattern,
+without setting up data in a local source. They are created as follows:
+
+```
+> CREATE SOURCE unit
+  FROM TEST SCRIPT
+  '[
+    {"command": "emit", "key": "fish", "value": "value", "offset": 0},
+    {"command": "emit", "key": "fish2", "value": "hmm", "offset": 1},
+    {"command": "emit" ,"key": "fish", "value": "value2", "offset": 2}
+  ]'
+  KEY FORMAT BYTES
+  VALUE FORMAT BYTES
+  ENVELOPE UPSERT
+```
+
+Each "command" can be:
+- `"emit"`: emit data at a specific offset. The `"key"` is optional, but required
+for some envelopes, like `UPSERT`
+- `"terminate"`: terminate the source, ignoring all later commands. This closes the
+source's `upper`
+  - The default behavior if there is no `"terminate"` command is for the source
+  to pend forever, after it processes all other commands.
+
+Note that this soure has some limitations:
+- It does not work with formats like `avro`
+- It requires the key and value format to specified individually, as
+it does not support CSR formats.
+
+These limitations may be lifted in the future; additionally, more features may
+be added to this source.
+
 ## Actions on local files
 
 #### `$ file-append path=file.name [compression=gzip] [repeat=N]`

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -966,6 +966,9 @@ pub enum CreateSourceConnection<T: AstInfo> {
         generator: LoadGenerator,
         options: Vec<LoadGeneratorOption<T>>,
     },
+    TestScript {
+        desc_json: String,
+    },
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
@@ -1026,6 +1029,12 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
                     f.write_node(&display::comma_separated(options));
                     f.write_str(")");
                 }
+            }
+            CreateSourceConnection::TestScript { desc_json } => {
+                f.write_str("TEST SCRIPT ");
+                f.write_str("'");
+                f.write_str(&display::escape_single_quote_string(desc_json));
+                f.write_str("'");
             }
         }
     }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -285,6 +285,7 @@ Sasl
 Scan
 Schema
 Schemas
+Script
 Second
 Seconds
 Secret
@@ -323,6 +324,7 @@ Tables
 Tail
 Temp
 Temporary
+Test
 Text
 Then
 Tick

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2431,7 +2431,7 @@ impl<'a> Parser<'a> {
     fn parse_create_source_connection(
         &mut self,
     ) -> Result<CreateSourceConnection<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[KAFKA, KINESIS, S3, POSTGRES, LOAD])? {
+        match self.expect_one_of_keywords(&[KAFKA, KINESIS, S3, POSTGRES, LOAD, TEST])? {
             POSTGRES => {
                 self.expect_keyword(CONNECTION)?;
                 let connection = self.parse_raw_name()?;
@@ -2541,6 +2541,12 @@ impl<'a> Parser<'a> {
                     vec![]
                 };
                 Ok(CreateSourceConnection::LoadGenerator { generator, options })
+            }
+            TEST => {
+                self.expect_keyword(SCRIPT)?;
+                Ok(CreateSourceConnection::TestScript {
+                    desc_json: self.parse_literal_string()?,
+                })
             }
             _ => unreachable!(),
         }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -228,6 +228,9 @@ pub async fn purify_create_source(
                 }
             }
         }
+        CreateSourceConnection::TestScript { desc_json: _ } => {
+            // TODO: verify valid json and valid schema
+        }
         CreateSourceConnection::S3 { connection, .. } => {
             let scx = StatementContext::new(None, &*catalog);
             let aws = {
@@ -539,8 +542,12 @@ async fn purify_source_format(
     connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
     if matches!(format, CreateSourceFormat::KeyValue { .. })
-        && !matches!(connection, CreateSourceConnection::Kafka { .. })
+        && !matches!(
+            connection,
+            CreateSourceConnection::Kafka { .. } | CreateSourceConnection::TestScript { .. }
+        )
     {
+        // We don't mention `TestScript` to users here
         bail!("Kafka sources are the only source type that can provide KEY/VALUE formats")
     }
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -31,6 +31,7 @@ use crate::source::types::{DecodeResult, SourceOutput};
 use crate::source::{
     self, persist_source, DelimitedValueSource, KafkaSourceReader, KinesisSourceReader,
     LoadGeneratorSourceReader, PostgresSourceReader, RawSourceCreationConfig, S3SourceReader,
+    TestScriptSourceReader,
 };
 use crate::types::errors::{DataflowError, DecodeError, EnvelopeError};
 use crate::types::sources::{encoding::*, *};
@@ -165,6 +166,17 @@ where
                 resumption_calculator,
             );
             let oks = oks.into_iter().map(SourceType::Row).collect();
+            ((oks, err), cap)
+        }
+        SourceConnection::TestScript(connection) => {
+            let ((oks, err), cap) = source::create_raw_source::<_, TestScriptSourceReader, _>(
+                scope,
+                base_source_config,
+                connection,
+                storage_state.connection_context.clone(),
+                resumption_calculator,
+            );
+            let oks: Vec<_> = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)
         }
     };

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -51,6 +51,7 @@ mod reclock;
 mod resumption;
 mod s3;
 mod source_reader_pipeline;
+mod testscript;
 pub mod types;
 pub mod util;
 
@@ -62,6 +63,7 @@ pub use postgres::PostgresSourceReader;
 pub use s3::S3SourceReader;
 pub use source_reader_pipeline::create_raw_source;
 pub use source_reader_pipeline::RawSourceCreationConfig;
+pub use testscript::TestScriptSourceReader;
 
 /// Returns true if the given source id/worker id is responsible for handling the given
 /// partition.

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -1,0 +1,116 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use timely::scheduling::SyncActivator;
+use tokio::time::sleep;
+
+use mz_expr::PartitionId;
+use mz_repr::GlobalId;
+
+use crate::source::commit::LogCommitter;
+use crate::source::{SourceMessage, SourceMessageType, SourceReader, SourceReaderError};
+use crate::types::connections::ConnectionContext;
+use crate::types::sources::encoding::SourceDataEncoding;
+use crate::types::sources::{MzOffset, TestScriptSourceConnection};
+
+#[derive(serde::Deserialize)]
+#[serde(tag = "command")]
+#[serde(rename_all = "lowercase")]
+enum ScriptCommand {
+    /// Emit a value (and possibly a key, which may be required
+    /// by the envelope), at an offset.
+    Emit {
+        key: Option<String>,
+        value: String,
+        offset: u64,
+    },
+    /// Terminate the source. Commands after this command
+    /// are ignored. Absence of this command causes the source
+    /// to pend forever after all commands are processed, like
+    /// a kafka source for a topic with no new messages.
+    Terminate,
+}
+
+struct Script {
+    commands: std::vec::IntoIter<ScriptCommand>,
+}
+
+pub struct TestScriptSourceReader {
+    script: Script,
+}
+
+#[async_trait::async_trait(?Send)]
+impl SourceReader for TestScriptSourceReader {
+    type Key = Option<Vec<u8>>;
+    type Value = Option<Vec<u8>>;
+    type Diff = ();
+    type OffsetCommitter = LogCommitter;
+    type Connection = TestScriptSourceConnection;
+
+    fn new(
+        _source_name: String,
+        source_id: GlobalId,
+        worker_id: usize,
+        worker_count: usize,
+        _consumer_activator: SyncActivator,
+        conn: Self::Connection,
+        _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
+        _encoding: SourceDataEncoding,
+        _metrics: crate::source::metrics::SourceBaseMetrics,
+        _connection_context: ConnectionContext,
+    ) -> Result<(Self, Self::OffsetCommitter), anyhow::Error> {
+        let commands: Vec<ScriptCommand> = serde_json::from_str(&conn.desc_json)?;
+        Ok((
+            TestScriptSourceReader {
+                script: Script {
+                    commands: commands.into_iter(),
+                },
+            },
+            LogCommitter {
+                source_id,
+                worker_id,
+                worker_count,
+            },
+        ))
+    }
+    async fn next(
+        &mut self,
+        timestamp_granularity: Duration,
+    ) -> Option<Result<SourceMessageType<Self::Key, Self::Value, Self::Diff>, SourceReaderError>>
+    {
+        if let Some(command) = self.script.commands.next() {
+            match command {
+                ScriptCommand::Terminate => {
+                    return None;
+                }
+                ScriptCommand::Emit { key, value, offset } => {
+                    // For now we only support `Finalized` messages
+                    return Some(Ok(SourceMessageType::Finalized(SourceMessage {
+                        // For now, we only support single-output, single partition
+                        output: 0,
+                        partition: PartitionId::None,
+                        offset: MzOffset { offset },
+                        upstream_time_millis: None,
+                        key: key.map(|k| k.into_bytes()),
+                        value: Some(value.into_bytes()),
+                        headers: None,
+                        specific_diff: (),
+                    })));
+                }
+            }
+        } else {
+            loop {
+                // sleep continuously
+                sleep(timestamp_granularity).await;
+            }
+        }
+    }
+}

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -176,6 +176,7 @@ message ProtoSourceConnection {
         ProtoS3SourceConnection s3 = 3;
         ProtoPostgresSourceConnection postgres = 4;
         ProtoLoadGeneratorSourceConnection loadgen = 6;
+        ProtoTestScriptSourceConnection testscript = 7;
     }
 }
 
@@ -216,6 +217,11 @@ message ProtoLoadGeneratorSourceConnection {
     }
     optional uint64 tick_micros = 2;
 }
+
+message ProtoTestScriptSourceConnection {
+    string desc_json = 1;
+}
+
 
 message ProtoS3SourceConnection {
     mz_repr.global_id.ProtoGlobalId connection_id = 5;

--- a/test/testdrive/testscript_source.td
+++ b/test/testdrive/testscript_source.td
@@ -1,0 +1,57 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+
+# Basic test for `TEST SCRIPT` sources.
+
+# replace timestamps
+$ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
+
+
+> CREATE CONNECTION c_conn
+  FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}'
+
+> CREATE SOURCE unit
+  FROM TEST SCRIPT
+  '[
+    {"command": "emit", "key": "fish", "value": "value", "offset": 0},
+    {"command": "emit", "key": "fish2", "value": "hmm", "offset": 1},
+    {"command": "emit" ,"key": "fish", "value": "value2", "offset": 2}
+  ]'
+  KEY FORMAT BYTES
+  VALUE FORMAT BYTES
+  ENVELOPE UPSERT
+
+> SELECT * from unit
+key           data
+--------------------
+fish          value2
+fish2         hmm
+
+> EXPLAIN TIMESTAMP FOR SELECT * FROM unit
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.unit (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
+
+> CREATE SOURCE unit_terminated
+  FROM TEST SCRIPT
+  '[
+    {"command": "emit", "key": "fish", "value": "value", "offset": 0},
+    {"command": "terminate"}
+  ]'
+  KEY FORMAT BYTES
+  VALUE FORMAT BYTES
+  ENVELOPE UPSERT
+
+> SELECT * from unit_terminated
+key           data
+--------------------
+fish          value
+
+# Terminal sources have empty uppers
+> EXPLAIN TIMESTAMP FOR SELECT * FROM unit_terminated
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.unit_terminated (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[]\n"


### PR DESCRIPTION
This pr adds a new source `UNITTEST`, that lets the user describe a script of values, offset, keys, etc. that the source emits in turn.

I chose to go with the simplest possible route: a source that emits values and possibly keys, of just bytes, just like kafka. This means that in theory, every format and envelope is supported (in practice, some things around avro confluent schemas are broken).

This is the bare-bones implementation, and supports only keys, offsets, values, and terminating and non-terminating sources. Additionally, I went with the most basic implementation: a json string in the source, un-validated by anything but the source-reader. In the future, we likely want to validate this json (but for the proto transport, the json is still probably the best way to transfer the script). I chose this because this is the the most perma-unstable source, and I want people refactoring to have as little to do to fix it up as possible.

In the future, features I'd like to see:
- controlled delays before and after value emission
- transactions (i.e. `InProgress` messages)
- `INCLUDE OFFSET` working
- control over how _batches in the source pipeline are formed_ (this requires an escape hatch through the `SourceReader` trait)
- (maybe) assertions, including assertions about committed offsets.
- a cargo-test compatible driver for source rendering (which this source will drop perfectly into)
  - ^ is what I want to work on next, but its non-trivia
  - 
### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

