### PR TITLE
storage: bandaid over as_of panic

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -411,9 +411,6 @@ pub struct ReclockOperator {
     /// Write handle of the remap persist shard
     write_handle: WriteHandle<SourceData, (), Timestamp, Diff>,
     /// Read handle of the remap persist shard
-    ///
-    /// NB: Until #13534 is addressed, this intentionally holds back the since
-    /// of the remap shard indefinitely.
     read_handle: ReadHandle<SourceData, (), Timestamp, Diff>,
     /// A listener to tail the remap shard for new updates
     listener: Listen<SourceData, (), Timestamp, Diff>,

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -443,6 +443,12 @@ impl ReclockOperator {
 
         let (since, upper) = (read_handle.since(), write_handle.upper().clone());
 
+        // NOTE: We only use the `as_of` to assert that what is requested from
+        // us is possible with the current `since` of the shard, that is that we
+        // haven't compacted away resolution. We don't need to start our listen
+        // from the `as_of` or do the initial snapshot in `sync` from the
+        // `as_of`. Using the `since` is just as valid and using it to
+        // initialize our `self.since` is a more conservative option.
         assert!(
             PartialOrder::less_equal(since, &as_of),
             "invalid as_of: as_of({as_of:?}) < since({since:?})"
@@ -456,13 +462,13 @@ impl ReclockOperator {
         let listener = read_handle
             .clone()
             .await
-            .listen(as_of.clone())
+            .listen(since.clone())
             .await
             .expect("since <= as_of asserted");
 
         let mut operator = Self {
             remap_trace: HashMap::new(),
-            since: as_of.clone(),
+            since: since.clone(),
             upper: Antichain::from_elem(Timestamp::minimum()),
             source_upper: HashMap::new(),
             write_handle,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -578,11 +578,16 @@ where
                         Either::Right((Some(Event::Progress(resume_frontier_update)), _)) => {
                             // The first message from the resumption frontier source
                             // could be the same frontier as the initialization frontier, so we
-                            // just move on
+                            // just move on.
+                            //
+                            // Additionally, the empty
+                            // `resumption_frontier` currently has no meaningful mapping, and
+                            // occurs only when a source is terminating.
                             if PartialOrder::less_equal(
                                 &resume_frontier_update,
                                 &initial_resume_upper,
-                            ) {
+                            ) || resume_frontier_update.elements().is_empty()
+                            {
                                 continue;
                             }
                             tracing::trace!(
@@ -916,16 +921,36 @@ where
                 // from the source_reader_operator does.
                 //
                 // Note that we are able to compact to JUST before the resumption frontier.
-                let upper_ts = frontiers.borrow()[1].as_option().copied().unwrap();
-                let compaction_since = Antichain::from_elem(upper_ts.saturating_sub(1));
-                if PartialOrder::less_than(&last_compaction_since, &compaction_since) {
-                    trace!(
-                        "remap({id}) {worker_id}/{worker_count}: compacting remap \
+                // Also note this can happen BEFORE we inspect the input. This is somewhat
+                // of an oddity in the timely world, but this frontier can ONLY advance
+                // past the input AFTER the output capability of this operator itself has
+                // been downgraded (which drives the data shard upper), AND the
+                // remap shard has been advanced below.
+                //
+                // Additionally, the empty
+                // `resumption_frontier` currently occurs only when a source is terminating,
+                // and we avoid compacting when this happens, as reclocking does not support
+                // empty frontiers.
+                //
+                // TODO(guswynn|petrosagg): support compaction to the empty frontier.
+                //
+                // This extra block is necessary to avoid holding a `RefCell` across an await,
+                // or at least convincing clippy of this fact.
+                if let Some(upper_ts) = {
+                    let f = frontiers.borrow();
+                    let upper_ts: Option<Timestamp> = f[1].as_option().copied();
+                    upper_ts
+                } {
+                    let compaction_since = Antichain::from_elem(upper_ts.saturating_sub(1));
+                    if PartialOrder::less_than(&last_compaction_since, &compaction_since) {
+                        trace!(
+                            "remap({id}) {worker_id}/{worker_count}: compacting remap \
                         shard to: {:?}",
-                        compaction_since,
-                    );
-                    timestamper.compact(compaction_since.clone()).await;
-                    last_compaction_since = compaction_since;
+                            compaction_since,
+                        );
+                        timestamper.compact(compaction_since.clone()).await;
+                        last_compaction_since = compaction_since;
+                    }
                 }
 
                 input.for_each(|_cap, data| {


### PR DESCRIPTION
This bandaids over https://github.com/MaterializeInc/materialize/issues/15402 while we debug what is actually going on

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR _attempts to_ fix a recognized bug.


### Tips for reviewer
This pr contains: https://github.com/MaterializeInc/materialize/pull/15345; we could merge them separately or together.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
