### PR TITLE
sql-parser: support option value sequences with parentheses

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2136,11 +2136,17 @@ pub enum WithOptionValue<T: AstInfo> {
     DataType(T::DataType),
     Secret(T::ObjectName),
     Object(T::ObjectName),
+    Sequence(Vec<WithOptionValue<T>>),
 }
 
 impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
+            WithOptionValue::Sequence(values) => {
+                f.write_str("(");
+                f.write_node(&display::comma_separated(values));
+                f.write_str(")");
+            }
             WithOptionValue::Value(value) => f.write_node(value),
             WithOptionValue::Ident(id) => f.write_node(id),
             WithOptionValue::DataType(typ) => f.write_node(typ),

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -56,8 +56,6 @@ pub enum Value {
     /// ```
     /// e.g. `INTERVAL '123:45.678' MINUTE TO SECOND(2)`.
     Interval(IntervalValue),
-    /// Array of Values.
-    Array(Vec<Value>),
     /// `NULL` value.
     Null,
 }
@@ -125,11 +123,6 @@ impl AstDisplay for Value {
                         f.write_str(")");
                     }
                 }
-            }
-            Value::Array(values) => {
-                f.write_str("[");
-                f.write_node(&display::comma_separated(values));
-                f.write_str("]");
             }
             Value::Null => f.write_str("NULL"),
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3299,13 +3299,29 @@ impl<'a> Parser<'a> {
         // means there's no value, anything else means we expect a valid value.
         match self.peek_token() {
             Some(Token::RParen) | Some(Token::Comma) | Some(Token::Semicolon) | None => Ok(None),
-            _ => Ok(Some(self.parse_option_value()?)),
+            _ => {
+                let _ = self.consume_token(&Token::Eq);
+                Ok(Some(self.parse_option_value()?))
+            }
         }
     }
 
     fn parse_option_value(&mut self) -> Result<WithOptionValue<Raw>, ParserError> {
-        let _ = self.consume_token(&Token::Eq);
-        if self.parse_keyword(SECRET) {
+        if self.consume_token(&Token::LParen) {
+            if self.consume_token(&Token::RParen) {
+                return Ok(WithOptionValue::Sequence(vec![]));
+            }
+            let options = self.parse_comma_separated(Parser::parse_option_value)?;
+            self.expect_token(&Token::RParen)?;
+            Ok(WithOptionValue::Sequence(options))
+        } else if self.consume_token(&Token::LBracket) {
+            if self.consume_token(&Token::RBracket) {
+                return Ok(WithOptionValue::Sequence(vec![]));
+            }
+            let options = self.parse_comma_separated(Parser::parse_option_value)?;
+            self.expect_token(&Token::RBracket)?;
+            Ok(WithOptionValue::Sequence(options))
+        } else if self.parse_keyword(SECRET) {
             if let Some(secret) = self.maybe_parse(Parser::parse_raw_name) {
                 Ok(WithOptionValue::Secret(secret))
             } else {
@@ -3667,7 +3683,6 @@ impl<'a> Parser<'a> {
                 Token::Number(ref n) => Ok(Value::Number(n.to_string())),
                 Token::String(ref s) => Ok(Value::String(s.to_string())),
                 Token::HexString(ref s) => Ok(Value::HexString(s.to_string())),
-                Token::LBracket => self.parse_value_array(),
                 _ => parser_err!(
                     self,
                     self.peek_prev_pos(),
@@ -3680,21 +3695,6 @@ impl<'a> Parser<'a> {
                 "Expecting a value, but found EOF"
             ),
         }
-    }
-
-    fn parse_value_array(&mut self) -> Result<Value, ParserError> {
-        let mut values = vec![];
-        loop {
-            if let Some(Token::RBracket) = self.peek_token() {
-                break;
-            }
-            values.push(self.parse_value()?);
-            if !self.consume_token(&Token::Comma) {
-                break;
-            }
-        }
-        self.expect_token(&Token::RBracket)?;
-        Ok(Value::Array(values))
     }
 
     fn parse_array(&mut self) -> Result<Expr<Raw>, ParserError> {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -975,37 +975,37 @@ CREATE CLUSTER cluster REPLICAS (), BADOPT
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1'))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']), b (SIZE = '1'))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1')), b (SIZE = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING true), b (SIZE '1', INTROSPECTION INTERVAL 0))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1'], INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = '1', INTROSPECTION INTERVAL = 0))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = '1', INTROSPECTION INTERVAL = 0))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1'], SIZE = '1'))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), SIZE = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1:2400', 'host2:2400'], COMPUTE ['host1:2401', 'host2:2401'], WORKERS '1'))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1:2400', 'host2:2400'], COMPUTE = ['host1:2401', 'host2:2401'], WORKERS = '1'))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1:2400', 'host2:2400'), COMPUTE = ('host1:2401', 'host2:2401'), WORKERS = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1:2400"), String("host2:2400")]))) }, ReplicaOption { name: Compute, value: Some(Value(Array([String("host1:2401"), String("host2:2401")]))) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1:2400")), Value(String("host2:2400"))])) }, ReplicaOption { name: Compute, value: Some(Sequence([Value(String("host1:2401")), Value(String("host2:2401"))])) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])] })
 
 parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ['host1']
@@ -1052,9 +1052,9 @@ CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"
 parse-statement
 CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 ----
-CREATE CLUSTER REPLICA default.replica REMOTE = ['host1'], AVAILABILITY ZONE = 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE = ('host1'), AVAILABILITY ZONE = 'a'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING = false
@@ -1073,9 +1073,9 @@ CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"
 parse-statement
 CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], INTROSPECTION INTERVAL NULL
 ----
-CREATE CLUSTER REPLICA default.replica REMOTE = ['host1'], INTROSPECTION INTERVAL = NULL
+CREATE CLUSTER REPLICA default.replica REMOTE = ('host1'), INTROSPECTION INTERVAL = NULL
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] } })
 
 parse-statement
 DROP CLUSTER cluster
@@ -1388,9 +1388,9 @@ AlterSystemSet(AlterSystemSetStatement { name: Ident("log_connections"), value: 
 parse-statement
 ALTER SYSTEM SET some_array_key = [667, 668]
 ----
+error: Expected variable value, found left square bracket
 ALTER SYSTEM SET some_array_key = [667, 668]
-=>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("some_array_key"), value: Literal(Array([Number("667"), Number("668")])) })
+                                   ^
 
 parse-statement
 ALTER SYSTEM SET quantum_enabled = true

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1057,6 +1057,11 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
     ) -> mz_sql_parser::ast::WithOptionValue<Aug> {
         use mz_sql_parser::ast::WithOptionValue::*;
         match node {
+            Sequence(vs) => Sequence(
+                vs.into_iter()
+                    .map(|v| self.fold_with_option_value(v))
+                    .collect(),
+            ),
             Value(v) => Value(self.fold_value(v)),
             Ident(i) => Ident(self.fold_ident(i)),
             DataType(dt) => DataType(self.fold_data_type(dt)),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4414,11 +4414,6 @@ fn plan_literal<'a>(l: &'a Value) -> Result<CoercibleScalarExpr, PlanError> {
         }
         Value::String(s) => return Ok(CoercibleScalarExpr::LiteralString(s.clone())),
         Value::Null => return Ok(CoercibleScalarExpr::LiteralNull),
-        Value::Array(_) => {
-            sql_bail!(
-                "bare [] arrays are not supported in this context; use ARRAY[] or LIST[] instead"
-            )
-        }
     };
     let expr = HirScalarExpr::literal(datum, scalar_type);
     Ok(expr.into())

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2489,7 +2489,7 @@ impl KafkaConnectionOptionExtracted {
                 .to_string();
             if broker.contains(',') {
                 sql_bail!("invalid CONNECTION: cannot specify multiple Kafka broker addresses in one string.\n\n
-Instead, specify BROKERS using an array of strings, e.g. BROKERS ['kafka:9092', 'kafka:9093']");
+Instead, specify BROKERS using multiple strings, e.g. BROKERS ('kafka:9092', 'kafka:9093')");
             }
         }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -216,12 +216,14 @@ pub async fn purify_create_source(
                         info!("add start_offset {:?}", start_offsets);
                         base_with_options.push(KafkaConfigOption {
                             name: KafkaConfigOptionName::StartOffset,
-                            value: Some(WithOptionValue::Value(Value::Array(
+                            value: Some(WithOptionValue::Sequence(
                                 start_offsets
                                     .iter()
-                                    .map(|offset| Value::Number(offset.to_string()))
+                                    .map(|offset| {
+                                        WithOptionValue::Value(Value::Number(offset.to_string()))
+                                    })
                                     .collect(),
-                            ))),
+                            )),
                         });
                     }
                     None => {}


### PR DESCRIPTION
We use array-valued options in two user-facing places in our syntax:

    CREATE CONNECTION ... TO KAFKA (BROKERS ['a', 'b'])
    CREATE SOURCE ... FROM KAFKA CONNECTION ... (START OFFSET [0, 1])

This matches how you represent an array in SQL (`ARRAY[1, 2]`), but is inconsistent with how DDL statements typically represent sequences of things, e.g.:

    CREATE INDEX ... ON t (col1, col2)

This commit allows array-valued options to delimit their options with *either* square brackets or parentheses. The following syntax immediately becomes valid:

    CREATE CONNECTION ... TO KAFKA (BROKERS ('a', 'b'))
    CREATE SOURCE ... FROM KAFKA CONNECTION ... (START OFFSET (0, 1))

The primary impetus is to allow consistent extension of the `BROKERS` option with the forthcoming AWS PrivateLink connection, which proposes to use the syntax:

    CREATE CONNECTION ... TO KAFKA (
        BROKERS (
            'a' USING AWS PRIVATELINK s1,
            'b' USING AWS PRIVATELINK s2 (PORT 9093)
        )
    )

By allowing parentheses instead of square brackets, it's a bit clearer that it's the same underlying `BROKERS` option, just with an optional `USING AWS PRIVATELINK` clause attached to the elements of the sequence.

We cannot entirely remove the square bracket syntax, as that would be a backwards incompatible change. We do, however, manage to eliminate the `Value::Array` enum variant internally, which cleans up a match statement in the code.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a new feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
