### PR TITLE
Fix CREATE CONNECTION so that it errors on item already exists, unless command contains 'if not exists'

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -613,7 +613,7 @@ impl<S: Append + 'static> Coordinator<S> {
             Err(AdapterError::Catalog(catalog::Error {
                 kind: catalog::ErrorKind::ItemAlreadyExists(_, _),
                 ..
-            })) => Ok(ExecuteResponse::CreatedConnection),
+            })) if plan.if_not_exists => Ok(ExecuteResponse::CreatedConnection),
             Err(err) => Err(err),
         }
     }

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -24,11 +24,17 @@ CREATE TABLE not_a_secret (a int);
 statement ok
 CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker');
 
+statement error catalog item 'kafka_conn' already exists
+CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker');
+
+statement ok
+CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER 'broker');
+
 statement error materialize.public.not_a_secret is not a secret
-CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_a_secret);
+CREATE CONNECTION kafka_conn2 TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_a_secret);
 
 statement error unknown catalog item 'not_an_object_at_all'
-CREATE CONNECTION kafka_conn TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_an_object_at_all);
+CREATE CONNECTION kafka_conn2 TO KAFKA (BROKER 'broker', SASL PASSWORD = SECRET not_an_object_at_all);
 
 statement ok
 CREATE SECRET pgpass AS 'postgres'


### PR DESCRIPTION
Brings back `if not exists` check in error handling logic which was accidentally removed during a previous refactor.
Also add test coverage.
 
 * This PR fixes a recognized bug. #15478

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
