### PR TITLE
zippy: Increase the stressfullness of the ClusterReplicas scenario

### DIFF
--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -24,6 +24,7 @@ from materialize.zippy.replica_actions import (
     CreateReplica,
     DropDefaultReplica,
     DropReplica,
+    KillReplica,
 )
 from materialize.zippy.sink_actions import CreateSink
 from materialize.zippy.source_actions import CreateSource
@@ -110,7 +111,7 @@ class PostgresCdc(Scenario):
 
 
 class ClusterReplicas(Scenario):
-    """A Zippy test that uses CREATE / DROP REPLICA."""
+    """A Zippy test that uses CREATE / DROP REPLICA and random killing."""
 
     def bootstrap(self) -> List[Type[Action]]:
         return [KafkaStart, MzStart, DropDefaultReplica, CreateReplica]
@@ -120,14 +121,15 @@ class ClusterReplicas(Scenario):
         return {
             KillStoraged: 10,
             KillComputed: 10,
-            CreateReplica: 20,
-            DropReplica: 20,
+            CreateReplica: 30,
+            KillReplica: 10,
+            DropReplica: 10,
             CreateTopic: 10,
             CreateSource: 10,
             CreateTable: 10,
-            CreateView: 10,
+            CreateView: 20,
             CreateSink: 10,
-            ValidateView: 10,
+            ValidateView: 20,
             Ingest: 25,
             DML: 25,
         }


### PR DESCRIPTION
The ClusterReplicas scenario was quite lenient, so beef it up:


- increase the maximum number of replicas to 4
- do not create SIZE 1 replicas
- increase the proportion of multi-process vs. multi-worker replicas to 75%
- add killing of replicas via mz_panic()
- increase the number of materialized views

### Motivation


  * This PR adds a feature that has not yet been specified.

The Zippy ClusterReplicas scenario was not very stressfull