### PR TITLE
testdrive: Fix various tests to be SIZE-independent

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -31,6 +31,8 @@ DEFAULT_MZ_VOLUMES = [
     "tmp:/share/tmp",
 ]
 
+DEFAULT_SIZE = 1
+
 
 class Materialized(Service):
     def __init__(
@@ -43,8 +45,8 @@ class Materialized(Service):
         memory: Optional[str] = None,
         persist_blob_url: Optional[str] = None,
         data_directory: str = "/mzdata",
-        workers: Optional[int] = None,
-        size: Optional[str] = None,
+        workers: Optional[int] = DEFAULT_SIZE,
+        size: Optional[str] = str(DEFAULT_SIZE),
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         environment_extra: Optional[List[str]] = None,
@@ -86,6 +88,7 @@ class Materialized(Service):
 
         if size:
             environment += [
+                f"MZ_BOOTSTRAP_BUILTIN_CLUSTER_REPLICA_SIZE={size}",
                 f"MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE={size}",
                 f"MZ_DEFAULT_STORAGE_HOST_SIZE={size}",
             ]
@@ -159,7 +162,7 @@ class Computed(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        workers: Optional[int] = None,
+        workers: Optional[int] = DEFAULT_SIZE,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:
@@ -219,7 +222,7 @@ class Storaged(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        workers: Optional[int] = None,
+        workers: Optional[int] = DEFAULT_SIZE,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -492,91 +492,34 @@ mz_storage_usage
 
 # Check default sources, tables, and views in mz_internal.
 
-# The sources in the catalog depend on the number of replicas and computeds
+# The sources in the catalog depend on the number of replicas
 $ skip-if
-SELECT ${arg.replicas} > 1 OR ${arg.size} > 1;
+SELECT ${arg.replicas} > 1;
 
 > SHOW SOURCES FROM mz_internal
 name                                           type   size
 ------------------------------------------------------------
 mz_arrangement_batches_internal                 log   <null>
-mz_arrangement_batches_internal_1               log   <null>
-mz_arrangement_batches_internal_2               log   <null>
-mz_arrangement_batches_internal_3               log   <null>
 mz_arrangement_records_internal                 log   <null>
-mz_arrangement_records_internal_1               log   <null>
-mz_arrangement_records_internal_2               log   <null>
-mz_arrangement_records_internal_3               log   <null>
 mz_arrangement_sharing_internal                 log   <null>
-mz_arrangement_sharing_internal_1               log   <null>
-mz_arrangement_sharing_internal_2               log   <null>
-mz_arrangement_sharing_internal_3               log   <null>
 mz_dataflow_channels                            log   <null>
-mz_dataflow_channels_1                          log   <null>
-mz_dataflow_channels_2                          log   <null>
-mz_dataflow_channels_3                          log   <null>
 mz_dataflow_addresses                           log   <null>
-mz_dataflow_addresses_1                         log   <null>
-mz_dataflow_addresses_2                         log   <null>
-mz_dataflow_addresses_3                         log   <null>
 mz_dataflow_operator_reachability_internal      log   <null>
-mz_dataflow_operator_reachability_internal_1    log   <null>
-mz_dataflow_operator_reachability_internal_2    log   <null>
-mz_dataflow_operator_reachability_internal_3    log   <null>
 mz_dataflow_operators                           log   <null>
-mz_dataflow_operators_1                         log   <null>
-mz_dataflow_operators_2                         log   <null>
-mz_dataflow_operators_3                         log   <null>
 mz_worker_compute_dependencies                  log   <null>
-mz_worker_compute_dependencies_1                log   <null>
-mz_worker_compute_dependencies_2                log   <null>
-mz_worker_compute_dependencies_3                log   <null>
 mz_compute_exports                              log   <null>
-mz_compute_exports_1                            log   <null>
-mz_compute_exports_2                            log   <null>
-mz_compute_exports_3                            log   <null>
 mz_message_counts_received_internal             log   <null>
-mz_message_counts_received_internal_1           log   <null>
-mz_message_counts_received_internal_2           log   <null>
-mz_message_counts_received_internal_3           log   <null>
 mz_message_counts_sent_internal                 log   <null>
-mz_message_counts_sent_internal_1               log   <null>
-mz_message_counts_sent_internal_2               log   <null>
-mz_message_counts_sent_internal_3               log   <null>
 mz_raw_peek_durations                           log   <null>
-mz_raw_peek_durations_1                         log   <null>
-mz_raw_peek_durations_2                         log   <null>
-mz_raw_peek_durations_3                         log   <null>
 mz_raw_worker_compute_delays                    log   <null>
-mz_raw_worker_compute_delays_1                  log   <null>
-mz_raw_worker_compute_delays_2                  log   <null>
-mz_raw_worker_compute_delays_3                  log   <null>
 mz_active_peeks                                 log   <null>
-mz_active_peeks_1                               log   <null>
-mz_active_peeks_2                               log   <null>
-mz_active_peeks_3                               log   <null>
 mz_scheduling_elapsed_internal                  log   <null>
-mz_scheduling_elapsed_internal_1                log   <null>
-mz_scheduling_elapsed_internal_2                log   <null>
-mz_scheduling_elapsed_internal_3                log   <null>
 mz_raw_compute_operator_durations_internal      log   <null>
-mz_raw_compute_operator_durations_internal_1    log   <null>
-mz_raw_compute_operator_durations_internal_2    log   <null>
-mz_raw_compute_operator_durations_internal_3    log   <null>
 mz_scheduling_parks_internal                    log   <null>
-mz_scheduling_parks_internal_1                  log   <null>
-mz_scheduling_parks_internal_2                  log   <null>
-mz_scheduling_parks_internal_3                  log   <null>
 mz_source_status_history                        source <null>
 mz_storage_shards                               source <null>
 mz_worker_compute_frontiers                     log   <null>
-mz_worker_compute_frontiers_1                   log   <null>
-mz_worker_compute_frontiers_2                   log   <null>
-mz_worker_compute_frontiers_3                   log   <null>
 mz_worker_compute_import_frontiers              log   <null>
-mz_worker_compute_import_frontiers_1            log   <null>
-mz_worker_compute_import_frontiers_2            log   <null>
-mz_worker_compute_import_frontiers_3            log   <null>
 
 > SHOW TABLES FROM mz_internal
 name
@@ -591,73 +534,22 @@ mz_view_keys
 name
 -------------------------------------
 mz_arrangement_sharing
-mz_arrangement_sharing_1
-mz_arrangement_sharing_2
-mz_arrangement_sharing_3
 mz_arrangement_sizes
-mz_arrangement_sizes_1
-mz_arrangement_sizes_2
-mz_arrangement_sizes_3
 mz_dataflows
-mz_dataflows_1
-mz_dataflows_2
-mz_dataflows_3
 mz_dataflow_operator_dataflows
-mz_dataflow_operator_dataflows_1
-mz_dataflow_operator_dataflows_2
-mz_dataflow_operator_dataflows_3
 mz_dataflow_operator_reachability
-mz_dataflow_operator_reachability_1
-mz_dataflow_operator_reachability_2
-mz_dataflow_operator_reachability_3
 mz_compute_frontiers
-mz_compute_frontiers_1
-mz_compute_frontiers_2
-mz_compute_frontiers_3
 mz_compute_import_frontiers
-mz_compute_import_frontiers_1
-mz_compute_import_frontiers_2
-mz_compute_import_frontiers_3
 mz_compute_operator_durations
-mz_compute_operator_durations_1
-mz_compute_operator_durations_2
-mz_compute_operator_durations_3
 mz_message_counts
-mz_message_counts_1
-mz_message_counts_2
-mz_message_counts_3
 mz_peek_durations
-mz_peek_durations_1
-mz_peek_durations_2
-mz_peek_durations_3
 mz_raw_compute_operator_durations
-mz_raw_compute_operator_durations_1
-mz_raw_compute_operator_durations_2
-mz_raw_compute_operator_durations_3
 mz_records_per_dataflow
-mz_records_per_dataflow_1
-mz_records_per_dataflow_2
-mz_records_per_dataflow_3
 mz_records_per_dataflow_global
-mz_records_per_dataflow_global_1
-mz_records_per_dataflow_global_2
-mz_records_per_dataflow_global_3
 mz_records_per_dataflow_operator
-mz_records_per_dataflow_operator_1
-mz_records_per_dataflow_operator_2
-mz_records_per_dataflow_operator_3
 mz_scheduling_elapsed
-mz_scheduling_elapsed_1
-mz_scheduling_elapsed_2
-mz_scheduling_elapsed_3
 mz_scheduling_parks
-mz_scheduling_parks_1
-mz_scheduling_parks_2
-mz_scheduling_parks_3
 mz_worker_compute_delays
-mz_worker_compute_delays_1
-mz_worker_compute_delays_2
-mz_worker_compute_delays_3
 mz_show_cluster_replicas
 mz_show_indexes
 mz_show_materialized_views
@@ -677,7 +569,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-57
+72
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -89,7 +89,7 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(\d{13}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
 "          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[]\n"
 

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -11,7 +11,7 @@
 
 > CREATE SOURCE demo FROM LOAD GENERATOR AUCTION (TICK INTERVAL '50ms') FOR ALL TABLES
 
-$ set-regex match=\d replacement=<SIZE>
+$ set-regex match=\d+ replacement=<SIZE>
 
 > SHOW SOURCES
 name          type           size

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -9,7 +9,7 @@
 
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
-$ set-regex match=\d replacement=<SIZE>
+$ set-regex match=\d+ replacement=<SIZE>
 
 > SHOW SOURCES
 accounts      subsource      <null>

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -334,7 +334,7 @@ a  b
 3  4
 1  2
 
-$ set-regex match=\d replacement=<SIZE>
+$ set-regex match=\d+ replacement=<SIZE>
 
 > SHOW SOURCES
 name     type    size

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -50,7 +50,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="set the default number of kafka partitions per topic",
     )
     parser.add_argument(
-        "--size", type=int, default=4, help="use SIZE 'N' for replicas and sources"
+        "--size", type=int, default=1, help="use SIZE 'N' for replicas and sources"
     )
 
     parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
@@ -85,7 +85,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.start_and_wait_for_tcp(services=dependencies)
         c.wait_for_materialized("materialized")
 
-        if args.replicas > 1 or args.size > 1:
+        if args.replicas > 1:
             c.sql("DROP CLUSTER default CASCADE")
             # Make sure a replica named 'r1' always exists
             replica_names = [

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -162,7 +162,7 @@ renamed_sink
 # Clean up temp view
 > DROP VIEW public_objects;
 
-$ set-regex match=\d replacement=<SIZE>
+$ set-regex match=\d+ replacement=<SIZE>
 
 # Source was successfully renamed
 > SHOW SOURCES;

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -106,7 +106,7 @@ name               type   size
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
-$ set-regex match=\d replacement=<D>
+$ set-regex match=\d+ replacement=<D>
 
 > SHOW SINKS
 name               type   size
@@ -204,7 +204,7 @@ $ kafka-verify-data format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"column1": 2}}}
 {"before": null, "after": {"row":{"column1": 3}}}
 
-$ set-regex match=\d replacement=<D>
+$ set-regex match=\d+ replacement=<D>
 
 > SHOW SINKS
 name               type   size

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -67,7 +67,7 @@ INSERT INTO temp SELECT * FROM temp
 2
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 1
+mz_system r1 ${arg.size}
 
 $ postgres-execute connection=mz_system
 DROP CLUSTER REPLICA mz_system.r1
@@ -75,7 +75,7 @@ DROP CLUSTER REPLICA mz_system.r1
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
 
 $ postgres-execute connection=mz_system
-CREATE CLUSTER REPLICA mz_system.r1 SIZE '1';
+CREATE CLUSTER REPLICA mz_system.r1 SIZE '${arg.size}';
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 1
+mz_system r1 ${arg.size}

--- a/test/testdrive/testscript_source.td
+++ b/test/testdrive/testscript_source.td
@@ -11,7 +11,7 @@
 # Basic test for `TEST SCRIPT` sources.
 
 # replace timestamps
-$ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(\d{13}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 
 
 > CREATE CONNECTION c_conn


### PR DESCRIPTION
In preparation for running the entire CI with SIZE 4, fix various issues with .td tests.

### Motivation

  * This PR adds a feature that has not yet been specified.
We need to be able to run the entire CI with SIZE 4 by default eventually. This is not currently possible due to blocking bugs, but  test files still need to be made compatible with various sizes.