### PR TITLE
adapter: issue a notice for an available index

### DIFF
--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -424,6 +424,7 @@ impl ErrorResponse {
             }
             AdapterNotice::UserRequested { .. } => SqlState::WARNING,
             AdapterNotice::ClusterReplicaStatusChanged { .. } => SqlState::WARNING,
+            AdapterNotice::AvailableIndex { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -571,6 +572,7 @@ impl Severity {
                 NoticeSeverity::Warning => Severity::Warning,
             },
             AdapterNotice::ClusterReplicaStatusChanged { .. } => Severity::Notice,
+            AdapterNotice::AvailableIndex { .. } => Severity::Notice,
         }
     }
 }

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -1,0 +1,77 @@
+# Test various NOTICE expectations.
+
+# Test that a query with an available index sends a notice if the index is on another cluster.
+send
+Query {"query": "drop cluster if exists c1 cascade"}
+Query {"query": "drop cluster if exists c2 cascade"}
+Query {"query": "drop table if exists t cascade"}
+Query {"query": "drop view if exists v cascade"}
+Query {"query": "create cluster c1 replicas (ra (size '1'))"}
+Query {"query": "create cluster c2 replicas (rb (size '1'))"}
+Query {"query": "create table t ()"}
+Query {"query": "create view v as select count(*) from t"}
+Query {"query": "set cluster = c1"}
+Query {"query": "create default index on v"}
+Query {"query": "set cluster = c2"}
+Query {"query": "select * from v"}
+Query {"query": "set cluster = c1"}
+Query {"query": "select * from v"}
+Query {"query": "drop cluster c1 cascade"}
+Query {"query": "drop cluster c2 cascade"}
+----
+
+until err_field_typs=SMDH
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"count"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"M","value":"cluster c1 has a fast-path index for this query"},{"typ":"H","value":"to change to the cluster: `SET cluster = \"c1\";`"}]}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"count"}]}
+DataRow {"fields":["0"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
If a user issues a query that has an index on a different cluster than
their session setting, inform them with a notice. This is more general
than the linked issue, but will probably benefit users.

Fixes #15427

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a