### PR TITLE
docs: Add docs about SHOW command indexes

### DIFF
--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -7,7 +7,7 @@ menu:
 
 ---
 
-`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time.
+`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -7,7 +7,9 @@ menu:
 
 ---
 
-`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW CLUSTER REPLICAS` lists the [replicas](/overview/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -7,7 +7,9 @@ menu:
 
 ---
 
-`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -7,7 +7,7 @@ menu:
 
 ---
 
-`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time.
+`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-columns.md
+++ b/doc/user/content/sql/show-columns.md
@@ -8,7 +8,9 @@ aliases:
     - /sql/show-column
 ---
 
-`SHOW COLUMNS` lists the columns available from an item&mdash;either sources, materialized views, or non-materialized views. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW COLUMNS` lists the columns available from an item&mdash;either sources, materialized views, or non-materialized views.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-columns.md
+++ b/doc/user/content/sql/show-columns.md
@@ -8,7 +8,7 @@ aliases:
     - /sql/show-column
 ---
 
-`SHOW COLUMNS` lists the columns available from an item&mdash;either sources, materialized views, or non-materialized views.
+`SHOW COLUMNS` lists the columns available from an item&mdash;either sources, materialized views, or non-materialized views. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -8,7 +8,9 @@ aliases:
     - /sql/show-connection
 ---
 
-`SHOW CONNECTIONS` lists the connections configured in Materialize. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW CONNECTIONS` lists the connections configured in Materialize.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -8,7 +8,7 @@ aliases:
     - /sql/show-connection
 ---
 
-`SHOW CONNECTIONS` lists the connections configured in Materialize.
+`SHOW CONNECTIONS` lists the connections configured in Materialize. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-databases.md
+++ b/doc/user/content/sql/show-databases.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 `SHOW DATABASES` returns a list of all databases available to your Materialize
-instances.
+instances. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-databases.md
+++ b/doc/user/content/sql/show-databases.md
@@ -6,8 +6,10 @@ menu:
     parent: commands
 ---
 
+{{< show-command-note >}}
+
 `SHOW DATABASES` returns a list of all databases available to your Materialize
-instances. For best performance execute this command on the `mz_introspection` cluster.
+instances.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -6,7 +6,9 @@ menu:
     parent: commands
 ---
 
-`SHOW INDEXES` provides details about indexes built on a source, view, or materialized view. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW INDEXES` provides details about indexes built on a source, view, or materialized view.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`SHOW INDEXES` provides details about indexes built on a source, view, or materialized view.
+`SHOW INDEXES` provides details about indexes built on a source, view, or materialized view. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 `SHOW MATERIALIZED VIEWS` returns a list of materialized views being maintained
-in Materialize.
+in Materialize. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -6,8 +6,10 @@ menu:
     parent: commands
 ---
 
+{{< show-command-note >}}
+
 `SHOW MATERIALIZED VIEWS` returns a list of materialized views being maintained
-in Materialize. For best performance execute this command on the `mz_introspection` cluster.
+in Materialize.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -8,8 +8,10 @@ aliases:
     - /sql/show-object
 ---
 
+{{< show-command-note >}}
+
 `SHOW OBJECTS` returns a list of all objects available to your Materialize instances in a given schema.
-Objects include tables, sources, sinks, views, indexes, secrets and connections.  For best performance execute this command on the `mz_introspection` cluster.
+Objects include tables, sources, sinks, views, indexes, secrets and connections.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -9,7 +9,7 @@ aliases:
 ---
 
 `SHOW OBJECTS` returns a list of all objects available to your Materialize instances in a given schema.
-Objects include tables, sources, sinks, views, indexes, secrets and connections.
+Objects include tables, sources, sinks, views, indexes, secrets and connections.  For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-schemas.md
+++ b/doc/user/content/sql/show-schemas.md
@@ -6,8 +6,10 @@ menu:
     parent: commands
 ---
 
+{{< show-command-note >}}
+
 `SHOW SCHEMAS` returns a list of all schemas available to your Materialize
-instances. For best performance execute this command on the `mz_introspection` cluster.
+instances.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-schemas.md
+++ b/doc/user/content/sql/show-schemas.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 `SHOW SCHEMAS` returns a list of all schemas available to your Materialize
-instances.
+instances. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-secrets.md
+++ b/doc/user/content/sql/show-secrets.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`SHOW SECRETS` lists the names of the secrets securely stored in Materialize's secret management system. There is no way to show the contents of an existing secret, though you can override it using the [`ALTER SECRET`](../alter-secret) statement.
+`SHOW SECRETS` lists the names of the secrets securely stored in Materialize's secret management system. There is no way to show the contents of an existing secret, though you can override it using the [`ALTER SECRET`](../alter-secret) statement. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-secrets.md
+++ b/doc/user/content/sql/show-secrets.md
@@ -6,7 +6,9 @@ menu:
     parent: commands
 ---
 
-`SHOW SECRETS` lists the names of the secrets securely stored in Materialize's secret management system. There is no way to show the contents of an existing secret, though you can override it using the [`ALTER SECRET`](../alter-secret) statement. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW SECRETS` lists the names of the secrets securely stored in Materialize's secret management system. There is no way to show the contents of an existing secret, though you can override it using the [`ALTER SECRET`](../alter-secret) statement.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -8,7 +8,9 @@ aliases:
     - /sql/show-sink
 ---
 
-`SHOW SINKS` returns a list of all sinks available to your Materialize instances. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW SINKS` returns a list of all sinks available to your Materialize instances.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -8,7 +8,7 @@ aliases:
     - /sql/show-sink
 ---
 
-`SHOW SINKS` returns a list of all sinks available to your Materialize instances.
+`SHOW SINKS` returns a list of all sinks available to your Materialize instances. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -7,7 +7,7 @@ menu:
 ---
 
 `SHOW SOURCES` returns a list of all sources available to your Materialize
-instances.
+instances. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -6,8 +6,10 @@ menu:
     parent: commands
 ---
 
+{{< show-command-note >}}
+
 `SHOW SOURCES` returns a list of all sources available to your Materialize
-instances. For best performance execute this command on the `mz_introspection` cluster.
+instances.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-tables.md
+++ b/doc/user/content/sql/show-tables.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`SHOW TABLES` returns a list of all tables available to your Materialize instances.
+`SHOW TABLES` returns a list of all tables available to your Materialize instances. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-tables.md
+++ b/doc/user/content/sql/show-tables.md
@@ -6,7 +6,9 @@ menu:
     parent: commands
 ---
 
-`SHOW TABLES` returns a list of all tables available to your Materialize instances. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW TABLES` returns a list of all tables available to your Materialize instances.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-types.md
+++ b/doc/user/content/sql/show-types.md
@@ -6,7 +6,9 @@ menu:
     parent: commands
 ---
 
-`SHOW TYPES` returns a list of the data types in your Materialize instance. By default, only custom types are returned. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW TYPES` returns a list of the data types in your Materialize instance. By default, only custom types are returned.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-types.md
+++ b/doc/user/content/sql/show-types.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`SHOW TYPES` returns a list of the data types in your Materialize instance. By default, only custom types are returned.
+`SHOW TYPES` returns a list of the data types in your Materialize instance. By default, only custom types are returned. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -6,7 +6,9 @@ menu:
     parent: commands
 ---
 
-`SHOW VIEWS` returns a list of views in your Materialize instances. For best performance execute this command on the `mz_introspection` cluster.
+{{< show-command-note >}}
+
+`SHOW VIEWS` returns a list of views in your Materialize instances.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`SHOW VIEWS` returns a list of views in your Materialize instances.
+`SHOW VIEWS` returns a list of views in your Materialize instances. For best performance execute this command on the `mz_introspection` cluster.
 
 ## Syntax
 

--- a/doc/user/layouts/shortcodes/show-command-note.html
+++ b/doc/user/layouts/shortcodes/show-command-note.html
@@ -1,0 +1,4 @@
+<div class="note">
+  <strong class="gutter">NOTE!</strong>
+  For improved performance, execute this command in the <code>mz_introspection</code> cluster. To switch clusters, use <code>SET CLUSTER = mz_introspection;</code>.
+</div>


### PR DESCRIPTION
A default index for all SHOW commands have been added to the mz_introspection cluster. This commit adds documentation to all the SHOW commands that tells users that they should execute SHOW on the mz_introspection cluster for best performance.

### Motivation
Adds docs.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
