### PR TITLE
doc/user: Consolidate pagerank to 10-90 system

### DIFF
--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: "Key concepts"
 description: "Understand Materialize's architecture."
-pagerank: 5
+pagerank: 30
 menu:
   main:
     parent: 'overview'

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE CLUSTER REPLICA"
 description: "`CREATE CLUSTER REPLICA` provisions physical resources to perform computations."
-pagerank: 20
+pagerank: 50
 menu:
   main:
     parent: commands

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE CLUSTER"
 description: "`CREATE CLUSTER` creates a logical cluster, which contains indexes."
-pagerank: 10
+pagerank: 40
 menu:
   main:
     parent: commands

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE CONNECTION"
 description: "`CREATE CONNECTION` describes how to connect and authenticate to an external system in Materialize"
-pagerank: 10
+pagerank: 40
 menu:
   main:
     parent: 'commands'

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE MATERIALIZED VIEW"
 description: "`CREATE MATERIALIZED VIEW` defines a view that is persisted in durable storage and incrementally updated as new data arrives."
-pagerank: 10
+pagerank: 40
 menu:
   main:
     parent: 'commands'

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE SINK"
 description: "`CREATE SINK` sends data from Materialize to an external sink."
-pagerank: 10
+pagerank: 40
 menu:
   # This should also have a "non-content entry" under Connect, which is
   # configured in doc/user/config.toml

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -2,7 +2,7 @@
 title: "CREATE SOURCE"
 description: "`CREATE SOURCE` connects Materialize to an external data source."
 disable_list: true
-pagerank: 10
+pagerank: 30
 menu:
   main:
     parent: reference

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE SOURCE: Kafka"
 description: "Connecting Materialize to a Kafka or Redpanda broker"
-pagerank: 10
+pagerank: 40
 menu:
   main:
     parent: 'create-source'

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -1,7 +1,7 @@
 ---
 title: "CREATE SOURCE: PostgreSQL"
 description: "Connecting Materialize to a PostgreSQL database"
-pagerank: 10
+pagerank: 40
 menu:
   main:
     parent: 'create-source'


### PR DESCRIPTION
### Motivation

In their infinite wisdom, Algolia developers require the "pagerank" attribute to be a "any numeric value, including negatives of type: string"
<img width="955" alt="image" src="https://user-images.githubusercontent.com/11527560/196821536-34bfe65e-0d1f-49b4-832f-da49b1cb0ac7.png">
https://docsearch.algolia.com/docs/record-extractor/#boost-search-results-with-pagerank

I carelessly assumed that 5 is less than 10.

This PR updates pagerank values to follow a 10-90 scale that should be ok when sorted as a string.

