### PR TITLE
persist: fallback to rebuild spine before applying diffs

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -860,6 +860,7 @@ impl CodecMetrics {
 pub struct StateMetrics {
     pub(crate) apply_spine_fast_path: IntCounter,
     pub(crate) apply_spine_slow_path: IntCounter,
+    pub(crate) apply_spine_slow_path_with_reconstruction: IntCounter,
     pub(crate) update_state_fast_path: IntCounter,
     pub(crate) update_state_slow_path: IntCounter,
     pub(crate) rollup_at_seqno_migration: IntCounter,
@@ -875,6 +876,10 @@ impl StateMetrics {
             apply_spine_slow_path: registry.register(metric!(
                 name: "mz_persist_state_apply_spine_slow_path",
                 help: "count of spine diff applications that hit the slow path",
+            )),
+            apply_spine_slow_path_with_reconstruction: registry.register(metric!(
+                name: "mz_persist_state_apply_spine_slow_path_with_reconstruction",
+                help: "count of spine diff applications that hit the slow path with extra spine reconstruction step",
             )),
             update_state_fast_path: registry.register(metric!(
                 name: "mz_persist_state_update_state_fast_path",

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -33,16 +33,16 @@ use crate::{Metrics, PersistConfig};
 
 use self::StateFieldValDiff::*;
 
-#[derive(Debug)]
-#[cfg_attr(any(test, debug_assertions), derive(Clone, PartialEq))]
+#[derive(Clone, Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub enum StateFieldValDiff<V> {
     Insert(V),
     Update(V, V),
     Delete(V),
 }
 
-#[derive(Debug)]
-#[cfg_attr(any(test, debug_assertions), derive(Clone, PartialEq))]
+#[derive(Clone, Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub struct StateFieldDiff<K, V> {
     pub key: K,
     pub val: StateFieldValDiff<V>,

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -545,9 +545,39 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
         diffs, trace
     );
 
-    let mut batches = BTreeMap::new();
-    trace.map_batches(|b| assert!(batches.insert(b.clone(), ()).is_none()));
-    apply_diffs_map("spine", diffs, &mut batches)?;
+    let batches = {
+        let mut batches = BTreeMap::new();
+        trace.map_batches(|b| assert!(batches.insert(b.clone(), ()).is_none()));
+        apply_diffs_map("spine", diffs.clone(), &mut batches).map(|_ok| batches)
+    };
+
+    let batches = match batches {
+        Ok(batches) => batches,
+        Err(err) => {
+            metrics
+                .state
+                .apply_spine_slow_path_with_reconstruction
+                .inc();
+            debug!(
+                "apply_diffs_spines could not apply diffs directly to existing trace batches: {}. diffs={:?} trace={:?}",
+                err, diffs, trace
+            );
+            // if we couldn't apply our diffs directly to our trace's batches, we can
+            // try one more trick: reconstruct a new spine with our existing batches,
+            // in an attempt to create different merges than we currently have. then,
+            // we can try to apply our diffs on top of these new (potentially) merged
+            // batches.
+            let mut reconstructed_spine = Trace::default();
+            trace.map_batches(|b| {
+                let _merge_reqs = reconstructed_spine.push_batch(b.clone());
+            });
+
+            let mut batches = BTreeMap::new();
+            reconstructed_spine.map_batches(|b| assert!(batches.insert(b.clone(), ()).is_none()));
+            apply_diffs_map("spine", diffs, &mut batches)?;
+            batches
+        }
+    };
 
     let mut new_trace = Trace::default();
     new_trace.downgrade_since(trace.since());


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds another fallback to `apply_diffs_spine` when the current batches don't match the diffs by reconstructing spine from the existing batches (which might create different merges and change the batches), and then applying the diffs.

Before the environment that saw this was cleared, this change did fix reading in state for a crash-looping shard when run locally. I'll try to recreate its state in a forthcoming test case.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/15493 / https://sentry.io/organizations/materializeinc/issues/3684196820/?project=6780145

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
