### PR TITLE
doc/user: polish v0.28.0 release notes

### DIFF
--- a/doc/user/content/ops/static-ips.md
+++ b/doc/user/content/ops/static-ips.md
@@ -1,0 +1,50 @@
+---
+title: "Static IP addresses"
+description: "Materialize uses static IP addresses for outbound connections from sources and sinks"
+menu:
+  main:
+    parent: ops
+    weight: 80
+---
+
+Your Materialize region initiates connections from a static set of IP addresses.
+When connecting Materialize to services in your private networks (e.g., Kafka
+clusters or PostgreSQL databases), you must configure any firewalls to allow
+connections from these IP addresses.
+
+# Details
+
+Your Materialize region is associated with a static set of egress IP addresses.
+Most regions have four egress IP addresses, but this is not guaranteed. All
+connections to the public internet initiated by a source or sink in your region
+will originate from one of these egress IP addresses.
+
+We do not allocate unique IP addresses for each Materialize region. Multiple
+regions may share the same egress IP addresses.
+
+When connecting Materialize to services in your private networks (e.g., Kafka
+clusters or PostgreSQL databases), you must configure any firewalls to allow
+connections from your region's egress IP addresses. You must allow connections
+from all egress IP addresses associated with your region. Connections may
+originate from any one of the egress IP addresses.
+
+To find the egress IP addresses associated with your region, you can query the
+[`mz_egress_ips`](/sql/system-catalog/mz_catalog/#mz_egress_ips) system table.
+
+{{< note >}}
+On rare occasion, we may need to change the egress IP addresses associated with
+a region. We make every effort to provide advance notice of such changes.
+{{< /note >}}
+
+
+# Example
+
+Show the static egress IPs associated with a region:
+
+```sql
+SELECT * FROM mz_egress_ips;
+   egress_ip
+----------------
+ 1.2.3.4
+ 5.6.7.8
+```

--- a/doc/user/content/releases/v0.27.md
+++ b/doc/user/content/releases/v0.27.md
@@ -1,7 +1,8 @@
 ---
-title: "Materialize v0.27.0"
+title: "Materialize v0.27"
 date: 2022-10-12
 released: true
+aliases: v0.27.0
 ---
 
 v0.27.0 is the first cloud-native release of Materialize. It contains

--- a/doc/user/content/releases/v0.28.md
+++ b/doc/user/content/releases/v0.28.md
@@ -1,0 +1,77 @@
+---
+title: "Materialize v0.28"
+date: 2022-10-19
+released: true
+patch: 4
+---
+
+## Changes
+
+* Use [static IPs](/ops/static-ips/) when initiating connections from sources
+  and sinks. You can use these IPs in your firewall configuration to authorize
+  connections from your Materialize region.
+
+* Improve the syntax for [`CREATE CONNECTION`](/sql/create-connection). The
+  `FROM` keyword was replaced with `TO`, and the option list must now be
+  enclosed in parenthesis.
+
+  **New syntax**
+
+  ```sql
+  CREATE CONNECTION kafka_connection TO KAFKA (
+    BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092',
+    SASL MECHANISMS = 'SCRAM-SHA-256',
+    SASL USERNAME = 'foo',
+    SASL PASSWORD = SECRET kafka_password
+  );
+  ```
+
+  **Old syntax**
+
+  ```sql
+  CREATE CONNECTION kafka_connection FOR KAFKA
+    BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092',
+    SASL MECHANISMS = 'SCRAM-SHA-256',
+    SASL USERNAME = 'foo',
+    SASL PASSWORD = SECRET kafka_password;
+  ```
+
+  The old syntax is still supported for backwards compatibility, but its use is
+  discouraged.
+
+* Improve the usability of the `EXPLAIN` command. For an overview of the new
+  `EXPLAIN` syntax, check the [updated documentation](/sql/explain/).
+
+* Include all indexes when running the [`SHOW INDEXES`](/sql/show-indexes)
+  command, regardless of the number of columns. Previously, `SHOW INDEXES`
+  would omit any indexes with 0 columns.
+
+* Include all indexes when a schema is specified using `SHOW INDEXES ON`.
+  Previously, the command would not correctly display existing indexes in
+  non-active schemas.
+
+* Add a default index for all `SHOW` commands in the
+  [`mz_introspection`](/sql/show-clusters/#mz_introspection-system-cluster)
+  cluster. For the best performance when executing `SHOW` commands, switch to
+  the `mz_introspection` cluster using:
+
+  ```sql
+  SET CLUSTER = mz_introspection;
+  ```
+
+* Correctly use the `char` type for `pg_type.typcategory`. Previously,
+  `typcategory` used the `text` type, which caused errors in language drivers
+  that expect the documented `char` type, like sqlx.
+
+* Add the [`mz_introspection` system
+  cluster](/sql/show-clusters/#mz_introspection-system-cluster) to support
+  efficiently serving common introspection queries.
+
+* Add the [`mz_system` system
+  cluster](/sql/show-clusters/#mz_system-system-cluster) to support various
+  internal system tasks.
+
+* **Breaking change.** Change the type of a materialized view in the
+  `mz_objects` relation from `materialized view` to `materialized-view`, for
+  consistency with how multi-word types are represented elsewhere in the
+  catalog.

--- a/doc/user/content/releases/v0.29.md
+++ b/doc/user/content/releases/v0.29.md
@@ -1,6 +1,6 @@
 ---
-title: "Materialize v0.28.0"
-date: 2022-10-19
+title: "Materialize v0.29"
+date: 2022-10-26
 released: false
 ---
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -9,11 +9,55 @@ menu:
 
 {{< show-command-note >}}
 
-`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize. A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time.
+`SHOW CLUSTERS` lists the [clusters](/overview/key-concepts/#clusters) configured in Materialize.
 
 ## Syntax
 
 {{< diagram "show-clusters.svg" >}}
+
+## Pre-installed clusters
+
+Materialize has several pre-installed clusters.
+
+### Default cluster
+
+A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time.
+
+The `default` cluster is the default value for the `cluster` session parameter.
+If you drop the default cluster, each connection to Materialize will need to run
+[`SET CLUSTER`](/sql/select/#ad-hoc-queries) to choose a valid cluster in order
+to run `SELECT` queries.
+
+### `mz_introspection` system cluster
+
+The `mz_introspection` cluster has several indexes installed by default that
+speed up common `SHOW` statements. You are not billed for this cluster.
+It has the following restrictions:
+
+  * You cannot create indexes or materialized views on this cluster.
+  * You cannot drop this cluster.
+
+You are, however, are permitted to run `SELECT` or `SUBSCRIBE` statements on
+this cluster.
+
+You are encouraged to use this cluster when running queries against the
+system catalog:
+
+```sql
+SET cluster = mz_introspection;
+SELECT * FROM mz_sources;
+SHOW CLUSTERS;
+```
+
+### `mz_system` system cluster
+
+The `mz_system` cluster is used for various internal system tasks. You are not
+billed for this cluster. You are not permitted to use this cluster.
+Specifically:
+
+  * You cannot create indexes or materialized views on this cluster.
+  * You cannot drop this cluster.
+  * You cannot run `SELECT` or `SUBSCRIBE` on this cluster.
 
 ## Examples
 

--- a/doc/user/layouts/shortcodes/alpha.html
+++ b/doc/user/layouts/shortcodes/alpha.html
@@ -7,5 +7,5 @@
   <br><br>
   You must
   <a href="https://materialize.com/contact/">contact us</a>
-  to enable this feature in your Materialize Cloud region.
+  to enable this feature in your Materialize region.
 </div>

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -34,10 +34,12 @@ def released_materialize_versions() -> List[Version]:
     The list is returned in version order with newest versions first.
     """
     files = Path(ROOT / "doc" / "user" / "content" / "releases").glob("v*.md")
-    versions = [
-        Version.parse(f.stem.lstrip("v"))
-        for f in files
-        if frontmatter.load(f).get("released", False)
-    ]
+    versions = []
+    for f in files:
+        base = f.stem.lstrip("v")
+        metadata = frontmatter.load(f)
+        if metadata.get("released", False):
+            patch = metadata.get("patch", 0)
+            versions.append(Version.parse(f"{base}.{patch}"))
     versions.sort(reverse=True)
     return versions


### PR DESCRIPTION
Flesh out the `v0.28.0` release notes. I'd still like to add an overview of the improvements to the `EXPLAIN` syntax, but would rather unblock this task for the time being!