### PR TITLE
persist: no-op rather than panic when `maybe_replace` would increase updates

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -607,6 +607,7 @@ pub struct CompactionMetrics {
 
     pub(crate) applied_exact_match: IntCounter,
     pub(crate) applied_subset_match: IntCounter,
+    pub(crate) not_applied_too_many_updates: IntCounter,
 
     pub(crate) batch: BatchWriteMetrics,
     pub(crate) steps: CompactionStepTimings,
@@ -678,6 +679,10 @@ impl CompactionMetrics {
             applied_subset_match: registry.register(metric!(
                 name: "mz_persist_compaction_applied_subset_match",
                 help: "count of merge results that replaced a subset of a SpineBatch",
+            )),
+            not_applied_too_many_updates: registry.register(metric!(
+                name: "mz_persist_compaction_not_applied_too_many_updates",
+                help: "count of merge results that did not apply due to too many updates",
             )),
             batch: BatchWriteMetrics::new(registry, "compaction"),
             steps: CompactionStepTimings::new(step_timings.clone()),

--- a/src/persist-client/tests/trace/compaction_apply_res
+++ b/src/persist-client/tests/trace/compaction_apply_res
@@ -77,6 +77,18 @@ apply-merge-res
 ----
 no-op
 
+# cannot apply batch with more updates than entire spine batch
+apply-merge-res
+[0][16][0] 9 nope
+----
+no-op too many updates
+
+# cannot apply batch with more updates than a subset of fueled merge
+apply-merge-res
+[0][4][0] 3 nope
+----
+no-op too many updates
+
 # perform a merge res at the start of the fueled merge
 apply-merge-res
 [0][4][0] 2 k0-4


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Currently persist's spine requires that a merge result has <= the # of updates of the batch parts it is replacing. However if there are overlapping compaction requests for different subsets of batches, and compaction runs up against the memory limit and cannot fully consolidate the results, it is possible for their interleaving to break this invariant. Dan has a more cogent sequence [here](https://github.com/MaterializeInc/materialize/issues/15498#issuecomment-1282741574) to explain how this happens.

This PR relaxes the assertion to be a no-op instead -- if we try to replace a spine batch or subset of a spine batch with one with more updates, we early exit and bubble up this information to record it in a new `not_applied_too_many_updates` metric.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/15498
Fixes https://github.com/MaterializeInc/materialize/issues/14670

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

A lot of the complexity of this change is to bubble up the cause of a `NotApplied` result -- is it worth it?

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
