### PR TITLE
Include map prefix in the `column_types` passed to `column_knowledge::optimize`

### DIFF
--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -119,15 +119,15 @@ impl ColumnKnowledge {
                 }
                 MirRelationExpr::Map { input, scalars } => {
                     let mut input_knowledge = self.harvest(input, knowledge, knowledge_stack)?;
-                    let input_typ = input.typ();
+                    let mut column_types = input.typ().column_types;
                     for scalar in scalars.iter_mut() {
-                        let know = optimize(
+                        input_knowledge.push(optimize(
                             scalar,
-                            &input_typ.column_types,
+                            &column_types,
                             &input_knowledge[..],
                             knowledge_stack,
-                        )?;
-                        input_knowledge.push(know);
+                        )?);
+                        column_types.push(scalar.typ(&column_types));
                     }
                     Ok(input_knowledge)
                 }

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -553,3 +553,18 @@ Source materialize.public.double_table
   filter=((#0) IS NOT NULL)
 
 EOF
+
+statement ok
+CREATE TABLE json_table(data JSONB);
+
+# Include map prefix in the `column_types` passed to `column_knowledge::optimize` (https://github.com/MaterializeInc/materialize/issues/15570)
+
+query T multiline
+EXPLAIN WITH(arity, types) SELECT COALESCE(field, '') FROM (SELECT data->>'field' AS field FROM json_table);
+----
+Explained Query:
+  Project (#1) // { arity: 1, types: "(text?)" }
+    Map (coalesce((#0 ->> "field"), "")) // { arity: 2, types: "(jsonb?, text?)" }
+      Get materialize.public.json_table // { arity: 1, types: "(jsonb?)" }
+
+EOF


### PR DESCRIPTION
Because `Map` scalar expressions can refer to columns produced in the prefix of the same `Map`, we have to make sure that the type associated with the prefix is included in the `column_types` value passed to `column_knowledge::optimize`.

Fix due to @ggevay.

### Motivation

  * This PR fixes a recognized bug.

  Fixes #15570.

### Tips for reviewer

@ggevay: The fix is identical to what we discussed offline, modulo renaming and inlining variables.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a bug where json field projection results were used as an argument of another scalar function.
