### PR TITLE
adapter: Set default cluster for internal users

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -27,7 +27,7 @@ use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 use mz_sql_parser::ast::TransactionIsolationLevel;
 
-use crate::catalog::SYSTEM_USER;
+use crate::catalog::{INTERNAL_USER_NAMES, SYSTEM_USER};
 use crate::client::ConnectionId;
 use crate::coord::peek::PeekResponseUnary;
 use crate::error::AdapterError;
@@ -100,8 +100,8 @@ impl<T: TimestampManipulation> Session<T> {
 
     fn new_internal(conn_id: ConnectionId, user: User) -> Session<T> {
         let (notices_tx, notices_rx) = mpsc::unbounded_channel();
-        let vars = if user == *SYSTEM_USER {
-            SessionVars::for_cluster(&SYSTEM_USER.name)
+        let vars = if INTERNAL_USER_NAMES.contains(&user.name) {
+            SessionVars::for_cluster(&user.name)
         } else {
             SessionVars::default()
         };


### PR DESCRIPTION
Previously, the mz_system user would default to using the mz_system cluster. This commit updates that logic so that all internal users default to using a cluster with the same name as the user. Currently the only other internal user is mz_introspection.

Works towards resolving #15520

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
