### PR TITLE
storage: add way to run the source ingestion pipeline as a unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,6 +4241,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "csv-core",
+ "datadriven",
  "dec",
  "derivative",
  "differential-dataflow",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -82,6 +82,7 @@ protobuf-src = "1.1.0"
 tonic-build = "0.8.2"
 
 [dev-dependencies]
+datadriven = { version = "0.6.0", features = ["async"] }
 itertools = "0.10.5"
 tokio = { version = "1.20.2", features = ["test-util"] }
 

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -51,7 +51,9 @@ mod reclock;
 mod resumption;
 mod s3;
 mod source_reader_pipeline;
-mod testscript;
+// Public for integration testing.
+#[doc(hidden)]
+pub mod testscript;
 pub mod types;
 pub mod util;
 

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -21,10 +21,10 @@ use crate::types::connections::ConnectionContext;
 use crate::types::sources::encoding::SourceDataEncoding;
 use crate::types::sources::{MzOffset, TestScriptSourceConnection};
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[serde(tag = "command")]
 #[serde(rename_all = "lowercase")]
-enum ScriptCommand {
+pub enum ScriptCommand {
     /// Emit a value (and possibly a key, which may be required
     /// by the envelope), at an offset.
     Emit {

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -21,7 +21,7 @@ use crate::types::connections::ConnectionContext;
 use crate::types::sources::encoding::SourceDataEncoding;
 use crate::types::sources::{MzOffset, TestScriptSourceConnection};
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 #[serde(tag = "command")]
 #[serde(rename_all = "lowercase")]
 pub enum ScriptCommand {

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -13,7 +13,6 @@
 // #![allow(missing_docs)]
 
 use std::collections::HashMap;
-use std::fmt;
 use std::fmt::Debug;
 use std::marker::{Send, Sync};
 use std::rc::Rc;
@@ -202,6 +201,7 @@ pub enum NextMessage<Key, Value, Diff> {
 
 /// A wrapper around [`SourceMessage`] that allows [`SourceReader`]'s to
 /// communicate additional "maintenance" messages.
+#[derive(Debug)]
 pub enum SourceMessageType<Key, Value, Diff> {
     /// Communicate that this [`SourceMessage`] is the final
     /// message its its offset.
@@ -222,6 +222,7 @@ pub enum SourceMessageType<Key, Value, Diff> {
 
 /// Source-agnostic wrapper for messages. Each source must implement a
 /// conversion to Message.
+#[derive(Debug)]
 pub struct SourceMessage<Key, Value, Diff> {
     /// The output stream this message belongs to. Later in the pipeline the stream is partitioned
     /// based on this value and is fed to the appropriate source exports
@@ -247,28 +248,6 @@ pub struct SourceMessage<Key, Value, Diff> {
     ///
     /// Only supported with `SourceEnvelope::None`
     pub specific_diff: Diff,
-}
-
-impl fmt::Debug for SourceMessage<(), Option<Vec<u8>>, ()> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SourceMessage")
-            .field("partition", &self.partition)
-            .field("offset", &self.offset)
-            .field("upstream_time_millis", &self.upstream_time_millis)
-            .finish()
-    }
-}
-
-impl fmt::Debug for SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>, ()> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SourceMessage")
-            .field("partition", &self.partition)
-            .field("offset", &self.offset)
-            .field("upstream_time_millis", &self.upstream_time_millis)
-            .field("key[present]", &self.key.is_some())
-            .field("value[present]", &self.value.is_some())
-            .finish()
-    }
 }
 
 /// A record produced by a source
@@ -369,6 +348,7 @@ pub struct DecodeResult {
 /// A structured error for `SourceReader::get_next_message`
 /// implementors. Also implements `From<anyhow::Error>`
 /// for convenience.
+#[derive(Debug)]
 pub struct SourceReaderError {
     pub inner: SourceErrorDetails,
 }

--- a/src/storage/tests/datadriven/basic_source
+++ b/src/storage/tests/datadriven/basic_source
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+register-source name=s1
+{
+  "script": [
+    {"command": "emit", "value": "gus", "offset": 0},
+    {"command": "emit", "value": "gus2", "offset": 1}
+  ],
+  "encoding": {
+    "Single": {
+      "force_nullable_columns": false,
+      "inner": "Bytes"
+    }
+  },
+  "envelope": {
+    "None": {
+      "key_envelope": "None",
+      "key_arity": 0
+    }
+  }
+}
+----
+<empty>
+
+# TODO(guswynn): make the output less verbose
+run-source name=s1 expected_len=2
+----
+[
+    SourceData(
+        Ok(
+            Row{[
+                Bytes(
+                    [
+                        103,
+                        117,
+                        115,
+                    ],
+                ),
+            ]},
+        ),
+    ),
+    SourceData(
+        Ok(
+            Row{[
+                Bytes(
+                    [
+                        103,
+                        117,
+                        115,
+                        50,
+                    ],
+                ),
+            ]},
+        ),
+    ),
+]

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -11,7 +11,6 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::marker::{Send, Sync};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,12 +32,12 @@ use mz_storage::types::sources::{
 };
 use mz_storage::DecodeMetrics;
 
-pub fn assert_source_results_in(
+pub fn run_script_source(
     source: Vec<ScriptCommand>,
     encoding: SourceDataEncoding,
     envelope: SourceEnvelope,
-    expected_values: Vec<SourceData>,
-) -> Result<(), anyhow::Error> {
+    expected_values: usize,
+) -> Result<Vec<SourceData>, anyhow::Error> {
     let timestamp_interval = Duration::from_secs(1);
 
     let desc = SourceDesc {
@@ -51,7 +50,7 @@ pub fn assert_source_results_in(
         timestamp_interval,
     };
 
-    build_and_run_source(desc, timestamp_interval, move |upper, mut rh| {
+    build_and_run_source(desc, timestamp_interval, move |upper, mut read| {
         let expected_values = expected_values.clone();
         async move {
             let as_of = if let Some(cur_time) = upper.as_option().copied() {
@@ -60,20 +59,22 @@ pub fn assert_source_results_in(
                 // terminated source, we try to fetch everything
                 Antichain::from_elem(Timestamp::maximum())
             };
-            let mut snapshot = rh.snapshot_and_fetch(as_of).await.unwrap();
+            let snapshot = read.snapshot_and_fetch(as_of).await.unwrap();
 
-            // retry until we have enough data.
+            // Retry until we have enough data.
             //
             // TODO(guswynn): have a builtin timeout here for a source
             // not producing enough data.
-            if snapshot.len() < expected_values.len() {
-                false
+            if snapshot.len() < expected_values {
+                None
             } else {
-                differential_dataflow::consolidation::consolidate_updates(&mut snapshot);
+                // Ignore the totally-ordered time field when consolidating the snapshot, for now.
+                let mut snapshot: Vec<_> = snapshot.into_iter().map(|(v, _t, d)| (v, d)).collect();
+                differential_dataflow::consolidation::consolidate(&mut snapshot);
 
                 let values: Vec<SourceData> = snapshot
                     .into_iter()
-                    .map(|((key, value), _time, diff)| {
+                    .map(|((key, value), diff)| {
                         assert_eq!(diff, 1);
                         assert_eq!(value, Ok(()));
                         // unwrap any errors from persist
@@ -81,9 +82,7 @@ pub fn assert_source_results_in(
                     })
                     .collect();
 
-                assert_eq!(values, expected_values);
-
-                true
+                Some(values)
             }
         }
     })
@@ -95,7 +94,7 @@ fn build_and_run_source<F, Fut>(
     desc: SourceDesc,
     timestamp_interval: Duration,
     until: F,
-) -> Result<(), anyhow::Error>
+) -> Result<Vec<SourceData>, anyhow::Error>
 where
     F: Fn(
             Antichain<Timestamp>,
@@ -105,166 +104,164 @@ where
         + Sync
         + Clone
         + 'static,
-    Fut: std::future::Future<Output = bool> + Send + 'static,
+    Fut: std::future::Future<Output = Option<Vec<SourceData>>> + Send + 'static,
 {
     // Start a tokio runtime.
     let tokio_runtime = tokio::runtime::Runtime::new().unwrap();
     // Safe to have a single value because we are single-worker
-    let finished = Arc::new(AtomicBool::new(false));
 
-    let guards = {
-        let finished = Arc::clone(&finished);
-        timely::execute::execute(
-            timely::Config {
-                worker: timely::WorkerConfig::default(),
-                // single-worker
-                communication: timely::CommunicationConfig::Thread,
-            },
-            move |timely_worker| {
-                // Various required metrics and persist setup.
-                let metrics_registry = MetricsRegistry::new();
-                let source_metrics = SourceBaseMetrics::register_with(&metrics_registry);
-                let sink_metrics = SinkBaseMetrics::register_with(&metrics_registry);
-                let decode_metrics = DecodeMetrics::register_with(&metrics_registry);
+    let guards = timely::execute::execute(
+        timely::Config {
+            worker: timely::WorkerConfig::default(),
+            // TODO: test multi-worker as well!
+            communication: timely::CommunicationConfig::Thread,
+        },
+        move |timely_worker| {
+            // Various required metrics and persist setup.
+            let metrics_registry = MetricsRegistry::new();
+            let source_metrics = SourceBaseMetrics::register_with(&metrics_registry);
+            let sink_metrics = SinkBaseMetrics::register_with(&metrics_registry);
+            let decode_metrics = DecodeMetrics::register_with(&metrics_registry);
 
-                let mut persistcfg =
-                    mz_persist_client::PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
-                persistcfg.reader_lease_duration = std::time::Duration::from_secs(60 * 15);
-                persistcfg.now = SYSTEM_TIME.clone();
+            let mut persistcfg =
+                mz_persist_client::PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+            persistcfg.reader_lease_duration = std::time::Duration::from_secs(60 * 15);
+            persistcfg.now = SYSTEM_TIME.clone();
 
-                let persist_location = mz_persist_client::PersistLocation {
-                    blob_uri: "mem://".to_string(),
-                    consensus_uri: "mem://".to_string(),
-                };
-                let mut persist_cache = mz_persist_client::cache::PersistClientCache::new(
-                    persistcfg,
-                    &metrics_registry,
-                );
+            let persist_location = mz_persist_client::PersistLocation {
+                blob_uri: "mem://".to_string(),
+                consensus_uri: "mem://".to_string(),
+            };
+            let mut persist_cache =
+                mz_persist_client::cache::PersistClientCache::new(persistcfg, &metrics_registry);
 
-                // create a client for use with the `until` closure later.
-                let persist_client = tokio_runtime
-                    .block_on(persist_cache.open(persist_location.clone()))
-                    .unwrap();
+            // create a client for use with the `until` closure later.
+            let persist_client = tokio_runtime
+                .block_on(persist_cache.open(persist_location.clone()))
+                .unwrap();
 
-                let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_cache));
+            let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_cache));
 
-                let storage_state = mz_storage::storage_state::StorageState {
-                    source_uppers: HashMap::new(),
-                    source_tokens: HashMap::new(),
-                    decode_metrics,
-                    reported_frontiers: HashMap::new(),
-                    ingestions: HashMap::new(),
-                    exports: HashMap::new(),
-                    now: SYSTEM_TIME.clone(),
-                    source_metrics,
-                    sink_metrics,
-                    timely_worker_index: 0,
-                    timely_worker_peers: 0,
-                    connection_context: mz_storage::types::connections::ConnectionContext {
-                        librdkafka_log_level: tracing::Level::INFO,
-                        aws_external_id_prefix: None,
-                        secrets_reader: Arc::new(mz_secrets::InMemorySecretsController::new()),
-                    },
-                    persist_clients,
-                    sink_tokens: HashMap::new(),
-                    sink_write_frontiers: HashMap::new(),
-                };
+            let storage_state = mz_storage::storage_state::StorageState {
+                source_uppers: HashMap::new(),
+                source_tokens: HashMap::new(),
+                decode_metrics,
+                reported_frontiers: HashMap::new(),
+                ingestions: HashMap::new(),
+                exports: HashMap::new(),
+                now: SYSTEM_TIME.clone(),
+                source_metrics,
+                sink_metrics,
+                timely_worker_index: 0,
+                timely_worker_peers: 0,
+                connection_context: mz_storage::types::connections::ConnectionContext {
+                    librdkafka_log_level: tracing::Level::INFO,
+                    aws_external_id_prefix: None,
+                    secrets_reader: Arc::new(mz_secrets::InMemorySecretsController::new()),
+                },
+                persist_clients,
+                sink_tokens: HashMap::new(),
+                sink_write_frontiers: HashMap::new(),
+            };
 
-                let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);
-                let mut worker = mz_storage::storage_state::Worker {
-                    timely_worker,
-                    storage_state,
-                    client_rx: fake_rx,
-                };
-                let collection_metadata = mz_storage::controller::CollectionMetadata {
-                    persist_location,
-                    remap_shard: mz_persist_client::ShardId::new(),
-                    data_shard: mz_persist_client::ShardId::new(),
-                    status_shard: None,
-                };
-                let data_shard = collection_metadata.data_shard.clone();
-                let id = GlobalId::User(1);
-                let source_exports = BTreeMap::from([(
-                    id,
-                    mz_storage::types::sources::SourceExport {
-                        storage_metadata: collection_metadata.clone(),
-                        output_index: 0,
-                    },
-                )]);
+            let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);
+            let mut worker = mz_storage::storage_state::Worker {
+                timely_worker,
+                storage_state,
+                client_rx: fake_rx,
+            };
+            let collection_metadata = mz_storage::controller::CollectionMetadata {
+                persist_location,
+                remap_shard: mz_persist_client::ShardId::new(),
+                data_shard: mz_persist_client::ShardId::new(),
+                status_shard: None,
+            };
+            let data_shard = collection_metadata.data_shard.clone();
+            let id = GlobalId::User(1);
+            let source_exports = BTreeMap::from([(
+                id,
+                mz_storage::types::sources::SourceExport {
+                    storage_metadata: collection_metadata.clone(),
+                    output_index: 0,
+                },
+            )]);
 
-                {
-                    let _tokio_guard = tokio_runtime.enter();
-                    worker.handle_storage_command(StorageCommand::CreateSources(vec![
-                        mz_storage::protocol::client::CreateSourceCommand {
-                            id,
-                            description: mz_storage::types::sources::IngestionDescription {
-                                desc: desc.clone(),
-                                ingestion_metadata: collection_metadata,
-                                source_exports,
-                                // Only used for Debezium
-                                source_imports: BTreeMap::new(),
-                                host_config: mz_storage::types::hosts::StorageHostConfig::Remote {
-                                    addr: "test".to_string(),
-                                },
+            {
+                let _tokio_guard = tokio_runtime.enter();
+                worker.handle_storage_command(StorageCommand::CreateSources(vec![
+                    mz_storage::protocol::client::CreateSourceCommand {
+                        id,
+                        description: mz_storage::types::sources::IngestionDescription {
+                            desc: desc.clone(),
+                            ingestion_metadata: collection_metadata,
+                            source_exports,
+                            // Only used for Debezium
+                            source_imports: BTreeMap::new(),
+                            host_config: mz_storage::types::hosts::StorageHostConfig::Remote {
+                                addr: "test".to_string(),
                             },
-                            resume_upper: Antichain::from_elem(Timestamp::minimum()),
                         },
-                    ]));
-                }
+                        // TODO: test resumption as well!
+                        resume_upper: Antichain::from_elem(Timestamp::minimum()),
+                    },
+                ]));
+            }
 
-                // Run the assertions in a tokio task, so we can step the dataflow
-                // while we check the snapshot
-                let check_task = {
-                    let until = until.clone();
-                    (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
-                        loop {
-                            let (mut data_write_handle, data_read_handle) = persist_client
-                                .open::<SourceData, (), Timestamp, Diff>(data_shard.clone())
-                                .await
-                                .unwrap();
-                            if until(
-                                data_write_handle.fetch_recent_upper().await.clone(),
-                                data_read_handle,
-                            )
+            // Run the assertions in a tokio task, so we can step the dataflow
+            // while we check the snapshot
+            let check_task = {
+                let until = until.clone();
+                (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
+                    loop {
+                        let (mut data_write_handle, data_read_handle) = persist_client
+                            .open::<SourceData, (), Timestamp, Diff>(data_shard.clone())
                             .await
-                            {
-                                return;
-                            }
-                            tokio::time::sleep(timestamp_interval).await;
+                            .unwrap();
+                        if let Some(values) = until(
+                            data_write_handle.fetch_recent_upper().await.clone(),
+                            data_read_handle,
+                        )
+                        .await
+                        {
+                            return values;
                         }
-                    })
-                };
-
-                {
-                    let _tokio_guard = tokio_runtime.enter();
-                    while !check_task.is_finished() {
-                        worker.timely_worker.step();
+                        tokio::time::sleep(timestamp_interval).await;
                     }
+                })
+            };
+
+            {
+                let _tokio_guard = tokio_runtime.enter();
+                while !check_task.is_finished() {
+                    worker.timely_worker.step();
                 }
 
-                let res = tokio_runtime.block_on(check_task);
-                finished.store(true, Ordering::SeqCst);
-                match res {
-                    Err(e) => std::panic::resume_unwind(e.into_panic()),
-                    Ok(()) => {
-                        // We passed!
-                    }
-                }
-            },
-        )
-        .unwrap()
-    };
+                // Drop the dataflow before we move on, as we could
+                // get additional activations that cause problems.
+                //
+                // TODO(guswynn): consider using `AllowCompaction` here,
+                // if it works.
+                worker
+                    .timely_worker
+                    .drop_dataflow(worker.timely_worker.installed_dataflows()[0]);
+            }
 
+            let res = tokio_runtime.block_on(check_task);
+            match res {
+                Err(e) => std::panic::resume_unwind(e.into_panic()),
+                Ok(values) => values,
+            }
+        },
+    )
+    .unwrap();
+
+    let mut value = None;
     for g in guards.join() {
-        g.map_err(|_| {
+        value = Some(g.map_err(|_| {
             anyhow::anyhow!("timely thread panicked, cargo test should print the failure")
-        })?
+        })?);
     }
 
-    // Assert that we actually went through the dataflow and checked the results.
-    if !finished.load(Ordering::SeqCst) {
-        return Err(anyhow::anyhow!("dataflow never actually produce results"));
-    }
-
-    Ok(())
+    // There is always exactly one worker.
+    Ok(value.unwrap())
 }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -1,0 +1,270 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Unit tests for sources.
+
+use std::collections::{BTreeMap, HashMap};
+use std::marker::{Send, Sync};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use timely::progress::{Antichain, Timestamp as _};
+
+use mz_build_info::DUMMY_BUILD_INFO;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
+use mz_ore::task::RuntimeExt;
+use mz_repr::TimestampManipulation;
+use mz_repr::{Diff, GlobalId, Timestamp};
+use mz_storage::protocol::client::StorageCommand;
+use mz_storage::sink::SinkBaseMetrics;
+use mz_storage::source::metrics::SourceBaseMetrics;
+use mz_storage::source::testscript::ScriptCommand;
+use mz_storage::types::sources::{
+    encoding::SourceDataEncoding, SourceConnection, SourceData, SourceDesc, SourceEnvelope,
+    TestScriptSourceConnection,
+};
+use mz_storage::DecodeMetrics;
+
+pub fn assert_source_results_in(
+    source: Vec<ScriptCommand>,
+    encoding: SourceDataEncoding,
+    envelope: SourceEnvelope,
+    expected_values: Vec<SourceData>,
+) -> Result<(), anyhow::Error> {
+    let timestamp_interval = Duration::from_secs(1);
+
+    let desc = SourceDesc {
+        connection: SourceConnection::TestScript(TestScriptSourceConnection {
+            desc_json: serde_json::to_string(&source).unwrap(),
+        }),
+        encoding,
+        envelope,
+        metadata_columns: vec![],
+        timestamp_interval,
+    };
+
+    build_and_run_source(desc, timestamp_interval, move |upper, mut rh| {
+        let expected_values = expected_values.clone();
+        async move {
+            let as_of = if let Some(cur_time) = upper.as_option().copied() {
+                Antichain::from_elem(cur_time.step_back().unwrap_or_else(Timestamp::minimum))
+            } else {
+                // terminated source, we try to fetch everything
+                Antichain::from_elem(Timestamp::maximum())
+            };
+            let mut snapshot = rh.snapshot_and_fetch(as_of).await.unwrap();
+
+            // retry until we have enough data.
+            //
+            // TODO(guswynn): have a builtin timeout here for a source
+            // not producing enough data.
+            if snapshot.len() < expected_values.len() {
+                false
+            } else {
+                differential_dataflow::consolidation::consolidate_updates(&mut snapshot);
+
+                let values: Vec<SourceData> = snapshot
+                    .into_iter()
+                    .map(|((key, value), _time, diff)| {
+                        assert_eq!(diff, 1);
+                        assert_eq!(value, Ok(()));
+                        // unwrap any errors from persist
+                        key.unwrap()
+                    })
+                    .collect();
+
+                assert_eq!(values, expected_values);
+
+                true
+            }
+        }
+    })
+}
+
+/// Setups up a single-worker dataflow for the given `SourceDesc` and
+/// runs it until the `until` future returns `True`
+fn build_and_run_source<F, Fut>(
+    desc: SourceDesc,
+    timestamp_interval: Duration,
+    until: F,
+) -> Result<(), anyhow::Error>
+where
+    F: Fn(
+            Antichain<Timestamp>,
+            mz_persist_client::read::ReadHandle<SourceData, (), Timestamp, Diff>,
+        ) -> Fut
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    Fut: std::future::Future<Output = bool> + Send + 'static,
+{
+    // Start a tokio runtime.
+    let tokio_runtime = tokio::runtime::Runtime::new().unwrap();
+    // Safe to have a single value because we are single-worker
+    let finished = Arc::new(AtomicBool::new(false));
+
+    let guards = {
+        let finished = Arc::clone(&finished);
+        timely::execute::execute(
+            timely::Config {
+                worker: timely::WorkerConfig::default(),
+                // single-worker
+                communication: timely::CommunicationConfig::Thread,
+            },
+            move |timely_worker| {
+                // Various required metrics and persist setup.
+                let metrics_registry = MetricsRegistry::new();
+                let source_metrics = SourceBaseMetrics::register_with(&metrics_registry);
+                let sink_metrics = SinkBaseMetrics::register_with(&metrics_registry);
+                let decode_metrics = DecodeMetrics::register_with(&metrics_registry);
+
+                let mut persistcfg =
+                    mz_persist_client::PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+                persistcfg.reader_lease_duration = std::time::Duration::from_secs(60 * 15);
+                persistcfg.now = SYSTEM_TIME.clone();
+
+                let persist_location = mz_persist_client::PersistLocation {
+                    blob_uri: "mem://".to_string(),
+                    consensus_uri: "mem://".to_string(),
+                };
+                let mut persist_cache = mz_persist_client::cache::PersistClientCache::new(
+                    persistcfg,
+                    &metrics_registry,
+                );
+
+                // create a client for use with the `until` closure later.
+                let persist_client = tokio_runtime
+                    .block_on(persist_cache.open(persist_location.clone()))
+                    .unwrap();
+
+                let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_cache));
+
+                let storage_state = mz_storage::storage_state::StorageState {
+                    source_uppers: HashMap::new(),
+                    source_tokens: HashMap::new(),
+                    decode_metrics,
+                    reported_frontiers: HashMap::new(),
+                    ingestions: HashMap::new(),
+                    exports: HashMap::new(),
+                    now: SYSTEM_TIME.clone(),
+                    source_metrics,
+                    sink_metrics,
+                    timely_worker_index: 0,
+                    timely_worker_peers: 0,
+                    connection_context: mz_storage::types::connections::ConnectionContext {
+                        librdkafka_log_level: tracing::Level::INFO,
+                        aws_external_id_prefix: None,
+                        secrets_reader: Arc::new(mz_secrets::InMemorySecretsController::new()),
+                    },
+                    persist_clients,
+                    sink_tokens: HashMap::new(),
+                    sink_write_frontiers: HashMap::new(),
+                };
+
+                let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);
+                let mut worker = mz_storage::storage_state::Worker {
+                    timely_worker,
+                    storage_state,
+                    client_rx: fake_rx,
+                };
+                let collection_metadata = mz_storage::controller::CollectionMetadata {
+                    persist_location,
+                    remap_shard: mz_persist_client::ShardId::new(),
+                    data_shard: mz_persist_client::ShardId::new(),
+                    status_shard: None,
+                };
+                let data_shard = collection_metadata.data_shard.clone();
+                let id = GlobalId::User(1);
+                let source_exports = BTreeMap::from([(
+                    id,
+                    mz_storage::types::sources::SourceExport {
+                        storage_metadata: collection_metadata.clone(),
+                        output_index: 0,
+                    },
+                )]);
+
+                {
+                    let _tokio_guard = tokio_runtime.enter();
+                    worker.handle_storage_command(StorageCommand::CreateSources(vec![
+                        mz_storage::protocol::client::CreateSourceCommand {
+                            id,
+                            description: mz_storage::types::sources::IngestionDescription {
+                                desc: desc.clone(),
+                                ingestion_metadata: collection_metadata,
+                                source_exports,
+                                // Only used for Debezium
+                                source_imports: BTreeMap::new(),
+                                host_config: mz_storage::types::hosts::StorageHostConfig::Remote {
+                                    addr: "test".to_string(),
+                                },
+                            },
+                            resume_upper: Antichain::from_elem(Timestamp::minimum()),
+                        },
+                    ]));
+                }
+
+                // Run the assertions in a tokio task, so we can step the dataflow
+                // while we check the snapshot
+                let check_task = {
+                    let until = until.clone();
+                    (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
+                        loop {
+                            let (mut data_write_handle, data_read_handle) = persist_client
+                                .open::<SourceData, (), Timestamp, Diff>(data_shard.clone())
+                                .await
+                                .unwrap();
+                            if until(
+                                data_write_handle.fetch_recent_upper().await.clone(),
+                                data_read_handle,
+                            )
+                            .await
+                            {
+                                return;
+                            }
+                            tokio::time::sleep(timestamp_interval).await;
+                        }
+                    })
+                };
+
+                {
+                    let _tokio_guard = tokio_runtime.enter();
+                    while !check_task.is_finished() {
+                        worker.timely_worker.step();
+                    }
+                }
+
+                let res = tokio_runtime.block_on(check_task);
+                finished.store(true, Ordering::SeqCst);
+                match res {
+                    Err(e) => std::panic::resume_unwind(e.into_panic()),
+                    Ok(()) => {
+                        // We passed!
+                    }
+                }
+            },
+        )
+        .unwrap()
+    };
+
+    for g in guards.join() {
+        g.map_err(|_| {
+            anyhow::anyhow!("timely thread panicked, cargo test should print the failure")
+        })?
+    }
+
+    // Assert that we actually went through the dataflow and checked the results.
+    if !finished.load(Ordering::SeqCst) {
+        return Err(anyhow::anyhow!("dataflow never actually produce results"));
+    }
+
+    Ok(())
+}

--- a/src/storage/tests/sources.rs
+++ b/src/storage/tests/sources.rs
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Basic unit tests for sources.
+
+use mz_repr::{Datum, Row};
+use mz_storage::source::testscript::ScriptCommand;
+use mz_storage::types::sources::{
+    encoding::{DataEncoding, DataEncodingInner, SourceDataEncoding},
+    KeyEnvelope, NoneEnvelope, SourceData, SourceEnvelope,
+};
+
+mod setup;
+
+#[test]
+fn test_basic() -> Result<(), anyhow::Error> {
+    let script = vec![ScriptCommand::Emit {
+        value: "gus".to_string(),
+        key: None,
+        offset: 0,
+    }];
+
+    setup::assert_source_results_in(
+        script,
+        SourceDataEncoding::Single(DataEncoding {
+            force_nullable_columns: false,
+            inner: DataEncodingInner::Bytes,
+        }),
+        SourceEnvelope::None(NoneEnvelope {
+            key_envelope: KeyEnvelope::None,
+            key_arity: 0,
+        }),
+        vec![SourceData(Ok(Row::pack([Datum::Bytes(b"gus")])))],
+    )
+}
+
+#[test]
+fn test_basic_failing() {
+    let script = vec![ScriptCommand::Emit {
+        value: "gus".to_string(),
+        key: None,
+        offset: 0,
+    }];
+
+    assert!(setup::assert_source_results_in(
+        script,
+        SourceDataEncoding::Single(DataEncoding {
+            force_nullable_columns: false,
+            inner: DataEncodingInner::Bytes,
+        }),
+        SourceEnvelope::None(NoneEnvelope {
+            key_envelope: KeyEnvelope::None,
+            key_arity: 0,
+        }),
+        vec![SourceData(Ok(Row::pack([Datum::Bytes(b"gus2")])))],
+    )
+    .is_err())
+}


### PR DESCRIPTION
I feel that we should be able to unit-test the source pipeline, to add regression tests for things like https://github.com/MaterializeInc/materialize/pull/15407, that don't rely on timing. This pr is a first step towards that goal.

The exact way that I setup the tests and the dataflow are definitely up for debate, i don't expect i got it perfectly right first try (though I feel we can merge and iterate on stuff like this). Another thing to note is that this test does not attempt to control the timing of the source pipeline (the various sleeps and choices that the remap operator and friends make. That will require a deeper dive into the source pipeline itself (and extensions to the `TestScript` source as well). For now, this seems like a nice start!

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
