### PR TITLE
doc/user: track a subscription sources

### DIFF
--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -314,7 +314,7 @@ SELECT count(1) FROM (
 );
 ```
 
-## Which object is a `SUBSCRIBE` command reading?
+## Which objects are a `SUBSCRIBE` command reading?
 
 Each `SUBSCRIBE` command reads data from particular **objects** as indexes, tables, sources, or materialized views.
 Query the **object name and type** by issuing the following statement:

--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -300,7 +300,7 @@ WHERE
     AND mdo.worker_id = 0;
 ```
 
-## How many `SUBSCRIBE` processes are running?
+## How many `SUBSCRIBE` commands are running?
 
 Materialize creates a dataflow using the `Dataflow: subscribe` prefix with a unique identifier **for each subscription running**.
 Query the number of active `SUBSCRIBE` dataflows in Materialize by using the following statement:
@@ -314,4 +314,48 @@ SELECT count(1) FROM (
 );
 ```
 
-[`mz_cluster_replicas`]: /sql/system-catalog/mz_catalog/#mz_cluster_replicas
+## Which object is a `SUBSCRIBE` command reading?
+
+Each `SUBSCRIBE` command reads data from particular **objects** as indexes, tables, sources, or materialized views.
+Query the **object name and type** by issuing the following statement:
+
+```sql
+-- Subscriptions in execution:
+WITH subscriptions AS (
+    SELECT name, split_part(name, '-', 2) as dataflow
+    FROM mz_internal.mz_dataflows
+    WHERE substring(name, 0, 20) = 'Dataflow: subscribe'
+),
+-- Object dependency:
+first_level_dependencies AS (
+	SELECT name, dataflow, export_id, import_id, worker_id
+	FROM mz_internal.mz_worker_compute_dependencies D
+	JOIN subscriptions S ON (D.export_id = S.dataflow)
+),
+-- Second-level object dependency. In case the first dependency is an index:
+second_level_dependencies AS (
+	SELECT name, dataflow, D.export_id, D.import_id, D.worker_id
+	FROM mz_internal.mz_worker_compute_dependencies D
+	JOIN first_level_dependencies F ON (F.import_id = D.export_id)
+),
+-- All dependencies together but prioritizing second-level dependencies:
+dependencies AS (
+	SELECT *
+	FROM first_level_dependencies
+	WHERE first_level_dependencies.name NOT IN (SELECT name FROM second_level_dependencies)
+	UNION ALL (
+        SELECT *
+        FROM
+        second_level_dependencies
+    )
+)
+-- Join the dependency id with the object name.
+SELECT DISTINCT
+    D.export_id,
+    D.import_id,
+    D.name,
+    O.name as object_name,
+    O.type
+FROM dependencies D
+JOIN mz_objects O ON (D.import_id = O.id);
+```

--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -314,9 +314,9 @@ SELECT count(1) FROM (
 );
 ```
 
-## Which objects are a `SUBSCRIBE` command reading?
+## Which objects is a `SUBSCRIBE` command reading?
 
-Each `SUBSCRIBE` command reads data from particular **objects** as indexes, tables, sources, or materialized views.
+Each `SUBSCRIBE` command reads data from **objects** such as indexes, tables, sources, or materialized views.
 Query the **object name and type** by issuing the following statement:
 
 ```sql


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
[Surface a way to track the number of active TAILs on a materialized view](https://github.com/MaterializeInc/materialize/issues/14809)

This PR is an adaptation of the comment in the issue.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I'm not 100% happy with the title:

_Which objects are a `SUBSCRIBE` command reading?_

So any suggestion is welcome.
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
