### PR TITLE
doc/user: use new parenthesis syntax for options

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -35,7 +35,9 @@ Field                       | Value            | Required | Description
 `SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate in PEM format. Required for SSL client authentication.
 `SSL KEY`                   | secret           | ✓        | Your SSL certificate's key in PEM format. Required for SSL client authentication.
 
-##### Example
+##### Examples
+
+Create an SSL-authenticated Kafka connection:
 
 ```sql
 CREATE SECRET kafka_ssl_crt AS '<BROKER_SSL_CRT>';
@@ -45,6 +47,14 @@ CREATE CONNECTION kafka_connection TO KAFKA (
     BROKER 'rp-f00000bar.data.vectorized.cloud:30365',
     SSL KEY = SECRET kafka_ssl_key,
     SSL CERTIFICATE = SECRET kafka_ssl_crt
+);
+```
+
+Create a connection to multiple Kafka brokers:
+
+```sql
+CREATE CONNECTION kafka_connection TO KAFKA (
+    BROKERS ('broker1:9092', 'broker2:9092')
 );
 ```
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -230,17 +230,20 @@ To start consuming a Kafka stream from a specific offset, you can use the `START
 
 ```sql
 CREATE SOURCE kafka_offset
-  -- Start reading from the earliest offset in the first partition,
-  -- the second partition at 10, and the third partition at 100
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'data', START OFFSET=[0,10,100])
+  FROM KAFKA CONNECTION kafka_connection (
+    TOPIC 'data',
+    -- Start reading from the earliest offset in the first partition,
+    -- the second partition at 10, and the third partition at 100.
+    START OFFSET (0, 10, 100)
+  )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   WITH (SIZE = '3xsmall');
 ```
 
 Note that:
 
-- If fewer offsets than partitions are provided, the remaining partitions will start at offset 0. This is true if you provide `START OFFSET=1` or `START OFFSET=[1, ...]`.
-- If more offsets than partitions are provided, then any partitions added later will incorrectly be read from that offset. So, if you have a single partition, but you provide `START OFFSET=[1,2]`, when you add the second partition you will miss the first 2 records of data.
+- If fewer offsets than partitions are provided, the remaining partitions will start at offset 0. This is true if you provide `START OFFSET (1)` or `START OFFSET (1, ...)`.
+- If more offsets than partitions are provided, then any partitions added later will incorrectly be read from that offset. So, if you have a single partition, but you provide `START OFFSET (1, 2)`, when you add the second partition you will miss the first 2 records of data.
 
 #### Time-based offsets
 


### PR DESCRIPTION
**Not for merging.** Merge when v0.29.0 ships.

Update documentation for #15494.

### Motivation

* Use new syntax in docs.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Consistently allow parentheses to represent sequences of values in options. Previously, the `BROKERS` option for Kafka connections and the `START OFFSET` option when referencing a Kafka connection in a Kafka source used square brackets rather than parentheses. The old syntax is still supported for backwards compatibility. 
