### PR TITLE
testdrive: use readonly stash during catalog verify

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -839,6 +839,9 @@ impl<S: Append> Connection<S> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, Error> {
+        if amount == 0 {
+            return Ok(Vec::new());
+        }
         let key = IdAllocKey {
             name: id_type.to_string(),
         };

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1015,6 +1015,9 @@ impl From<tokio_postgres::Error> for StashError {
 impl Append for Postgres {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn append_batch(&mut self, batches: &[AppendBatch]) -> Result<(), StashError> {
+        if batches.is_empty() {
+            return Ok(());
+        }
         let batches = batches.to_vec();
         self.transact(move |stmts, tx| {
             let batches = batches.clone();

--- a/src/testdrive/src/action/psql.rs
+++ b/src/testdrive/src/action/psql.rs
@@ -26,6 +26,9 @@ pub async fn run_execute(
     let expected_output = cmd.input.join("\n");
     let output = Command::new("psql")
         .args(&[
+            // Ignore .psqlrc so that local execution of testdrive isn't
+            // affected by it.
+            "--no-psqlrc",
             "--pset",
             "footer=off",
             "--command",


### PR DESCRIPTION
This eliminates the need to copy and drop tables for every DDL.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a