### PR TITLE
compute-client: maintain peek read holds long enough

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -704,13 +704,12 @@ where
                 instance.update_write_frontiers(&updates).await?;
                 Ok(None)
             }
-            ActiveReplicationResponse::PeekResponse(uuid, peek_response, otel_ctx) => {
+            ActiveReplicationResponse::PeekResponse(uuid, peek_response, otel_ctx) => Ok(Some(
+                ComputeControllerResponse::PeekResponse(uuid, peek_response, otel_ctx),
+            )),
+            ActiveReplicationResponse::PeekFinished(uuid) => {
                 instance.remove_peeks(&[uuid].into()).await?;
-                Ok(Some(ComputeControllerResponse::PeekResponse(
-                    uuid,
-                    peek_response,
-                    otel_ctx,
-                )))
+                Ok(None)
             }
             ActiveReplicationResponse::SubscribeResponse(global_id, response) => {
                 if let SubscribeResponse::Batch(SubscribeBatch { lower, .. }) = &response {


### PR DESCRIPTION
This PR changes the compute controller to defer dropping of read holds installed for peeks until all replicas have responded to the peek in some way. This prevents the controller from dropping the read hold too early, namely when the fastest replica has responded to a peek but slow ones might still be reading from the source collections at times that could be compacted away after dropping the read hold.

### Motivation

  * This PR fixes a recognized bug.

Improves on #15426.

This is not a complete fix, as it doesn't work for replica-targeted peeks. See https://github.com/MaterializeInc/materialize/issues/15426#issuecomment-1283812125 for an explanation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
