### PR TITLE
doc/user: [Kafka sources] add confluent schema registry basic auth

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -320,7 +320,7 @@ CREATE CONNECTION csr_ssl TO CONFLUENT SCHEMA REGISTRY (
 );
 ```
 {{< /tab >}}
-{{< tab "SASL">}}
+{{< tab "Basic Authentication">}}
 ```sql
 CREATE SECRET IF NOT EXISTS csr_username AS '<CSR_USERNAME>';
 CREATE SECRET IF NOT EXISTS csr_password AS '<CSR_PASSWORD>';

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -320,12 +320,12 @@ CREATE CONNECTION csr_ssl TO CONFLUENT SCHEMA REGISTRY (
 );
 ```
 {{< /tab >}}
-{{< tab "Basic Authentication">}}
+{{< tab "Basic HTTP Authentication">}}
 ```sql
 CREATE SECRET IF NOT EXISTS csr_username AS '<CSR_USERNAME>';
 CREATE SECRET IF NOT EXISTS csr_password AS '<CSR_PASSWORD>';
 
-CREATE CONNECTION csr_sasl
+CREATE CONNECTION csr_basic_http
   FOR CONFLUENT SCHEMA REGISTRY
   URL '<CONFLUENT_REGISTRY_URL>',
   USERNAME = SECRET csr_username,

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -320,6 +320,18 @@ CREATE CONNECTION csr_ssl TO CONFLUENT SCHEMA REGISTRY (
 );
 ```
 {{< /tab >}}
+{{< tab "SASL">}}
+```sql
+CREATE SECRET IF NOT EXISTS csr_username AS '<CSR_USERNAME>';
+CREATE SECRET IF NOT EXISTS csr_password AS '<CSR_PASSWORD>';
+
+CREATE CONNECTION csr_sasl
+  FOR CONFLUENT SCHEMA REGISTRY
+  URL '<CONFLUENT_REGISTRY_URL>',
+  USERNAME = SECRET csr_username,
+  PASSWORD = SECRET csr_password;
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Creating a source


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds the `Confluent Schema Registry` SASL plain mechanism to the Kafka source guide.

![Screen Shot 2022-10-17 at 20 31 45](https://user-images.githubusercontent.com/11491779/196302433-d6594f5b-45d3-4437-abfa-3782c2b4e0ff.png)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

It works well with Confluent Schema Registry, but I haven't tested if it works with local deployments of the confluent schema registry.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
