### PR TITLE
storage: in reclock::compact, turn assert into no-op

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -324,6 +324,13 @@ impl ReclockFollowerInner {
             // As long as the assertion about `as_of` and `since` on creation
             // are correct, it is fine to ignore these compaction requests if
             // they don't advance the since.
+            tracing::error!(
+                ?new_since,
+                ?self.since,
+                "We are forced to skip the compaction in \
+                the _ReclockFollower_ because the `new_since` >= the `since`. \
+                This is a bug that should be fixed."
+            );
             return;
         }
 
@@ -544,6 +551,13 @@ impl ReclockOperator {
             // As long as the assertion about `as_of` and `since` on creation are
             // correct, it is fine to ignore these compaction requests if they
             // don't advance the since.
+            tracing::error!(
+                ?new_since,
+                ?self.since,
+                "We are forced to skip the compaction in \
+                the _ReclockOperator_ because the `new_since` >= the `since`. \
+                This is a bug that should be fixed."
+            );
             return;
         }
 

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -320,7 +320,13 @@ impl ReclockFollower {
 
 impl ReclockFollowerInner {
     pub fn compact(&mut self, new_since: Antichain<Timestamp>) {
-        assert!(PartialOrder::less_equal(&self.since, &new_since));
+        if PartialOrder::less_equal(&new_since, &self.since) {
+            // As long as the assertion about `as_of` and `since` on creation
+            // are correct, it is fine to ignore these compaction requests if
+            // they don't advance the since.
+            return;
+        }
+
         for bindings in self.remap_trace.values_mut() {
             // Compact the remap trace according to the computed frontier
             for (timestamp, _) in bindings.iter_mut() {
@@ -534,7 +540,13 @@ impl ReclockOperator {
 
     /// Compacts the internal state
     pub async fn compact(&mut self, new_since: Antichain<Timestamp>) {
-        assert!(PartialOrder::less_equal(&self.since, &new_since));
+        if PartialOrder::less_equal(&new_since, &self.since) {
+            // As long as the assertion about `as_of` and `since` on creation are
+            // correct, it is fine to ignore these compaction requests if they
+            // don't advance the since.
+            return;
+        }
+
         for bindings in self.remap_trace.values_mut() {
             // Compact the remap trace according to the computed frontier
             for (timestamp, _) in bindings.iter_mut() {


### PR DESCRIPTION
As long as the assertion about `as_of` and `since` on creation are correct, it is fine to ignore these compaction requests if they don't advance the since.

We have seen at least one occurrence of the assert firing in production, which is not good.

Fixes #13974

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
