### PR TITLE
[sinks] Create healthchecker and surface indefinite errors

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -470,7 +470,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // This is disabled for the moment because it has unusual upper
         // advancement behavior.
         // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
-        let status_collection_id = if false {
+        let source_status_collection_id = if false {
             Some(self.catalog.resolve_builtin_storage_collection(
                 &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
             ))
@@ -531,7 +531,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 desc: source.desc.clone(),
                                 data_source,
                                 since: None,
-                                status_collection_id,
+                                status_collection_id: source_status_collection_id,
                             },
                         )])
                         .await

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -419,6 +419,17 @@ impl<S: Append + 'static> Coordinator<S> {
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.collection(sink.from)?;
 
+        // This is disabled for the moment because it has unusual upper
+        // advancement behavior.
+        // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
+        let status_id = if false {
+            Some(self.catalog.resolve_builtin_storage_collection(
+                &crate::catalog::builtin::MZ_SINK_STATUS_HISTORY,
+            ))
+        } else {
+            None
+        };
+
         // The AsOf is used to determine at what time to snapshot reading from the persist collection.  This is
         // primarily relevant when we do _not_ want to include the snapshot in the sink.  Choosing now will mean
         // that only things going forward are exported.
@@ -445,6 +456,7 @@ impl<S: Append + 'static> Coordinator<S> {
             connection,
             envelope: Some(sink.envelope),
             as_of,
+            status_id,
             from_storage_metadata: (),
         };
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -419,9 +419,8 @@ impl<S: Append + 'static> Coordinator<S> {
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.collection(sink.from)?;
 
-        // This is disabled for the moment because it has unusual upper
-        // advancement behavior.
-        // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
+        // This is disabled for the moment because we want to attempt to roll out the change slowly as we're
+        // stressing persist in a new way.
         let status_id = if false {
             Some(self.catalog.resolve_builtin_storage_collection(
                 &crate::catalog::builtin::MZ_SINK_STATUS_HISTORY,

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -20,6 +20,7 @@ use std::iter;
 
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
+use mz_persist_client::ShardId;
 use proptest::prelude::{any, Arbitrary};
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
@@ -188,7 +189,7 @@ impl RustType<ProtoCreateSinkCommand> for CreateSinkCommand<mz_repr::Timestamp> 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct CreateSinkCommand<T> {
     pub id: GlobalId,
-    pub description: StorageSinkDesc<CollectionMetadata, T>,
+    pub description: StorageSinkDesc<CollectionMetadata, ShardId, T>,
 }
 
 impl Arbitrary for CreateSinkCommand<mz_repr::Timestamp> {
@@ -198,7 +199,7 @@ impl Arbitrary for CreateSinkCommand<mz_repr::Timestamp> {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<GlobalId>(),
-            any::<StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>>(),
+            any::<StorageSinkDesc<CollectionMetadata, ShardId, mz_repr::Timestamp>>(),
         )
             .prop_map(|(id, description)| Self { id, description })
             .boxed()

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -102,6 +102,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
+use mz_persist_client::ShardId;
 use timely::communication::Allocate;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
@@ -174,7 +175,7 @@ pub fn build_export_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     storage_state: &mut StorageState,
     id: GlobalId,
-    description: StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>,
+    description: StorageSinkDesc<CollectionMetadata, ShardId, mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -121,7 +121,21 @@ impl Healthchecker {
         Ok(healthchecker)
     }
 
-    /// Process a [`SourceStatusUpdate`] emitted by a source
+    /// Report a SinkStatus::Stalled and then panic with the same message
+    pub async fn report_stall_and_panic<S>(hc: Option<&mut Self>, msg: S) -> !
+    where
+        S: ToString + std::fmt::Debug,
+    {
+        if let Some(healthchecker) = hc {
+            healthchecker
+                .update_status(SinkStatus::Stalled(msg.to_string()))
+                .await;
+        }
+
+        panic!("{msg:?}")
+    }
+
+    /// Process a [`SinkStatusUpdate`] emitted by a sink
     pub async fn update_status(&mut self, status_update: SinkStatus) {
         trace!(
             "Processing status update: {status_update:?}, current status is {current_status}",

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -1,0 +1,788 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Healthchecks for sinks
+use std::fmt::Display;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+use anyhow::Context;
+use bytes::BufMut;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use mz_persist_client::ShardId;
+use mz_persist_types::Codec;
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
+use prost::Message;
+use timely::progress::{Antichain, Timestamp as _};
+use timely::PartialOrder;
+use tokio::sync::Mutex;
+use tracing::trace;
+
+use mz_ore::now::NowFn;
+use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::read::{Listen, ListenEvent, ReadHandle};
+use mz_persist_client::write::WriteHandle;
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
+
+use crate::controller::CollectionMetadata;
+use crate::types::sources::SourceData;
+
+/// The Healthchecker is responsible for tracking the current state
+/// of a Timely worker for a source, as well as updating the relevant
+/// state collection based on it.
+pub struct Healthchecker {
+    /// Internal ID of the source (e.g. s1)
+    sink_id: GlobalId,
+    /// Current status of this source
+    current_status: SinkStatus,
+    /// Last observed upper
+    upper: Antichain<Timestamp>,
+    /// Write handle of the Healthchecker persist shard
+    ///
+    /// The schema used matches the one used in regular sources and tables.
+    write_handle: WriteHandle<HealthcheckerData, (), Timestamp, i64>,
+    /// A listener to tail the Healthchecker shard for new updates
+    listener: Listen<HealthcheckerData, (), Timestamp, i64>,
+    /// The function that should be used to get the current time when updating upper
+    now: NowFn,
+}
+
+// XXX: make this less general than just a "Row"
+// Defined as pub struct SourceData(pub Result<Row, DataflowError>);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HealthcheckerData(crate::types::sources::SourceData);
+impl Deref for HealthcheckerData {
+    type Target = crate::types::sources::SourceData;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl DerefMut for HealthcheckerData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl RustType<crate::types::sources::ProtoSourceData> for HealthcheckerData {
+    fn into_proto(&self) -> crate::types::sources::ProtoSourceData {
+        use crate::types::sources::proto_source_data::Kind;
+        crate::types::sources::ProtoSourceData {
+            kind: Some(match &***self {
+                Ok(row) => Kind::Ok(row.into_proto()),
+                Err(err) => Kind::Err(err.into_proto()),
+            }),
+        }
+    }
+
+    fn from_proto(
+        proto: crate::types::sources::ProtoSourceData,
+    ) -> Result<Self, TryFromProtoError> {
+        use crate::types::sources::proto_source_data::Kind;
+        match proto.kind {
+            Some(kind) => match kind {
+                Kind::Ok(row) => Ok(HealthcheckerData(crate::types::sources::SourceData(Ok(
+                    row.into_rust()?,
+                )))),
+                Kind::Err(err) => Ok(HealthcheckerData(crate::types::sources::SourceData(Err(
+                    err.into_rust()?,
+                )))),
+            },
+            None => Result::Err(TryFromProtoError::missing_field("ProtoSourceData::kind")),
+        }
+    }
+}
+
+impl Codec for HealthcheckerData {
+    fn codec_name() -> String {
+        "protobuf[HealthcheckerData]".into()
+    }
+
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        (&*self)
+            .into_proto()
+            .encode(buf)
+            .expect("no required fields means no initialization errors");
+    }
+
+    fn decode(buf: &[u8]) -> Result<Self, String> {
+        let proto =
+            crate::types::sources::ProtoSourceData::decode(buf).map_err(|err| err.to_string())?;
+        proto.into_rust().map_err(|err| err.to_string())
+    }
+}
+
+impl Healthchecker {
+    pub async fn new(
+        sink_id: GlobalId,
+        persist_clients: &Arc<Mutex<PersistClientCache>>,
+        storage_metadata: &CollectionMetadata,
+        now: NowFn,
+    ) -> Option<anyhow::Result<Self>> {
+        // TODO: encode the presense of status_shard into the type
+        let status_shard_id = storage_metadata.status_shard?;
+        Some(
+            Self::new_unchecked(
+                sink_id,
+                persist_clients,
+                storage_metadata,
+                status_shard_id,
+                now,
+            )
+            .await,
+        )
+    }
+
+    async fn new_unchecked(
+        sink_id: GlobalId,
+        persist_clients: &Arc<Mutex<PersistClientCache>>,
+        storage_metadata: &CollectionMetadata,
+        status_shard_id: ShardId,
+        now: NowFn,
+    ) -> anyhow::Result<Self> {
+        trace!("Initializing healthchecker for sink {sink_id}");
+        let persist_client = persist_clients
+            .lock()
+            .await
+            .open(storage_metadata.persist_location.clone())
+            .await
+            .context("error creating persist client for Healthchecker")?;
+
+        let (write_handle, read_handle) = persist_client
+            .open(status_shard_id)
+            .await
+            .context("error opening Healthchecker persist shard")?;
+
+        let (since, upper) = (read_handle.since().clone(), write_handle.upper().clone());
+
+        // More details on why the listener starts at `since` instead of `upper` in the docstring for [`bootstrap_state`]
+        let listener = read_handle
+            .clone()
+            .await
+            .listen(since.clone())
+            .await
+            .expect("since <= as_of asserted");
+
+        let mut healthchecker = Self {
+            sink_id,
+            current_status: SinkStatus::Starting,
+            upper: Antichain::from_elem(Timestamp::minimum()),
+            write_handle,
+            listener,
+            now,
+        };
+
+        // Bootstrap should reload the previous state of the source, if any
+        healthchecker.bootstrap_state(read_handle, &upper).await;
+        tracing::trace!(
+            "Healthchecker for source {} at status {} finished bootstrapping!",
+            &healthchecker.sink_id,
+            &healthchecker.current_status
+        );
+
+        Ok(healthchecker)
+    }
+
+    /// Process a [`SourceStatusUpdate`] emitted by a source
+    pub async fn update_status(&mut self, status_update: SinkStatus) {
+        trace!(
+            "Processing status update: {status_update:?}, current status is {current_status}",
+            current_status = &self.current_status
+        );
+        // Only update status if it is a valid transition
+        if self.current_status.can_transition(&status_update) {
+            loop {
+                let next_ts = (self.now)();
+                let new_upper = Antichain::from_elem(Timestamp::from(next_ts).step_forward());
+
+                let updates = self.prepare_row_update(&status_update, next_ts);
+                match self
+                    .write_handle
+                    .compare_and_append(updates.iter(), self.upper.clone(), new_upper.clone())
+                    .await
+                {
+                    Ok(Ok(Ok(()))) => {
+                        self.upper = new_upper;
+                        // Update internal status only after a successful append
+                        self.current_status = status_update;
+                        break;
+                    }
+                    Ok(Ok(Err(actual_upper))) => {
+                        trace!(
+                            "Had to retry updating status, old upper {:?}, new upper {:?}",
+                            &self.upper,
+                            &actual_upper
+                        );
+                        // Sync to the new upper, go to the loop again
+                        self.sync(&actual_upper.0).await;
+                        // If we can't transition to the new status after the sync, no need to do anything else
+                        if !self.current_status.can_transition(&status_update) {
+                            break;
+                        }
+                    }
+                    Ok(Err(invalid_use)) => panic!("compare_and_append failed: {invalid_use}"),
+                    // An external error means that the operation might have succeeded or failed but we
+                    // don't know. In either case it is safe to retry because:
+                    // * If it succeeded, then on retry we'll get an `Upper(_)` error as if some other
+                    //   process raced us. This is safe and will just cause the healthchecker to sync
+                    //   again, and on retry it will notice that the new state was already processed and
+                    //   finish successfully.
+                    // * If it failed, then we'll succeed on retry and proceed normally.
+                    Err(external_err) => {
+                        trace!("compare_and_append in update_status failed: {external_err}");
+                        continue;
+                    }
+                };
+            }
+        }
+    }
+
+    /// Synchronizes internal state with state in the storage collection up until a given timestamp
+    async fn sync(&mut self, target_upper: &Antichain<Timestamp>) {
+        while PartialOrder::less_than(&self.upper, target_upper) {
+            for event in self.listener.next().await {
+                match event {
+                    ListenEvent::Progress(new_upper) => {
+                        self.upper = new_upper;
+                    }
+                    ListenEvent::Updates(updates) => {
+                        self.process_collection_updates(updates);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Bootstraps the state of this Healthchecker instance by reading data from the
+    /// underlying storage collection
+    ///
+    /// This function works by first reading a snapshot of the collection at its `since`,
+    /// and then using the listener to read all updates from `since` up until (but not including)
+    /// `upper`. This is done as a way to read all data in the collection, but without
+    /// having to assume that the `upper` is a single `u64`.
+    async fn bootstrap_state(
+        &mut self,
+        mut read_handle: ReadHandle<HealthcheckerData, (), Timestamp, i64>,
+        upper: &Antichain<Timestamp>,
+    ) {
+        let since = read_handle.since().clone();
+        trace!("Bootstrapping state as of {:?}!", since);
+        // Ensure the collection is readable at `since`
+        if PartialOrder::less_than(&since, &self.upper) {
+            let updates = read_handle
+                .snapshot_and_fetch(since.clone())
+                .await
+                .expect("local since is not beyond read handle's since");
+            self.process_collection_updates(updates);
+        };
+        self.sync(upper).await;
+        trace!("State bootstrapped as of {since:?}!");
+    }
+
+    /// Process any updates that might be in the collection to update current status
+    /// Currently assumes that the collection only contains assertions (rows with diff = 1)
+    fn process_collection_updates(
+        &mut self,
+        mut updates: Vec<(
+            (Result<HealthcheckerData, String>, Result<(), String>),
+            Timestamp,
+            i64,
+        )>,
+    ) {
+        // Sort by timestamp and diff
+        updates.sort_by(|(_, t1, d1), (_, t2, d2)| (t1, d1).cmp(&(t2, d2)));
+        for ((source_data, _), ts, _diff) in updates {
+            trace!("Reading from snapshot at time {}: {:?}", ts, &source_data);
+            let row = source_data
+                .expect("failed to deserialize row")
+                .0
+                 .0
+                .expect("status collection should not have errors");
+            let row_vec = row.unpack();
+            let row_source_id = row_vec[1].unwrap_str();
+            let row_status = row_vec[2].unwrap_str();
+
+            if self.sink_id.to_string() == row_source_id {
+                self.current_status = SinkStatus::try_from(row_status).expect("invalid status");
+            }
+        }
+    }
+
+    fn prepare_row_update(
+        &self,
+        status_update: &SinkStatus,
+        ts: u64,
+    ) -> Vec<((HealthcheckerData, ()), Timestamp, i64)> {
+        let timestamp = NaiveDateTime::from_timestamp(
+            (ts / 1000)
+                .try_into()
+                .expect("timestamp seconds does not fit into i64"),
+            (ts % 1000 * 1_000_000)
+                .try_into()
+                .expect("timestamp millis does not fit into a u32"),
+        );
+        let timestamp = Datum::TimestampTz(
+            DateTime::from_utc(timestamp, Utc)
+                .try_into()
+                .expect("must fit"),
+        );
+        let sink_id = self.sink_id.to_string();
+        let sink_id = Datum::String(&sink_id);
+        let status = Datum::String(status_update.name());
+        let error = status_update.error().into();
+        let metadata = Datum::Null;
+        let row = Row::pack_slice(&[timestamp, sink_id, status, error, metadata]);
+
+        vec![(
+            (
+                HealthcheckerData(crate::types::sources::SourceData(Ok(row))),
+                (),
+            ),
+            ts.try_into()
+                .expect("timestamp does not fit into MzTimestamp"),
+            1,
+        )]
+    }
+}
+
+/// Identify the state a worker for a given source can be at a point in time
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SinkStatus {
+    /// Initial state of a Sink during initialization.
+    Setup,
+    /// Intended to be the state while the `storaged` process is initializing itself
+    /// Pushed by the Healthchecker on creation.
+    Starting,
+    /// State indicating the sink is running fine. Pushed automatically as long
+    /// as rows are being consumed.
+    Running,
+    /// Represents a stall in the export process that might get resolved.
+    /// Existing data is still available and queryable.
+    Stalled(String),
+    /// Represents a irrecoverable failure in the pipeline. Data from this collection
+    /// is not queryable any longer. The only valid transition from Failed is Dropped.
+    Failed(String),
+    /// Represents a sink that was dropped.
+    Dropped,
+}
+
+impl SinkStatus {
+    fn name(&self) -> &'static str {
+        match self {
+            SinkStatus::Setup => "setup",
+            SinkStatus::Starting => "starting",
+            SinkStatus::Running => "running",
+            SinkStatus::Stalled(_) => "stalled",
+            SinkStatus::Failed(_) => "failed",
+            SinkStatus::Dropped => "dropped",
+        }
+    }
+
+    fn error(&self) -> Option<&str> {
+        match self {
+            SinkStatus::Stalled(e) => Some(e.deref()),
+            SinkStatus::Failed(e) => Some(e.deref()),
+            SinkStatus::Setup => None,
+            SinkStatus::Starting => None,
+            SinkStatus::Running => None,
+            SinkStatus::Dropped => None,
+        }
+    }
+
+    fn can_transition(&self, new_status: &SinkStatus) -> bool {
+        match self {
+            // Failed can only transition to Dropped
+            SinkStatus::Failed(_) => matches!(new_status, SinkStatus::Dropped),
+            // Dropped is a terminal state
+            SinkStatus::Dropped => false,
+            // All other states can transition freely to any other state
+            SinkStatus::Setup
+            | SinkStatus::Starting
+            | SinkStatus::Running
+            | SinkStatus::Stalled(_) => self != new_status,
+        }
+    }
+}
+
+impl Display for SinkStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl TryFrom<&str> for SinkStatus {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "setup" => Ok(SinkStatus::Setup),
+            "starting" => Ok(SinkStatus::Starting),
+            "running" => Ok(SinkStatus::Running),
+            "stalled" => Ok(SinkStatus::Stalled(String::default())),
+            "failed" => Ok(SinkStatus::Failed(String::default())),
+            "dropped" => Ok(SinkStatus::Dropped),
+            _ => Err(format!("{value} is not a valid SourceStatus")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use itertools::Itertools;
+    use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_ore::now::SYSTEM_TIME;
+    use once_cell::sync::Lazy;
+
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
+
+    // Test suite
+    #[tokio::test(start_paused = true)]
+    async fn test_startup() {
+        let persist_cache = persist_cache();
+        let healthchecker = simple_healthchecker(ShardId::new(), 1, &persist_cache).await;
+
+        assert_eq!(healthchecker.current_status, SinkStatus::Starting);
+    }
+
+    fn stalled() -> SinkStatus {
+        SinkStatus::Stalled("".into())
+    }
+
+    fn failed() -> SinkStatus {
+        SinkStatus::Stalled("".into())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_simple_bootstrap() {
+        let shard_id = ShardId::new();
+        let persist_cache = persist_cache();
+
+        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        // Update status to Running
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Check that the status is indeed Running
+        assert_eq!(healthchecker.current_status, SinkStatus::Running);
+
+        // Start new healthchecker on the same shard
+        let healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+
+        // Ensure that we loaded the previous state
+        assert_eq!(healthchecker.current_status, SinkStatus::Running);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_bootstrap_last_state() {
+        let shard_id = ShardId::new();
+        let persist_cache = persist_cache();
+
+        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        // Update status to Running
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Now update status to Stalled
+        tokio::time::advance(Duration::from_millis(1)).await;
+        let error = String::from("some error here");
+        healthchecker
+            .update_status(SinkStatus::Stalled(error.clone()))
+            .await;
+
+        // Check that the status is indeed Stalled
+        assert_eq!(
+            healthchecker.current_status,
+            SinkStatus::Stalled(error.clone())
+        );
+
+        // Start new healthchecker on the same shard
+        let healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+
+        // Ensure that it is at the latest state, Stalled, not Running or Starting
+        assert_eq!(healthchecker.current_status, SinkStatus::Stalled(error));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_bootstrap_different_sources() {
+        let shard_id = ShardId::new();
+        let persist_cache = persist_cache();
+
+        // First healthchecker is for source u1
+        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        // Update status to Running
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Start new healthchecker on the same shard for source u2
+        let healthchecker = simple_healthchecker(shard_id, 2, &persist_cache).await;
+
+        // It should ignore the state for source u1, and be at the Starting state
+        assert_eq!(healthchecker.current_status, SinkStatus::Starting);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_repeated_update() {
+        let shard_id = ShardId::new();
+        let persist_cache = persist_cache();
+        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        // Update status to Running
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Now update status to Running multiple times, which is a no-op
+        tokio::time::advance(Duration::from_millis(1)).await;
+        healthchecker.update_status(SinkStatus::Running).await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Check in the storage collection that there is just a single row
+        assert_eq!(
+            dump_storage_collection(shard_id, &persist_cache)
+                .await
+                .len(),
+            1
+        );
+
+        // Create another healthchecker with a different id, and also set it to Running
+        let mut healthchecker = simple_healthchecker(shard_id, 2, &persist_cache).await;
+        // Advance past the previous update, since each healthchecker has its own notion of time
+        tokio::time::advance(Duration::from_millis(2)).await;
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Now we should have two rows in the storage collection, one for each source_id
+        assert_eq!(
+            dump_storage_collection(shard_id, &persist_cache)
+                .await
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_forbidden_transition() {
+        let shard_id = ShardId::new();
+        let persist_cache = persist_cache();
+        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        // Update status to Running
+        healthchecker.update_status(SinkStatus::Running).await;
+
+        // Now update status to Failed
+        tokio::time::advance(Duration::from_millis(1)).await;
+        let error = String::from("some error here");
+        healthchecker
+            .update_status(SinkStatus::Failed(error.clone()))
+            .await;
+        assert_eq!(
+            healthchecker.current_status,
+            SinkStatus::Failed(error.clone())
+        );
+
+        // Validate that we can't transition back to Running
+        tokio::time::advance(Duration::from_millis(1)).await;
+        healthchecker.update_status(SinkStatus::Running).await;
+        assert_eq!(healthchecker.current_status, SinkStatus::Failed(error));
+
+        // Check that the error message is persisted
+        let error_message = dump_storage_collection(shard_id, &persist_cache)
+            .await
+            .into_iter()
+            .find_map(|row| {
+                let error = row.unpack()[3];
+                if !error.is_null() {
+                    Some(error.unwrap_str().to_string())
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert_eq!(error_message, "some error here")
+    }
+
+    #[test]
+    fn test_can_transition() {
+        let test_cases = [
+            // Allowed transitions
+            (
+                SinkStatus::Setup,
+                vec![
+                    SinkStatus::Starting,
+                    SinkStatus::Running,
+                    stalled(),
+                    failed(),
+                    SinkStatus::Dropped,
+                ],
+                true,
+            ),
+            (
+                SinkStatus::Starting,
+                vec![
+                    SinkStatus::Setup,
+                    SinkStatus::Running,
+                    stalled(),
+                    failed(),
+                    SinkStatus::Dropped,
+                ],
+                true,
+            ),
+            (
+                SinkStatus::Running,
+                vec![
+                    SinkStatus::Setup,
+                    SinkStatus::Starting,
+                    stalled(),
+                    failed(),
+                    SinkStatus::Dropped,
+                ],
+                true,
+            ),
+            (
+                stalled(),
+                vec![
+                    SinkStatus::Setup,
+                    SinkStatus::Starting,
+                    SinkStatus::Running,
+                    failed(),
+                    SinkStatus::Dropped,
+                ],
+                true,
+            ),
+            (failed(), vec![SinkStatus::Dropped], true),
+            // Forbidden transitions
+            (SinkStatus::Setup, vec![SinkStatus::Setup], false),
+            (SinkStatus::Starting, vec![SinkStatus::Starting], false),
+            (SinkStatus::Running, vec![SinkStatus::Running], false),
+            (stalled(), vec![stalled()], false),
+            (
+                failed(),
+                vec![
+                    SinkStatus::Setup,
+                    SinkStatus::Starting,
+                    SinkStatus::Running,
+                    stalled(),
+                    failed(),
+                ],
+                false,
+            ),
+            (
+                SinkStatus::Dropped,
+                vec![
+                    SinkStatus::Setup,
+                    SinkStatus::Starting,
+                    SinkStatus::Running,
+                    stalled(),
+                    failed(),
+                    SinkStatus::Dropped,
+                ],
+                false,
+            ),
+        ];
+
+        for test_case in test_cases {
+            run_test(test_case)
+        }
+
+        fn run_test(test_case: (SinkStatus, Vec<SinkStatus>, bool)) {
+            let (from_status, to_status, allowed) = test_case;
+            for status in to_status {
+                assert_eq!(allowed, from_status.can_transition(&status))
+            }
+        }
+    }
+
+    // Auxiliary functions
+    fn persist_cache() -> Arc<Mutex<PersistClientCache>> {
+        Arc::new(Mutex::new(PersistClientCache::new(
+            PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
+            &MetricsRegistry::new(),
+        )))
+    }
+
+    static PERSIST_LOCATION: Lazy<PersistLocation> = Lazy::new(|| PersistLocation {
+        blob_uri: "mem://".to_owned(),
+        consensus_uri: "mem://".to_owned(),
+    });
+
+    async fn new_healthchecker(
+        status_shard_id: ShardId,
+        source_id: GlobalId,
+        active: bool,
+        persist_clients: &Arc<Mutex<PersistClientCache>>,
+    ) -> Healthchecker {
+        let start = tokio::time::Instant::now();
+        let now_fn = NowFn::from(move || start.elapsed().as_millis() as u64);
+
+        let storage_metadata = CollectionMetadata {
+            persist_location: (*PERSIST_LOCATION).clone(),
+            remap_shard: ShardId::new(),
+            data_shard: ShardId::new(),
+            status_shard: Some(status_shard_id),
+        };
+
+        Healthchecker::new(source_id, persist_clients, &storage_metadata, now_fn)
+            .await
+            .expect("status shard not present")
+            .expect("error creating healthchecker")
+    }
+
+    async fn simple_healthchecker(
+        status_shard_id: ShardId,
+        source_id: u64,
+        persist_clients: &Arc<Mutex<PersistClientCache>>,
+    ) -> Healthchecker {
+        new_healthchecker(
+            status_shard_id,
+            GlobalId::User(source_id),
+            true,
+            &Arc::clone(persist_clients),
+        )
+        .await
+    }
+
+    async fn dump_storage_collection(
+        shard_id: ShardId,
+        persist_clients: &Arc<Mutex<PersistClientCache>>,
+    ) -> Vec<Row> {
+        let persist_client = persist_clients
+            .lock()
+            .await
+            .open((*PERSIST_LOCATION).clone())
+            .await
+            .unwrap();
+
+        let (write_handle, mut read_handle) = persist_client.open(shard_id).await.unwrap();
+
+        let upper = write_handle.upper();
+        let readable_upper = Antichain::from_elem(upper.elements()[0] - 1);
+
+        read_handle
+            .snapshot_and_fetch(readable_upper)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(
+                |((v, _), _, _): ((Result<SourceData, String>, Result<(), String>), u64, i64)| {
+                    v.unwrap().0.unwrap()
+                },
+            )
+            .collect_vec()
+    }
+}

--- a/src/storage/src/sink/mod.rs
+++ b/src/storage/src/sink/mod.rs
@@ -14,6 +14,7 @@ mod kafka;
 mod metrics;
 mod sink_connection;
 
+pub use healthcheck::{Healthchecker, SinkStatus};
 pub(crate) use metrics::KafkaBaseMetrics;
 pub use metrics::SinkBaseMetrics;
 pub use sink_connection::build_sink_connection;

--- a/src/storage/src/sink/mod.rs
+++ b/src/storage/src/sink/mod.rs
@@ -9,6 +9,7 @@
 
 //! Moving data to external systems
 
+mod healthcheck;
 mod kafka;
 mod metrics;
 mod sink_connection;

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use crossbeam_channel::TryRecvError;
 use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::ShardId;
 use timely::communication::Allocate;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
@@ -68,7 +69,8 @@ pub struct StorageState {
     /// Descriptions of each installed ingestion.
     pub ingestions: HashMap<GlobalId, IngestionDescription<CollectionMetadata>>,
     /// Descriptions of each installed export.
-    pub exports: HashMap<GlobalId, StorageSinkDesc<CollectionMetadata, mz_repr::Timestamp>>,
+    pub exports:
+        HashMap<GlobalId, StorageSinkDesc<CollectionMetadata, ShardId, mz_repr::Timestamp>>,
     /// Undocumented
     pub now: NowFn,
     /// Metrics for the source-specific side of dataflows.

--- a/src/storage/src/types/sinks.proto
+++ b/src/storage/src/types/sinks.proto
@@ -26,6 +26,7 @@ message ProtoStorageSinkDesc {
     optional ProtoSinkEnvelope envelope = 4;
     ProtoSinkAsOf as_of = 5;
     optional mz_storage.controller.ProtoCollectionMetadata from_storage_metadata = 6;
+    optional string status_id = 7;
 }
 
 message ProtoSinkEnvelope {


### PR DESCRIPTION
Modeled off of the source healthchecker, create a new sink healthchecker that reports indefinite errors to a persistent collection.  At the moment, sinks only produce indefinite errors so this is relatively straighforward! We take the error, give it a timestamp at the current time (as determined by the storage controller) and then write it out to a persist shard.

A couple design decisions to note:
- @bkirwi and I have talked about removing the initial snapshotting from the healthchecker.  lmk if you'd like me to roll that into this change
- I used an `Arc<Mutex<Healthchecker>>` within the kafka sink instead of something like `Rc<RefCell<Healthchecker>>`.  While we don't strictly _need_ the `Arc<Mutex>` (since the healthchecker is only used on a single thread), it was tricky to get both the borrow checker and clippy to allow compilation at the same time.  There shouldn't be any lock contention and the code is more future-proofed since we don't have to worry about the single-thread restriction.
- It's becoming increasingly clear that we'll want to reorganize the `KafkaSinkState` struct at some point -- there are a decent number of gymnastics to appease the borrow checker because different subfields have mutable borrows at overlapping points.  All that said, I don't think rolling into this PR is the place to do this.

### Motivation
https://github.com/MaterializeInc/materialize/issues/15163
https://github.com/MaterializeInc/materialize/issues/15164

### Tips for reviewer
I've currently disabled the use of the introspection collection (as the source's is also currently disabled) but I did do a test run with it enabled: https://buildkite.com/materialize/tests/builds/43940

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
