### PR TITLE
persist: `inspect state-rollups` to pull down all known rollups

### DIFF
--- a/src/persist-client/examples/inspect.rs
+++ b/src/persist-client/examples/inspect.rs
@@ -30,6 +30,9 @@ pub(crate) enum Command {
     /// Prints latest consensus rollup state as JSON
     StateRollup(StateArgs),
 
+    /// Prints consensus rollup state of all known rollups as JSON
+    StateRollups(StateArgs),
+
     /// Prints the count and size of blobs in an environment
     BlobCount(BlobCountArgs),
 
@@ -128,6 +131,19 @@ pub async fn run(command: InspectArgs) -> Result<(), anyhow::Error> {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&state_rollup).expect("unserializable state")
+            );
+        }
+        Command::StateRollups(args) => {
+            let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
+            let state_rollups = mz_persist_client::inspect::fetch_state_rollups(
+                shard_id,
+                &args.consensus_uri,
+                &args.blob_uri,
+            )
+            .await?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&state_rollups).expect("unserializable state")
             );
         }
         Command::StateDiff(args) => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

One of the debug tools that turned out to be handy. This adds `persistcli inspect state-rollups` which fetches all rollups referenced across live consensus state.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
