### PR TITLE
mzcompose,cloudtest: Get Debezium to retry network errors

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/debezium.py
+++ b/misc/python/materialize/cloudtest/k8s/debezium.py
@@ -53,6 +53,8 @@ class DebeziumDeployment(K8sDeployment):
             V1EnvVar(
                 name="CONNECT_OFFSET_COMMIT_POLICY", value="AlwaysCommitOffsetPolicy"
             ),
+            V1EnvVar(name="CONNECT_ERRORS_RETRY_TIMEOUT", value="60000"),
+            V1EnvVar(name="CONNECT_ERRORS_RETRY_DELAY_MAX_MS", value="1000"),
         ]
 
         container = V1Container(

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -526,6 +526,8 @@ class Debezium(Service):
             "CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081",
             "CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081",
             "CONNECT_OFFSET_COMMIT_POLICY=AlwaysCommitOffsetPolicy",
+            "CONNECT_ERRORS_RETRY_TIMEOUT=60000",
+            "CONNECT_ERRORS_RETRY_DELAY_MAX_MS=1000",
         ],
     ) -> None:
         super().__init__(


### PR DESCRIPTION
Debezium will not retry certain network errors, e.g. a "connection refused" while attempting to publish a schema in the Schema Registry, unless a set of options is explicitly set.

This causes sporadic errors in the "Checks + Restart Redpanda" Nigthtly CI job, which manifested as the source no longer ingesting data.

### Motivation

  * This PR fixes a previously unreported bug.
A Nightly CI job was failing because Debezium was giving up immediately on Redpanda instead of retrying.