### PR TITLE
Use index when `a=<literal>` gets an implicit cast

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -470,6 +470,10 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
         }
         .nullable(input.nullable)
     }
+
+    fn preserves_uniqueness(&self) -> bool {
+        self.fail_on_len || self.length.is_none()
+    }
 }
 
 impl fmt::Display for CastStringToVarChar {

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -729,6 +729,236 @@ WHERE
 ----
 2  l2  32
 
+# Implicit casts between literals and indexed column types shouldn't prevent index access
+
+statement ok
+CREATE TABLE foo(a SMALLINT, b INT, c BIGINT, v VARCHAR);
+
+statement ok
+CREATE DEFAULT INDEX ON foo;
+
+statement ok
+INSERT INTO foo VALUES (0, 1, 2, 'xxx'), (3, 4, 5, 'yyy');
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE a = 0 AND b = 1 AND c = 2 AND v = 'xxx';
+----
+Explained Query (fast path):
+  Project (#0..=#3)
+    ReadExistingIndex materialize.public.foo_primary_idx lookup value (0, 1, 2, "xxx")
+
+Used Indexes:
+  - materialize.public.foo_primary_idx
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE 0 = a AND 1 = b AND 2 = c AND 'xxx' = v;
+----
+Explained Query (fast path):
+  Project (#0..=#3)
+    ReadExistingIndex materialize.public.foo_primary_idx lookup value (0, 1, 2, "xxx")
+
+Used Indexes:
+  - materialize.public.foo_primary_idx
+
+EOF
+
+query IIIT rowsort
+SELECT * FROM foo
+WHERE a = 0 AND b = 1 AND c = 2 AND v = 'xxx';
+----
+0  1  2  xxx
+
+statement ok
+CREATE INDEX idx_foo_a ON foo(a);
+
+# Check that the deduplication in `remove_impossible_or_args` treats `a = 0` and `a = 0::SMALLINT` the same
+
+query T multiline
+EXPLAIN SELECT a FROM foo
+WHERE a = 0 AND a = 0::SMALLINT;
+----
+Explained Query (fast path):
+  Project (#0)
+    ReadExistingIndex materialize.public.idx_foo_a lookup value (0)
+
+Used Indexes:
+  - materialize.public.idx_foo_a
+
+EOF
+
+query I rowsort
+SELECT a FROM foo
+WHERE a = 0 AND a = 0::SMALLINT;
+----
+0
+
+# Check that `remove_impossible_or_args` recognizes that `a = 0 AND a = 2::SMALLINT` is impossible.
+# For this, `any_expr_eq_literal` should peel off the cast in the returned expression.
+
+query T multiline
+EXPLAIN SELECT a FROM foo
+WHERE (a = 0 AND a = 2::SMALLINT) OR a = 3;
+----
+Explained Query (fast path):
+  Project (#0)
+    ReadExistingIndex materialize.public.idx_foo_a lookup value (3)
+
+Used Indexes:
+  - materialize.public.idx_foo_a
+
+EOF
+
+query I rowsort
+SELECT a FROM foo
+WHERE (a = 0 AND a = 2::SMALLINT) OR a = 3;
+----
+3
+
+# The (not-anymore-needed) workaround of explicitly casting the literal to the smaller type should still work for
+# SMALLINT. (It never worked for VARCHAR.)
+
+query T multiline
+EXPLAIN SELECT a FROM foo
+WHERE a = 3::SMALLINT;
+----
+Explained Query (fast path):
+  Project (#0)
+    ReadExistingIndex materialize.public.idx_foo_a lookup value (3)
+
+Used Indexes:
+  - materialize.public.idx_foo_a
+
+EOF
+
+query I rowsort
+SELECT a FROM foo
+WHERE a = 3::SMALLINT;
+----
+3
+
+# The (not-anymore-needed) workaround of adding an explicit cast at index creation should still work for SMALLINT
+
+statement ok
+DROP INDEX idx_foo_a;
+
+statement ok
+CREATE INDEX idx_foo_a_cast ON foo(a::INTEGER);
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE a = 0;
+----
+Explained Query (fast path):
+  Project (#1..=#4)
+    ReadExistingIndex materialize.public.idx_foo_a_cast lookup value (0)
+
+Used Indexes:
+  - materialize.public.idx_foo_a_cast
+
+EOF
+
+query IIIT rowsort
+SELECT * FROM foo
+WHERE a = 0;
+----
+0  1  2  xxx
+
+# The (not-anymore-needed) workaround of adding an explicit cast at index creation should still work for VARCHAR
+
+statement ok
+CREATE INDEX idx_foo_v_cast ON foo(v::TEXT);
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE v = 'xxx';
+----
+Explained Query (fast path):
+  Project (#1..=#4)
+    ReadExistingIndex materialize.public.idx_foo_v_cast lookup value ("xxx")
+
+Used Indexes:
+  - materialize.public.idx_foo_v_cast
+
+EOF
+
+query IIIT rowsort
+SELECT * FROM foo
+WHERE v = 'xxx';
+----
+0  1  2  xxx
+
+# When both an explicitly cast and a raw index are present, we should choose the raw one by performing the inverse cast.
+# SMALLINT
+
+statement ok
+CREATE INDEX idx_foo_a ON foo(a);
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE a = 0;
+----
+Explained Query (fast path):
+  Project (#0..=#3)
+    ReadExistingIndex materialize.public.idx_foo_a lookup value (0)
+
+Used Indexes:
+  - materialize.public.idx_foo_a
+
+EOF
+
+query IIIT rowsort
+SELECT * FROM foo
+WHERE a = 0;
+----
+0  1  2  xxx
+
+# When both an explicitly cast and a raw index are present, we should choose the raw one by performing the inverse cast.
+# VARCHAR
+
+statement ok
+CREATE INDEX idx_foo_v ON foo(v);
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE v = 'xxx';
+----
+Explained Query (fast path):
+  Project (#1..=#3, #0)
+    ReadExistingIndex materialize.public.idx_foo_v lookup value ("xxx")
+
+Used Indexes:
+  - materialize.public.idx_foo_v
+
+EOF
+
+query IIIT rowsort
+SELECT * FROM foo
+WHERE v = 'xxx';
+----
+0  1  2  xxx
+
+# Literal equalities with a cast where the inverse cast on the literal errors out should be detected as impossible.
+# See `MirScalarExpr::impossible_literal_equality_because_types`.
+
+query T multiline
+EXPLAIN SELECT * FROM foo
+WHERE a = 1000000;
+----
+Explained Query (fast path):
+  Constant
+
+EOF
+
+query IIIT rowsort
+SELECT * FROM foo
+WHERE a = 1000000;
+----
+
+
 # In the following query, we would be able to detect literal constraints if we called `canonicalize_equivalences`
 
 query T multiline

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -775,7 +775,7 @@ SELECT * FROM (SELECT 123, COUNT(right_table.f1) AS aggregate FROM t1 AS left_ta
 123  0  0
 
 
-# non-null requeriment on a non-count aggregation coming from a join predicate
+# non-null requirement on a non-count aggregation coming from a join predicate
 statement ok
 drop table t1
 


### PR DESCRIPTION
If we have `<expr> = <literal>` where an implicit cast is inserted on `<expr>`, then an index on `<expr>` will not be used. For example, let's say we have an index on a SMALLINT column `a`, and we do `WHERE a = 5`. The overload resolution for the `=` will insert a cast:
`smallint_to_integer(a) = 5`, and then the literal constraint detection won't find `a`'s index.

We have the same issue if `a` is a VARCHAR column, and we do `WHERE a = 'xxx'`. (The situation here is harder to work around than the SMALLINT example above, because even `WHERE a = 'xxx'::VARCHAR` won't work, because we don't have an `=` implementation for VARCHAR. The only workaround currently is to create the index on `a::VARCHAR`.)

This PR solves some common cases of this problem by moving the cast from the indexed column to the literal: We do
```
<lit> = f(<expr>), where f is invertible
 -->
<f^-1(lit)> = <expr>
```
There are two shortcomings of this PR:
1. We only do the transform if `f^-1(lit)` doesn't error out. This means that if we have `WHERE a = 3000000000` and a SMALLINT index on `a`, then we do an index scan instead of realizing that this is an impossible filter.
2. The bigger problem is that finding a cast function's inverse in general currently seems a bit hard, so I just hardcoded some common cases for now. @sploiselle is thinking about a more general solution.

I think we should quickly merge this before tomorrow's release even if the above shortcomings are not solved until then, and then we'll have time to think about a more general solution until next week.

### Motivation

  * This PR fixes a recognized bug:
    * https://github.com/MaterializeInc/materialize/issues/15525
    * #10738
    * another user running into this: https://materializeinc.slack.com/archives/C02PPB50ZHS/p1665769455773719,
    * older discussion: https://materializeinc.slack.com/archives/CMHDK0DK8/p1645629475658999
    * (Also occurs in TPC-H Q08)

(Note that this is related also to https://github.com/MaterializeInc/materialize/issues/4171, but that cannot be fixed by casting some magic spell inside `MirScalarExpr::reduce`, since a cast on either the left-hand side or the right-hand side of a join equality would prevent index usage in one of the directions of a Delta join. To fix that, we'll need to do an inversion inside the  join planning.)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Use `a`'s index even when an implicit cast is needed in `a = <literal>`.
