### PR TITLE
coord: Normalize storage update timestamps

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1189,8 +1189,8 @@ impl CatalogState {
         builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
         shard_id: Option<String>,
         size_bytes: u64,
+        collection_timestamp: EpochMillis,
     ) -> Result<(), Error> {
-        let collection_timestamp = (self.config.now)();
         let id = tx.get_and_increment_id(storage::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
 
         let details = VersionedStorageUsage::new(id, shard_id, size_bytes, collection_timestamp);
@@ -4424,8 +4424,15 @@ impl<S: Append> Catalog<S> {
                 Op::UpdateStorageUsage {
                     shard_id,
                     size_bytes,
+                    collection_timestamp,
                 } => {
-                    state.add_to_storage_usage(tx, builtin_table_updates, shard_id, size_bytes)?;
+                    state.add_to_storage_usage(
+                        tx,
+                        builtin_table_updates,
+                        shard_id,
+                        size_bytes,
+                        collection_timestamp,
+                    )?;
                 }
                 Op::UpdateSystemConfiguration { name, value } => {
                     tx.upsert_system_config(&name, &value)?;
@@ -5181,6 +5188,7 @@ pub enum Op {
     UpdateStorageUsage {
         shard_id: Option<String>,
         size_bytes: u64,
+        collection_timestamp: EpochMillis,
     },
     UpdateSystemConfiguration {
         name: String,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -109,11 +109,13 @@ impl<S: Append + 'static> Coordinator<S> {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn storage_usage_update(&mut self, shard_sizes: HashMap<Option<ShardId>, u64>) {
+        let collection_timestamp = (self.catalog.config().now)();
         let mut ops = vec![];
         for (shard_id, size_bytes) in shard_sizes {
             ops.push(catalog::Op::UpdateStorageUsage {
                 shard_id: shard_id.map(|shard_id| shard_id.to_string()),
                 size_bytes,
+                collection_timestamp,
             });
         }
 


### PR DESCRIPTION
Previously the timestamp of a row in the storage_usage table corresponded to when that row was inserted. This resulted in many rows that were inserted as part of the same update having timestamps that differed by a couple of milliseconds, making it hard to aggregate the rows from a single update.

This commit fixes this issue so that all rows from the same update contain the same timestamp.

Fixes #15464

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
