### PR TITLE
persist: allow Listens to delay the internally held since by some amount

### DIFF
--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -76,3 +76,15 @@ pub trait Codec64: Sized + 'static {
     /// handle bytes output by all previous versions of encode.
     fn decode(buf: [u8; 8]) -> Self;
 }
+
+/// Trait to allow us to apply a temporary band-aid for #15402
+pub trait ListenTimestampBandAid {
+    /// Computes `self - x`, saturating at `Timestamp::minimum()`.
+    fn saturating_sub(&self, x: &Self) -> Self;
+}
+
+impl ListenTimestampBandAid for u64 {
+    fn saturating_sub(&self, x: &Self) -> Self {
+        u64::saturating_sub(*self, *x)
+    }
+}

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -318,6 +318,14 @@ impl mz_persist_types::Codec64 for Timestamp {
     }
 }
 
+impl mz_persist_types::ListenTimestampBandAid for Timestamp {
+    fn saturating_sub(&self, x: &Self) -> Self {
+        Self {
+            internal: self.internal.saturating_sub(x.internal),
+        }
+    }
+}
+
 impl std::fmt::Display for Timestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.internal, f)

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -85,11 +85,14 @@ impl Healthchecker {
 
         let (since, upper) = (read_handle.since().clone(), write_handle.upper().clone());
 
+        // WIP does this one need to be delayed, too?
+        let since_delay = Timestamp::minimum();
+
         // More details on why the listener starts at `since` instead of `upper` in the docstring for [`bootstrap_state`]
         let listener = read_handle
             .clone()
             .await
-            .listen(since.clone())
+            .listen_with_since_delay_band_aid(since.clone(), since_delay)
             .await
             .expect("since <= as_of asserted");
 

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -456,10 +456,13 @@ impl ReclockOperator {
             "invalid as_of: upper({upper:?}) <= as_of({as_of:?})",
         );
 
+        // WIP what should this be?
+        let since_delay = Timestamp::minimum();
+
         let listener = read_handle
             .clone()
             .await
-            .listen(as_of.clone())
+            .listen_with_since_delay_band_aid(as_of.clone(), since_delay)
             .await
             .expect("since <= as_of asserted");
 


### PR DESCRIPTION
Attempt to band-aid #15402 by always holding back the Listen's internally held since capability by some (possibly no-op) delay. In practice, the ReadHandle storaged computes since updates as `upper - <some window>`. Since the above code guarantees that this since is less_than upper, if we also subtract the same window here, we should be guaranteed that a Listen can't cause the shard-global since to advance past what storaged wants it to be, even if storaged has lost its lease.

Touches #15402

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I wasn't entirely sure how to write the reclock side of this, looking for guidance.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
