### PR TITLE
Add size column to SHOW CLUSTER REPLICAS command (already in the docs)

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2340,7 +2340,8 @@ pub const MZ_SHOW_CLUSTER_REPLICAS: BuiltinView = BuiltinView {
     sql: r#"CREATE VIEW mz_internal.mz_show_cluster_replicas
 AS SELECT
     mz_catalog.mz_clusters.name AS cluster,
-    mz_catalog.mz_cluster_replicas.name AS replica
+    mz_catalog.mz_cluster_replicas.name AS replica,
+    mz_catalog.mz_cluster_replicas.size AS size
 FROM
     mz_catalog.mz_cluster_replicas
     JOIN mz_catalog.mz_clusters ON
@@ -2458,7 +2459,7 @@ pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_show_cluster_replicas_ind
 IN CLUSTER mz_introspection
-ON mz_internal.mz_show_cluster_replicas (cluster, replica)",
+ON mz_internal.mz_show_cluster_replicas (cluster, replica, size)",
 };
 
 pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -543,7 +543,8 @@ pub fn show_cluster_replicas<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let query = "SELECT cluster, replica FROM mz_internal.mz_show_cluster_replicas".to_string();
+    let query =
+        "SELECT cluster, replica, size FROM mz_internal.mz_show_cluster_replicas".to_string();
 
     ShowSelect::new(scx, query, filter, None, None)
 }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -368,26 +368,26 @@ CREATE CLUSTER REPLICA default.size_1 SIZE;
 statement ok
 CREATE CLUSTER REPLICA default.size_1 SIZE '1';
 
-query TT
+query TTT
 SHOW CLUSTER REPLICAS
 ----
-default r1
-default size_1
-mz_introspection r1
-mz_system r1
+default r1 1
+default size_1 1
+mz_introspection r1 1
+mz_system r1 1
 
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 
-query TT
+query TTT
 SHOW CLUSTER REPLICAS
 ----
-default r1
-default size_1
-foo size_1
-foo size_2
-mz_introspection r1
-mz_system r1
+default r1 1
+default size_1 1
+foo size_1 1
+foo size_2 2
+mz_introspection r1 1
+mz_system r1 1
 
 statement ok
 DROP CLUSTER REPLICA IF EXISTS default.bar
@@ -407,12 +407,12 @@ DROP CLUSTER REPLICA default.size_1
 statement ok
 DROP CLUSTER REPLICA foo.size_1, foo.size_2
 
-query TT
+query TTT
 SHOW CLUSTER REPLICAS
 ----
-default r1
-mz_introspection r1
-mz_system r1
+default r1 1
+mz_introspection r1 1
+mz_system r1 1
 
 statement ok
 CREATE CLUSTER REPLICA default.foo_bar SIZE '1'


### PR DESCRIPTION
Our documentation states that this column should exist, but it's currently missing. This change adds it.
Fixes bug #15481.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
