### PR TITLE
dbt-materialize: disallow cluster config in view materializations

### DIFF
--- a/doc/user/content/integrations/dbt.md
+++ b/doc/user/content/integrations/dbt.md
@@ -226,7 +226,6 @@ Here, the model depends on the view defined above, and is referenced as such via
 
 ### Configuration
 
-
 #### Clusters
 
 Use the [cluster](/sql/create-cluster/) option to specify the cluster in which a `materialized view` is created. If unspecified, the default cluster for the connection is used.

--- a/doc/user/layouts/shortcodes/dbt-materializations.html
+++ b/doc/user/layouts/shortcodes/dbt-materializations.html
@@ -1,4 +1,4 @@
-Type             | Details                                                                                                                                                         | Config Options
+Type             | Details                                                                                                                                                         | Config options
 -----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------
 source           | Creates a [source](/sql/create-source).                                                                                                                         | indexes
 view             | Creates a [view](/sql/create-view).                                                                                                                             | indexes

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,4 +1,11 @@
 # dbt-materialize Changelog
+
+## Unreleased - 2022-10-16
+
+* Disallow the `cluster` option for `view` materializations. In the new
+  architecture, only materialized views and indexes are associated with a
+  cluster.
+
 ## 1.2.0 - 2022-08-31
 
 * Enable additional configuration for indexes created on view,

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -18,12 +18,8 @@
 -- See: https://github.com/dbt-labs/dbt-core/blob/13b18654f/plugins/postgres/dbt/include/postgres/macros/adapters.sql
 
 {% macro materialize__create_view_as(relation, sql) -%}
-  {%- set cluster = config.get('cluster', None) -%}
 
   create view {{ relation }}
-  {% if cluster %}
-    in cluster {{ cluster }}
-  {% endif %}
   as (
     {{ sql }}
   );


### PR DESCRIPTION
As discussed [on Slack](https://materializeinc.slack.com/archives/C0414ER457U/p1665520304586769), the `view` materialization shouldn't allow the `cluster` configuration option.