### PR TITLE
testdrive,mzcompose: Remove all traces of --validate-data-dir

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -259,9 +259,9 @@ Shuffle the list of tests before running them (using the value from --seed, if a
 
 ## Other options
 
-#### `--validate-data-dir /path/to/mzdata`
+#### `--validate-postgres-stash=postgres://root@materialized:26257?options=--search_path=adapter`
 
-After executing a DDL statement, validate that the on-disk representation of the catalog is identical to the in-memory one.
+After executing a DDL statement, validate that representation of the catalog in the stash is identical to the in-memory one.
 
 # Executing statements
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -637,7 +637,6 @@ class Testdrive(Service):
         default_timeout: str = "120s",
         seed: Optional[int] = None,
         consistent_seed: bool = False,
-        validate_data_dir: bool = True,
         validate_postgres_stash: bool = False,
         entrypoint: Optional[List[str]] = None,
         entrypoint_extra: List[str] = [],
@@ -686,9 +685,6 @@ class Testdrive(Service):
 
         if aws_endpoint and not aws_region:
             entrypoint.append(f"--aws-endpoint={aws_endpoint}")
-
-        if validate_data_dir:
-            entrypoint.append("--validate-data-dir=/mzdata")
 
         if validate_postgres_stash:
             entrypoint.append(

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -140,9 +140,6 @@ struct Args {
     /// Materialize.
     #[clap(long, value_name = "KEY=VAL", parse(from_str = parse_kafka_opt))]
     materialize_param: Vec<(String, String)>,
-    /// Validate the on-disk state of the specified Materialize data directory.
-    #[clap(long, value_name = "PATH")]
-    validate_data_dir: Option<PathBuf>,
     /// Validate the stash state of the specified postgres connection string.
     #[clap(long, value_name = "POSTGRES_URL")]
     validate_postgres_stash: Option<String>,

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -249,7 +249,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
         with c.override(
             Testdrive(
-                validate_data_dir=False,
                 no_reset=True,
                 materialize_params={"cluster": "cluster2"},
                 seed=id,

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -89,7 +89,6 @@ SERVICES = [
     # avoid recompiling the current source unless we will actually be benchmarking it.
     Materialized(image="materialize/materialized:unstable"),
     Testdrive(
-        validate_data_dir=False,
         default_timeout=default_timeout,
     ),
     KgenService(),

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -463,7 +463,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
         with c.override(
             Testdrive(
-                validate_data_dir=False,
                 no_reset=True,
                 materialize_params={"cluster": "cluster1"},
                 seed=id,

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -30,7 +30,6 @@ SERVICES = [
     Postgres(),
     Materialized(),
     Testdrive(
-        validate_data_dir=False,
         no_reset=True,
         seed=1,
         default_timeout="600s",


### PR DESCRIPTION
Testdrive's --validate-data-dir option was not doing anything so needs to be removed.

### Motivation

  * This PR fixes a previously unreported bug.
The legacy upgrade test was not performing stash validation because it was still using --validate-data-dir