### PR TITLE
Doc: clarify source name in Confluent guide

### DIFF
--- a/doc/user/content/integrations/confluent-cloud.md
+++ b/doc/user/content/integrations/confluent-cloud.md
@@ -66,7 +66,7 @@ The process to connect Materialize to a Confluent Cloud Kafka cluster consists o
         SASL PASSWORD = SECRET confluent_password
       );
 
-      CREATE SOURCE <topic-name>
+      CREATE SOURCE <source-name>
         FROM KAFKA CONNECTION confluent_cloud (TOPIC '<topic-name>')
         FORMAT BYTES
         WITH (SIZE = '3xsmall');


### PR DESCRIPTION
### Motivation

Change the source name from `topic-name` to `source-name` so you're not left thinking there is a dependency between the source name and the topic name as suggested by @heeringa and also make sure to match the same structure as the MSK guide.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
