### PR TITLE
adapter: fix wonky error message on `CREATE SUBSOURCE`

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -441,9 +441,7 @@ impl<S: Append + 'static> Coordinator<S> {
             // `CREATE SUBSOURCE` statements are disallowed for users and are only generated
             // automatically as part of purification
             Statement::CreateSubsource(_) => tx.send(
-                Err(AdapterError::Unsupported(
-                    "CREATE SUBSOURCE cannot be executed directly",
-                )),
+                Err(AdapterError::Unsupported("CREATE SUBSOURCE statements")),
                 session,
             ),
 

--- a/test/sqllogictest/subsource.slt
+++ b/test/sqllogictest/subsource.slt
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement error CREATE SUBSOURCE statements are not supported
+CREATE SUBSOURCE "materialize"."public"."subsource" ();


### PR DESCRIPTION
Fix #15543.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Not important enough to mention.
