### PR TITLE
doc,test: update for correct handling of subsource sizes

### DIFF
--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -39,7 +39,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | Default: `3xsmall`. The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
 
 ## Description
 
@@ -158,12 +158,12 @@ SHOW SOURCES;
 ```nofmt
      name      |      type      |  size
 ---------------+----------------+---------
- accounts      | subsource      | 3xsmall
+ accounts      | subsource      |
  auction_house | load-generator | 3xsmall
- auctions      | subsource      | 3xsmall
- bids          | subsource      | 3xsmall
- organizations | subsource      | 3xsmall
- users         | subsource      | 3xsmall
+ auctions      | subsource      |
+ bids          | subsource      |
+ organizations | subsource      |
+ users         | subsource      |
 ```
 
 To examine the simulated bids:

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -65,8 +65,8 @@ SHOW SOURCES;
 ```nofmt
          name         |   type    |  size
 ----------------------+-----------+---------
- table_1              | subsource | 3xsmall
- table_2              | subsource | 3xsmall
+ table_1              | subsource |
+ table_2              | subsource |
  mz_source            | postgres  | 3xsmall
 ```
 

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -41,7 +41,7 @@ use crate::plan::PlanError;
 /// `FullObjectName`.
 ///
 /// [`normalize::unresolved_object_name`]: crate::normalize::unresolved_object_name
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct FullObjectName {
     /// The database name.
     pub database: RawDatabaseSpecifier,
@@ -206,7 +206,7 @@ impl fmt::Display for PartialSchemaName {
 }
 
 /// A human readable name of a database.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum RawDatabaseSpecifier {
     /// The "ambient" database, which is always present and is not named
     /// explicitly, but by omission.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -12,7 +12,7 @@
 //! This module houses the handlers for statements that modify the catalog, like
 //! `ALTER`, `CREATE`, and `DROP`.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
@@ -602,7 +602,7 @@ pub fn plan_create_source(
                 ProtoPostgresSourceDetails::decode(&*details).map_err(|e| sql_err!("{}", e))?;
 
             // Register the available subsources
-            let mut available_subsources = HashMap::new();
+            let mut available_subsources = BTreeMap::new();
 
             for (i, table) in details.tables.iter().enumerate() {
                 let name = FullObjectName {
@@ -699,7 +699,7 @@ pub fn plan_create_source(
             let (load_generator, available_subsources) =
                 load_generator_ast_to_generator(generator, options)?;
             let available_subsources = available_subsources
-                .map(|a| HashMap::from_iter(a.into_iter().map(|(k, v)| (k, v.0))));
+                .map(|a| BTreeMap::from_iter(a.into_iter().map(|(k, v)| (k, v.0))));
             let generator = as_generator(&load_generator);
 
             let LoadGeneratorOptionExtracted { tick_interval, .. } = options.clone().try_into()?;
@@ -878,7 +878,7 @@ pub fn plan_create_source(
         (None, Some(_)) | (Some(_), Some(CreateSourceSubsources::All)) => {
             sql_bail!("[internal error] subsources should be resolved during purification")
         }
-        (None, None) => (HashMap::<FullObjectName, usize>::new(), vec![]),
+        (None, None) => (BTreeMap::new(), vec![]),
     };
 
     let mut subsource_exports = HashMap::new();
@@ -1062,7 +1062,7 @@ pub(crate) fn load_generator_ast_to_generator(
 ) -> Result<
     (
         mz_storage::types::sources::LoadGenerator,
-        Option<HashMap<FullObjectName, (usize, RelationDesc)>>,
+        Option<BTreeMap<FullObjectName, (usize, RelationDesc)>>,
     ),
     PlanError,
 > {
@@ -1110,7 +1110,7 @@ pub(crate) fn load_generator_ast_to_generator(
         }
     };
 
-    let mut available_subsources = HashMap::new();
+    let mut available_subsources = BTreeMap::new();
     let generator = as_generator(&load_generator);
     for (i, (name, desc)) in generator.views().iter().enumerate() {
         let name = FullObjectName {

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -69,6 +69,9 @@ statement ok
 DROP SOURCE s;
 
 statement ok
+CREATE SOURCE multiplex FROM LOAD GENERATOR AUCTION FOR ALL TABLES WITH (SIZE '1');
+
+statement ok
 DROP CLUSTER REPLICA foo.r;
 
 statement ok
@@ -107,5 +110,11 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 28  create  source  {"database":"materialize","id":"u7","item":"s","schema":"public","size":"1"}  materialize
 29  alter  source  {"database":"materialize","id":"u7","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
 30  drop  source  {"database":"materialize","id":"u7","item":"s","schema":"public"}  materialize
-31  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
-32  drop  cluster  {"id":"u2","name":"foo"}  materialize
+31  create  source  {"database":"materialize","id":"u8","item":"accounts","schema":"public","size":null}  materialize
+32  create  source  {"database":"materialize","id":"u9","item":"auctions","schema":"public","size":null}  materialize
+33  create  source  {"database":"materialize","id":"u10","item":"bids","schema":"public","size":null}  materialize
+34  create  source  {"database":"materialize","id":"u11","item":"organizations","schema":"public","size":null}  materialize
+35  create  source  {"database":"materialize","id":"u12","item":"users","schema":"public","size":null}  materialize
+36  create  source  {"database":"materialize","id":"u13","item":"multiplex","schema":"public","size":"1"}  materialize
+37  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
+38  drop  cluster  {"id":"u2","name":"foo"}  materialize


### PR DESCRIPTION
The size of subsources was incorrectly always reported as `3xsmall` in v0.27.0. Turns out this got fixed in #15222. Update the docs accordingly, and also lock in the behavior with a test, as it's important for billing that the size of subsources be null.

Fix #15374.
Fix #15515.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds a test and corrects docs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
