### PR TITLE
fix task_ready ordering in timely async builder

### DIFF
--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -53,11 +53,11 @@ struct TimelyWaker {
 
 impl ArcWake for TimelyWaker {
     fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.task_ready.store(true, Ordering::SeqCst);
         // Only activate the timely operator if it's not already active to avoid an infinite loop
         if !arc_self.active.load(Ordering::SeqCst) {
             arc_self.activator.activate().unwrap();
         }
-        arc_self.task_ready.store(true, Ordering::SeqCst);
     }
 }
 


### PR DESCRIPTION
`task_ready` is used communicate to the operator's callback that the future should actually be polled. There is a CHANCE that the timely operator runs after its activation BEFORE we set the task_ready flag.

### Motivation

  * This PR _is related to_ a recognized bug.
  #15026 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

