### PR TITLE
sql-parser,sql: use standard macro for cluster replica parsing

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1004,6 +1004,37 @@ impl<T: AstInfo> AstDisplay for CreateTypeStatement<T> {
 }
 impl_display_t!(CreateTypeStatement);
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ClusterOptionName {
+    /// The `REPLICAS` option.
+    Replicas,
+}
+
+impl AstDisplay for ClusterOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            ClusterOptionName::Replicas => f.write_str("REPLICAS"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// An option in a `CREATE CLUSTER` ostatement.
+pub struct ClusterOption<T: AstInfo> {
+    pub name: ClusterOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for ClusterOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" ");
+            f.write_node(v);
+        }
+    }
+}
+
 /// `CREATE CLUSTER ..`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateClusterStatement<T: AstInfo> {
@@ -1024,25 +1055,6 @@ impl<T: AstInfo> AstDisplay for CreateClusterStatement<T> {
     }
 }
 impl_display_t!(CreateClusterStatement);
-
-/// An option in a `CREATE CLUSTER` statement.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ClusterOption<T: AstInfo> {
-    /// The `REPLICAS` option.
-    Replicas(Vec<ReplicaDefinition<T>>),
-}
-
-impl<T: AstInfo> AstDisplay for ClusterOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            ClusterOption::Replicas(replicas) => {
-                f.write_str("REPLICAS (");
-                f.write_node(&display::comma_separated(replicas));
-                f.write_str(")");
-            }
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReplicaDefinition<T: AstInfo> {
@@ -1118,7 +1130,7 @@ impl AstDisplay for ReplicaOptionName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-/// An option in a `CREATE CLUSTER` or `CREATE CLUSTER REPLICA` statement.
+/// An option in a `CREATE CLUSTER REPLICA` statement.
 pub struct ReplicaOption<T: AstInfo> {
     pub name: ReplicaOptionName,
     pub value: Option<WithOptionValue<T>>,
@@ -2137,6 +2149,8 @@ pub enum WithOptionValue<T: AstInfo> {
     Secret(T::ObjectName),
     Object(T::ObjectName),
     Sequence(Vec<WithOptionValue<T>>),
+    // Special cases.
+    ClusterReplicas(Vec<ReplicaDefinition<T>>),
 }
 
 impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
@@ -2155,6 +2169,11 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 f.write_node(name)
             }
             WithOptionValue::Object(obj) => f.write_node(obj),
+            WithOptionValue::ClusterReplicas(replicas) => {
+                f.write_str("(");
+                f.write_node(&display::comma_separated(replicas));
+                f.write_str(")");
+            }
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -956,56 +956,56 @@ CREATE CLUSTER cluster REPLICAS ()
 ----
 CREATE CLUSTER cluster REPLICAS ()
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([])) }] })
 
 parse-statement
 CREATE CLUSTER cluster WITH REPLICAS ()
 ----
-error: Expected end of statement, found WITH
+error: Expected REPLICAS, found WITH
 CREATE CLUSTER cluster WITH REPLICAS ()
                        ^
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (), BADOPT
 ----
-error: Expected end of statement, found comma
+error: Expected REPLICAS, found identifier "badopt"
 CREATE CLUSTER cluster REPLICAS (), BADOPT
-                                  ^
+                                    ^
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }] }])) }] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1'))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1')), b (SIZE = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])) }] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], INTROSPECTION INTERVAL '1s', INTROSPECTION DEBUGGING true), b (SIZE '1', INTROSPECTION INTERVAL 0))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = true), b (SIZE = '1', INTROSPECTION INTERVAL = 0))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])) }] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), SIZE = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])) }] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1:2400', 'host2:2400'], COMPUTE ['host1:2401', 'host2:2401'], WORKERS '1'))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1:2400', 'host2:2400'), COMPUTE = ('host1:2401', 'host2:2401'), WORKERS = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1:2400")), Value(String("host2:2400"))])) }, ReplicaOption { name: Compute, value: Some(Sequence([Value(String("host1:2401")), Value(String("host2:2401"))])) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1:2400")), Value(String("host2:2400"))])) }, ReplicaOption { name: Compute, value: Some(Sequence([Value(String("host1:2401")), Value(String("host2:2401"))])) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])) }] })
 
 parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ['host1']

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1092,6 +1092,12 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 }
                 Object(object_name)
             }
+            ClusterReplicas(replicas) => ClusterReplicas(
+                replicas
+                    .into_iter()
+                    .map(|r| self.fold_replica_definition(r))
+                    .collect(),
+            ),
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -65,7 +65,7 @@ use crate::ast::display::AstDisplay;
 use crate::ast::{
     AlterConnectionStatement, AlterIndexAction, AlterIndexStatement, AlterObjectRenameStatement,
     AlterSecretStatement, AvroSchema, AvroSchemaOption, AvroSchemaOptionName, AwsConnectionOption,
-    AwsConnectionOptionName, ClusterOption, ColumnOption, Compression,
+    AwsConnectionOptionName, ClusterOption, ClusterOptionName, ColumnOption, Compression,
     CreateClusterReplicaStatement, CreateClusterStatement, CreateConnection,
     CreateConnectionStatement, CreateDatabaseStatement, CreateIndexStatement,
     CreateMaterializedViewStatement, CreateRoleOption, CreateRoleStatement, CreateSchemaStatement,
@@ -2258,32 +2258,23 @@ pub fn describe_create_cluster(
     Ok(StatementDesc::new(None))
 }
 
+generate_extracted_config!(ClusterOption, (Replicas, Vec<ReplicaDefinition<Aug>>));
+
 pub fn plan_create_cluster(
     scx: &StatementContext,
     CreateClusterStatement { name, options }: CreateClusterStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    let mut replicas_definitions = None;
+    let ClusterOptionExtracted { replicas, .. }: ClusterOptionExtracted = options.try_into()?;
 
-    for option in options {
-        match option {
-            ClusterOption::Replicas(replicas) => {
-                if replicas_definitions.is_some() {
-                    sql_bail!("REPLICAS specified more than once");
-                }
-
-                let mut defs = Vec::with_capacity(replicas.len());
-                for ReplicaDefinition { name, options } in replicas {
-                    defs.push((normalize::ident(name), plan_replica_config(scx, options)?));
-                }
-                replicas_definitions = Some(defs);
-            }
-        }
-    }
-
-    let replicas = match replicas_definitions {
-        Some(r) => r,
-        None => bail_unsupported!("CLUSTER without REPLICAS option"),
+    let replica_defs = match replicas {
+        Some(replica_defs) => replica_defs,
+        None => sql_bail!("REPLICAS option is required"),
     };
+
+    let mut replicas = vec![];
+    for ReplicaDefinition { name, options } in replica_defs {
+        replicas.push((normalize::ident(name), plan_replica_config(scx, options)?));
+    }
 
     Ok(Plan::CreateComputeInstance(CreateComputeInstancePlan {
         name: normalize::ident(name),
@@ -2305,7 +2296,7 @@ generate_extracted_config!(
     (Compute, Vec<String>),
     (Workers, u16),
     (IntrospectionInterval, OptionalInterval),
-    (IntrospectionDebugging, bool)
+    (IntrospectionDebugging, bool, Default(false))
 );
 
 fn plan_replica_config(
@@ -2339,9 +2330,9 @@ fn plan_replica_config(
     let introspection = match introspection_interval {
         Some(interval) => Some(ComputeReplicaIntrospectionConfig {
             interval: interval.duration()?,
-            debugging: introspection_debugging.unwrap_or(false),
+            debugging: introspection_debugging,
         }),
-        None if introspection_debugging == Some(true) => {
+        None if introspection_debugging => {
             sql_bail!("INTROSPECTION DEBUGGING cannot be specified without INTROSPECTION INTERVAL")
         }
         None => None,

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -9,6 +9,7 @@
 
 //! Provides tooling to handle `WITH` options.
 
+use mz_sql_parser::ast::ReplicaDefinition;
 use serde::{Deserialize, Serialize};
 
 use mz_repr::adt::interval::Interval;
@@ -353,13 +354,15 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
             WithOptionValue::Sequence(_)
             | WithOptionValue::Object(_)
             | WithOptionValue::Secret(_)
-            | WithOptionValue::DataType(_) => sql_bail!(
+            | WithOptionValue::DataType(_)
+            | WithOptionValue::ClusterReplicas(_) => sql_bail!(
                 "incompatible value types: cannot convert {} to {}",
                 match v {
                     WithOptionValue::Sequence(_) => "sequences",
                     WithOptionValue::Object(_) => "object references",
                     WithOptionValue::Secret(_) => "secrets",
                     WithOptionValue::DataType(_) => "data types",
+                    WithOptionValue::ClusterReplicas(_) => "cluster replicas",
                     _ => unreachable!(),
                 },
                 V::name()
@@ -380,5 +383,23 @@ impl<T, V: TryFromValue<T> + ImpliedValue> TryFromValue<Option<T>> for V {
     }
     fn name() -> String {
         V::name()
+    }
+}
+
+impl TryFromValue<WithOptionValue<Aug>> for Vec<ReplicaDefinition<Aug>> {
+    fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
+        match v {
+            WithOptionValue::ClusterReplicas(replicas) => Ok(replicas),
+            _ => sql_bail!("cannot use value as cluster replicas"),
+        }
+    }
+    fn name() -> String {
+        "cluster replicas".to_string()
+    }
+}
+
+impl ImpliedValue for Vec<ReplicaDefinition<Aug>> {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide a set of cluster replicas")
     }
 }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -11,7 +11,7 @@
 
 mode cockroach
 
-statement error CLUSTER without REPLICAS option not yet supported
+statement error Expected REPLICAS, found EOF
 CREATE CLUSTER foo
 
 statement ok
@@ -20,13 +20,13 @@ CREATE CLUSTER foo REPLICAS ()
 statement ok
 DROP CLUSTER foo
 
-statement error Expected end of statement, found comma
+statement error REPLICAS specified more than once
 CREATE CLUSTER foo REPLICAS (), REPLICAS()
 
 # Creating cluster w/ remote replica works.
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234;']))
 
 statement error cluster 'foo' already exists
 CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))


### PR DESCRIPTION
To trailblaze a new path for AWS PRIVATELINK.
