### PR TITLE
compute: share repro for empty uppers on materialized views

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -139,15 +139,17 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut since = Antichain::new();
         {
             for id in id_bundle.storage_ids.iter() {
-                since.extend(
-                    self.controller
-                        .storage
-                        .collection(*id)
-                        .unwrap()
-                        .write_frontier
-                        .iter()
-                        .cloned(),
+                let write_frontier = &self
+                    .controller
+                    .storage
+                    .collection(*id)
+                    .unwrap()
+                    .write_frontier;
+                assert!(
+                    !write_frontier.is_empty(),
+                    "write_frontier is empty in least_valid_write"
                 );
+                since.extend(write_frontier.iter().cloned());
             }
         }
         {

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -1153,6 +1153,13 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         }
         // Allow compaction only after emmitting peek commands.
         if !final_frontiers.is_empty() {
+            for (id, compaction_update) in final_frontiers.iter() {
+                if id.is_user() && compaction_update.is_empty() {
+                    panic!(
+                        "ComputeCommandHistory::reduce: final compaction update for {id} is empty"
+                    );
+                }
+            }
             self.commands.push(ComputeCommand::AllowCompaction(
                 final_frontiers.into_iter().collect(),
             ));

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1226,6 +1226,13 @@ where
             .filter(|(id, _)| self.storage_controller.collection(*id).is_ok())
             .map(|(id, bounds)| (*id, bounds.upper.clone()))
             .collect();
+
+        for (id, frontier_update) in storage_updates.iter() {
+            if id.is_user() && frontier_update.is_empty() {
+                panic!("ActiveInstate::update_write_frontiers: frontier update for {id} is empty");
+            }
+        }
+
         self.storage_controller
             .update_write_frontiers(&storage_updates)
             .await?;

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -1292,6 +1292,13 @@ where
             }
         }
         if !compaction_commands.is_empty() {
+            for (id, compaction_update) in compaction_commands.iter() {
+                if id.is_user() && compaction_update.is_empty() {
+                    panic!(
+                        "ActiveInstance::update_read_capabilities: compaction update for {id} is empty"
+                    );
+                }
+            }
             self.compute
                 .replicas
                 .send(ComputeCommand::AllowCompaction(compaction_commands));

--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -319,6 +319,14 @@ where
         }
 
         if !new_uppers.is_empty() {
+            for (id, frontier_update) in new_uppers.iter() {
+                if id.is_user() && frontier_update.upper.is_empty() {
+                    panic!(
+                        "ActiveReplicationState::remove_replica: frontier update for {id} is empty, uppers: {:?}", self.uppers
+                    );
+                }
+            }
+
             self.pending_response
                 .push_back(ActiveReplicationResponse::FrontierUppers(new_uppers));
         }
@@ -458,6 +466,12 @@ where
         }
 
         if !new_uppers.is_empty() {
+            for (id, frontier_update) in new_uppers.iter() {
+                if id.is_user() && frontier_update.upper.is_empty() {
+                    panic!("ActiveReplicationState::handle_frontier_uppers: frontier update for {id} is empty, uppers: {:?}", self.uppers);
+                }
+            }
+
             Some(ActiveReplicationResponse::FrontierUppers(new_uppers))
         } else {
             None
@@ -510,6 +524,12 @@ where
                 }
 
                 let frontier_updates = vec![(subscribe_id, entry.bounds.clone())];
+
+                for (id, frontier_update) in frontier_updates.iter() {
+                    if id.is_user() && frontier_update.upper.is_empty() {
+                        panic!("ActiveReplicationState::handle_subscribe_response: frontier update for {id} is empty, uppers: {:?}", self.uppers);
+                    }
+                }
                 self.pending_response
                     .push_back(ActiveReplicationResponse::FrontierUppers(frontier_updates));
 

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -237,6 +237,11 @@ where
                 if new_uppers.is_empty() {
                     None
                 } else {
+                    for (id, frontier_update) in new_uppers.iter() {
+                        if id.is_user() && frontier_update.is_empty() {
+                            panic!("PartitionedState::absorb_response: frontier update for {id} is empty");
+                        }
+                    }
                     Some(Ok(ComputeResponse::FrontierUppers(new_uppers)))
                 }
             }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -220,6 +220,11 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         }
 
         if !final_uppers.is_empty() {
+            for (id, frontier_update) in final_uppers.iter() {
+                if id.is_user() && frontier_update.is_empty() {
+                    panic!("ActiveComputeState::handle_allow_compaction: frontier update for {id} is empty");
+                }
+            }
             self.send_compute_response(ComputeResponse::FrontierUppers(final_uppers));
         }
     }
@@ -600,6 +605,11 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         }
 
         if !new_uppers.is_empty() {
+            for (id, frontier_update) in new_uppers.iter() {
+                if id.is_user() && frontier_update.is_empty() {
+                    panic!("ActiveComputeState::report_compute_frontier: frontier update for {id} is empty");
+                }
+            }
             self.send_compute_response(ComputeResponse::FrontierUppers(new_uppers));
         }
     }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -725,6 +725,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                                     // and compact its outputs to the dataflow's `as_of`.
                                     old_dataflows.remove(&export_ids);
                                     for id in export_ids.iter() {
+                                        if id.is_user()
+                                            && dataflow.as_of.as_ref().unwrap().is_empty()
+                                        {
+                                            tracing::info!("for {id}, dataflow.as_of inserted into old_compaction is empty");
+                                        }
                                         old_compaction.insert(*id, dataflow.as_of.clone().unwrap());
                                     }
                                     retain_ids.extend(export_ids);
@@ -764,6 +769,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     // We want to drop anything that has not yet been dropped,
                     // and nothing that has already been dropped.
                     if old_frontiers.get(&id) != Some(&&timely::progress::Antichain::default()) {
+                        if id.is_user() {
+                            tracing::info!(
+                                "for {id}, inserting empty frontier into old_compaction to drop it"
+                            );
+                        }
                         old_compaction.insert(id, timely::progress::Antichain::default());
                     }
                 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -774,7 +774,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                                 "for {id}, inserting empty frontier into old_compaction to drop it"
                             );
                         }
-                        old_compaction.insert(id, timely::progress::Antichain::default());
+                        // old_compaction.insert(id, timely::progress::Antichain::default());
                     }
                 }
             }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -769,6 +769,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
             }
             if !old_compaction.is_empty() {
+                for (id, compaction_update) in old_compaction.iter() {
+                    if id.is_user() && compaction_update.is_empty() {
+                        panic!("Worker::reconcile: old compaction update for {id} is empty");
+                    }
+                }
                 todo_commands.insert(
                     0,
                     ComputeCommand::AllowCompaction(old_compaction.into_iter().collect::<Vec<_>>()),

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -319,6 +319,12 @@ where
                 }
 
                 let empty_updates: &[((SourceData, ()), Timestamp, Diff)] = &[];
+
+                assert!(
+                    !write_lower_bound.is_empty(),
+                    "write_lower_bound is empty, in mint_batch_descriptions"
+                );
+
                 // It's fine if we don't succeed here. This just means that
                 // someone else already advanced the persist frontier further,
                 // which is great!

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -380,6 +380,11 @@ where
                 let desired_frontier = &frontiers[0];
                 let persist_frontier = &frontiers[1];
 
+                assert!(
+                    !desired_frontier.is_empty(),
+                    "desired frontier is empty, in mint_batch_descriptions"
+                );
+
                 if PartialOrder::less_than(&*shared_frontier.borrow(), persist_frontier) {
                     if sink_id.is_user() {
                         trace!(
@@ -1049,6 +1054,11 @@ where
                     let (batch_lower, batch_upper) = done_batch_metadata;
 
                     let mut to_append = batches.iter_mut().collect::<Vec<_>>();
+
+                    assert!(
+                        !batch_upper.is_empty(),
+                        "batch upper is empty, in append_batches"
+                    );
 
                     let result = write
                         .compare_and_append_batch(

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -607,6 +607,8 @@ impl<T: Timestamp + Lattice> Spine<T> {
         assert!(batch.lower() != batch.upper());
         assert_eq!(batch.lower(), &self.upper);
 
+        assert!(!batch.upper().is_empty(), "empty upper in Spine::insert");
+
         self.upper.clone_from(batch.upper());
 
         // If `batch` and the most recently inserted batch are both empty,

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1225,6 +1225,11 @@ where
         }
 
         for (id, new_upper) in collections {
+            if let Some(new_upper) = new_upper.as_ref() {
+                if id.is_user() && new_upper.is_empty() {
+                    panic!("StorageController::update_write_frontiers: frontier update for {id} is empty");
+                }
+            }
             let mut update = self
                 .generate_new_capability_for_collection(id, |c| {
                     if let Some(new_upper) = new_upper {

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -2106,6 +2106,7 @@ mod persist_write_handles {
 
                                             futs.push(async move {
                                                 let persist_upper = persist_upper.clone();
+                                                assert!(!new_upper.is_empty(), "new_upper is empty in controller::append");
                                                 let mut result =
                                                 write
                                                     .compare_and_append(
@@ -2127,6 +2128,7 @@ mod persist_write_handles {
                                                     if write.upper() == &persist_upper {
                                                         // If the upper frontier is the prior frontier, the commit
                                                         // did not happen and we should retry it.
+                                                        assert!(!new_upper.is_empty(), "new_upper is empty in controller::append");
                                                         result =
                                                         write
                                                             .compare_and_append(

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1229,6 +1229,11 @@ where
                 .generate_new_capability_for_collection(id, |c| {
                     if let Some(new_upper) = new_upper {
                         c.write_frontier.join_assign(new_upper);
+                        assert!(
+                            !c.write_frontier.is_empty(),
+                            "c.write_frontier is empty in update_write_frontiers, new_upper: {:?}",
+                            new_upper
+                        );
                     }
                 })
                 .expect("Collection previously validated to exist");
@@ -1490,6 +1495,10 @@ impl<T: Timestamp> CollectionState<T> {
     ) -> Self {
         let mut read_capabilities = MutableAntichain::new();
         read_capabilities.update_iter(since.iter().map(|time| (time.clone(), 1)));
+        assert!(
+            !write_frontier.is_empty(),
+            "write_frontier is empty in CollectionState::new",
+        );
         Self {
             description,
             read_capabilities,


### PR DESCRIPTION
**DON'T MERGE**: Just for sharing a reproduction of a bug.

While debugging https://github.com/MaterializeInc/materialize/issues/15185 I found that when the bug hits (as per Philips excellent repro instructions on the issue) the `upper` of the materialized view that has wrong data is _empty_.

It seems that the view is being dropped during reconciliation, which in turn makes `computed` report an empty `upper` back to the controller. You can peel back the layers of commits to see it fail at various points where I put in asserts that catch the empty upper.

The last commit adds a "fix", with this, you can see that the `upper` is no longer empty when the bug hits. It's not correct to do it like this, of course!