### PR TITLE
environmentd: bump timeout for test_no_block to 60s

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -102,7 +102,7 @@ fn test_no_block() -> Result<(), anyhow::Error> {
 
     // This is better than relying on CI to time out, because an actual failure
     // (as opposed to a CI timeout) causes `services.log` to be uploaded.
-    mz_ore::test::timeout(Duration::from_secs(30), || {
+    mz_ore::test::timeout(Duration::from_secs(60), || {
         info!("test_no_block: starting server");
         let server = util::start_server(util::Config::default())?;
 


### PR DESCRIPTION
It appears that server startup has gotten slow enough that a 30s timeout is too little. Bump to 60s.

Fix #15433.

### Motivation

  * This PR fixes a recognized CI flake.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
