### PR TITLE
ci,testdrive: Move catalog validation to Nightly

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -29,6 +29,7 @@ steps:
           - { value: testdrive-replicas-4}
           - { value: testdrive-size-4}
           - { value: testdrive-in-cloudtest}
+          - { value: testdrive-validate-stash}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
@@ -224,6 +225,19 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
           args: [-m=long, --aws-region=us-east-2, test/cloudtest/test_full_testdrive.py]
+
+
+  - id: testdrive-validate-stash
+    label: ":racing_car: testdrive with --validate-postgres-stash"
+    timeout_in_minutes: 600
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          args: [--aws-region=us-east-2, --validate-postgres-stash]
+
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -259,9 +259,9 @@ Shuffle the list of tests before running them (using the value from --seed, if a
 
 ## Other options
 
-#### `--validate-data-dir /path/to/mzdata`
+#### `--validate-postgres-stash=postgres://root@materialized:26257?options=--search_path=adapter`
 
-After executing a DDL statement, validate that the on-disk representation of the catalog is identical to the in-memory one.
+After executing a DDL statement, validate that representation of the catalog in the stash is identical to the in-memory one.
 
 # Executing statements
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -637,7 +637,6 @@ class Testdrive(Service):
         default_timeout: str = "120s",
         seed: Optional[int] = None,
         consistent_seed: bool = False,
-        validate_data_dir: bool = True,
         validate_postgres_stash: bool = False,
         entrypoint: Optional[List[str]] = None,
         entrypoint_extra: List[str] = [],
@@ -686,9 +685,6 @@ class Testdrive(Service):
 
         if aws_endpoint and not aws_region:
             entrypoint.append(f"--aws-endpoint={aws_endpoint}")
-
-        if validate_data_dir:
-            entrypoint.append("--validate-data-dir=/mzdata")
 
         if validate_postgres_stash:
             entrypoint.append(

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -140,9 +140,6 @@ struct Args {
     /// Materialize.
     #[clap(long, value_name = "KEY=VAL", parse(from_str = parse_kafka_opt))]
     materialize_param: Vec<(String, String)>,
-    /// Validate the on-disk state of the specified Materialize data directory.
-    #[clap(long, value_name = "PATH")]
-    validate_data_dir: Option<PathBuf>,
     /// Validate the stash state of the specified postgres connection string.
     #[clap(long, value_name = "POSTGRES_URL")]
     validate_postgres_stash: Option<String>,

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -249,7 +249,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
         with c.override(
             Testdrive(
-                validate_data_dir=False,
                 no_reset=True,
                 materialize_params={"cluster": "cluster2"},
                 seed=id,

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -89,7 +89,6 @@ SERVICES = [
     # avoid recompiling the current source unless we will actually be benchmarking it.
     Materialized(image="materialize/materialized:unstable"),
     Testdrive(
-        validate_data_dir=False,
         default_timeout=default_timeout,
     ),
     KgenService(),

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -463,7 +463,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
         with c.override(
             Testdrive(
-                validate_data_dir=False,
                 no_reset=True,
                 materialize_params={"cluster": "cluster1"},
                 seed=id,

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -56,6 +56,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
 
     parser.add_argument(
+        "--validate-postgres-stash",
+        action="store_true",
+        help="Have testdrive validate the postgres stash",
+    )
+
+    parser.add_argument(
         "files",
         nargs="*",
         default=["*.td"],
@@ -76,7 +82,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
-        validate_postgres_stash=True,
+        validate_postgres_stash=args.validate_postgres_stash,
     )
 
     materialized = Materialized(size=args.size) if args.size else Materialized()

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -30,7 +30,6 @@ SERVICES = [
     Postgres(),
     Materialized(),
     Testdrive(
-        validate_data_dir=False,
         no_reset=True,
         seed=1,
         default_timeout="600s",


### PR DESCRIPTION
Repeatedly validating the catalog after every DDL is expensive and slows down all CI jobs. So, disable it by default and create a dedicated CI job where it is enabled.

Also:

- remove all traces of validate_data_dir, as this was no longer doing anything at all.

- fix the legacy upgrade framework to validate the catalog properly post-upgrade.

### Motivation

  * This PR fixes a previously unreported bug.
Repeated catalog validations during testing slowed down all CI jobs