### PR TITLE
sql: use kebab case for materialized view type

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -96,11 +96,11 @@
         d.name as database,
         s.name as schema,
         o.name,
-        case when o.type = 'materialized view' then 'materializedview' else o.type end as type
+        case when o.type = 'materialized-view' then 'materializedview' else o.type end as type
     from mz_objects o
     join mz_schemas s on o.schema_id = s.id and s.name = '{{ schema_relation.schema }}'
     join mz_databases d on s.database_id = d.id and d.name = '{{ schema_relation.database }}'
-    where type in ('table', 'source', 'view', 'materialized view', 'index', 'sink')
+    where type in ('table', 'source', 'view', 'materialized-view', 'index', 'sink')
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -24,7 +24,7 @@
             d.name as table_database,
             s.name as table_schema,
             o.name as table_name,
-            case when o.type = 'materialized view' then 'materializedview' else o.type end as table_type,
+            case when o.type = 'materialized-view' then 'materializedview' else o.type end as table_type,
             '' as table_comment,
             c.name as column_name,
             c.position as column_index,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1470,7 +1470,7 @@ pub const MZ_RELATIONS: BuiltinView = BuiltinView {
       SELECT id, oid, schema_id, name, 'table' FROM mz_catalog.mz_tables
 UNION ALL SELECT id, oid, schema_id, name, 'source' FROM mz_catalog.mz_sources
 UNION ALL SELECT id, oid, schema_id, name, 'view' FROM mz_catalog.mz_views
-UNION ALL SELECT id, oid, schema_id, name, 'materialized view' FROM mz_catalog.mz_materialized_views",
+UNION ALL SELECT id, oid, schema_id, name, 'materialized-view' FROM mz_catalog.mz_materialized_views",
 };
 
 pub const MZ_OBJECTS: BuiltinView = BuiltinView {
@@ -1648,7 +1648,7 @@ pub const PG_CLASS: BuiltinView = BuiltinView {
         WHEN class_objects.type = 'source' THEN 'r'
         WHEN class_objects.type = 'index' THEN 'i'
         WHEN class_objects.type = 'view' THEN 'v'
-        WHEN class_objects.type = 'materialized view' THEN 'm'
+        WHEN class_objects.type = 'materialized-view' THEN 'm'
     END relkind,
     -- MZ doesn't support CHECK constraints so relchecks is filled with 0
     0::pg_catalog.int2 AS relchecks,
@@ -2197,6 +2197,7 @@ pub const INFORMATION_SCHEMA_TABLES: BuiltinView = BuiltinView {
     s.name AS table_schema,
     r.name AS table_name,
     CASE r.type
+        WHEN 'materialized-view' THEN 'MATERIALIZED VIEW'
         WHEN 'table' THEN 'BASE TABLE'
         ELSE pg_catalog.upper(r.type)
     END AS table_type

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -325,7 +325,7 @@ SHOW OBJECTS
 ----
 name type
 mv
-materialized view
+materialized-view
 t
 table
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -305,7 +305,7 @@ v2          view
 tbl         table
 pass_secret secret
 kafka_conn  connection
-mv          "materialized view"
+mv          materialized-view
 source_data source
 snk         sink
 
@@ -315,7 +315,7 @@ type
 table
 source
 view
-"materialized view"
+materialized-view
 sink
 index
 connection
@@ -328,7 +328,7 @@ bool        type
 csr_conn    connection
 int_list    type
 kafka_conn  connection
-mv          "materialized view"
+mv          materialized-view
 pass_secret secret
 snk         sink
 source_data source


### PR DESCRIPTION
Change the type string for a materialized view in the system catalog from `materialized view` to `materialized-view`.

This is _technically_ a breaking change, but it's so early in our product's life and it's such a minor change that I think we can tolerate it without trouble.

Per a new guideline in our new SQL design principles doc [0].

[0]: https://www.notion.so/materialize/SQL-design-principles-2e2069797f7c46b8b4c7dd10043afdcd#8a999832fd00433ba0eb29dff73bb571

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - **Breaking change.** Change the `type` of a materialized view in the `mz_objects` relation from `materialized view` to `materialized-view`, for consistency with how multi-word types are represented elsewhere in the catalog.
