### PR TITLE
storage, WIP: preparatory work for fixing capability tracking in source ingestion

### DIFF
--- a/src/storage/src/source/antichain.rs
+++ b/src/storage/src/source/antichain.rs
@@ -11,6 +11,8 @@
 use std::collections::HashMap;
 
 use mz_expr::PartitionId;
+use timely::progress::frontier::MutableAntichain;
+use timely::PartialOrder;
 
 use crate::types::sources::MzOffset;
 
@@ -170,5 +172,182 @@ impl OffsetAntichain {
         Self {
             inner: HashMap::from_iter(iter),
         }
+    }
+}
+
+/// A wrapper around [`MutableAntichain`] that allows adding (inserting all
+/// contents with a `+1`) and subtracting (inserting all contents with a `-1`)
+/// of whole [`OffsetAntichains`](OffsetAntichain).
+///
+/// The frontier of this mutable antichain can be revealed in the form of an
+/// [`OffsetAntichain`].
+#[derive(Debug)]
+pub struct MutableOffsetAntichain {
+    inner: MutableAntichain<PartitionOffset>,
+}
+
+impl MutableOffsetAntichain {
+    /// Creates a new, empty [`MutableOffsetAntichain`].
+    pub fn new() -> Self {
+        Self {
+            inner: MutableAntichain::new(),
+        }
+    }
+
+    /// Inserts all partition/offset pairs contained in the given
+    /// [`OffsetAntichain`] into this [`MutableOffsetAntichain`], with a `diff`
+    /// of `+1`.
+    ///
+    /// In laymans terms, this adds the contained partition/offset pairs.
+    pub fn add(&mut self, offsets: &OffsetAntichain) {
+        let iter = offsets
+            .iter()
+            .map(|(pid, offset)| (PartitionOffset::new(pid.clone(), *offset), 1));
+        self.inner.update_iter(iter);
+    }
+
+    /// Inserts all partition/offset pairs contained in the given
+    /// [`OffsetAntichain`] into this [`MutableOffsetAntichain`], with a `diff`
+    /// of `-1`.
+    ///
+    /// In laymans terms, this subtracts the contained partition/offset pairs.
+    pub fn subtract(&mut self, offsets: &OffsetAntichain) {
+        let iter = offsets
+            .iter()
+            .map(|(pid, offset)| (PartitionOffset::new(pid.clone(), *offset), -1));
+        self.inner.update_iter(iter);
+    }
+
+    /// Reveals the minimal elements with positive count.
+    ///
+    /// In laymans terms, this returns an [`OffsetAntichain`] that contains all
+    /// partitions with positive counts, and their respective minimal offset.
+    pub fn frontier(&self) -> OffsetAntichain {
+        let mut result = OffsetAntichain::new();
+
+        for PartitionOffset { partition, offset } in self.inner.frontier().iter() {
+            result.insert(partition.clone(), *offset);
+        }
+
+        result
+    }
+}
+
+// NOTE: Ord is only required as an implementation detail of `MutableAntichain`,
+// but it feels iffy.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PartitionOffset {
+    partition: PartitionId,
+    offset: MzOffset,
+}
+
+impl PartitionOffset {
+    fn new(partition: PartitionId, offset: MzOffset) -> Self {
+        PartitionOffset { partition, offset }
+    }
+}
+
+impl PartialOrder for PartitionOffset {
+    fn less_equal(&self, other: &Self) -> bool {
+        // Only offsets for the same partition are comparable!
+        if self.partition != other.partition {
+            false
+        } else {
+            self.offset <= other.offset
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutable_antichain_basic_usage() {
+        let mut mutable_antichain = MutableOffsetAntichain::new();
+
+        let offset_antichain_a = OffsetAntichain::from_iter([
+            (pid(0), 5.into()),
+            (pid(1), 10.into()),
+            (pid(3), 11.into()),
+        ]);
+
+        let offset_antichain_b = OffsetAntichain::from_iter([
+            (pid(0), 10.into()),
+            (pid(1), 5.into()),
+            (pid(4), 11.into()),
+        ]);
+
+        mutable_antichain.add(&offset_antichain_a);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, offset_antichain_a);
+
+        // Adding the same `OffsetAntichain` again doesn't affect the overall
+        // frontier.
+        mutable_antichain.add(&offset_antichain_a);
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, offset_antichain_a);
+
+        // Adding a different `OffsetAntichain` will make the overall frontier
+        // go to the "minimum per partition".
+        mutable_antichain.add(&offset_antichain_b);
+
+        let expected_frontier = OffsetAntichain::from_iter([
+            (pid(0), 5.into()),
+            (pid(1), 5.into()),
+            (pid(3), 11.into()),
+            (pid(4), 11.into()),
+        ]);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, expected_frontier);
+
+        // Subtracting "a" once does not change the frontier.
+        mutable_antichain.subtract(&offset_antichain_a);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, expected_frontier);
+
+        // Completely removing any vestiges of "a" will make the frontier mirror
+        // "b".
+        mutable_antichain.subtract(&offset_antichain_a);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, offset_antichain_b);
+
+        // Removing everything will render the frontier empty.
+        mutable_antichain.subtract(&offset_antichain_b);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, OffsetAntichain::new());
+    }
+
+    #[test]
+    fn mutable_antichain_negative_counts() {
+        let mut mutable_antichain = MutableOffsetAntichain::new();
+
+        let offset_antichain_a = OffsetAntichain::from_iter([
+            (pid(0), 5.into()),
+            (pid(1), 10.into()),
+            (pid(3), 11.into()),
+        ]);
+
+        // Negative counts should not show up in the frontier.
+        mutable_antichain.subtract(&offset_antichain_a);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, OffsetAntichain::new());
+
+        // These cancel out the negative counts. Frontier will still be empty.
+        mutable_antichain.add(&offset_antichain_a);
+
+        let frontier = mutable_antichain.frontier();
+        assert_eq!(frontier, OffsetAntichain::new());
+    }
+
+    /// Testing helper.
+    fn pid(pid: i32) -> PartitionId {
+        PartitionId::Kafka(pid)
     }
 }


### PR DESCRIPTION
Commits have useful descriptions!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
