### PR TITLE
coord: Set default cluster for mz_system user

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -31,7 +31,7 @@ use crate::catalog::SYSTEM_USER;
 use crate::client::ConnectionId;
 use crate::coord::peek::PeekResponseUnary;
 use crate::error::AdapterError;
-use crate::session::vars::{IsolationLevel, CLUSTER};
+use crate::session::vars::IsolationLevel;
 use crate::util::ComputeSinkId;
 use crate::AdapterNotice;
 
@@ -100,11 +100,11 @@ impl<T: TimestampManipulation> Session<T> {
 
     fn new_internal(conn_id: ConnectionId, user: User) -> Session<T> {
         let (notices_tx, notices_rx) = mpsc::unbounded_channel();
-        let mut vars = SessionVars::default();
-        if user == *SYSTEM_USER {
-            vars.set(CLUSTER.name.as_ref(), SYSTEM_USER.name.as_ref(), false)
-                .expect("cluster var known to exist and system user is a valid value");
-        }
+        let vars = if user == *SYSTEM_USER {
+            SessionVars::for_cluster(&SYSTEM_USER.name)
+        } else {
+            SessionVars::default()
+        };
         Session {
             conn_id,
             transaction: TransactionStatus::Default,

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -58,7 +58,7 @@ const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
     description: "Sets the message levels that are sent to the client (PostgreSQL).",
 };
 
-pub(crate) const CLUSTER: ServerVar<str> = ServerVar {
+const CLUSTER: ServerVar<str> = ServerVar {
     name: UncasedStr::new("cluster"),
     value: "default",
     description: "Sets the current cluster (Materialize).",
@@ -331,6 +331,16 @@ impl Default for SessionVars {
 }
 
 impl SessionVars {
+    /// Returns a new SessionVars with the cluster variable set to `cluster`.
+    pub fn for_cluster(cluster_name: &str) -> Self {
+        let mut cluster = SessionVar::new(&CLUSTER);
+        cluster.session_value = Some(cluster_name.into());
+        Self {
+            cluster,
+            ..Default::default()
+        }
+    }
+
     /// Returns an iterator over the configuration parameters and their current
     /// values for this session.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
@@ -1017,7 +1027,7 @@ pub struct ServerVar<V>
 where
     V: fmt::Debug + ?Sized + 'static,
 {
-    pub(crate) name: &'static UncasedStr,
+    name: &'static UncasedStr,
     value: &'static V,
     description: &'static str,
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -58,7 +58,7 @@ const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
     description: "Sets the message levels that are sent to the client (PostgreSQL).",
 };
 
-const CLUSTER: ServerVar<str> = ServerVar {
+pub(crate) const CLUSTER: ServerVar<str> = ServerVar {
     name: UncasedStr::new("cluster"),
     value: "default",
     description: "Sets the current cluster (Materialize).",
@@ -1017,7 +1017,7 @@ pub struct ServerVar<V>
 where
     V: fmt::Debug + ?Sized + 'static,
 {
-    name: &'static UncasedStr,
+    pub(crate) name: &'static UncasedStr,
     value: &'static V,
     description: &'static str,
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1444,6 +1444,26 @@ fn test_system_user() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn test_system_user_cluster() -> Result<(), Box<dyn Error>> {
+    mz_ore::test::init_logging();
+
+    let config = util::Config::default();
+    let server = util::start_server(config)?;
+
+    let mut internal_client = server
+        .pg_config_internal()
+        .user(&SYSTEM_USER.name)
+        .connect(postgres::NoTls)?;
+
+    let cluster = internal_client
+        .query_one("SHOW CLUSTER", &[])?
+        .get::<_, String>(0);
+    assert_eq!(SYSTEM_USER.name, cluster);
+
+    Ok(())
+}
+
 // Tests that you can have simultaneous connections on the internal and external ports without
 // crashing
 #[test]


### PR DESCRIPTION
This commit sets the default cluster of the mz_system user to the
mz_system cluster.

Fixes https://github.com/MaterializeInc/materialize/issues/15441

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
