### PR TITLE
Perform add replica orchestrator calls outside coord thread

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -431,7 +431,6 @@ impl<S: Append + 'static> Coordinator<S> {
                 self.controller
                     .active_compute()
                     .add_replica_to_instance(instance.id, replica_id, replica.config)
-                    .await
                     .unwrap();
             }
         }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -20,7 +20,6 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use mz_build_info::BuildInfo;
 use mz_ore::retry::Retry;
-use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_service::client::GenericClient;
 
 use crate::command::{CommunicationConfig, ComputeCommand, ReplicaId};
@@ -28,11 +27,12 @@ use crate::logging::LoggingConfig;
 use crate::response::ComputeResponse;
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
+use super::orchestrator::ComputeOrchestrator;
+use super::{ComputeInstanceId, ComputeReplicaLocation};
+
 /// State for a single replica.
 #[derive(Debug)]
 pub(super) struct Replica<T> {
-    /// The ID of this replica.
-    id: ReplicaId,
     /// A sender for commands for the replica.
     ///
     /// If sending to this channel fails, the replica has failed and requires
@@ -43,14 +43,10 @@ pub(super) struct Replica<T> {
     /// If receiving from the channel returns `None`, the replica has failed
     /// and requires rehydration.
     response_rx: UnboundedReceiver<ComputeResponse<T>>,
-    /// A handle to the task that aborts it when the replica is dropped.
-    _task: AbortOnDropHandle<()>,
-    /// The network addresses of the processes that make up the replica.
-    pub addrs: Vec<String>,
+    /// Location of the replica
+    pub location: ComputeReplicaLocation,
     /// The logging config specific to this replica.
     pub logging_config: Option<LoggingConfig>,
-    /// The communication config specific to this replica.
-    pub communication_config: CommunicationConfig,
 }
 
 impl<T> Replica<T>
@@ -60,44 +56,45 @@ where
 {
     pub(super) fn spawn(
         id: ReplicaId,
+        instance_id: ComputeInstanceId,
         build_info: &'static BuildInfo,
-        addrs: Vec<String>,
+        location: ComputeReplicaLocation,
         logging_config: Option<LoggingConfig>,
-        communication_config: CommunicationConfig,
+        orchestrator: ComputeOrchestrator,
     ) -> Self {
         // Launch a task to handle communication with the replica
         // asynchronously. This isolates the main controller thread from
         // the replica.
         let (command_tx, command_rx) = unbounded_channel();
         let (response_tx, response_rx) = unbounded_channel();
-        let task = mz_ore::task::spawn(
+        mz_ore::task::spawn(
             || format!("active-replication-replica-{id}"),
-            replica_task(ReplicaTaskConfig {
+            ReplicaTask {
+                instance_id,
                 replica_id: id,
                 build_info,
-                addrs: addrs.clone(),
+                location: location.clone(),
+                logging_config: logging_config.clone(),
+                orchestrator,
                 command_rx,
                 response_tx,
-            }),
+            }
+            .run(),
         );
 
         Self {
-            id,
             command_tx,
             response_rx,
-            _task: task.abort_on_drop(),
-            addrs,
+            location,
             logging_config,
-            communication_config,
         }
     }
 
     /// Sends a command to this replica.
     pub(super) fn send(
         &self,
-        mut command: ComputeCommand<T>,
+        command: ComputeCommand<T>,
     ) -> Result<(), SendError<ComputeCommand<T>>> {
-        self.specialize_command(&mut command);
         self.command_tx.send(command)
     }
 
@@ -107,60 +104,97 @@ where
     pub(super) async fn recv(&mut self) -> Option<ComputeResponse<T>> {
         self.response_rx.recv().await
     }
-
-    /// Specialize a command for this replica.
-    ///
-    /// Most `ComputeCommand`s are independent of the target replica, but some
-    /// contain replica-specific fields that must be adjusted before sending.
-    fn specialize_command(&self, command: &mut ComputeCommand<T>) {
-        // Set new replica ID and obtain set the sinked logs specific to this replica
-        if let ComputeCommand::CreateInstance(config) = command {
-            config.replica_id = self.id;
-            config.logging = self.logging_config.clone();
-        }
-
-        if let ComputeCommand::CreateTimely(comm_config) = command {
-            *comm_config = self.communication_config.clone();
-        }
-    }
 }
 
 /// Configuration for `replica_task`.
-struct ReplicaTaskConfig<T> {
+struct ReplicaTask<T> {
+    /// The ID of the compute instance.
+    instance_id: ComputeInstanceId,
     /// The ID of the replica.
     replica_id: ReplicaId,
-    /// The network addresses of the processes in the replica.
-    addrs: Vec<String>,
+    /// Location
+    location: ComputeReplicaLocation,
+    /// Logging
+    logging_config: Option<LoggingConfig>,
     /// The build information for this process.
     build_info: &'static BuildInfo,
     /// A channel upon which commands intended for the replica are delivered.
     command_rx: UnboundedReceiver<ComputeCommand<T>>,
     /// A channel upon which responses from the replica are delivered.
     response_tx: UnboundedSender<ComputeResponse<T>>,
+    /// Orchestrator responsible for setting up computeds
+    orchestrator: ComputeOrchestrator,
 }
 
-/// Asynchronously forwards commands to and responses from a single replica.
-async fn replica_task<T>(config: ReplicaTaskConfig<T>)
+impl<T> ReplicaTask<T>
 where
     T: Timestamp + Lattice,
     ComputeGrpcClient: ComputeClient<T>,
 {
-    let replica_id = config.replica_id;
-    tracing::info!("starting replica task for {replica_id}");
-    match run_replica_core(config).await {
-        Ok(()) => tracing::info!("gracefully stopping replica task for {replica_id}"),
-        Err(e) => tracing::warn!("replica task for {replica_id} failed: {e}"),
+    /// Asynchronously forwards commands to and responses from a single replica.
+    async fn run(self) {
+        let replica_id = self.replica_id;
+        tracing::info!("starting replica task for {replica_id}");
+        match self.run_core().await {
+            Ok(()) => tracing::info!("gracefully stopping replica task for {replica_id}"),
+            Err(e) => tracing::warn!("replica task for {replica_id} failed: {e}"),
+        }
+    }
+
+    /// Instruct orchestrator to ensure replica and run the message loop. In the case of a
+    /// graceful termination after a DropInstance command this method will tell the orchestrator
+    /// to remove the process.
+    async fn run_core(self) -> Result<(), anyhow::Error> {
+        let ReplicaTask {
+            instance_id,
+            replica_id,
+            location,
+            logging_config,
+            build_info,
+            command_rx,
+            response_tx,
+            orchestrator,
+        } = self;
+
+        let is_managed = matches!(location, ComputeReplicaLocation::Managed { .. });
+        let (addrs, comm_config) = orchestrator
+            .ensure_replica_location(instance_id, replica_id, location)
+            .await?;
+
+        let cmd_spec = CommandSpecialization {
+            replica_id,
+            logging_config,
+            comm_config,
+        };
+
+        let res = run_message_loop(
+            replica_id,
+            command_rx,
+            response_tx,
+            build_info,
+            addrs,
+            cmd_spec,
+        )
+        .await;
+
+        if res.is_ok() && is_managed {
+            orchestrator.drop_replica(instance_id, replica_id).await?;
+        };
+
+        res
     }
 }
 
-async fn run_replica_core<T>(
-    ReplicaTaskConfig {
-        replica_id,
-        addrs,
-        build_info,
-        mut command_rx,
-        response_tx,
-    }: ReplicaTaskConfig<T>,
+/// Connects to replica and runs the message loop. Retries with backoff forever to connects. Once
+/// connected, the task terminates on an error condition (with Err) or on graceful termination
+/// (with Ok, after receiving a DropInstance command)
+async fn run_message_loop<T>(
+    replica_id: ReplicaId,
+    mut command_rx: UnboundedReceiver<ComputeCommand<T>>,
+    response_tx: UnboundedSender<ComputeResponse<T>>,
+    build_info: &BuildInfo,
+    addrs: Vec<String>,
+    cmd_spec: CommandSpecialization,
 ) -> Result<(), anyhow::Error>
 where
     T: Timestamp + Lattice,
@@ -171,6 +205,7 @@ where
         .retry_async(|state| {
             let addrs = addrs.clone();
             let version = build_info.semver_version();
+
             async move {
                 match ComputeGrpcClient::connect_partitioned(addrs, version).await {
                     Ok(client) => Ok(client),
@@ -192,11 +227,21 @@ where
             // Command from controller to forward to replica.
             command = command_rx.recv() => match command {
                 None => {
-                    // Controller is no longer interested in this replica. Shut
-                    // down.
-                    return Ok(())
+                    // Controller unexpectedly dropped command_tx
+                    bail!("command_rx received None")
                 }
-                Some(command) => client.send(command).await?,
+                Some(mut command) => {
+                    let is_drop = command == ComputeCommand::DropInstance;
+                    cmd_spec.specialize_command(&mut command);
+                    let res = client.send(command).await;
+
+                    if is_drop {
+                        // Controller is no longer interested in this replica. Shut down.
+                        return Ok(())
+                    };
+
+                    res?
+                }
             },
             // Response from replica to forward to controller.
             response = client.recv() => {
@@ -204,12 +249,32 @@ where
                     None => bail!("replica unexpectedly gracefully terminated connection"),
                     Some(response) => response,
                 };
-                if response_tx.send(response).is_err() {
-                    // Controller is no longer interested in this replica. Shut
-                    // down.
-                    return Ok(());
-                }
+                response_tx.send(response)?
             }
+        }
+    }
+}
+
+struct CommandSpecialization {
+    replica_id: ReplicaId,
+    logging_config: Option<LoggingConfig>,
+    comm_config: CommunicationConfig,
+}
+
+impl CommandSpecialization {
+    /// Specialize a command for the given `Replica` and `ReplicaId`.
+    ///
+    /// Most `ComputeCommand`s are independent of the target replica, but some
+    /// contain replica-specific fields that must be adjusted before sending.
+    fn specialize_command<T>(&self, command: &mut ComputeCommand<T>) {
+        // Set new replica ID and obtain set the sinked logs specific to this replica
+        if let ComputeCommand::CreateInstance(config) = command {
+            config.replica_id = self.replica_id;
+            config.logging = self.logging_config.clone();
+        }
+
+        if let ComputeCommand::CreateTimely(comm_config) = command {
+            *comm_config = self.comm_config.clone();
         }
     }
 }


### PR DESCRIPTION
This PR moves the orchestrator calls of `ActiveComputeController::add_replica_to_instance` and `ActiveComputeController::drop_replica` into the replica specific task. 

It should fix #15368, however not by returning a `oneshot` channel but rather by moving any network operation into the per replica tokio task.


### Tips for reviewers

 * First commit does add replica, second drop.
 * Note that `Instance::drop` was a no-op so far (see #14687). It now has the purpose of signaling the replica task to remove the service from the orchestrator and to terminate gracefully the background task.

### Motivation

  * This PR fixes a recognized bug. Fixes #15368

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): None
