### PR TITLE
sql: Fix connection renaming

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3584,7 +3584,7 @@ impl<'a> Parser<'a> {
                 let to_item_name = self.parse_identifier()?;
 
                 Statement::AlterObjectRename(AlterObjectRenameStatement {
-                    object_type: ObjectType::Secret,
+                    object_type: ObjectType::Connection,
                     if_exists,
                     name,
                     to_item_name,

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -13,14 +13,14 @@ use mz_repr::GlobalId;
 use std::collections::{HashMap, HashSet};
 
 use mz_ore::str::StrExt;
-use mz_sql_parser::ast::CreateConnectionStatement;
 
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
 use crate::ast::{
-    AstInfo, CreateIndexStatement, CreateMaterializedViewStatement, CreateSecretStatement,
-    CreateSinkStatement, CreateSourceStatement, CreateTableStatement, CreateViewStatement, Expr,
-    Ident, Query, Raw, RawObjectName, Statement, UnresolvedObjectName, ViewDefinition,
+    AstInfo, CreateConnectionStatement, CreateIndexStatement, CreateMaterializedViewStatement,
+    CreateSecretStatement, CreateSinkStatement, CreateSourceStatement, CreateTableStatement,
+    CreateViewStatement, Expr, Ident, Query, Raw, RawObjectName, Statement, UnresolvedObjectName,
+    ViewDefinition,
 };
 use crate::names::FullObjectName;
 

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -13,6 +13,7 @@ use mz_repr::GlobalId;
 use std::collections::{HashMap, HashSet};
 
 use mz_ore::str::StrExt;
+use mz_sql_parser::ast::CreateConnectionStatement;
 
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
@@ -47,6 +48,10 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
             name.0[object_name_len] = Ident::new(to_item_name);
         }
         Statement::CreateSecret(CreateSecretStatement { name, .. }) => {
+            let object_name_len = name.0.len() - 1;
+            name.0[object_name_len] = Ident::new(to_item_name);
+        }
+        Statement::CreateConnection(CreateConnectionStatement { name, .. }) => {
             let object_name_len = name.0.len() - 1;
             name.0[object_name_len] = Ident::new(to_item_name);
         }
@@ -97,7 +102,10 @@ pub fn create_stmt_rename_refs(
         | Statement::CreateMaterializedView(CreateMaterializedViewStatement { query, .. }) => {
             rewrite_query(from_name, to_item_name, query)?;
         }
-        Statement::CreateSource(_) | Statement::CreateTable(_) | Statement::CreateSecret(_) => {}
+        Statement::CreateSource(_)
+        | Statement::CreateTable(_)
+        | Statement::CreateSecret(_)
+        | Statement::CreateConnection(_) => {}
         _ => unreachable!("Internal error: only catalog items need to update item refs"),
     }
 

--- a/test/sqllogictest/alter.slt
+++ b/test/sqllogictest/alter.slt
@@ -10,13 +10,29 @@
 mode cockroach
 
 query error system schema 'mz_catalog.mz_tables' cannot be modified
-alter table mz_tables rename to foo;
+ALTER TABLE mz_tables RENAME TO foo;
 
 query error system schema 'mz_internal.mz_dataflow_channels' cannot be modified
-alter source mz_internal.mz_dataflow_channels rename to foo;
+ALTER SOURCE mz_internal.mz_dataflow_channels RENAME TO foo;
 
 query error system schema 'mz_internal.mz_storage_shards' cannot be modified
-alter source mz_internal.mz_storage_shards rename to foo;
+ALTER SOURCE mz_internal.mz_storage_shards RENAME TO foo;
 
 query error system schema 'mz_internal.mz_storage_shards' cannot be modified
-alter source mz_internal.mz_storage_shards reset (size);
+ALTER SOURCE mz_internal.mz_storage_shards RESET (size);
+
+statement ok
+CREATE CONNECTION c TO KAFKA (BROKER 'localhost:9092');
+
+query TT
+SHOW CONNECTIONS
+----
+c   kafka
+
+statement ok
+ALTER CONNECTION c RENAME TO d;
+
+query TT
+SHOW CONNECTIONS
+----
+d   kafka


### PR DESCRIPTION
This commit fixes `ALTER CONNECTION <name> RENAME TO <new-name>`, which was previously broken.

Fixes #15552

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds the ability to rename connections.
