### PR TITLE
adapter: Add mz_introspection system user

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -107,7 +107,7 @@ pub static INTROSPECTION_USER: Lazy<User> = Lazy::new(|| User {
 });
 
 pub static INTERNAL_USER_NAMES: Lazy<BTreeSet<String>> = Lazy::new(|| {
-    vec![&SYSTEM_USER, &INTROSPECTION_USER]
+    [&SYSTEM_USER, &INTROSPECTION_USER]
         .into_iter()
         .map(|user| user.name.clone())
         .collect()

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -101,6 +101,18 @@ pub static SYSTEM_USER: Lazy<User> = Lazy::new(|| User {
     external_metadata: None,
 });
 
+pub static INTROSPECTION_USER: Lazy<User> = Lazy::new(|| User {
+    name: "mz_introspection".into(),
+    external_metadata: None,
+});
+
+pub static INTERNAL_USER_NAMES: Lazy<BTreeSet<String>> = Lazy::new(|| {
+    vec![&SYSTEM_USER, &INTROSPECTION_USER]
+        .into_iter()
+        .map(|user| user.name.clone())
+        .collect()
+});
+
 pub static HTTP_DEFAULT_USER: Lazy<User> = Lazy::new(|| User {
     name: "anonymous_http_user".into(),
     external_metadata: None,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -34,7 +34,7 @@ use mz_sql::catalog::{
 };
 use mz_storage::controller::IntrospectionType;
 
-use crate::catalog::{DEFAULT_CLUSTER_REPLICA_NAME, SYSTEM_USER};
+use crate::catalog::{DEFAULT_CLUSTER_REPLICA_NAME, INTROSPECTION_USER, SYSTEM_USER};
 
 pub const MZ_TEMP_SCHEMA: &str = "mz_temp";
 pub const MZ_CATALOG_SCHEMA: &str = "mz_catalog";
@@ -2468,6 +2468,10 @@ pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
     name: &*SYSTEM_USER.name,
 });
 
+pub static MZ_INTROSPECTION_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
+    name: &*INTROSPECTION_USER.name,
+});
+
 pub static MZ_SYSTEM_COMPUTE_INSTANCE: Lazy<BuiltinComputeInstance> =
     Lazy::new(|| BuiltinComputeInstance {
         name: &*SYSTEM_USER.name,
@@ -2479,14 +2483,15 @@ pub static MZ_SYSTEM_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =
         compute_instance_name: MZ_SYSTEM_COMPUTE_INSTANCE.name,
     });
 
-pub static MZ_INTROSPECTION: Lazy<BuiltinComputeInstance> = Lazy::new(|| BuiltinComputeInstance {
-    name: "mz_introspection",
-});
+pub static MZ_INTROSPECTION_COMPUTE_INSTANCE: Lazy<BuiltinComputeInstance> =
+    Lazy::new(|| BuiltinComputeInstance {
+        name: &*INTROSPECTION_USER.name,
+    });
 
-pub static MZ_INTROSPECTION_REPLICA: Lazy<BuiltinComputeReplica> =
+pub static MZ_INTROSPECTION_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =
     Lazy::new(|| BuiltinComputeReplica {
         name: DEFAULT_CLUSTER_REPLICA_NAME,
-        compute_instance_name: MZ_INTROSPECTION.name,
+        compute_instance_name: MZ_INTROSPECTION_COMPUTE_INSTANCE.name,
     });
 
 /// List of all builtin objects sorted topologically by dependency.
@@ -2699,11 +2704,20 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
 
     builtins
 });
-pub static BUILTIN_ROLES: Lazy<Vec<&BuiltinRole>> = Lazy::new(|| vec![&*MZ_SYSTEM_ROLE]);
-pub static BUILTIN_COMPUTE_INSTANCES: Lazy<Vec<&BuiltinComputeInstance>> =
-    Lazy::new(|| vec![&*MZ_SYSTEM_COMPUTE_INSTANCE, &*MZ_INTROSPECTION]);
-pub static BUILTIN_COMPUTE_REPLICAS: Lazy<Vec<&BuiltinComputeReplica>> =
-    Lazy::new(|| vec![&*MZ_SYSTEM_COMPUTE_REPLICA, &*MZ_INTROSPECTION_REPLICA]);
+pub static BUILTIN_ROLES: Lazy<Vec<&BuiltinRole>> =
+    Lazy::new(|| vec![&*MZ_SYSTEM_ROLE, &*MZ_INTROSPECTION_ROLE]);
+pub static BUILTIN_COMPUTE_INSTANCES: Lazy<Vec<&BuiltinComputeInstance>> = Lazy::new(|| {
+    vec![
+        &*MZ_SYSTEM_COMPUTE_INSTANCE,
+        &*MZ_INTROSPECTION_COMPUTE_INSTANCE,
+    ]
+});
+pub static BUILTIN_COMPUTE_REPLICAS: Lazy<Vec<&BuiltinComputeReplica>> = Lazy::new(|| {
+    vec![
+        &*MZ_SYSTEM_COMPUTE_REPLICA,
+        &*MZ_INTROSPECTION_COMPUTE_REPLICA,
+    ]
+});
 
 #[allow(non_snake_case)]
 pub mod BUILTINS {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -349,6 +349,12 @@ async fn migrate<S: Append>(
                 .insert(USER_VERSION.to_string(), ConfigValue { value: 0 })?;
             Ok(())
         },
+        // These three migrations were removed, but we need to keep empty migrations because the
+        // user version depends on the length of this array. New migrations should still go after
+        // these empty migrations.
+        |_, _| {},
+        |_, _| {},
+        |_, _| {},
         // Add new migrations above.
         //
         // Migrations should be preceded with a comment of the following form:

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -352,9 +352,9 @@ async fn migrate<S: Append>(
         // These three migrations were removed, but we need to keep empty migrations because the
         // user version depends on the length of this array. New migrations should still go after
         // these empty migrations.
-        |_, _| {},
-        |_, _| {},
-        |_, _| {},
+        |_, _| Ok(()),
+        |_, _| Ok(()),
+        |_, _| Ok(()),
         // Add new migrations above.
         //
         // Migrations should be preceded with a comment of the following form:

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -349,13 +349,6 @@ async fn migrate<S: Append>(
                 .insert(USER_VERSION.to_string(), ConfigValue { value: 0 })?;
             Ok(())
         },
-        |txn: &mut Transaction<'_, S>, _bootstrap_args| add_new_builtin_roles_migration(txn),
-        |txn: &mut Transaction<'_, S>, _bootstrap_args| {
-            add_new_builtin_compute_instances_migration(txn)
-        },
-        |txn: &mut Transaction<'_, S>, bootstrap_args| {
-            add_new_builtin_compute_replicas_migration(txn, bootstrap_args)
-        },
         // Add new migrations above.
         //
         // Migrations should be preceded with a comment of the following form:
@@ -384,6 +377,9 @@ async fn migrate<S: Append>(
         (migration)(&mut txn, bootstrap_args)?;
         txn.update_user_version(u64::cast_from(i))?;
     }
+    add_new_builtin_roles_migration(&mut txn)?;
+    add_new_builtin_compute_instances_migration(&mut txn)?;
+    add_new_builtin_compute_replicas_migration(&mut txn, bootstrap_args)?;
     txn.commit().await?;
     Ok(())
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -35,7 +35,7 @@ use tokio_postgres::config::Host;
 use tokio_postgres::Client;
 use tracing::info;
 
-use mz_adapter::catalog::SYSTEM_USER;
+use mz_adapter::catalog::{INTROSPECTION_USER, SYSTEM_USER};
 use mz_ore::assert_contains;
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO, SYSTEM_TIME};
 use mz_ore::retry::Retry;
@@ -1419,7 +1419,7 @@ fn test_linearizability() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_system_user() -> Result<(), Box<dyn Error>> {
+fn test_internal_users() -> Result<(), Box<dyn Error>> {
     mz_ore::test::init_logging();
 
     let config = util::Config::default();
@@ -1433,6 +1433,11 @@ fn test_system_user() -> Result<(), Box<dyn Error>> {
     assert!(server
         .pg_config_internal()
         .user(&SYSTEM_USER.name)
+        .connect(postgres::NoTls)
+        .is_ok());
+    assert!(server
+        .pg_config_internal()
+        .user(&INTROSPECTION_USER.name)
         .connect(postgres::NoTls)
         .is_ok());
     assert!(server

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -25,7 +25,7 @@ use tokio::select;
 use tokio::time::{self, Duration, Instant};
 use tracing::{debug, warn, Instrument};
 
-use mz_adapter::catalog::SYSTEM_USER;
+use mz_adapter::catalog::INTERNAL_USER_NAMES;
 use mz_adapter::session::User;
 use mz_adapter::session::{
     EndTransactionAction, ExternalUserMetadata, InProgressRows, Portal, PortalState,
@@ -124,8 +124,8 @@ where
     let user = params.remove("user").unwrap_or_else(String::new);
 
     if internal {
-        // The internal server can only be used to connect to the system user.
-        if user != SYSTEM_USER.name {
+        // The internal server can only be used to connect to the internal users.
+        if !INTERNAL_USER_NAMES.contains(&user) {
             let msg = format!("unauthorized login to user '{user}'");
             return conn
                 .send(ErrorResponse::fatal(SqlState::INSUFFICIENT_PRIVILEGE, msg))

--- a/test/sqllogictest/id_reuse.slt
+++ b/test/sqllogictest/id_reuse.slt
@@ -68,6 +68,7 @@ query TT rowsort
 SELECT id, name FROM mz_roles
 ----
 s1 mz_system
+s2 mz_introspection
 u1 materialize
 u2 foo
 
@@ -81,6 +82,7 @@ query TT rowsort
 SELECT id, name FROM mz_roles
 ----
 s1 mz_system
+s2 mz_introspection
 u1 materialize
 u3 bar
 

--- a/test/sqllogictest/pg_catalog_roles.slt
+++ b/test/sqllogictest/pg_catalog_roles.slt
@@ -13,4 +13,5 @@ query IT
 SELECT oid, rolname FROM pg_roles ORDER BY oid
 ----
 20007  mz_system
-20008  materialize
+20008  mz_introspection
+20009  materialize

--- a/test/testdrive/roles.td
+++ b/test/testdrive/roles.td
@@ -13,6 +13,7 @@ $ set-regex match=u\d{1,3} replacement=<RID>
 # Verify initial roles.
 > SELECT id, name FROM mz_roles
 s1 mz_system
+s2 mz_introspection
 <RID> materialize
 
 # Verify that invalid options are rejected.
@@ -30,6 +31,7 @@ contains:conflicting or redundant options
 > CREATE USER fms SUPERUSER
 > SELECT id, name FROM mz_roles
 s1 mz_system
+s2 mz_introspection
 <RID> materialize
 <RID> rj
 <RID> fms
@@ -40,6 +42,7 @@ s1 mz_system
 contains:unknown role 'bad'
 > SELECT id, name FROM mz_roles
 s1 mz_system
+s2 mz_introspection
 <RID> materialize
 <RID> rj
 <RID> fms
@@ -48,17 +51,20 @@ s1 mz_system
 > DROP ROLE IF EXISTS rj, fms, bad
 > SELECT id, name FROM mz_roles
 s1 mz_system
+s2 mz_introspection
 <RID> materialize
 
 # Verify that the single name version of DROP ROLE works too.
 > CREATE ROLE nlb LOGIN SUPERUSER
 > SELECT id, name FROM mz_roles
 s1 mz_system
+s2 mz_introspection
 <RID> materialize
 <RID> nlb
 > DROP ROLE nlb
 > SELECT id, name FROM mz_roles
 s1 mz_system
+s2 mz_introspection
 <RID> materialize
 > DROP ROLE IF EXISTS nlb
 

--- a/test/upgrade/check-from-v0.27.0-role.td
+++ b/test/upgrade/check-from-v0.27.0-role.td
@@ -9,6 +9,7 @@
 
 > SELECT name FROM mz_roles;
 mz_system
+mz_introspection
 materialize
 superuser_login
 "space role"


### PR DESCRIPTION
Works towards resolving #15520

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
