### PR TITLE
adapter: Add user permissions framework

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -34,7 +34,7 @@ use mz_sql::catalog::{
 };
 use mz_storage::controller::IntrospectionType;
 
-use crate::catalog::{DEFAULT_CLUSTER_REPLICA_NAME, INTROSPECTION_USER, SYSTEM_USER};
+use crate::catalog::{DEFAULT_CLUSTER_REPLICA_NAME, INTROSPECTION_USER_NAME, SYSTEM_USER_NAME};
 
 pub const MZ_TEMP_SCHEMA: &str = "mz_temp";
 pub const MZ_CATALOG_SCHEMA: &str = "mz_catalog";
@@ -2465,16 +2465,16 @@ ON mz_catalog.mz_secrets (schema_id)",
 };
 
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
-    name: &*SYSTEM_USER.name,
+    name: &*SYSTEM_USER_NAME,
 });
 
 pub static MZ_INTROSPECTION_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
-    name: &*INTROSPECTION_USER.name,
+    name: &*INTROSPECTION_USER_NAME,
 });
 
 pub static MZ_SYSTEM_COMPUTE_INSTANCE: Lazy<BuiltinComputeInstance> =
     Lazy::new(|| BuiltinComputeInstance {
-        name: &*SYSTEM_USER.name,
+        name: &*SYSTEM_USER_NAME,
     });
 
 pub static MZ_SYSTEM_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =
@@ -2485,7 +2485,7 @@ pub static MZ_SYSTEM_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =
 
 pub static MZ_INTROSPECTION_COMPUTE_INSTANCE: Lazy<BuiltinComputeInstance> =
     Lazy::new(|| BuiltinComputeInstance {
-        name: &*INTROSPECTION_USER.name,
+        name: &*INTROSPECTION_USER_NAME,
     });
 
 pub static MZ_INTROSPECTION_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2464,35 +2464,31 @@ IN CLUSTER mz_introspection
 ON mz_catalog.mz_secrets (schema_id)",
 };
 
-pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
+pub const MZ_SYSTEM_ROLE: BuiltinRole = BuiltinRole {
     name: &*SYSTEM_USER_NAME,
-});
+};
 
-pub static MZ_INTROSPECTION_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
+pub const MZ_INTROSPECTION_ROLE: BuiltinRole = BuiltinRole {
     name: &*INTROSPECTION_USER_NAME,
-});
+};
 
-pub static MZ_SYSTEM_COMPUTE_INSTANCE: Lazy<BuiltinComputeInstance> =
-    Lazy::new(|| BuiltinComputeInstance {
-        name: &*SYSTEM_USER_NAME,
-    });
+pub const MZ_SYSTEM_COMPUTE_INSTANCE: BuiltinComputeInstance = BuiltinComputeInstance {
+    name: &*SYSTEM_USER_NAME,
+};
 
-pub static MZ_SYSTEM_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =
-    Lazy::new(|| BuiltinComputeReplica {
-        name: DEFAULT_CLUSTER_REPLICA_NAME,
-        compute_instance_name: MZ_SYSTEM_COMPUTE_INSTANCE.name,
-    });
+pub const MZ_SYSTEM_COMPUTE_REPLICA: BuiltinComputeReplica = BuiltinComputeReplica {
+    name: DEFAULT_CLUSTER_REPLICA_NAME,
+    compute_instance_name: MZ_SYSTEM_COMPUTE_INSTANCE.name,
+};
 
-pub static MZ_INTROSPECTION_COMPUTE_INSTANCE: Lazy<BuiltinComputeInstance> =
-    Lazy::new(|| BuiltinComputeInstance {
-        name: &*INTROSPECTION_USER_NAME,
-    });
+pub const MZ_INTROSPECTION_COMPUTE_INSTANCE: BuiltinComputeInstance = BuiltinComputeInstance {
+    name: &*INTROSPECTION_USER_NAME,
+};
 
-pub static MZ_INTROSPECTION_COMPUTE_REPLICA: Lazy<BuiltinComputeReplica> =
-    Lazy::new(|| BuiltinComputeReplica {
-        name: DEFAULT_CLUSTER_REPLICA_NAME,
-        compute_instance_name: MZ_INTROSPECTION_COMPUTE_INSTANCE.name,
-    });
+pub const MZ_INTROSPECTION_COMPUTE_REPLICA: BuiltinComputeReplica = BuiltinComputeReplica {
+    name: DEFAULT_CLUSTER_REPLICA_NAME,
+    compute_instance_name: MZ_INTROSPECTION_COMPUTE_INSTANCE.name,
+};
 
 /// List of all builtin objects sorted topologically by dependency.
 pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
@@ -2705,17 +2701,17 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
     builtins
 });
 pub static BUILTIN_ROLES: Lazy<Vec<&BuiltinRole>> =
-    Lazy::new(|| vec![&*MZ_SYSTEM_ROLE, &*MZ_INTROSPECTION_ROLE]);
+    Lazy::new(|| vec![&MZ_SYSTEM_ROLE, &MZ_INTROSPECTION_ROLE]);
 pub static BUILTIN_COMPUTE_INSTANCES: Lazy<Vec<&BuiltinComputeInstance>> = Lazy::new(|| {
     vec![
-        &*MZ_SYSTEM_COMPUTE_INSTANCE,
-        &*MZ_INTROSPECTION_COMPUTE_INSTANCE,
+        &MZ_SYSTEM_COMPUTE_INSTANCE,
+        &MZ_INTROSPECTION_COMPUTE_INSTANCE,
     ]
 });
 pub static BUILTIN_COMPUTE_REPLICAS: Lazy<Vec<&BuiltinComputeReplica>> = Lazy::new(|| {
     vec![
-        &*MZ_SYSTEM_COMPUTE_REPLICA,
-        &*MZ_INTROSPECTION_COMPUTE_REPLICA,
+        &MZ_SYSTEM_COMPUTE_REPLICA,
+        &MZ_INTROSPECTION_COMPUTE_REPLICA,
     ]
 });
 

--- a/src/adapter/src/session/permissions.rs
+++ b/src/adapter/src/session/permissions.rs
@@ -1,0 +1,324 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::catalog::builtin::MZ_SYSTEM_COMPUTE_INSTANCE;
+use crate::catalog::Catalog;
+use mz_compute_client::controller::ComputeInstanceId;
+use mz_sql::names::{ObjectQualifiers, RawDatabaseSpecifier};
+use mz_sql::plan::Plan;
+use mz_stash::Append;
+use std::collections::{HashMap, HashSet};
+
+/// Describes the permission of a particular user.
+#[derive(Debug, Clone)]
+pub enum UserPermissions {
+    /// User has no restrictions.
+    All,
+    /// User is only allowed to do what is defined in permissions.
+    AllowList(Permissions),
+    /// User is blocked from doing anything defined in permissions.
+    BlockList(Permissions),
+}
+
+/// A specific set of permissions.
+#[derive(Debug, Clone)]
+pub struct Permissions {
+    pub(crate) compute_instances: HashSet<String>,
+    pub(crate) schemas: HashMap<RawDatabaseSpecifier, HashSet<String>>,
+    pub(crate) action: HashSet<UserAction>,
+}
+
+/// Actions that a user can take.
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+pub(crate) enum UserAction {
+    Read,
+    Write,
+    Create,
+    Drop,
+    Alter,
+    Show,
+    Set,
+    AlterSystem,
+}
+
+impl Default for UserPermissions {
+    // default permission is able to do anything except interact with mz_system cluster.
+    fn default() -> Self {
+        Self::BlockList(Permissions {
+            compute_instances: HashSet::from_iter([MZ_SYSTEM_COMPUTE_INSTANCE.name.to_string()]),
+            schemas: HashMap::new(),
+            action: HashSet::new(),
+        })
+    }
+}
+
+impl UserPermissions {
+    /// Returns whether a user has any restrictions.
+    pub fn is_all(&self) -> bool {
+        matches!(self, Self::All)
+    }
+
+    /// Returns whether a user is allowed to interact with the compute instance `cluster`.
+    pub fn is_allowed_compute_instance(&self, cluster: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::AllowList(permissions) => permissions.contains_compute_instance(cluster),
+
+            Self::BlockList(permissions) => !permissions.contains_compute_instance(cluster),
+        }
+    }
+
+    /// Returns whether a user is allowed to interact with the schema `schema` in database `database`.
+    pub fn is_allowed_schema(&self, database: &RawDatabaseSpecifier, schema: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::AllowList(permissions) => permissions.contains_schema(database, schema),
+            Self::BlockList(permissions) => !permissions.contains_schema(database, schema),
+        }
+    }
+
+    /// Returns whether user is allowed to execute `plan`.
+    pub fn is_allowed_plan(&self, plan: &Plan) -> bool {
+        match UserAction::from_plan(plan) {
+            Some(action) => match self {
+                Self::All => true,
+                Self::AllowList(permissions) => permissions.contains_action(&action),
+                Self::BlockList(permission) => !permission.contains_action(&action),
+            },
+            None => true,
+        }
+    }
+}
+
+impl Permissions {
+    fn contains_compute_instance(&self, cluster: &str) -> bool {
+        self.compute_instances.contains(cluster)
+    }
+
+    fn contains_schema(&self, database: &RawDatabaseSpecifier, schema: &str) -> bool {
+        self.schemas
+            .get(database)
+            .map(|schemas| schemas.contains(schema))
+            .unwrap_or(false)
+    }
+
+    fn contains_action(&self, action: &UserAction) -> bool {
+        self.action.contains(action)
+    }
+}
+
+impl UserAction {
+    fn from_plan(plan: &Plan) -> Option<Self> {
+        match plan {
+            Plan::Peek(_) | Plan::Explain(_) | Plan::SendRows(_) | Plan::Subscribe(_) => {
+                Some(Self::Read)
+            }
+            Plan::CreateConnection(_)
+            | Plan::CreateDatabase(_)
+            | Plan::CreateSchema(_)
+            | Plan::CreateRole(_)
+            | Plan::CreateComputeInstance(_)
+            | Plan::CreateComputeReplica(_)
+            | Plan::CreateSource(_)
+            | Plan::CreateSecret(_)
+            | Plan::CreateSink(_)
+            | Plan::CreateTable(_)
+            | Plan::CreateView(_)
+            | Plan::CreateMaterializedView(_)
+            | Plan::CreateIndex(_)
+            | Plan::CreateType(_) => Some(Self::Create),
+            Plan::DiscardTemp
+            | Plan::DiscardAll
+            | Plan::DropDatabase(_)
+            | Plan::DropSchema(_)
+            | Plan::DropRoles(_)
+            | Plan::DropComputeInstances(_)
+            | Plan::DropComputeReplicas(_)
+            | Plan::DropItems(_) => Some(Self::Drop),
+            Plan::ShowAllVariables | Plan::ShowVariable(_) => Some(Self::Show),
+            Plan::SetVariable(_) | Plan::ResetVariable(_) => Some(Self::Set),
+            Plan::SendDiffs(_) | Plan::CopyFrom(_) | Plan::ReadThenWrite(_) | Plan::Insert(_) => {
+                Some(Self::Write)
+            }
+            Plan::AlterNoop(_)
+            | Plan::AlterIndexSetOptions(_)
+            | Plan::AlterIndexResetOptions(_)
+            | Plan::AlterSink(_)
+            | Plan::AlterSource(_)
+            | Plan::AlterItemRename(_)
+            | Plan::AlterSecret(_)
+            | Plan::RotateKeys(_) => Some(Self::Alter),
+            Plan::AlterSystemSet(_) | Plan::AlterSystemReset(_) | Plan::AlterSystemResetAll(_) => {
+                Some(Self::AlterSystem)
+            }
+            Plan::StartTransaction(_)
+            | Plan::CommitTransaction
+            | Plan::AbortTransaction
+            | Plan::EmptyQuery
+            | Plan::Declare(_)
+            | Plan::Fetch(_)
+            | Plan::Close(_)
+            | Plan::Prepare(_)
+            | Plan::Execute(_)
+            | Plan::Deallocate(_)
+            | Plan::Raise(_) => None,
+        }
+    }
+
+    fn uses_compute_instance(&self) -> bool {
+        match self {
+            Self::Read | Self::Write | Self::Create | Self::Drop | Self::Alter => true,
+            Self::Show | Self::Set | Self::AlterSystem => false,
+        }
+    }
+}
+
+/// Returns whether the plan might use a compute instance.
+pub fn uses_compute_instance(plan: &Plan) -> bool {
+    match UserAction::from_plan(plan) {
+        Some(action) => action.uses_compute_instance(),
+        None => false,
+    }
+}
+
+/// Returns the target compute instance from a plan if one exists.
+pub fn extract_target_compute_instance(plan: &Plan) -> Option<&ComputeInstanceId> {
+    match plan {
+        Plan::CreateMaterializedView(mv) => Some(&mv.materialized_view.compute_instance),
+        Plan::CreateIndex(index) => Some(&index.index.compute_instance),
+        Plan::CreateConnection(_)
+        | Plan::CreateDatabase(_)
+        | Plan::CreateSchema(_)
+        | Plan::CreateRole(_)
+        | Plan::CreateComputeInstance(_)
+        | Plan::CreateComputeReplica(_)
+        | Plan::CreateSource(_)
+        | Plan::CreateSecret(_)
+        | Plan::CreateSink(_)
+        | Plan::CreateTable(_)
+        | Plan::CreateView(_)
+        | Plan::CreateType(_)
+        | Plan::DiscardTemp
+        | Plan::DiscardAll
+        | Plan::DropDatabase(_)
+        | Plan::DropSchema(_)
+        | Plan::DropRoles(_)
+        | Plan::DropComputeInstances(_)
+        | Plan::DropComputeReplicas(_)
+        | Plan::DropItems(_)
+        | Plan::EmptyQuery
+        | Plan::ShowAllVariables
+        | Plan::ShowVariable(_)
+        | Plan::SetVariable(_)
+        | Plan::ResetVariable(_)
+        | Plan::StartTransaction(_)
+        | Plan::CommitTransaction
+        | Plan::AbortTransaction
+        | Plan::Peek(_)
+        | Plan::Subscribe(_)
+        | Plan::SendRows(_)
+        | Plan::CopyFrom(_)
+        | Plan::Explain(_)
+        | Plan::SendDiffs(_)
+        | Plan::Insert(_)
+        | Plan::AlterNoop(_)
+        | Plan::AlterIndexSetOptions(_)
+        | Plan::AlterIndexResetOptions(_)
+        | Plan::AlterSink(_)
+        | Plan::AlterSource(_)
+        | Plan::AlterItemRename(_)
+        | Plan::AlterSecret(_)
+        | Plan::AlterSystemSet(_)
+        | Plan::AlterSystemReset(_)
+        | Plan::AlterSystemResetAll(_)
+        | Plan::Declare(_)
+        | Plan::Fetch(_)
+        | Plan::Close(_)
+        | Plan::ReadThenWrite(_)
+        | Plan::Prepare(_)
+        | Plan::Execute(_)
+        | Plan::Deallocate(_)
+        | Plan::Raise(_)
+        | Plan::RotateKeys(_) => None,
+    }
+}
+
+/// Returns the target schema from a plan if one exists.
+pub fn extract_target_schema<'a, S: Append>(
+    plan: &'a Plan,
+    catalog: &'a Catalog<S>,
+) -> Option<Vec<&'a ObjectQualifiers>> {
+    match plan {
+        Plan::CreateConnection(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateSource(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateSecret(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateSink(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateTable(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateView(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateMaterializedView(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateIndex(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::CreateType(plan) => Some(vec![&plan.name.qualifiers]),
+        Plan::DropItems(plan) => Some(
+            plan.items
+                .iter()
+                .map(|id| &catalog.get_entry(id).name().qualifiers)
+                .collect(),
+        ),
+        Plan::AlterIndexSetOptions(plan) => {
+            Some(vec![&catalog.get_entry(&plan.id).name().qualifiers])
+        }
+        Plan::AlterIndexResetOptions(plan) => {
+            Some(vec![&catalog.get_entry(&plan.id).name().qualifiers])
+        }
+        Plan::AlterSink(plan) => Some(vec![&catalog.get_entry(&plan.id).name().qualifiers]),
+        Plan::AlterSource(plan) => Some(vec![&catalog.get_entry(&plan.id).name().qualifiers]),
+        Plan::AlterItemRename(plan) => Some(vec![&catalog.get_entry(&plan.id).name().qualifiers]),
+        Plan::AlterSecret(plan) => Some(vec![&catalog.get_entry(&plan.id).name().qualifiers]),
+        Plan::CreateDatabase(_)
+        | Plan::CreateSchema(_)
+        | Plan::CreateRole(_)
+        | Plan::CreateComputeInstance(_)
+        | Plan::CreateComputeReplica(_)
+        | Plan::DiscardTemp
+        | Plan::DiscardAll
+        | Plan::DropDatabase(_)
+        | Plan::DropSchema(_)
+        | Plan::DropRoles(_)
+        | Plan::DropComputeInstances(_)
+        | Plan::DropComputeReplicas(_)
+        | Plan::EmptyQuery
+        | Plan::ShowAllVariables
+        | Plan::ShowVariable(_)
+        | Plan::SetVariable(_)
+        | Plan::ResetVariable(_)
+        | Plan::StartTransaction(_)
+        | Plan::CommitTransaction
+        | Plan::AbortTransaction
+        | Plan::Peek(_)
+        | Plan::Subscribe(_)
+        | Plan::SendRows(_)
+        | Plan::CopyFrom(_)
+        | Plan::Explain(_)
+        | Plan::SendDiffs(_)
+        | Plan::Insert(_)
+        | Plan::AlterNoop(_)
+        | Plan::AlterSystemSet(_)
+        | Plan::AlterSystemReset(_)
+        | Plan::AlterSystemResetAll(_)
+        | Plan::Declare(_)
+        | Plan::Fetch(_)
+        | Plan::Close(_)
+        | Plan::ReadThenWrite(_)
+        | Plan::Prepare(_)
+        | Plan::Execute(_)
+        | Plan::Deallocate(_)
+        | Plan::Raise(_)
+        | Plan::RotateKeys(_) => None,
+    }
+}

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -26,6 +26,7 @@ use tokio::time::{self, Duration, Instant};
 use tracing::{debug, warn, Instrument};
 
 use mz_adapter::catalog::INTERNAL_USER_NAMES;
+
 use mz_adapter::session::User;
 use mz_adapter::session::{
     EndTransactionAction, ExternalUserMetadata, InProgressRows, Portal, PortalState,
@@ -224,13 +225,7 @@ where
     };
 
     // Construct session.
-    let mut session = Session::new(
-        conn.id(),
-        User {
-            name: user,
-            external_metadata,
-        },
-    );
+    let mut session = Session::new(conn.id(), User::new(user, external_metadata));
     for (name, value) in params {
         let local = false;
         let _ = session.vars_mut().set(&name, &value, local);

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -45,10 +45,10 @@ contains:system cluster 'mz_introspection' cannot be modified
 > SET CLUSTER TO mz_system
 
 ! SHOW MATERIALIZED VIEWS
-contains:system cluster 'mz_system' cannot execute user queries
+contains:unauthorized: user 'materialize' is unauthorized to use cluster mz_system
 
 ! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
-contains:system cluster 'mz_system' cannot be modified
+contains:unauthorized: user 'materialize' is unauthorized to use cluster mz_system
 
 > SET CLUSTER TO default
 


### PR DESCRIPTION
This commit adds a framework for specifying and enforcing user level
permissions. The permissions indicate what clusters and schemas a user
is allowed to interact with as well as what actions that user is
allowed to perform. The permissions check is done right after statement
planning, but before sequencing.

The mz_introspection user is given a set of permissions to restrict
what it's allowed to do.

The permissions framework is non-internal users to prevent users from
interacting with the mz_system cluster, which was previously done in an
incomplete way.

Closes #15520

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
