### PR TITLE
Improve error message for unknown types in postgres source

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -476,7 +476,10 @@ impl fmt::Display for AdapterError {
 
 impl From<anyhow::Error> for AdapterError {
     fn from(e: anyhow::Error) -> AdapterError {
-        AdapterError::Unstructured(e)
+        match e.downcast_ref::<PlanError>() {
+            Some(plan_error) => AdapterError::PlanError(plan_error.clone()),
+            None => AdapterError::Unstructured(e),
+        }
     }
 }
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -335,7 +335,7 @@ pub async fn purify_create_source(
                 for c in table.columns.iter() {
                     let name = Ident::new(c.name.clone());
                     let ty = mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod).map_err(
-                        |e| PlanError::UnknownTypeInPostgresSource {
+                        |e| PlanError::UnrecognizedTypeInPostgresSource {
                             table: subsource_name.to_string(),
                             column: name.to_string(),
                             e,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -51,6 +51,7 @@ use crate::kafka_util;
 use crate::kafka_util::KafkaConfigOptionExtracted;
 use crate::names::{Aug, RawDatabaseSpecifier, ResolvedObjectName};
 use crate::normalize;
+use crate::plan::error::PlanError;
 use crate::plan::statement::ddl::load_generator_ast_to_generator;
 use crate::plan::StatementContext;
 
@@ -333,9 +334,13 @@ pub async fn purify_create_source(
                 let mut columns = vec![];
                 for c in table.columns.iter() {
                     let name = Ident::new(c.name.clone());
-
-                    let ty = mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod)
-                        .map_err(|e| sql_err!("{}", e))?;
+                    let ty = mz_pgrepr::Type::from_oid_and_typmod(c.type_oid, c.type_mod).map_err(
+                        |e| PlanError::UnknownTypeInPostgresSource {
+                            table: subsource_name.to_string(),
+                            column: name.to_string(),
+                            e,
+                        },
+                    )?;
                     let data_type = scx.resolve_type(ty)?;
 
                     columns.push(ColumnDef {

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -392,10 +392,6 @@ async fn try_run_fail_sql(
         Err(err) => match err.source().and_then(|err| err.downcast_ref::<DbError>()) {
             Some(err) => {
                 let mut err_string = err.message().to_string();
-                if let Some(hint) = err.hint() {
-                    err_string.push_str("\nhint: ");
-                    err_string.push_str(hint);
-                }
                 if let Some(regex) = &state.regex {
                     err_string = regex
                         .replace_all(&err_string, state.regex_replacement.as_str())

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -392,6 +392,10 @@ async fn try_run_fail_sql(
         Err(err) => match err.source().and_then(|err| err.downcast_ref::<DbError>()) {
             Some(err) => {
                 let mut err_string = err.message().to_string();
+                if let Some(hint) = err.hint() {
+                    err_string.push_str("\nhint: ");
+                    err_string.push_str(hint);
+                }
                 if let Some(regex) = &state.regex {
                     err_string = regex
                         .replace_all(&err_string, state.regex_replacement.as_str())

--- a/test/pg-cdc/types-unsupported.td
+++ b/test/pg-cdc/types-unsupported.td
@@ -28,4 +28,4 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 # Todo: add test for hint once testdrive supports that
 ! CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES;
-regex:type with OID.*is unknown
+regex:type with OID .* is unknown\nhint: You may be using an unsupported type in Materialize for column "current_mood" in table "person".

--- a/test/pg-cdc/types-unsupported.td
+++ b/test/pg-cdc/types-unsupported.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass
+  )
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+
+CREATE SCHEMA public;
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+CREATE TABLE person (name TEXT, current_mood mood);
+INSERT INTO person VALUES ('Moe', 'happy');
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+# Todo: add test for hint once testdrive supports that
+! CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES;
+regex:type with OID.*is unknown

--- a/test/pg-cdc/types-unsupported.td
+++ b/test/pg-cdc/types-unsupported.td
@@ -26,6 +26,6 @@ CREATE TABLE person (name TEXT, current_mood mood);
 INSERT INTO person VALUES ('Moe', 'happy');
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
-# Todo: add test for hint once testdrive supports that
+# Todo: add test for detail and hint once testdrive supports that
 ! CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES;
-regex:type with OID .* is unknown\nhint: You may be using an unsupported type in Materialize for column "current_mood" in table "person".
+contains: column "person.current_mood" uses unrecognized type


### PR DESCRIPTION
Update error message for unknown types in postgres source to specify which table/column are the culprit. Add detail and hint messages.
As per conversation in #15502 and the new style guidelines in https://github.com/MaterializeInc/materialize/pull/15631.

Example:
```
materialize=> CREATE SOURCE pg_source FROM POSTGRES CONNECTION pg_connection2 (PUBLICATION 'mz_source') FOR ALL TABLES WITH (SIZE = '3xsmall');
ERROR:  column "person.current_mood" uses unrecognized type
DETAIL:  type with OID 211538 is unknown
HINT:  You may be using an unsupported type in Materialize, such as an enum. Try excluding the table from the publication.
```

Required follow up: add testdrive support for hints and details.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

Add hint to "type with OID x is unknown" errors for postgres sources, indicating the table and column of the unsupported type.
