### PR TITLE
sql: don't ever interpret idents as objects for string options

### DIFF
--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -46,21 +46,21 @@ COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Object(Name(UnresolvedObjectName([Ident("text")])))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMITER '|')
 ----
 COPY t FROM STDIN WITH (FORMAT = csv, DELIMITER = '|')
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Object(Name(UnresolvedObjectName([Ident("csv")])))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [CopyOption { name: Format, value: Some(Ident(Ident("csv"))) }, CopyOption { name: Delimiter, value: Some(Value(String("|"))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (FORMAT = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Object(Name(UnresolvedObjectName([Ident("text")])))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [CopyOption { name: Format, value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
 COPY t TO STDOUT ()

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -379,7 +379,7 @@ CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHO
 ----
 CREATE CONNECTION pgconn TO POSTGRES (HOST = foo, PORT = 1234, SSL CERTIFICATE AUTHORITY = 'foo', SSH TUNNEL = tun)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Object(Name(UnresolvedObjectName([Ident("foo")])))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Object(Name(UnresolvedObjectName([Ident("tun")])))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("pgconn")]), connection: Postgres { with_options: [PostgresConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, PostgresConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, PostgresConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("foo"))) }, PostgresConnectionOption { name: SshTunnel, value: Some(Object(Name(UnresolvedObjectName([Ident("tun")])))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn (PUBLICATION 'red');
@@ -871,7 +871,7 @@ ALTER SOURCE name SET (SIZE LARGE)
 ----
 ALTER SOURCE name SET (SIZE = large)
 =>
-AlterSource(AlterSourceStatement { source_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSourceOption { name: Size, value: Some(Object(Name(UnresolvedObjectName([Ident("large")])))) }]) })
+AlterSource(AlterSourceStatement { source_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
 
 parse-statement
 ALTER SOURCE name RESET (SIZE)
@@ -907,7 +907,7 @@ ALTER SINK name SET (SIZE LARGE)
 ----
 ALTER SINK name SET (SIZE = large)
 =>
-AlterSink(AlterSinkStatement { sink_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSinkOption { name: Size, value: Some(Object(Name(UnresolvedObjectName([Ident("large")])))) }]) })
+AlterSink(AlterSinkStatement { sink_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([CreateSinkOption { name: Size, value: Some(Ident(Ident("large"))) }]) })
 
 parse-statement
 ALTER SINK name RESET (SIZE)

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1077,46 +1077,13 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 Secret(object_name)
             }
             Object(obj) => {
-                // If we are not in an error state, we can treat non-qualified
-                // identifiers that we fail to resolve as if they were entered
-                // as strings.
-                //
-                // This is acceptable because all with option values are more
-                // tightly type-checked in planning, i.e. they must be declared
-                // as either a string or an object. If we fail to find an object
-                // here, and treat it as a string here, the later type checking
-                // will still error.
-                //
-                // The one complex error case this introduces is users expecting
-                // to be able to use a value as a non-quoted "string" when its
-                // ident resolves to an object. In this case, the user will be
-                // forced to quote the string, even though they don't need to do
-                // this elsewhere.
-                let string_candidate = match &obj {
-                    RawObjectName::Name(name) if name.0.len() == 1 && self.status.is_ok() => {
-                        Some(name.0[0].clone().into_string())
-                    }
-                    _ => None,
-                };
-
                 let object_name = self.fold_object_name(obj);
                 match &object_name {
                     ResolvedObjectName::Object { .. } => {}
                     ResolvedObjectName::Cte { .. } => {
                         self.status = Err(PlanError::InvalidObject(object_name.clone()));
                     }
-                    ResolvedObjectName::Error => {
-                        if let Some(string) = string_candidate {
-                            // We are no longer in an error state; we know that
-                            // we introduced the error during folding the object
-                            // name because we weren't in an error state prior
-                            // to calling it.
-                            self.status = Ok(());
-                            return Value(
-                                self.fold_value(mz_sql_parser::ast::Value::String(string)),
-                            );
-                        }
-                    }
+                    ResolvedObjectName::Error => {}
                 }
                 Object(object_name)
             }

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -33,8 +33,7 @@ CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET n
 statement ok
 CREATE SECRET pgpass AS 'postgres'
 
-# SSH TUNNELs are required to be objects, but we'll interpret it as a string
-statement error invalid SSH TUNNEL: must provide an object
+statement error unknown catalog item 'not_an_object_at_all'
 CREATE CONNECTION pg TO POSTGRES (
   HOST postgres,
   DATABASE postgres,
@@ -47,12 +46,10 @@ CREATE CONNECTION pg TO POSTGRES (
 statement ok
 CREATE TABLE object_reference (a int);
 
-statement error invalid HOST: incompatible value types
+# It's okay if idents for string options refer to objects.
+statement ok
 CREATE CONNECTION pg TO POSTGRES (
   HOST object_reference,
   DATABASE postgres,
-  USER postgres,
-  PASSWORD SECRET pgpass,
-  SSL MODE require,
-  SSH TUNNEL not_an_object_at_all
+  USER postgres
 )

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -91,7 +91,7 @@ name     pkey1 pkey2
     USER 'yshtola',
     SSH TUNNEL johto
   );
-contains: invalid SSH TUNNEL: must provide an object
+contains: unknown catalog item 'johto'
 
 ! CREATE CONNECTION papalymo TO POSTGRES (
     HOST 'gridania.example.com',


### PR DESCRIPTION
@sploiselle—sorry I put you through this in #15113 in the first place. I think my attempt to remove the special case from the parser was totally misguided.

---

This is a partial reversion of c7a4c0ac2. The intent was to avoid a special case in the parser for options that take objects as values; unfortunately this introduced *more* special cases than it saved. In particular, it introduced a special case that leaked out into the user experience: idents that named valid objects in the current schema could not be coerced to strings, while idents that named invalid objects could.

Seems better to just special-case the options that take values as objects in the parser, and avoid the special cases everywhere else.

Follow up from #15113.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - This is technically a user-facing change, but it's both incredibly minor and hard to explain, so I propose we omit it.
