### PR TITLE
stash: improve memory performance

### DIFF
--- a/src/stash/src/memory.rs
+++ b/src/stash/src/memory.rs
@@ -312,7 +312,7 @@ impl<S: Stash> Stash for Memory<S> {
 #[async_trait]
 impl<S: Append> Append for Memory<S> {
     async fn append_batch(&mut self, batches: &[AppendBatch]) -> Result<(), StashError> {
-        self.stash.append(batches).await?;
+        self.stash.append_batch(batches).await?;
         for batch in batches {
             self.uppers.insert(batch.collection_id, batch.upper.clone());
             self.sinces

--- a/src/stash/src/memory.rs
+++ b/src/stash/src/memory.rs
@@ -136,7 +136,39 @@ impl<S: Stash> Stash for Memory<S> {
         K: Data,
         V: Data,
     {
-        self.stash.iter_key(collection, key).await
+        Ok(match self.entries.entry(collection.id) {
+            Entry::Occupied(entry) => entry
+                .get()
+                .iter()
+                .filter_map(|((k, v), ts, diff)| {
+                    let k: K = serde_json::from_slice(k).expect("must deserialize");
+                    if &k == key {
+                        let v: V = serde_json::from_slice(v).expect("must deserialize");
+                        Some((v, *ts, *diff))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            Entry::Vacant(_) => {
+                // If vacant, do a full `iter` to correctly populate the cache
+                // (`entries`, if present, must contain all keys in the source
+                // collection).
+                let entries = self.iter(collection).await?;
+                entries
+                    .into_iter()
+                    .filter_map(
+                        |((k, v), ts, diff)| {
+                            if &k == key {
+                                Some((v, ts, diff))
+                            } else {
+                                None
+                            }
+                        },
+                    )
+                    .collect()
+            }
+        })
     }
 
     async fn update_many<K, V, I>(

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -313,16 +313,17 @@ where
     stash
         .update(orders, ("wombats".into(), "2".into()), 1, 2)
         .await?;
+    // Move this before iter to better test the memory stash's iter_key.
+    assert_eq!(
+        stash.iter_key(orders, &"widgets".to_string()).await?,
+        &[("1".into(), 1, 1)]
+    );
     assert_eq!(
         stash.iter(orders).await?,
         &[
             (("widgets".into(), "1".into()), 1, 1),
             (("wombats".into(), "2".into()), 1, 2),
         ]
-    );
-    assert_eq!(
-        stash.iter_key(orders, &"widgets".to_string()).await?,
-        &[("1".into(), 1, 1)]
     );
     assert_eq!(
         stash.iter_key(orders, &"wombats".to_string()).await?,


### PR DESCRIPTION
Various perf improvements to memory cache stash that should reduce our total cockroach transactions noticably.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a