### PR TITLE
Unify IndexedFilter printing between fast path and dataflow

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -26,8 +26,8 @@ use mz_compute_client::controller::ComputeInstanceId;
 use mz_compute_client::response::PeekResponse;
 use mz_expr::explain::Indices;
 use mz_expr::{EvalError, Id, MirScalarExpr, OptimizedMirRelationExpr};
+use mz_ore::str::Indent;
 use mz_ore::str::StrExt;
-use mz_ore::str::{separated, Indent};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain_new::{fmt_text_constant_rows, separated_text, DisplayText, ExprHumanizer};
 use mz_repr::{Diff, GlobalId, RelationType, Row};
@@ -118,25 +118,7 @@ where
                     writeln!(f, "{}Map ({})", ctx.as_mut(), scalars)?;
                     *ctx.as_mut() += 1;
                 }
-                let humanized_index = ctx
-                    .as_ref()
-                    .humanize_id(*id)
-                    .unwrap_or_else(|| id.to_string());
-                if let Some(literal_constraints) = literal_constraints {
-                    write!(
-                        f,
-                        "{}ReadExistingIndex {} lookup ",
-                        ctx.as_mut(),
-                        humanized_index
-                    )?;
-                    if literal_constraints.len() == 1 {
-                        writeln!(f, "value {}", literal_constraints.get(0).unwrap())?;
-                    } else {
-                        writeln!(f, "values [{}]", separated("; ", literal_constraints))?;
-                    }
-                } else {
-                    writeln!(f, "{}ReadExistingIndex {}", ctx.as_mut(), humanized_index)?;
-                }
+                Displayable::fmt_indexed_filter(f, ctx, id, literal_constraints.clone())?;
                 ctx.as_mut().reset();
                 Ok(())
             }
@@ -598,7 +580,7 @@ mod tests {
 
         let constant_err_exp = "Error \"division by zero\"\n";
         let no_lookup_exp = "Project (#1, #4)\n  Map ((#0 OR #2))\n    ReadExistingIndex u10\n";
-        let lookup_exp = "Filter (#0) IS NULL\n  ReadExistingIndex u11 lookup value (5)\n";
+        let lookup_exp = "Filter (#0) IS NULL\n  ReadExistingIndex u11 lookup_value=(5)\n";
 
         assert_eq!(text_string_at(&constant_err, ctx_gen), constant_err_exp);
         assert_eq!(text_string_at(&no_lookup, ctx_gen), no_lookup_exp);

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -662,11 +662,7 @@ Explained Query:
     Map (0)
       Reduce aggregates=[max(#0)]
         Project (#1)
-          Join on=(#0 = #2) type=indexed_filter
-            ArrangeBy keys=[[#0]]
-              Get materialize.public.t
-            Constant
-              - (0)
+          ReadExistingIndex materialize.public.t lookup_value=(0)
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -689,13 +685,7 @@ GROUP BY a
 Explained Query:
   Reduce group_by=[#0] aggregates=[max(#1)]
     Project (#0, #1)
-      Join on=(#0 = #2 AND #1 = #3) type=indexed_filter
-        ArrangeBy keys=[[#0, #1]]
-          Get materialize.public.t
-        Constant
-          - (0, 1)
-          - (3, 4)
-          - (7, 8)
+      ReadExistingIndex materialize.public.t lookup_values=[(0, 1); (3, 4); (7, 8)]
 
 Used Indexes:
   - materialize.public.t_a_b_idx
@@ -711,7 +701,7 @@ WHERE (a = 0 AND b = 1) OR (a = 3 AND b = 4) OR (a = 7 AND b = 8)
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    ReadExistingIndex materialize.public.t_a_b_idx lookup values [(0, 1); (3, 4); (7, 8)]
+    ReadExistingIndex materialize.public.t_a_b_idx lookup_values=[(0, 1); (3, 4); (7, 8)]
 
 Used Indexes:
   - materialize.public.t_a_b_idx

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -65,7 +65,7 @@ WHERE a IN (1, 1+1)
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    ReadExistingIndex materialize.public.idx_t1_a lookup values [(1); (2)]
+    ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (2)]
 
 Used Indexes:
   - materialize.public.idx_t1_a
@@ -88,7 +88,7 @@ WHERE a = 2 AND b = 'l2'
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    ReadExistingIndex materialize.public.idx_t1_a_b lookup value (2, "l2")
+    ReadExistingIndex materialize.public.idx_t1_a_b lookup_value=(2, "l2")
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -122,12 +122,7 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[count(true)] // { arity: 1 }
         Project () // { arity: 0 }
-          Join on=(#0 = #2 AND #1 = #3) type=indexed_filter // { arity: 4 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Get materialize.public.t1 // { arity: 2 }
-            Constant // { arity: 2 }
-              - (2, "l2")
-              - (3, "l3")
+          ReadExistingIndex materialize.public.t1 lookup_values=[(2, "l2"); (3, "l3")]
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -148,7 +143,7 @@ EXPLAIN WITH(arity, join_impls) SELECT a = 1 FROM t1 WHERE a = 1;
 Explained Query (fast path):
   Project (#3)
     Map (true)
-      ReadExistingIndex materialize.public.idx_t1_a lookup value (1)
+      ReadExistingIndex materialize.public.idx_t1_a lookup_value=(1)
 
 Used Indexes:
   - materialize.public.idx_t1_a
@@ -170,7 +165,7 @@ WHERE (a,b) IN ((1,'l1'), (2,'l2'))
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    ReadExistingIndex materialize.public.idx_t1_a_b lookup values [(1, "l1"); (2, "l2")]
+    ReadExistingIndex materialize.public.idx_t1_a_b lookup_values=[(1, "l1"); (2, "l2")]
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -192,7 +187,7 @@ WHERE (a,b) IN ((1, 'l1'), (1, 'a'))
 ----
 Explained Query (fast path):
   Project (#0, #1)
-    ReadExistingIndex materialize.public.idx_t1_a_b lookup values [(1, "a"); (1, "l1")]
+    ReadExistingIndex materialize.public.idx_t1_a_b lookup_values=[(1, "a"); (1, "l1")]
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -223,7 +218,7 @@ WHERE (a,b,c) IN ((1,2,3), (1,4,5), (1,4,7))
 ----
 Explained Query (fast path):
   Project (#0..=#2)
-    ReadExistingIndex materialize.public.idx_t2_a_b_c lookup values [(1, 2, 3); (1, 4, 5); (1, 4, 7)]
+    ReadExistingIndex materialize.public.idx_t2_a_b_c lookup_values=[(1, 2, 3); (1, 4, 5); (1, 4, 7)]
 
 Used Indexes:
   - materialize.public.idx_t2_a_b_c
@@ -255,7 +250,7 @@ WHERE (a = 1) OR (a = 3 AND b = 'l3')
 Explained Query (fast path):
   Project (#0, #1)
     Filter ((#0 = 1) OR ((#0 = 3) AND (#1 = "l3")))
-      ReadExistingIndex materialize.public.idx_t1_a lookup values [(1); (3)]
+      ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (3)]
 
 Used Indexes:
   - materialize.public.idx_t1_a
@@ -303,7 +298,7 @@ WHERE a+a = 2
 ----
 Explained Query (fast path):
   Project (#1)
-    ReadExistingIndex materialize.public.idx_t1_aa lookup value (2)
+    ReadExistingIndex materialize.public.idx_t1_aa lookup_value=(2)
 
 Used Indexes:
   - materialize.public.idx_t1_aa
@@ -325,7 +320,7 @@ WHERE a+a IN (-1, 1, 2, 3, 6, 7, 9)
 ----
 Explained Query (fast path):
   Project (#1)
-    ReadExistingIndex materialize.public.idx_t1_aa lookup values [(1); (2); (3); (6); (7); (9); (-1)]
+    ReadExistingIndex materialize.public.idx_t1_aa lookup_values=[(1); (2); (3); (6); (7); (9); (-1)]
 
 Used Indexes:
   - materialize.public.idx_t1_aa
@@ -351,7 +346,7 @@ WHERE a+a IN (2, 6);
 Explained Query (fast path):
   Project (#4)
     Map ((#1 + #1))
-      ReadExistingIndex materialize.public.idx_t1_aa lookup values [(2); (6)]
+      ReadExistingIndex materialize.public.idx_t1_aa lookup_values=[(2); (6)]
 
 Used Indexes:
   - materialize.public.idx_t1_aa
@@ -379,7 +374,7 @@ WHERE (a,b) IN ((1, 4*a), (2, 5*a), (3, a+20))
 Explained Query (fast path):
   Project (#0..=#2)
     Filter (((#0 = 1) AND (#1 = (4 * #0))) OR ((#0 = 2) AND (#1 = (5 * #0))) OR ((#0 = 3) AND (#1 = (#0 + 20))))
-      ReadExistingIndex materialize.public.idx_t2_a lookup values [(1); (2); (3)]
+      ReadExistingIndex materialize.public.idx_t2_a lookup_values=[(1); (2); (3)]
 
 Used Indexes:
   - materialize.public.idx_t2_a
@@ -432,7 +427,7 @@ WHERE (a < 3 OR a > 0) AND b IN ('l1', 'l2', 'l3', 'l9')
 Explained Query (fast path):
   Project (#1)
     Filter ((#1 < 3) OR (#1 > 0))
-      ReadExistingIndex materialize.public.idx_t1_b lookup values [("l1"); ("l2"); ("l3"); ("l9")]
+      ReadExistingIndex materialize.public.idx_t1_b lookup_values=[("l1"); ("l2"); ("l3"); ("l9")]
 
 Used Indexes:
   - materialize.public.idx_t1_b
@@ -456,7 +451,7 @@ WHERE (a < 3 OR a > 0 OR a < 7) AND b IN ('l1', 'l2', 'l3', 'l9') AND (b like 'l
 Explained Query (fast path):
   Project (#1)
     Filter ((#1 < 3) OR (#1 < 7) OR (#1 > 0)) AND ("l%" ~~(#0) OR (#1 > 5))
-      ReadExistingIndex materialize.public.idx_t1_b lookup values [("l1"); ("l2"); ("l3"); ("l9")]
+      ReadExistingIndex materialize.public.idx_t1_b lookup_values=[("l1"); ("l2"); ("l3"); ("l9")]
 
 Used Indexes:
   - materialize.public.idx_t1_b
@@ -477,7 +472,7 @@ WHERE ((b = 'l1' AND a = 1) OR (a = 2 AND b = 'l2')) AND (b like 'nonono' OR (b 
 Explained Query (fast path):
   Project (#0, #1)
     Filter ("nonono" ~~(#1) OR ("l%" ~~(#1) AND (#0 < 10)))
-      ReadExistingIndex materialize.public.idx_t1_a_b lookup values [(1, "l1"); (2, "l2")]
+      ReadExistingIndex materialize.public.idx_t1_a_b lookup_values=[(1, "l1"); (2, "l2")]
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -501,7 +496,7 @@ Explained Query (fast path):
   Project (#0)
     Filter ((#4 = 0) OR (#4 = 1))
       Map ((#0 % 3))
-        ReadExistingIndex materialize.public.idx_t1_a_b lookup values [(1, "l1"); (2, "l2"); (3, "l3"); (9, "l9")]
+        ReadExistingIndex materialize.public.idx_t1_a_b lookup_values=[(1, "l1"); (2, "l2"); (3, "l3"); (9, "l9")]
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -534,7 +529,7 @@ WHERE (
 Explained Query (fast path):
   Project (#0)
     Filter ("aaa" ~~(#1) OR "l%" ~~(#1)) AND ((#0 = 2) OR ("nope" ~~(#1) AND (#0 = 1)))
-      ReadExistingIndex materialize.public.idx_t1_a lookup values [(1); (2)]
+      ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (2)]
 
 Used Indexes:
   - materialize.public.idx_t1_a
@@ -569,7 +564,7 @@ WHERE (a = 4 AND a = 7) OR (a = 9)
 ----
 Explained Query (fast path):
   Project (#0)
-    ReadExistingIndex materialize.public.idx_t1_a lookup value (9)
+    ReadExistingIndex materialize.public.idx_t1_a lookup_value=(9)
 
 Used Indexes:
   - materialize.public.idx_t1_a
@@ -582,7 +577,7 @@ WHERE a IN (1,2) AND a IN (2,3,4)
 ----
 Explained Query (fast path):
   Project (#0)
-    ReadExistingIndex materialize.public.idx_t1_a lookup value (2)
+    ReadExistingIndex materialize.public.idx_t1_a lookup_value=(2)
 
 Used Indexes:
   - materialize.public.idx_t1_a
@@ -626,12 +621,7 @@ Explained Query:
           %0:t1 » %1:t2[#0]KA
           %1:t2 » %0:t1[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
-          Join on=(#1 = #2) type=indexed_filter // { arity: 3 }
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Get materialize.public.t1 // { arity: 2 }
-            Constant // { arity: 1 }
-              - ("l2")
-              - ("l3")
+          ReadExistingIndex materialize.public.t1 lookup_values=[("l2"); ("l3")]
         ArrangeBy keys=[[#0]] // { arity: 3 }
           Get materialize.public.t2 // { arity: 3 }
 
@@ -667,11 +657,7 @@ Explained Query:
           %0:t1 » %1:t2[#0]KA
           %1:t2 » %0:t1[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
-          Join on=(#1 = #2) type=indexed_filter // { arity: 3 }
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Get materialize.public.t1 // { arity: 2 }
-            Constant // { arity: 1 }
-              - ("l2")
+          ReadExistingIndex materialize.public.t1 lookup_value=("l2")
         ArrangeBy keys=[[#0]] // { arity: 3 }
           Get materialize.public.t2 // { arity: 3 }
 
@@ -707,17 +693,9 @@ Explained Query:
       %1:t2 » %0:t1[×]Ae
     ArrangeBy keys=[[]] // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2 AND #1 = #3) type=indexed_filter // { arity: 4 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 2 }
-            - (2, "l2")
+        ReadExistingIndex materialize.public.t1 lookup_value=(2, "l2")
     Project (#2) // { arity: 1 }
-      Join on=(#0 = #3) type=indexed_filter // { arity: 4 }
-        ArrangeBy keys=[[#0]] // { arity: 3 }
-          Get materialize.public.t2 // { arity: 3 }
-        Constant // { arity: 1 }
-          - (2)
+      ReadExistingIndex materialize.public.t2 lookup_value=(2)
 
 Used Indexes:
   - materialize.public.idx_t1_a_b
@@ -750,7 +728,7 @@ WHERE a = 0 AND b = 1 AND c = 2 AND v = 'xxx';
 ----
 Explained Query (fast path):
   Project (#0..=#3)
-    ReadExistingIndex materialize.public.foo_primary_idx lookup value (0, 1, 2, "xxx")
+    ReadExistingIndex materialize.public.foo_primary_idx lookup_value=(0, 1, 2, "xxx")
 
 Used Indexes:
   - materialize.public.foo_primary_idx
@@ -763,7 +741,7 @@ WHERE 0 = a AND 1 = b AND 2 = c AND 'xxx' = v;
 ----
 Explained Query (fast path):
   Project (#0..=#3)
-    ReadExistingIndex materialize.public.foo_primary_idx lookup value (0, 1, 2, "xxx")
+    ReadExistingIndex materialize.public.foo_primary_idx lookup_value=(0, 1, 2, "xxx")
 
 Used Indexes:
   - materialize.public.foo_primary_idx
@@ -787,7 +765,7 @@ WHERE a = 0 AND a = 0::SMALLINT;
 ----
 Explained Query (fast path):
   Project (#0)
-    ReadExistingIndex materialize.public.idx_foo_a lookup value (0)
+    ReadExistingIndex materialize.public.idx_foo_a lookup_value=(0)
 
 Used Indexes:
   - materialize.public.idx_foo_a
@@ -809,7 +787,7 @@ WHERE (a = 0 AND a = 2::SMALLINT) OR a = 3;
 ----
 Explained Query (fast path):
   Project (#0)
-    ReadExistingIndex materialize.public.idx_foo_a lookup value (3)
+    ReadExistingIndex materialize.public.idx_foo_a lookup_value=(3)
 
 Used Indexes:
   - materialize.public.idx_foo_a
@@ -831,7 +809,7 @@ WHERE a = 3::SMALLINT;
 ----
 Explained Query (fast path):
   Project (#0)
-    ReadExistingIndex materialize.public.idx_foo_a lookup value (3)
+    ReadExistingIndex materialize.public.idx_foo_a lookup_value=(3)
 
 Used Indexes:
   - materialize.public.idx_foo_a
@@ -858,7 +836,7 @@ WHERE a = 0;
 ----
 Explained Query (fast path):
   Project (#1..=#4)
-    ReadExistingIndex materialize.public.idx_foo_a_cast lookup value (0)
+    ReadExistingIndex materialize.public.idx_foo_a_cast lookup_value=(0)
 
 Used Indexes:
   - materialize.public.idx_foo_a_cast
@@ -882,7 +860,7 @@ WHERE v = 'xxx';
 ----
 Explained Query (fast path):
   Project (#1..=#4)
-    ReadExistingIndex materialize.public.idx_foo_v_cast lookup value ("xxx")
+    ReadExistingIndex materialize.public.idx_foo_v_cast lookup_value=("xxx")
 
 Used Indexes:
   - materialize.public.idx_foo_v_cast
@@ -907,7 +885,7 @@ WHERE a = 0;
 ----
 Explained Query (fast path):
   Project (#0..=#3)
-    ReadExistingIndex materialize.public.idx_foo_a lookup value (0)
+    ReadExistingIndex materialize.public.idx_foo_a lookup_value=(0)
 
 Used Indexes:
   - materialize.public.idx_foo_a
@@ -932,7 +910,7 @@ WHERE v = 'xxx';
 ----
 Explained Query (fast path):
   Project (#1..=#3, #0)
-    ReadExistingIndex materialize.public.idx_foo_v lookup value ("xxx")
+    ReadExistingIndex materialize.public.idx_foo_v lookup_value=("xxx")
 
 Used Indexes:
   - materialize.public.idx_foo_v
@@ -993,7 +971,7 @@ EXPLAIN SELECT * FROM bar WHERE (b AND a) = TRUE;
 ----
 Explained Query (fast path):
   Project (#1, #2)
-    ReadExistingIndex materialize.public.bar_expr_idx lookup value (true)
+    ReadExistingIndex materialize.public.bar_expr_idx lookup_value=(true)
 
 Used Indexes:
   - materialize.public.bar_expr_idx

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -81,11 +81,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -109,11 +105,7 @@ Explained Query:
         Get l0 // { arity: 2 }
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -139,11 +131,7 @@ Explained Query:
         Get l0 // { arity: 3 }
   With
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -214,11 +202,7 @@ Explained Query:
                 Project () // { arity: 0 }
                   Get l0 // { arity: 3 }
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -315,11 +299,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -345,11 +325,7 @@ Explained Query:
     cte l0 =
       Project (#0, #1) // { arity: 2 }
         Filter (#1 = 2) // { arity: 3 }
-          Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Get materialize.public.t1 // { arity: 2 }
-            Constant // { arity: 1 }
-              - (1)
+          ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -378,11 +354,7 @@ Explained Query:
           Get l0 // { arity: 3 }
   With
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -405,11 +377,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -431,11 +399,7 @@ Explained Query:
   With
     cte l0 =
       Project (#1) // { arity: 1 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -480,11 +444,7 @@ Explained Query:
                 Project () // { arity: 0 }
                   Get l0 // { arity: 3 }
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -539,11 +499,7 @@ Explained Query:
                 Project () // { arity: 0 }
                   Get l0 // { arity: 3 }
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -592,11 +548,7 @@ Explained Query:
       Project () // { arity: 0 }
         Get l0 // { arity: 3 }
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -642,11 +594,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Get l0 // { arity: 3 }
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -760,15 +708,9 @@ Explained Query:
           Get l2 // { arity: 3 }
   With
     cte l2 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (2)
+      ReadExistingIndex materialize.public.t1 lookup_value=(2)
     cte l1 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -804,11 +746,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 3 }
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -840,15 +778,9 @@ Explained Query:
         Get l2 // { arity: 3 }
   With
     cte l2 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (2)
+      ReadExistingIndex materialize.public.t1 lookup_value=(2)
     cte l1 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -877,11 +809,7 @@ Explained Query:
     cte l0 =
       Project (#0, #1) // { arity: 2 }
         Filter (#1 = 2) // { arity: 3 }
-          Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Get materialize.public.t1 // { arity: 2 }
-            Constant // { arity: 1 }
-              - (1)
+          ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -906,12 +834,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
-            - (2)
+        ReadExistingIndex materialize.public.t1 lookup_values=[(1); (2)]
 
 Used Indexes:
   - materialize.public.i1
@@ -942,11 +865,7 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 0 }
           Distinct // { arity: 0 }
             Project () // { arity: 0 }
-              Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Get materialize.public.t1 // { arity: 2 }
-                Constant // { arity: 1 }
-                  - (1)
+              ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -981,10 +900,7 @@ Explained Query:
                     Project () // { arity: 0 }
                       Get l1 // { arity: 3 }
     cte l1 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -1167,11 +1083,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -1198,11 +1110,7 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 0 }
           Distinct // { arity: 0 }
             Project () // { arity: 0 }
-              Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Get materialize.public.t1 // { arity: 2 }
-                Constant // { arity: 1 }
-                  - (1)
+              ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -1235,11 +1143,7 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 0 }
           Distinct // { arity: 0 }
             Project () // { arity: 0 }
-              Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-                ArrangeBy keys=[[#0]] // { arity: 2 }
-                  Get materialize.public.t1 // { arity: 2 }
-                Constant // { arity: 1 }
-                  - (1)
+              ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -1270,11 +1174,7 @@ Explained Query:
       ArrangeBy keys=[[]] // { arity: 0 }
         Distinct // { arity: 0 }
           Project () // { arity: 0 }
-            Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Get materialize.public.t1 // { arity: 2 }
-              Constant // { arity: 1 }
-                - (1)
+            ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -1303,11 +1203,7 @@ Explained Query:
   With
     cte l0 =
       Project (#0) // { arity: 1 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -1330,11 +1226,7 @@ Explained Query:
         Get l0 // { arity: 3 }
   With
     cte l0 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Get materialize.public.t1 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
 
 Used Indexes:
   - materialize.public.i1
@@ -1356,15 +1248,9 @@ Explained Query:
         %1:t1 » %0:t1[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-            Get l0 // { arity: 2 }
-            Constant // { arity: 1 }
-              - (1)
+          ReadExistingIndex materialize.public.t1 lookup_value=(1)
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          Get l0 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (2)
+        ReadExistingIndex materialize.public.t1 lookup_value=(2)
   With
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1402,15 +1288,9 @@ Explained Query:
           Get l2 // { arity: 3 }
   With
     cte l2 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (2)
+      ReadExistingIndex materialize.public.t1 lookup_value=(2)
     cte l1 =
-      Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-        Get l0 // { arity: 2 }
-        Constant // { arity: 1 }
-          - (1)
+      ReadExistingIndex materialize.public.t1 lookup_value=(1)
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -1430,15 +1310,9 @@ Explained Query:
   Return // { arity: 2 }
     Union // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          Get l0 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (1)
+        ReadExistingIndex materialize.public.t1 lookup_value=(1)
       Project (#0, #1) // { arity: 2 }
-        Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
-          Get l0 // { arity: 2 }
-          Constant // { arity: 1 }
-            - (2)
+        ReadExistingIndex materialize.public.t1 lookup_value=(2)
   With
     cte l0 =
       ArrangeBy keys=[[#0]] // { arity: 2 }

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -162,7 +162,7 @@ EXPLAIN SHOW COLUMNS IN t
 ----
 Explained Query (fast path):
   Project (#1, #3, #4)
-    ReadExistingIndex mz_internal.mz_show_columns_ind lookup value ("u1")
+    ReadExistingIndex mz_internal.mz_show_columns_ind lookup_value=("u1")
 
 Used Indexes:
   - mz_internal.mz_show_columns_ind

--- a/test/sqllogictest/transform/dataflow.slt
+++ b/test/sqllogictest/transform/dataflow.slt
@@ -55,11 +55,7 @@ EXPLAIN WITH(arity, join_impls) VIEW foo3
 ----
 Explained Query:
   Project (#0) // { arity: 1 }
-    Join on=(#0 = #1) type=indexed_filter // { arity: 2 }
-      ArrangeBy keys=[[#0]] // { arity: 1 }
-        Get materialize.public.foo2 // { arity: 1 }
-      Constant // { arity: 1 }
-        - (6)
+    ReadExistingIndex materialize.public.foo2 lookup_value=(6)
 
 Used Indexes:
   - materialize.public.foo2_primary_idx
@@ -71,7 +67,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * from foo3
 ----
 Explained Query (fast path):
   Project (#0)
-    ReadExistingIndex materialize.public.foo2_primary_idx lookup value (6)
+    ReadExistingIndex materialize.public.foo2_primary_idx lookup_value=(6)
 
 Used Indexes:
   - materialize.public.foo2_primary_idx

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -173,11 +173,7 @@ Explained Query:
                         Project () // { arity: 0 }
                           Get l0 // { arity: 9 }
     cte l0 =
-      Join on=(#0 = #8) type=indexed_filter // { arity: 9 }
-        ArrangeBy keys=[[#0]] // { arity: 8 }
-          Get materialize.public.lineitem // { arity: 8 }
-        Constant // { arity: 1 }
-          - (38)
+      ReadExistingIndex materialize.public.lineitem lookup_value=(38)
 
 Used Indexes:
   - materialize.public.pk_orders_orderkey
@@ -205,17 +201,9 @@ Explained Query:
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#2, #3) // { arity: 2 }
           Filter (#2 = (#2 % 5)) // { arity: 5 }
-            Join on=(#1 = #4) type=indexed_filter // { arity: 5 }
-              ArrangeBy keys=[[#1]] // { arity: 4 }
-                Get materialize.public.orders // { arity: 4 }
-              Constant // { arity: 1 }
-                - (134)
+            ReadExistingIndex materialize.public.orders lookup_value=(134)
       Project () // { arity: 0 }
-        Join on=(#0 = #3) type=indexed_filter // { arity: 4 }
-          ArrangeBy keys=[[#0]] // { arity: 3 }
-            Get materialize.public.customer // { arity: 3 }
-          Constant // { arity: 1 }
-            - (134)
+        ReadExistingIndex materialize.public.customer lookup_value=(134)
 
 Used Indexes:
   - materialize.public.pk_customer_custkey
@@ -241,18 +229,10 @@ Explained Query:
         Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }
       Project (#0..=#3) // { arity: 4 }
-        Join on=(#1 = #4) type=indexed_filter // { arity: 5 }
-          ArrangeBy keys=[[#1]] // { arity: 4 }
-            Get materialize.public.orders // { arity: 4 }
-          Constant // { arity: 1 }
-            - (229)
+        ReadExistingIndex materialize.public.orders lookup_value=(229)
       ArrangeBy keys=[[]] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #3) type=indexed_filter // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 3 }
-              Get materialize.public.customer // { arity: 3 }
-            Constant // { arity: 1 }
-              - (229)
+          ReadExistingIndex materialize.public.customer lookup_value=(229)
 
 Used Indexes:
   - materialize.public.pk_customer_custkey

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -663,11 +663,7 @@ Explained Query:
         ArrangeBy keys=[[#0]] // { arity: 14 }
           Get materialize.public.big // { arity: 14 }
         ArrangeBy keys=[[#1]] // { arity: 15 }
-          Join on=(#12 = #14) type=indexed_filter // { arity: 15 }
-            ArrangeBy keys=[[#12]] // { arity: 14 }
-              Get materialize.public.big // { arity: 14 }
-            Constant // { arity: 1 }
-              - (42)
+          ReadExistingIndex materialize.public.big lookup_value=(42)
         ArrangeBy keys=[[#2]] // { arity: 14 }
           Get materialize.public.big // { arity: 14 }
 

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -28,11 +28,11 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 "Explained Query (fast path):  Filter (#0) IS NULL AND (#1 = 5)    ReadExistingIndex t1_primary_idxUsed Indexes:  - t1_primary_idx"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
-"Explained Query (fast path):  Project (#0, #1)    ReadExistingIndex t1_primary_idx lookup value (5, 1)Used Indexes:  - t1_primary_idx"
+"Explained Query (fast path):  Project (#0, #1)    ReadExistingIndex t1_primary_idx lookup_value=(5, 1)Used Indexes:  - t1_primary_idx"
 
 # NULL-able expressions are dedupped
 > EXPLAIN SELECT * FROM t1 WHERE col_null = 1 AND (col_null = 1 AND col_not_null = 5);
-"Explained Query (fast path):  Project (#0, #1)    ReadExistingIndex t1_primary_idx lookup value (1, 5)Used Indexes:  - t1_primary_idx"
+"Explained Query (fast path):  Project (#0, #1)    ReadExistingIndex t1_primary_idx lookup_value=(1, 5)Used Indexes:  - t1_primary_idx"
 
 # OR/disjunction at the top level
 


### PR DESCRIPTION
@frankmcsherry pointed out that when we EXPLAIN an `IndexedFilter`, it's not so important that it's a join, and instead maybe we should just concentrate on the fact that it's an index lookup. (https://materializeinc.slack.com/archives/C02PPB50ZHS/p1666102508650069)

This PR modifies the `IndexedFilter` printing to omit the usual join stuff that we print for joins, and just print that it's an index lookup.

So instead of 
```
          Join on=(#1 = #2) type=indexed_filter
            ArrangeBy keys=[[#1]]
              Get materialize.public.t1
            Constant
              - ("l2")
              - ("l3")
```
we now have
```
ReadExistingIndex materialize.public.t1 lookup values [("l2"); ("l3")]
```

This unifies the printing of an index lookup between the fast path and dataflows. (But fast path is still distinguishable, because then the explain plan explicitly starts with saying "fast path".)

### Motivation

  * This PR fixes a recognized bug. https://materializeinc.slack.com/archives/C02PPB50ZHS/p1666102508650069

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Improve EXPLAIN for index lookups.
