### PR TITLE
sql: Prevent users from altering system clusters

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3966,7 +3966,11 @@ impl<S: Append> Catalog<S> {
                         )));
                     }
                     let on_cluster_id = state.resolve_compute_instance(&on_cluster_name)?.id();
-                    if on_cluster_id.is_system() {
+                    if on_cluster_id.is_system()
+                        && !session
+                            .map(|session| session.user().is_internal())
+                            .unwrap_or(false)
+                    {
                         return Err(AdapterError::Catalog(Error::new(
                             ErrorKind::ReadOnlyComputeInstance(on_cluster_name),
                         )));
@@ -4221,7 +4225,11 @@ impl<S: Append> Catalog<S> {
                         )));
                     }
                     let instance = state.resolve_compute_instance(&compute_name)?;
-                    if instance.id().is_system() {
+                    if instance.id().is_system()
+                        && !session
+                            .map(|session| session.user().is_internal())
+                            .unwrap_or(false)
+                    {
                         return Err(AdapterError::Catalog(Error::new(
                             ErrorKind::ReadOnlyComputeInstance(compute_name),
                         )));

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -47,9 +47,10 @@ use mz_secrets::InMemorySecretsController;
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Expr;
 use mz_sql::catalog::{
-    CatalogDatabase, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
-    CatalogItemType as SqlCatalogItemType, CatalogItemType, CatalogSchema, CatalogType,
-    CatalogTypeDetails, IdReference, NameReference, SessionCatalog, TypeReference,
+    CatalogComputeInstance, CatalogDatabase, CatalogError as SqlCatalogError,
+    CatalogItem as SqlCatalogItem, CatalogItemType as SqlCatalogItemType, CatalogItemType,
+    CatalogSchema, CatalogType, CatalogTypeDetails, IdReference, NameReference, SessionCatalog,
+    TypeReference,
 };
 use mz_sql::names::{
     Aug, DatabaseId, FullObjectName, ObjectQualifiers, PartialObjectName, QualifiedObjectName,
@@ -3495,7 +3496,7 @@ impl<S: Append> Catalog<S> {
             CreateComputeReplica {
                 id: ReplicaId,
                 name: String,
-                on_cluster_name: String,
+                on_cluster_id: ComputeInstanceId,
                 config: ComputeReplicaConfig,
             },
             CreateItem {
@@ -3964,6 +3965,12 @@ impl<S: Append> Catalog<S> {
                             ErrorKind::ReservedReplicaName(name),
                         )));
                     }
+                    let on_cluster_id = state.resolve_compute_instance(&on_cluster_name)?.id();
+                    if on_cluster_id.is_system() {
+                        return Err(AdapterError::Catalog(Error::new(
+                            ErrorKind::ReadOnlyComputeInstance(on_cluster_name),
+                        )));
+                    }
                     let (replica_id, compute_instance_id) =
                         tx.insert_compute_replica(&on_cluster_name, &name, &config.clone().into())?;
                     if let ComputeReplicaLocation::Managed { size, .. } = &config.location {
@@ -3991,7 +3998,7 @@ impl<S: Append> Catalog<S> {
                         Action::CreateComputeReplica {
                             id: replica_id,
                             name,
-                            on_cluster_name,
+                            on_cluster_id,
                             config,
                         },
                     )?;
@@ -4177,7 +4184,7 @@ impl<S: Append> Catalog<S> {
                 Op::DropComputeInstance { name } => {
                     if is_reserved_name(&name) {
                         return Err(AdapterError::Catalog(Error::new(
-                            ErrorKind::ReservedClusterName(name),
+                            ErrorKind::ReadOnlyComputeInstance(name),
                         )));
                     }
                     let (instance_id, introspection_source_index_ids) =
@@ -4214,6 +4221,11 @@ impl<S: Append> Catalog<S> {
                         )));
                     }
                     let instance = state.resolve_compute_instance(&compute_name)?;
+                    if instance.id().is_system() {
+                        return Err(AdapterError::Catalog(Error::new(
+                            ErrorKind::ReadOnlyComputeInstance(compute_name),
+                        )));
+                    }
                     tx.remove_compute_replica(&name, instance.id)?;
 
                     let replica_id = instance.replica_id_by_name[&name];
@@ -4609,17 +4621,16 @@ impl<S: Append> Catalog<S> {
                 Action::CreateComputeReplica {
                     id,
                     name,
-                    on_cluster_name,
+                    on_cluster_id,
                     config,
                 } => {
-                    let compute_instance_id = state.compute_instances_by_name[&on_cluster_name];
                     let introspection_ids: Vec<_> = config.logging.source_and_view_ids().collect();
-                    state.insert_compute_replica(compute_instance_id, name.clone(), id, config);
+                    state.insert_compute_replica(on_cluster_id, name.clone(), id, config);
                     for id in introspection_ids {
                         builtin_table_updates.extend(state.pack_item_update(id, 1));
                     }
                     builtin_table_updates.push(state.pack_compute_replica_update(
-                        compute_instance_id,
+                        on_cluster_id,
                         &name,
                         1,
                     ));

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -69,7 +69,7 @@ impl PartialEq for User {
 }
 
 impl User {
-    /// Returns true if this is an internal user, false otherwise.
+    /// Returns whether this is an internal user.
     pub fn is_internal(&self) -> bool {
         INTERNAL_USER_NAMES.contains(&self.name)
     }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -27,7 +27,7 @@ use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 use mz_sql_parser::ast::TransactionIsolationLevel;
 
-use crate::catalog::SYSTEM_USER;
+use crate::catalog::{INTERNAL_USER_NAMES, SYSTEM_USER};
 use crate::client::ConnectionId;
 use crate::coord::peek::PeekResponseUnary;
 use crate::error::AdapterError;
@@ -65,6 +65,13 @@ pub struct ExternalUserMetadata {
 impl PartialEq for User {
     fn eq(&self, other: &User) -> bool {
         self.name == other.name
+    }
+}
+
+impl User {
+    /// Returns true if this is an internal user, false otherwise.
+    pub fn is_internal(&self) -> bool {
+        INTERNAL_USER_NAMES.contains(&self.name)
     }
 }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -88,6 +88,10 @@ impl ComputeInstanceId {
     pub fn is_user(&self) -> bool {
         matches!(self, Self::User(_))
     }
+
+    pub fn is_system(&self) -> bool {
+        matches!(self, Self::System(_))
+    }
 }
 
 impl FromStr for ComputeInstanceId {

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -65,3 +65,17 @@ INSERT INTO temp SELECT * FROM temp
 2
 1
 2
+
+> SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
+mz_system r1 1
+
+$ postgres-execute connection=mz_system
+DROP CLUSTER REPLICA mz_system.r1
+
+> SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
+
+$ postgres-execute connection=mz_system
+CREATE CLUSTER REPLICA mz_system.r1 SIZE '1';
+
+> SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
+mz_system r1 1

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -15,13 +15,22 @@ mz_introspection
 default
 
 ! DROP CLUSTER mz_system CASCADE
-contains:cluster name "mz_system" is reserved
+contains:system cluster 'mz_system' cannot be modified
 
 ! DROP CLUSTER mz_introspection CASCADE
-contains:cluster name "mz_introspection" is reserved
+contains:system cluster 'mz_introspection' cannot be modified
+
+! DROP CLUSTER mz_joe CASCADE
+contains:unknown cluster 'mz_joe'
 
 ! CREATE CLUSTER mz_joe REPLICAS (r1 (size '1'))
 contains:cluster name "mz_joe" is reserved
+
+! CREATE CLUSTER REPLICA mz_system.r2 SIZE '1';
+contains:system cluster 'mz_system' cannot be modified
+
+! DROP CLUSTER REPLICA mz_system.r1
+contains:system cluster 'mz_system' cannot be modified
 
 > CREATE MATERIALIZED VIEW mv AS SELECT AVG(50)
 


### PR DESCRIPTION
This commit prevents users from adding and dropping replicas in the system clusters.

Fixes #15549

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Prevent creating and dropping replicas in system clusters.
