### PR TITLE
mzcompose: Pass --volumes to docker-compose down

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -603,6 +603,7 @@ class DownCommand(DockerComposeCommand):
         super().__init__("down", "Stop and remove containers, networks")
 
     def run(self, args: argparse.Namespace) -> Any:
+        args.unknown_subargs.append("--volumes")
         # --remove-orphans needs to be in effect at all times otherwise
         # services added to a composition after the fact will not be cleaned up
         args.unknown_subargs.append("--remove-orphans")


### PR DESCRIPTION
The fact that `mzcompose down` does not clean up volumes has been a source of frustration.

### Motivation

  * This PR fixes a previously unreported bug.
`mzcompose down` did not clean up volumes, leading to obscure failures and general frustration.