### PR TITLE
Fix handling of peeks in the compute controller

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -491,7 +491,6 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 self.controller
                     .active_compute()
                     .cancel_peeks(compute_instance, uuids)
-                    .await
                     .unwrap();
             }
 

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -928,6 +928,9 @@ pub struct Peek<T = mz_repr::Timestamp> {
     ///
     /// If `Some`, the peek is only handled by the given replica.
     /// If `None`, the peek is handled by all replicas.
+    ///
+    /// TODO(teskje): Now that this is handled in `ActiveReplication`, we should remove this field
+    /// from the compute command and pass it only to `ActiveReplication`, not to compute instances.
     pub target_replica: Option<ReplicaId>,
     /// An `OpenTelemetryContext` to forward trace information along
     /// to the compute worker to allow associating traces between

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -649,12 +649,13 @@ where
     ///   * A `PeekResponse::Canceled` affirming that the peek was canceled.
     ///
     ///   * No `PeekResponse` at all.
-    pub async fn cancel_peeks(
+    pub fn cancel_peeks(
         &mut self,
         instance_id: ComputeInstanceId,
         uuids: BTreeSet<Uuid>,
     ) -> Result<(), ComputeError> {
-        self.instance(instance_id)?.cancel_peeks(uuids).await
+        self.instance(instance_id)?.cancel_peeks(uuids);
+        Ok(())
     }
 
     /// Assign a read policy to specific identifiers.
@@ -1107,12 +1108,10 @@ where
     }
 
     /// Cancels existing peek requests.
-    async fn cancel_peeks(&mut self, uuids: BTreeSet<Uuid>) -> Result<(), ComputeError> {
-        self.remove_peeks(&uuids).await?;
+    fn cancel_peeks(&mut self, uuids: BTreeSet<Uuid>) {
         self.compute
             .replicas
             .send(ComputeCommand::CancelPeeks { uuids });
-        Ok(())
     }
 
     /// Assigns a read policy to specific identifiers.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -226,13 +226,6 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     fn handle_peek(&mut self, peek: Peek) {
-        // Only handle peeks that are not targeted at a different replica.
-        if let Some(target) = peek.target_replica {
-            if target != self.compute_state.replica_id {
-                return;
-            }
-        }
-
         // Acquire a copy of the trace suitable for fulfilling the peek.
         let mut trace_bundle = self.compute_state.traces.get(&peek.id).unwrap().clone();
         let timestamp_frontier = Antichain::from_elem(peek.timestamp);


### PR DESCRIPTION
TODO 

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
