### PR TITLE
storage: use async operator builder for the remap operator

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -23,7 +23,6 @@
 #![allow(missing_docs)]
 
 use std::any::Any;
-use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::pin::Pin;
@@ -34,8 +33,6 @@ use std::time::{Duration, Instant};
 use differential_dataflow::Hashable;
 use futures::future::Either;
 use itertools::Itertools;
-use mz_timely_util::builder_async::Event;
-use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
@@ -56,7 +53,9 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{GlobalId, Timestamp};
+use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 use mz_timely_util::operator::StreamExt as _;
+use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::controller::{CollectionMetadata, ResumptionFrontierCalculator};
 use crate::source::antichain::MutableOffsetAntichain;
@@ -113,6 +112,7 @@ pub struct RawSourceCreationConfig {
 
 /// A batch of messages from a source reader, along with the batch upper, the
 /// current source upper, and any errors that occurred while reading that batch.
+#[derive(Clone)]
 struct SourceMessageBatch<Key, Value, Diff> {
     messages: HashMap<PartitionId, Vec<(SourceMessage<Key, Value, Diff>, MzOffset)>>,
     /// Any errors that occurred while obtaining this batch. These errors should
@@ -455,10 +455,7 @@ pub enum HealthStatus {
 type WorkerId = usize;
 
 struct SourceReaderStreams<G: Scope<Timestamp = Timestamp>, S: SourceReader> {
-    batches: timely::dataflow::Stream<
-        G,
-        Rc<RefCell<Option<SourceMessageBatch<S::Key, S::Value, S::Diff>>>>,
-    >,
+    batches: timely::dataflow::Stream<G, SourceMessageBatch<S::Key, S::Value, S::Diff>>,
     batch_upper_summaries: timely::dataflow::Stream<G, BatchUpperSummary>,
     health_stream: timely::dataflow::Stream<G, (WorkerId, HealthStatus)>,
 }
@@ -721,8 +718,6 @@ where
                         batch_upper: batch_upper.clone(),
                         batch_lower,
                     };
-                    // Wrap in an Rc to avoid cloning when sending it on.
-                    let message_batch = Rc::new(RefCell::new(Some(message_batch)));
 
                     let cap = cap_set.delayed(&emit_ts);
                     {
@@ -772,32 +767,30 @@ where
                 let mut summary_output = summary_output.activate();
                 let mut health_output = health_output.activate();
 
-                for (message_batch, source_upper) in buffer.drain(..) {
-                    if let Some(batch) = &*message_batch.borrow() {
-                        let has_errors = batch.source_errors.first();
-                        let has_messages = batch.messages.values().any(|vs| !vs.is_empty());
+                for (batch, source_upper) in buffer.drain(..) {
+                    let has_errors = batch.source_errors.first();
+                    let has_messages = batch.messages.values().any(|vs| !vs.is_empty());
 
-                        let maybe_health = match (has_errors, has_messages) {
-                            (Some(error), _) => {
-                                // Arguably this case should be "failed", since generally a source
-                                // cannot recover by the time an error reaches this far down the pipe.
-                                // However, we don't actually shut down the source on error yet, so
-                                // treating this as a possibly-temporary stall for now.
-                                Some(HealthStatus::StalledWithError(error.error.to_string()))
-                            }
-                            (_, true) => Some(HealthStatus::Running),
-                            (None, false) => None,
-                        };
-
-                        if let Some(health) = maybe_health {
-                            let health_cap = cap.delayed_for_output(cap.time(), health_output_port);
-                            let mut session = health_output.session(&health_cap);
-                            session.give((config.worker_id, health));
+                    let maybe_health = match (has_errors, has_messages) {
+                        (Some(error), _) => {
+                            // Arguably this case should be "failed", since generally a source
+                            // cannot recover by the time an error reaches this far down the pipe.
+                            // However, we don't actually shut down the source on error yet, so
+                            // treating this as a possibly-temporary stall for now.
+                            Some(HealthStatus::StalledWithError(error.error.to_string()))
                         }
+                        (_, true) => Some(HealthStatus::Running),
+                        (None, false) => None,
+                    };
+
+                    if let Some(health) = maybe_health {
+                        let health_cap = cap.delayed_for_output(cap.time(), health_output_port);
+                        let mut session = health_output.session(&health_cap);
+                        session.give((config.worker_id, health));
                     }
 
                     let mut session = batch_output.session(&cap);
-                    session.give(message_batch);
+                    session.give(batch);
 
                     let summary_cap = cap.delayed_for_output(cap.time(), summary_output_port);
                     let mut session = summary_output.session(&summary_cap);
@@ -932,7 +925,7 @@ where
     let active_worker = chosen_worker == worker_id;
 
     let operator_name = format!("remap({})", id);
-    let mut remap_op = OperatorBuilder::new(operator_name, scope.clone());
+    let mut remap_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
     let (mut remap_output, remap_stream) = remap_op.new_output();
 
     let mut input = remap_op.new_input_connection(
@@ -944,7 +937,7 @@ where
         vec![Antichain::new()],
     );
 
-    let _resume_input = remap_op.new_input_connection(
+    let mut resume_input = remap_op.new_input_connection(
         resume_stream,
         Pipeline,
         // We don't need this to participate in progress
@@ -953,192 +946,173 @@ where
         vec![Antichain::new()],
     );
 
-    let token = Rc::new(());
-    let token_weak = Rc::downgrade(&token);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
-    // TODO(guswynn): figure out how to make this a native async operator without problems
-    remap_op.build_async(
-        scope.clone(),
-        move |mut capabilities, frontiers, scheduler| async move {
-            let mut buffer = Vec::new();
-            let mut cap_set = if active_worker {
-                CapabilitySet::from_elem(capabilities.pop().expect("missing capability"))
-            } else {
-                CapabilitySet::new()
-            };
-            // Explicitly release the unneeded capabilities!
-            capabilities.clear();
+    remap_op.build(move |capabilities| async move {
+        if !active_worker {
+            return;
+        }
 
-            let upper_ts = resume_upper.as_option().copied().unwrap();
+        let mut buffer = Vec::new();
+        let mut cap_set = CapabilitySet::from_elem(
+            capabilities
+                .into_iter()
+                .exactly_one()
+                .expect("there should be exactly as many capabilities as outputs"),
+        );
 
-            // Same value as our use of `derive_new_compaction_since`.
-            let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
-            let mut timestamper = match ReclockOperator::new(
-                Arc::clone(&persist_clients),
-                storage_metadata.clone(),
-                now.clone(),
-                timestamp_interval.clone(),
-                as_of,
-                id,
-                "remap",
-                worker_id,
-                worker_count,
-            )
-            .await
-            {
-                Ok(t) => t,
-                Err(e) => {
-                    panic!("Failed to create source {} timestamper: {:#}", name, e);
-                }
-            };
-            // The global view of the source_upper, which we track by combining
-            // summaries from the raw reader operators.
-            let mut global_source_upper = timestamper
-                .source_upper_at_frontier(resume_upper.borrow())
-                .expect("source_upper_at_frontier to be used correctly");
+        let upper_ts = resume_upper.as_option().copied().unwrap();
 
-            if active_worker {
-                let new_ts_upper = timestamper
-                    .reclock_frontier(&global_source_upper)
-                    .expect("compacted past upper");
-
-                cap_set.downgrade(new_ts_upper);
-
-                // Emit initial snapshot of the remap_shard, bootstrapping
-                // downstream reclock operators.
-                let remap_trace = timestamper.remap_trace();
-                trace!(
-                    "remap({id}) {worker_id}/{worker_count}: \
-                    emitting initial remap_trace. \
-                    source_upper: {:?} \
-                    trace_updates: {:?}",
-                    global_source_upper,
-                    remap_trace
-                );
-
-                let mut remap_output = remap_output.activate();
-                let cap = cap_set.delayed(cap_set.first().unwrap());
-                let mut session = remap_output.session(&cap);
-                session.give(remap_trace);
+        // Same value as our use of `derive_new_compaction_since`.
+        let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
+        let mut timestamper = match ReclockOperator::new(
+            Arc::clone(&persist_clients),
+            storage_metadata.clone(),
+            now.clone(),
+            timestamp_interval,
+            as_of,
+            id,
+            "remap",
+            worker_id,
+            worker_count,
+        )
+        .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                panic!("Failed to create source {} timestamper: {:#}", name, e);
             }
+        };
+        // The global view of the source_upper, which we track by combining
+        // summaries from the raw reader operators.
+        let mut global_source_upper = timestamper
+            .source_upper_at_frontier(resume_upper.borrow())
+            .expect("source_upper_at_frontier to be used correctly");
 
-            // The last frontier we compacted the remap shard to, starting at [0].
-            let mut last_compaction_since = Antichain::from_elem(Timestamp::minimum());
+        let new_ts_upper = timestamper
+            .reclock_frontier(&global_source_upper)
+            .expect("compacted past upper");
 
-            while scheduler.notified().await {
-                if token_weak.upgrade().is_none() {
-                    // Make sure we don't accidentally mint new updates when
-                    // this source has been dropped. This way, we also make sure
-                    // to not react to spurious frontier advancements to `[]`
-                    // that happen when the input source operator is shutting
-                    // down.
-                    return;
-                }
+        cap_set.downgrade(new_ts_upper);
 
-                if !active_worker {
-                    // We simply loop because we cannot return here. Otherwise
-                    // the one active worker would not get frontier upgrades
-                    // anymore or other things could break.
-                    //
-                    // TODO: Get rid of this once the async operator wrapper is
-                    // fixed.
-                    continue;
-                }
+        // Emit initial snapshot of the remap_shard, bootstrapping
+        // downstream reclock operators.
+        let remap_trace = timestamper.remap_trace();
+        trace!(
+            "remap({id}) {worker_id}/{worker_count}: \
+                emitting initial remap_trace. \
+                source_upper: {:?} \
+                trace_updates: {:?}",
+            global_source_upper,
+            remap_trace
+        );
 
-                // Wait until we know that we can mint new bindings. Any new
-                // summaries that we read from out input would not show up in
-                // the remap shard until that time anyways.
-                if let Err(wait_time) = timestamper.next_mint_timestamp() {
-                    tokio::time::sleep(wait_time).await;
-                }
+        // Out of an abundance of caution, do not hold the output handle
+        // across an await, and drop it before we downgrade the capability.
+        {
+            let mut remap_output = remap_output.activate();
+            let cap = cap_set.delayed(cap_set.first().unwrap());
+            let mut session = remap_output.session(&cap);
+            session.give(remap_trace);
+        }
 
-                // Every time we are woken up, we also attempt to compact the remap shard,
-                // but only if it has actually made progress. Note that resumption frontier
-                // progress does not drive this operator forward, only source upper updates
-                // from the source_reader_operator does.
-                //
-                // Note that we choose to compact to WELL before the resumption
-                // frontier, to paper over some subtle `as_of` < `since` bugs we
-                // are seeing.
-                // TODO(guswynn|aljoscha): figure out what is going on here.
-                //
-                // Also note this can happen BEFORE we inspect the input. This is somewhat
-                // of an oddity in the timely world, but this frontier can ONLY advance
-                // past the input AFTER the output capability of this operator itself has
-                // been downgraded (which drives the data shard upper), AND the
-                // remap shard has been advanced below.
-                //
-                // This extra block is necessary to avoid holding a `RefCell` across an await,
-                // or at least convincing clippy of this fact.
-                let resumption_frontier: Antichain<Timestamp> = {
-                    let f = frontiers.borrow();
-                    f[1].clone()
-                };
-                if let Some(new_compaction_since) = derive_new_compaction_since(
-                    resumption_frontier,
-                    &last_compaction_since,
-                    // Choose a `since` as aggresively as possible
-                    1,
-                    id,
-                    "remap",
-                    worker_id,
-                    worker_count,
-                ) {
-                    timestamper.compact(new_compaction_since.clone()).await;
-                    last_compaction_since = new_compaction_since;
-                }
+        // The last frontier we compacted the remap shard to, starting at [0].
+        let mut last_compaction_since = Antichain::from_elem(Timestamp::default());
 
-                input.for_each(|_cap, data| {
-                    data.swap(&mut buffer);
-
-                    for batch_upper_summary in buffer.drain(..) {
-                        for (pid, offset) in batch_upper_summary.batch_upper.iter() {
-                            global_source_upper.maybe_insert(pid.clone(), *offset);
-                        }
+        tokio::pin!(shutdown_rx);
+        let mut input_frontier = Antichain::from_elem(Timestamp::default());
+        loop {
+            // AsyncInputHandle::next is cancel safe
+            tokio::select! {
+                biased;
+                // Make sure we don't accidentally mint new updates when this source has
+                // been dropped. This way, we also make sure to not react to spurious
+                // frontier advancements to `[]` that happen when the input source operator
+                // is shutting down.
+                _ = shutdown_rx.as_mut() => return,
+                _ = async {
+                    if let Err(wait_time) = timestamper.next_mint_timestamp() {
+                        tokio::time::sleep(wait_time).await;
                     }
-                });
+                } => {
+                    let remap_trace_updates = timestamper.mint(&global_source_upper).await;
 
-                let remap_trace_updates = timestamper.mint(&global_source_upper).await;
+                    timestamper.advance().await;
+                    let new_ts_upper = timestamper
+                        .reclock_frontier(&global_source_upper)
+                        .expect("compacted past upper");
 
-                timestamper.advance().await;
-                let new_ts_upper = timestamper
-                    .reclock_frontier(&global_source_upper)
-                    .expect("compacted past upper");
+                    trace!(
+                        "remap({id}) {worker_id}/{worker_count}: minted new bindings. \
+                        source_upper: {:?} \
+                        trace_updates: {:?} \
+                        new_ts_upper: {:?}",
+                        global_source_upper,
+                        remap_trace_updates,
+                        new_ts_upper
+                    );
 
-                trace!(
-                    "remap({id}) {worker_id}/{worker_count}: minted new bindings. \
-                    source_upper: {:?} \
-                    trace_updates: {:?} \
-                    new_ts_upper: {:?}",
-                    global_source_upper,
-                    remap_trace_updates,
-                    new_ts_upper
-                );
+                    // Out of an abundance of caution, do not hold the output handle
+                    // across an await, and drop it before we downgrade the capability.
+                    {
+                        let mut remap_output = remap_output.activate();
+                        let cap = cap_set.delayed(cap_set.first().unwrap());
+                        let mut session = remap_output.session(&cap);
+                        session.give(remap_trace_updates);
+                    }
 
-                // Out of an abundance of caution, do not hold the output handle
-                // across an await, and drop it before we downgrade the capability.
-                {
-                    let mut remap_output = remap_output.activate();
-                    let cap = cap_set.delayed(cap_set.first().unwrap());
-                    let mut session = remap_output.session(&cap);
-                    session.give(remap_trace_updates);
+                    cap_set.downgrade(new_ts_upper);
+
+                    // Make sure we do this after writing any timestamp bindings to
+                    // the remap shard that might be needed for the reported source
+                    // uppers.
+                    if input_frontier.is_empty() {
+                        cap_set.downgrade(&[]);
+                        return;
+                    }
                 }
-
-                cap_set.downgrade(new_ts_upper);
-
-                // Make sure we do this after writing any timestamp bindings to
-                // the remap shard that might be needed for the reported source
-                // uppers.
-                let input_frontier = &frontiers.borrow()[0];
-                if input_frontier.is_empty() {
-                    cap_set.downgrade(&[]);
-                    return;
+                Some(Event::Progress(resumption_frontier)) = resume_input.next() => {
+                    // Ccompact the remap shard, but only if it has actually made progress. Note
+                    // that resumption frontier progress does not drive this operator forward, only
+                    // source upper updates from the source_reader_operator does.
+                    //
+                    // Also note this can happen BEFORE we inspect the input. This is somewhat
+                    // of an oddity in the timely world, but this frontier can ONLY advance
+                    // past the input AFTER the output capability of this operator itself has
+                    // been downgraded (which drives the data shard upper), AND the
+                    // remap shard has been advanced below.
+                    if let Some(new_compaction_since) = derive_new_compaction_since(
+                        resumption_frontier,
+                        &last_compaction_since,
+                        // Choose a `since` as aggresively as possible
+                        1,
+                        id,
+                        "remap",
+                        worker_id,
+                        worker_count,
+                    ) {
+                        timestamper.compact(new_compaction_since.clone()).await;
+                        last_compaction_since = new_compaction_since;
+                    }
                 }
+                Some(event) = input.next() => match event {
+                    Event::Data(_cap, data) => {
+                        data.swap(&mut buffer);
+                        for batch_upper_summary in buffer.drain(..) {
+                            for (pid, offset) in batch_upper_summary.batch_upper.iter() {
+                                global_source_upper.maybe_insert(pid.clone(), *offset);
+                            }
+                        }
+                    },
+                    Event::Progress(frontier) => {
+                        input_frontier = frontier;
+                    }
+                },
             }
-        },
-    );
+        }
+    });
 
-    (remap_stream, token)
+    (remap_stream, Rc::new(shutdown_tx))
 }
 
 /// Receives un-timestamped batches from the source reader and updates to the
@@ -1148,10 +1122,7 @@ fn reclock_operator<G, S: 'static>(
     scope: &G,
     config: RawSourceCreationConfig,
     timestamper: ReclockFollower,
-    batches: timely::dataflow::Stream<
-        G,
-        Rc<RefCell<Option<SourceMessageBatch<S::Key, S::Value, S::Diff>>>>,
-    >,
+    batches: timely::dataflow::Stream<G, SourceMessageBatch<S::Key, S::Value, S::Diff>>,
     remap_trace_updates: timely::dataflow::Stream<
         G,
         HashMap<PartitionId, Vec<(Timestamp, MzOffset)>>,
@@ -1240,11 +1211,6 @@ where
             batch_input.for_each(|cap, data| {
                 data.swap(&mut batch_buffer);
                 for batch in batch_buffer.drain(..) {
-                    let batch = batch
-                        .borrow_mut()
-                        .take()
-                        .expect("batch already taken, but we should be the only consumer");
-
                     trace!(
                         "reclock({id}) {worker_id}/{worker_count}: \
                         stashing update for global_source_upper: {:?}",

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -222,7 +222,7 @@ pub enum SourceMessageType<Key, Value, Diff> {
 
 /// Source-agnostic wrapper for messages. Each source must implement a
 /// conversion to Message.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SourceMessage<Key, Value, Diff> {
     /// The output stream this message belongs to. Later in the pipeline the stream is partitioned
     /// based on this value and is fed to the appropriate source exports


### PR DESCRIPTION
### Motivation

It's unclear if this was the cause of https://github.com/MaterializeInc/materialize/issues/15155 but the code this PR touches was written in a way that had the possibility of stalling the whole ingestion pipeline where timestamps would appear to stop advancing.

The old timely/async integration can only function correctly if the logic future only contains await points after it has seen updates to its input handles (either data or frontier updates). The remap operator however wants to process its inputs separately from producing its outputs, which happens on a timer.

This PR switches the implementation to the new timely/async integration which has no such limitations and the logic future can await at any point. Eventually all uses of the old timely/async integration in the codebase will be replaced and the old integration will be removed.


I also changed something that is unrelated to the async integration but seemed big enough of a footgun to bundle it here. We were using internal mutability over the data transfered through timely to avoid clones. Timely only clones values when they go from the output of one operator to the inputs of two or more operators. If the connection is one to one no clones are happening.
https://github.com/TimelyDataflow/timely-dataflow/blob/9548bf9c53418284a811ffc0d397d3d9c26c78ff/timely/src/dataflow/channels/pushers/tee.rs#L25-L43

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
