### PR TITLE
adapter: use correct type for pg_type.typcategory

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1765,7 +1765,7 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
         WHEN 'timespan' THEN 'T'
         WHEN 'user-defined' THEN 'U'
         WHEN 'unknown' THEN 'X'
-    END) AS typcategory,
+    END)::pg_catalog.char AS typcategory,
     0::pg_catalog.oid AS typrelid,
     coalesce(
         (


### PR DESCRIPTION
Was previously a `text`, causing errors in drivers (sqlx) that expected the documented char type.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Correctly use the `char` type for `pg_type.typcategory`.