### PR TITLE
adapter: Set default cluster size correctly

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -467,7 +467,7 @@ fn add_new_builtin_compute_replicas_migration<S: Append>(
         if matches!(compute_replica_names, None)
             || matches!(compute_replica_names, Some(names) if !names.contains(builtin_compute_replica.name))
         {
-            let config = default_compute_replica_config(bootstrap_args);
+            let config = builtin_compute_replica_config(bootstrap_args);
             txn.insert_compute_replica(
                 builtin_compute_replica.compute_instance_name,
                 builtin_compute_replica.name,
@@ -483,16 +483,33 @@ fn default_compute_replica_config(
 ) -> SerializedComputeReplicaConfig {
     SerializedComputeReplicaConfig {
         location: SerializedComputeReplicaLocation::Managed {
+            size: bootstrap_args.default_cluster_replica_size.clone(),
+            availability_zone: bootstrap_args.default_availability_zone.clone(),
+            az_user_specified: false,
+        },
+        logging: default_logging_config(),
+    }
+}
+
+fn builtin_compute_replica_config(
+    bootstrap_args: &BootstrapArgs,
+) -> SerializedComputeReplicaConfig {
+    SerializedComputeReplicaConfig {
+        location: SerializedComputeReplicaLocation::Managed {
             size: bootstrap_args.builtin_cluster_replica_size.clone(),
             availability_zone: bootstrap_args.default_availability_zone.clone(),
             az_user_specified: false,
         },
-        logging: SerializedComputeReplicaLogging {
-            log_logging: false,
-            interval: Some(Duration::from_secs(1)),
-            sources: None,
-            views: None,
-        },
+        logging: default_logging_config(),
+    }
+}
+
+fn default_logging_config() -> SerializedComputeReplicaLogging {
+    SerializedComputeReplicaLogging {
+        log_logging: false,
+        interval: Some(Duration::from_secs(1)),
+        sources: None,
+        views: None,
     }
 }
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -893,7 +893,7 @@ fn test_default_cluster_sizes() -> Result<(), Box<dyn Error>> {
 
     let builtin_size: String = client
         .query(
-            "SELECT size FROM mz_cluster_replicas WHERE name LIKE 'mz_%'",
+            "SELECT size FROM (SHOW CLUSTER REPLICAS WHERE cluster LIKE 'mz_%')",
             &[],
         )?
         .get(0)
@@ -903,7 +903,7 @@ fn test_default_cluster_sizes() -> Result<(), Box<dyn Error>> {
 
     let builtin_size: String = client
         .query(
-            "SELECT size FROM mz_cluster_replicas WHERE name = 'default'",
+            "SELECT size FROM (SHOW CLUSTER REPLICAS WHERE cluster = 'default')",
             &[],
         )?
         .get(0)

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -880,3 +880,36 @@ fn test_storage_usage_collection_interval_timestamps() -> Result<(), Box<dyn Err
 
     Ok(())
 }
+
+#[test]
+fn test_default_cluster_sizes() -> Result<(), Box<dyn Error>> {
+    mz_ore::test::init_logging();
+
+    let config = util::Config::default()
+        .with_builtin_cluster_replica_size("1".to_string())
+        .with_default_cluster_replica_size("2".to_string());
+    let server = util::start_server(config)?;
+    let mut client = server.connect(postgres::NoTls)?;
+
+    let builtin_size: String = client
+        .query(
+            "SELECT size FROM mz_cluster_replicas WHERE name LIKE 'mz_%'",
+            &[],
+        )?
+        .get(0)
+        .unwrap()
+        .get(0);
+    assert_eq!(builtin_size, "1");
+
+    let builtin_size: String = client
+        .query(
+            "SELECT size FROM mz_cluster_replicas WHERE name = 'default'",
+            &[],
+        )?
+        .get(0)
+        .unwrap()
+        .get(0);
+    assert_eq!(builtin_size, "2");
+
+    Ok(())
+}

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -59,6 +59,8 @@ pub struct Config {
     now: NowFn,
     seed: u32,
     storage_usage_collection_interval: Duration,
+    default_cluster_replica_size: String,
+    builtin_cluster_replica_size: String,
 }
 
 impl Default for Config {
@@ -72,6 +74,8 @@ impl Default for Config {
             now: SYSTEM_TIME.clone(),
             seed: rand::random(),
             storage_usage_collection_interval: Duration::from_secs(3600),
+            default_cluster_replica_size: "1".to_string(),
+            builtin_cluster_replica_size: "1".to_string(),
         }
     }
 }
@@ -121,6 +125,22 @@ impl Config {
         storage_usage_collection_interval: Duration,
     ) -> Self {
         self.storage_usage_collection_interval = storage_usage_collection_interval;
+        self
+    }
+
+    pub fn with_default_cluster_replica_size(
+        mut self,
+        default_cluster_replica_size: String,
+    ) -> Self {
+        self.default_cluster_replica_size = default_cluster_replica_size;
+        self
+    }
+
+    pub fn with_builtin_cluster_replica_size(
+        mut self,
+        builtin_cluster_replica_size: String,
+    ) -> Self {
+        self.builtin_cluster_replica_size = builtin_cluster_replica_size;
         self
     }
 }
@@ -209,8 +229,8 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
         cors_allowed_origin: AllowOrigin::list([]),
         cluster_replica_sizes: Default::default(),
-        bootstrap_default_cluster_replica_size: "1".into(),
-        bootstrap_builtin_cluster_replica_size: "1".into(),
+        bootstrap_default_cluster_replica_size: config.default_cluster_replica_size,
+        bootstrap_builtin_cluster_replica_size: config.builtin_cluster_replica_size,
         storage_host_sizes: Default::default(),
         default_storage_host_size: None,
         availability_zones: Default::default(),


### PR DESCRIPTION
Previously we were accidentally using the builtin cluster replica size to set the default cluster replica size. This commit fixes this mistake so that the default cluster replica size is set with the correct command line arg.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
