### PR TITLE
ci,mzcompose: Run all mzcompose tests with SIZE 4 / --workers 4 by de…

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -27,7 +27,8 @@ steps:
           - { value: limits-instance-size }
           - { value: testdrive-partitions-5 }
           - { value: testdrive-replicas-4}
-          - { value: testdrive-size-4}
+          - { value: testdrive-size-1}
+          - { value: testdrive-size-16}
           - { value: testdrive-in-cloudtest}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
@@ -211,8 +212,8 @@ steps:
           composition: testdrive
           args: [--aws-region=us-east-2, --replicas=4]
 
-  - id: testdrive-size-4
-    label: ":racing_car: testdrive with SIZE 4"
+  - id: testdrive-size-1
+    label: ":racing_car: testdrive with SIZE 1"
     timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
@@ -220,7 +221,18 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --size=4]
+          args: [--aws-region=us-east-2, --size=1]
+
+  - id: testdrive-size-16
+    label: ":racing_car: testdrive with SIZE 16"
+    timeout_in_minutes: 600
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          args: [--aws-region=us-east-2, --size=16]
 
   - id: testdrive-in-cloudtest
     label: Full Testdrive in Cloudtest (K8s)

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -31,7 +31,7 @@ DEFAULT_MZ_VOLUMES = [
     "tmp:/share/tmp",
 ]
 
-DEFAULT_SIZE = 1
+DEFAULT_SIZE = 4
 
 
 class Materialized(Service):


### PR DESCRIPTION
…fault

- create all sources, sinks and dataflows with SIZE 4 by default
- start all stand-alone Computed and Storaged with --workers 4 by default

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
