### PR TITLE
sql: add right_inverse to LazyUnaryFunc

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -396,6 +396,10 @@ message ProtoUnaryFunc {
         google.protobuf.Empty cast_uint32_to_mz_timestamp = 274;
         google.protobuf.Empty cast_int32_to_mz_timestamp = 275;
         google.protobuf.Empty step_mz_timestamp = 276;
+        google.protobuf.Empty cast_bool_to_int64 = 277;
+        google.protobuf.Empty cast_uint16_to_int16 = 278;
+        google.protobuf.Empty cast_uint32_to_int16 = 279;
+        google.protobuf.Empty cast_uint64_to_int16 = 280;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3799,55 +3799,6 @@ impl UnaryFunc {
             _ => true,
         }
     }
-
-    /// If the function is invertible, it returns the inverse.
-    /// Note that this cannot generally be used to transform `f_inv(f(x))` to `x`, because of range
-    /// issues when e.g. `f` is a narrowing conversion.
-    pub fn invert(&self) -> Option<Self> {
-        // TODO: Make this more general, and move it to the function-defining macro.
-        match self {
-            // VarChar <-> String
-            UnaryFunc::CastVarCharToString(_) => {
-                Some(UnaryFunc::CastStringToVarChar(CastStringToVarChar {
-                    length: None,
-                    fail_on_len: false,
-                }))
-            }
-            UnaryFunc::CastStringToVarChar(_) => {
-                Some(UnaryFunc::CastVarCharToString(CastVarCharToString))
-            }
-
-            // IntXX
-            UnaryFunc::CastInt64ToInt32(_) => Some(UnaryFunc::CastInt32ToInt64(CastInt32ToInt64)),
-            UnaryFunc::CastInt64ToInt16(_) => Some(UnaryFunc::CastInt16ToInt64(CastInt16ToInt64)),
-            UnaryFunc::CastInt32ToInt64(_) => Some(UnaryFunc::CastInt64ToInt32(CastInt64ToInt32)),
-            UnaryFunc::CastInt32ToInt16(_) => Some(UnaryFunc::CastInt16ToInt32(CastInt16ToInt32)),
-            UnaryFunc::CastInt16ToInt64(_) => Some(UnaryFunc::CastInt64ToInt16(CastInt64ToInt16)),
-            UnaryFunc::CastInt16ToInt32(_) => Some(UnaryFunc::CastInt32ToInt16(CastInt32ToInt16)),
-
-            // Int32 <-> UintX
-            UnaryFunc::CastInt32ToUint64(_) => {
-                Some(UnaryFunc::CastUint64ToInt32(CastUint64ToInt32))
-            }
-            UnaryFunc::CastInt32ToUint32(_) => {
-                Some(UnaryFunc::CastUint32ToInt32(CastUint32ToInt32))
-            }
-            UnaryFunc::CastInt32ToUint16(_) => {
-                Some(UnaryFunc::CastUint16ToInt32(CastUint16ToInt32))
-            }
-            UnaryFunc::CastUint64ToInt32(_) => {
-                Some(UnaryFunc::CastInt32ToUint64(CastInt32ToUint64))
-            }
-            UnaryFunc::CastUint32ToInt32(_) => {
-                Some(UnaryFunc::CastInt32ToUint32(CastInt32ToUint32))
-            }
-            UnaryFunc::CastUint16ToInt32(_) => {
-                Some(UnaryFunc::CastInt32ToUint16(CastInt32ToUint16))
-            }
-
-            _ => None,
-        }
-    }
 }
 
 /// An explicit [`Arbitrary`] implementation needed here because of a known

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -74,7 +74,7 @@ impl LazyUnaryFunc for CastArrayToListOneDim {
         true
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
 }
@@ -124,7 +124,7 @@ impl LazyUnaryFunc for CastArrayToString {
         true
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         // TODO? If we moved typeconv into `expr` we could determine the right
         // inverse of this.
         None

--- a/src/expr/src/scalar/func/impls/array.rs
+++ b/src/expr/src/scalar/func/impls/array.rs
@@ -73,6 +73,10 @@ impl LazyUnaryFunc for CastArrayToListOneDim {
     fn preserves_uniqueness(&self) -> bool {
         true
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
 }
 
 impl fmt::Display for CastArrayToListOneDim {
@@ -118,6 +122,12 @@ impl LazyUnaryFunc for CastArrayToString {
 
     fn preserves_uniqueness(&self) -> bool {
         true
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        // TODO? If we moved typeconv into `expr` we could determine the right
+        // inverse of this.
+        None
     }
 }
 

--- a/src/expr/src/scalar/func/impls/boolean.rs
+++ b/src/expr/src/scalar/func/impls/boolean.rs
@@ -12,7 +12,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "NOT"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(Not)]
+    #[inverse = to_unary!(Not)]
     fn not(a: bool) -> bool {
         !a
     }
@@ -21,7 +21,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToBool)]
+    #[inverse = to_unary!(super::CastStringToBool)]
     fn cast_bool_to_string<'a>(a: bool) -> &'a str {
         match a {
             true => "true",
@@ -33,7 +33,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_nonstandard_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToBool)]
+    #[inverse = to_unary!(super::CastStringToBool)]
     fn cast_bool_to_string_nonstandard<'a>(a: bool) -> &'a str {
         // N.B. this function differs from `cast_bool_to_string` because
         // the SQL specification requires `true` and `false` to be spelled out in
@@ -46,7 +46,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToBool)]
+    #[inverse = to_unary!(super::CastInt32ToBool)]
     fn cast_bool_to_int32(a: bool) -> i32 {
         match a {
             true => 1,
@@ -58,7 +58,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToBool)]
+    #[inverse = to_unary!(super::CastInt64ToBool)]
     fn cast_bool_to_int64(a: bool) -> i64 {
         match a {
             true => 1,

--- a/src/expr/src/scalar/func/impls/boolean.rs
+++ b/src/expr/src/scalar/func/impls/boolean.rs
@@ -12,6 +12,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "NOT"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(Not)]
     fn not(a: bool) -> bool {
         !a
     }
@@ -20,6 +21,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToBool)]
     fn cast_bool_to_string<'a>(a: bool) -> &'a str {
         match a {
             true => "true",
@@ -31,6 +33,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_nonstandard_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToBool)]
     fn cast_bool_to_string_nonstandard<'a>(a: bool) -> &'a str {
         // N.B. this function differs from `cast_bool_to_string` because
         // the SQL specification requires `true` and `false` to be spelled out in
@@ -43,7 +46,20 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "boolean_to_integer"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToBool)]
     fn cast_bool_to_int32(a: bool) -> i32 {
+        match a {
+            true => 1,
+            false => 0,
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "boolean_to_bigint"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToBool)]
+    fn cast_bool_to_int64(a: bool) -> i64 {
         match a {
             true => 1,
             false => 0,

--- a/src/expr/src/scalar/func/impls/byte.rs
+++ b/src/expr/src/scalar/func/impls/byte.rs
@@ -14,7 +14,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "bytea_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToBytes)]
+    #[inverse = to_unary!(super::CastStringToBytes)]
     fn cast_bytes_to_string(a: &'a [u8]) -> String {
         let mut buf = String::new();
         strconv::format_bytes(&mut buf, a);

--- a/src/expr/src/scalar/func/impls/byte.rs
+++ b/src/expr/src/scalar/func/impls/byte.rs
@@ -14,6 +14,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "bytea_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToBytes)]
     fn cast_bytes_to_string(a: &'a [u8]) -> String {
         let mut buf = String::new();
         strconv::format_bytes(&mut buf, a);

--- a/src/expr/src/scalar/func/impls/char.rs
+++ b/src/expr/src/scalar/func/impls/char.rs
@@ -50,10 +50,15 @@ impl fmt::Display for PadChar {
     }
 }
 
-// This function simply allows the expression of changing a's type from varchar to string
+// This function simply allows the expression of changing a's type from varchar
+// to string
 sqlfunc!(
     #[sqlname = "char_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToChar{
+        length: None,
+        fail_on_len: false,
+    })]
     fn cast_char_to_string<'a>(a: Char<&'a str>) -> &'a str {
         a.0
     }

--- a/src/expr/src/scalar/func/impls/char.rs
+++ b/src/expr/src/scalar/func/impls/char.rs
@@ -50,12 +50,12 @@ impl fmt::Display for PadChar {
     }
 }
 
-// This function simply allows the expression of changing a's type from varchar
-// to string
+// This function simply allows the expression of changing a's type from char to
+// string
 sqlfunc!(
     #[sqlname = "char_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToChar{
+    #[inverse = to_unary!(super::CastStringToChar{
         length: None,
         fail_on_len: false,
     })]

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -26,6 +26,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "date_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToDate)]
     fn cast_date_to_string(a: Date) -> String {
         let mut buf = String::new();
         strconv::format_date(&mut buf, a);
@@ -36,6 +37,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "date_to_timestamp"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastTimestampToDate)]
     fn cast_date_to_timestamp(a: Date) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
         Ok(CheckedTimestamp::from_timestamplike(
             NaiveDate::from(a).and_hms(0, 0, 0),
@@ -46,6 +48,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "date_to_timestamp_with_timezone"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastTimestampTzToDate)]
     fn cast_date_to_timestamp_tz(a: Date) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
         Ok(CheckedTimestamp::from_timestamplike(
             DateTime::<Utc>::from_utc(NaiveDate::from(a).and_hms(0, 0, 0), Utc),

--- a/src/expr/src/scalar/func/impls/date.rs
+++ b/src/expr/src/scalar/func/impls/date.rs
@@ -26,7 +26,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "date_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToDate)]
+    #[inverse = to_unary!(super::CastStringToDate)]
     fn cast_date_to_string(a: Date) -> String {
         let mut buf = String::new();
         strconv::format_date(&mut buf, a);
@@ -37,7 +37,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "date_to_timestamp"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastTimestampToDate)]
+    #[inverse = to_unary!(super::CastTimestampToDate)]
     fn cast_date_to_timestamp(a: Date) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
         Ok(CheckedTimestamp::from_timestamplike(
             NaiveDate::from(a).and_hms(0, 0, 0),
@@ -48,7 +48,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "date_to_timestamp_with_timezone"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastTimestampTzToDate)]
+    #[inverse = to_unary!(super::CastTimestampTzToDate)]
     fn cast_date_to_timestamp_tz(a: Date) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
         Ok(CheckedTimestamp::from_timestamplike(
             DateTime::<Utc>::from_utc(NaiveDate::from(a).and_hms(0, 0, 0), Utc),

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -20,6 +20,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "-"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(NegFloat32)]
     fn neg_float32(a: f32) -> f32 {
         -a
     }
@@ -68,6 +70,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_smallint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt16ToFloat32)]
     fn cast_float32_to_int16(a: f32) -> Result<i16, EvalError> {
         let f = round_float32(a);
         if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
@@ -80,6 +84,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_integer"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt32ToFloat32)]
     fn cast_float32_to_int32(a: f32) -> Result<i32, EvalError> {
         let f = round_float32(a);
         // This condition is delicate because i32::MIN can be represented exactly by
@@ -96,6 +102,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_bigint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt64ToFloat32)]
     fn cast_float32_to_int64(a: f32) -> Result<i64, EvalError> {
         let f = round_float32(a);
         // This condition is delicate because i64::MIN can be represented exactly by
@@ -112,6 +120,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_double"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat64ToFloat32)]
     fn cast_float32_to_float64(a: f32) -> f64 {
         a.into()
     }
@@ -119,6 +129,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_text"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastStringToFloat32)]
     fn cast_float32_to_string(a: f32) -> String {
         let mut s = String::new();
         strconv::format_float32(&mut s, a);
@@ -128,6 +140,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_uint2"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint16ToFloat32)]
     fn cast_float32_to_uint16(a: f32) -> Result<u16, EvalError> {
         let f = round_float32(a);
         if (f >= 0.0) && (f <= (u16::MAX as f32)) {
@@ -140,6 +154,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_uint4"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint32ToFloat32)]
     fn cast_float32_to_uint32(a: f32) -> Result<u32, EvalError> {
         let f = round_float32(a);
         if (f >= 0.0) && (f <= (u32::MAX as f32)) {
@@ -152,6 +168,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "real_to_uint8"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint64ToFloat32)]
     fn cast_float32_to_uint64(a: f32) -> Result<u64, EvalError> {
         let f = round_float32(a);
         if (f >= 0.0) && (f <= (u64::MAX as f32)) {
@@ -187,6 +205,10 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat32ToNumeric {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToFloat32)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/float32.rs
+++ b/src/expr/src/scalar/func/impls/float32.rs
@@ -21,7 +21,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(NegFloat32)]
+    #[inverse = to_unary!(NegFloat32)]
     fn neg_float32(a: f32) -> f32 {
         -a
     }
@@ -71,7 +71,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_smallint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt16ToFloat32)]
+    #[inverse = to_unary!(super::CastInt16ToFloat32)]
     fn cast_float32_to_int16(a: f32) -> Result<i16, EvalError> {
         let f = round_float32(a);
         if (f >= (i16::MIN as f32)) && (f < -(i16::MIN as f32)) {
@@ -85,7 +85,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_integer"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt32ToFloat32)]
+    #[inverse = to_unary!(super::CastInt32ToFloat32)]
     fn cast_float32_to_int32(a: f32) -> Result<i32, EvalError> {
         let f = round_float32(a);
         // This condition is delicate because i32::MIN can be represented exactly by
@@ -103,7 +103,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_bigint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt64ToFloat32)]
+    #[inverse = to_unary!(super::CastInt64ToFloat32)]
     fn cast_float32_to_int64(a: f32) -> Result<i64, EvalError> {
         let f = round_float32(a);
         // This condition is delicate because i64::MIN can be represented exactly by
@@ -121,7 +121,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_double"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat64ToFloat32)]
+    #[inverse = to_unary!(super::CastFloat64ToFloat32)]
     fn cast_float32_to_float64(a: f32) -> f64 {
         a.into()
     }
@@ -130,7 +130,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_text"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastStringToFloat32)]
+    #[inverse = to_unary!(super::CastStringToFloat32)]
     fn cast_float32_to_string(a: f32) -> String {
         let mut s = String::new();
         strconv::format_float32(&mut s, a);
@@ -141,7 +141,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_uint2"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint16ToFloat32)]
+    #[inverse = to_unary!(super::CastUint16ToFloat32)]
     fn cast_float32_to_uint16(a: f32) -> Result<u16, EvalError> {
         let f = round_float32(a);
         if (f >= 0.0) && (f <= (u16::MAX as f32)) {
@@ -155,7 +155,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_uint4"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint32ToFloat32)]
+    #[inverse = to_unary!(super::CastUint32ToFloat32)]
     fn cast_float32_to_uint32(a: f32) -> Result<u32, EvalError> {
         let f = round_float32(a);
         if (f >= 0.0) && (f <= (u32::MAX as f32)) {
@@ -169,7 +169,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "real_to_uint8"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint64ToFloat32)]
+    #[inverse = to_unary!(super::CastUint64ToFloat32)]
     fn cast_float32_to_uint64(a: f32) -> Result<u64, EvalError> {
         let f = round_float32(a);
         if (f >= 0.0) && (f <= (u64::MAX as f32)) {
@@ -207,7 +207,7 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat32ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToFloat32)
     }
 }

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -22,6 +22,8 @@ use crate::{scalar::DomainLimit, EvalError};
 
 sqlfunc!(
     #[sqlname = "-"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(NegFloat64)]
     fn neg_float64(a: f64) -> f64 {
         -a
     }
@@ -70,6 +72,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_smallint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt16ToFloat64)]
     fn cast_float64_to_int16(a: f64) -> Result<i16, EvalError> {
         let f = round_float64(a);
         if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
@@ -82,6 +86,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_integer"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt32ToFloat64)]
     fn cast_float64_to_int32(a: f64) -> Result<i32, EvalError> {
         let f = round_float64(a);
         // This condition is delicate because i32::MIN can be represented exactly by
@@ -98,6 +104,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "f64toi64"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt64ToFloat64)]
     fn cast_float64_to_int64(a: f64) -> Result<i64, EvalError> {
         let f = round_float64(a);
         // This condition is delicate because i64::MIN can be represented exactly by
@@ -114,6 +122,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToFloat64)]
     fn cast_float64_to_float32(a: f64) -> Result<f32, EvalError> {
         let result = a as f32;
         if result.is_infinite() && !a.is_infinite() {
@@ -128,6 +138,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_text"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastStringToFloat64)]
     fn cast_float64_to_string(a: f64) -> String {
         let mut s = String::new();
         strconv::format_float64(&mut s, a);
@@ -137,6 +149,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_uint2"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint16ToFloat64)]
     fn cast_float64_to_uint16(a: f64) -> Result<u16, EvalError> {
         let f = round_float64(a);
         if (f >= 0.0) && (f <= (u16::MAX as f64)) {
@@ -149,6 +163,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_uint4"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint32ToFloat64)]
     fn cast_float64_to_uint32(a: f64) -> Result<u32, EvalError> {
         let f = round_float64(a);
         if (f >= 0.0) && (f <= (u32::MAX as f64)) {
@@ -161,6 +177,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "double_to_uint8"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint64ToFloat64)]
     fn cast_float64_to_uint64(a: f64) -> Result<u64, EvalError> {
         let f = round_float64(a);
         if (f >= 0.0) && (f <= (u64::MAX as f64)) {
@@ -198,6 +216,10 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat64ToNumeric {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToFloat64)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/float64.rs
+++ b/src/expr/src/scalar/func/impls/float64.rs
@@ -23,7 +23,7 @@ use crate::{scalar::DomainLimit, EvalError};
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(NegFloat64)]
+    #[inverse = to_unary!(NegFloat64)]
     fn neg_float64(a: f64) -> f64 {
         -a
     }
@@ -73,7 +73,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_smallint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt16ToFloat64)]
+    #[inverse = to_unary!(super::CastInt16ToFloat64)]
     fn cast_float64_to_int16(a: f64) -> Result<i16, EvalError> {
         let f = round_float64(a);
         if (f >= (i16::MIN as f64)) && (f < -(i16::MIN as f64)) {
@@ -87,7 +87,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_integer"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt32ToFloat64)]
+    #[inverse = to_unary!(super::CastInt32ToFloat64)]
     fn cast_float64_to_int32(a: f64) -> Result<i32, EvalError> {
         let f = round_float64(a);
         // This condition is delicate because i32::MIN can be represented exactly by
@@ -105,7 +105,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "f64toi64"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt64ToFloat64)]
+    #[inverse = to_unary!(super::CastInt64ToFloat64)]
     fn cast_float64_to_int64(a: f64) -> Result<i64, EvalError> {
         let f = round_float64(a);
         // This condition is delicate because i64::MIN can be represented exactly by
@@ -123,7 +123,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToFloat64)]
+    #[inverse = to_unary!(super::CastFloat32ToFloat64)]
     fn cast_float64_to_float32(a: f64) -> Result<f32, EvalError> {
         let result = a as f32;
         if result.is_infinite() && !a.is_infinite() {
@@ -139,7 +139,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_text"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastStringToFloat64)]
+    #[inverse = to_unary!(super::CastStringToFloat64)]
     fn cast_float64_to_string(a: f64) -> String {
         let mut s = String::new();
         strconv::format_float64(&mut s, a);
@@ -150,7 +150,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_uint2"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint16ToFloat64)]
+    #[inverse = to_unary!(super::CastUint16ToFloat64)]
     fn cast_float64_to_uint16(a: f64) -> Result<u16, EvalError> {
         let f = round_float64(a);
         if (f >= 0.0) && (f <= (u16::MAX as f64)) {
@@ -164,7 +164,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_uint4"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint32ToFloat64)]
+    #[inverse = to_unary!(super::CastUint32ToFloat64)]
     fn cast_float64_to_uint32(a: f64) -> Result<u32, EvalError> {
         let f = round_float64(a);
         if (f >= 0.0) && (f <= (u32::MAX as f64)) {
@@ -178,7 +178,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "double_to_uint8"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint64ToFloat64)]
+    #[inverse = to_unary!(super::CastUint64ToFloat64)]
     fn cast_float64_to_uint64(a: f64) -> Result<u64, EvalError> {
         let f = round_float64(a);
         if (f >= 0.0) && (f <= (u64::MAX as f64)) {
@@ -218,7 +218,7 @@ impl<'a> EagerUnaryFunc<'a> for CastFloat64ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToFloat64)
     }
 }

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -20,6 +20,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "-"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(NegInt16)]
     fn neg_int16(a: i16) -> Result<i16, EvalError> {
         a.checked_neg().ok_or(EvalError::Int16OutOfRange)
     }
@@ -27,6 +29,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "~"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(BitNotInt16)]
     fn bit_not_int16(a: i16) -> i16 {
         !a
     }
@@ -42,6 +46,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_real"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastFloat32ToInt16)]
     fn cast_int16_to_float32(a: i16) -> f32 {
         f32::from(a)
     }
@@ -50,6 +55,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_double"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastFloat64ToInt16)]
     fn cast_int16_to_float64(a: i16) -> f64 {
         f64::from(a)
     }
@@ -58,6 +64,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_integer"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToInt16)]
     fn cast_int16_to_int32(a: i16) -> i32 {
         i32::from(a)
     }
@@ -66,6 +73,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_bigint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToInt16)]
     fn cast_int16_to_int64(a: i16) -> i64 {
         i64::from(a)
     }
@@ -74,6 +82,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToInt16)]
     fn cast_int16_to_string(a: i16) -> String {
         let mut buf = String::new();
         strconv::format_int16(&mut buf, a);
@@ -84,6 +93,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_uint2"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint16ToInt16)]
     fn cast_int16_to_uint16(a: i16) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -92,6 +102,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_uint4"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint32ToInt16)]
     fn cast_int16_to_uint32(a: i16) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -100,6 +111,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_uint8"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint64ToInt16)]
     fn cast_int16_to_uint64(a: i16) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -124,6 +136,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt16ToNumeric {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToInt16)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -21,7 +21,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(NegInt16)]
+    #[inverse = to_unary!(NegInt16)]
     fn neg_int16(a: i16) -> Result<i16, EvalError> {
         a.checked_neg().ok_or(EvalError::Int16OutOfRange)
     }
@@ -30,7 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(BitNotInt16)]
+    #[inverse = to_unary!(BitNotInt16)]
     fn bit_not_int16(a: i16) -> i16 {
         !a
     }
@@ -46,7 +46,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_real"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastFloat32ToInt16)]
+    #[inverse = to_unary!(super::CastFloat32ToInt16)]
     fn cast_int16_to_float32(a: i16) -> f32 {
         f32::from(a)
     }
@@ -55,7 +55,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_double"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastFloat64ToInt16)]
+    #[inverse = to_unary!(super::CastFloat64ToInt16)]
     fn cast_int16_to_float64(a: i16) -> f64 {
         f64::from(a)
     }
@@ -64,7 +64,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToInt16)]
+    #[inverse = to_unary!(super::CastInt32ToInt16)]
     fn cast_int16_to_int32(a: i16) -> i32 {
         i32::from(a)
     }
@@ -73,7 +73,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToInt16)]
+    #[inverse = to_unary!(super::CastInt64ToInt16)]
     fn cast_int16_to_int64(a: i16) -> i64 {
         i64::from(a)
     }
@@ -82,7 +82,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToInt16)]
+    #[inverse = to_unary!(super::CastStringToInt16)]
     fn cast_int16_to_string(a: i16) -> String {
         let mut buf = String::new();
         strconv::format_int16(&mut buf, a);
@@ -93,7 +93,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_uint2"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint16ToInt16)]
+    #[inverse = to_unary!(super::CastUint16ToInt16)]
     fn cast_int16_to_uint16(a: i16) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -102,7 +102,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_uint4"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint32ToInt16)]
+    #[inverse = to_unary!(super::CastUint32ToInt16)]
     fn cast_int16_to_uint32(a: i16) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -111,7 +111,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "smallint_to_uint8"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint64ToInt16)]
+    #[inverse = to_unary!(super::CastUint64ToInt16)]
     fn cast_int16_to_uint64(a: i16) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -138,7 +138,7 @@ impl<'a> EagerUnaryFunc<'a> for CastInt16ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt16)
     }
 }

--- a/src/expr/src/scalar/func/impls/int2vector.rs
+++ b/src/expr/src/scalar/func/impls/int2vector.rs
@@ -55,7 +55,7 @@ impl LazyUnaryFunc for CastInt2VectorToArray {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
 }
@@ -103,7 +103,7 @@ impl LazyUnaryFunc for CastInt2VectorToString {
         true
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastStringToInt2Vector)
     }
 }

--- a/src/expr/src/scalar/func/impls/int2vector.rs
+++ b/src/expr/src/scalar/func/impls/int2vector.rs
@@ -54,6 +54,10 @@ impl LazyUnaryFunc for CastInt2VectorToArray {
     fn preserves_uniqueness(&self) -> bool {
         false
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
 }
 
 impl fmt::Display for CastInt2VectorToArray {
@@ -97,6 +101,10 @@ impl LazyUnaryFunc for CastInt2VectorToString {
 
     fn preserves_uniqueness(&self) -> bool {
         true
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastStringToInt2Vector)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -21,6 +21,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "-"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(NegInt32)]
     fn neg_int32(a: i32) -> Result<i32, EvalError> {
         a.checked_neg().ok_or(EvalError::Int32OutOfRange)
     }
@@ -28,6 +30,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "~"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(BitNotInt32)]
     fn bit_not_int32(a: i32) -> i32 {
         !a
     }
@@ -42,6 +46,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "integer_to_boolean"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastBoolToInt32)]
     fn cast_int32_to_bool(a: i32) -> bool {
         a != 0
     }
@@ -49,6 +55,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "integer_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToInt32)]
     fn cast_int32_to_float32(a: i32) -> f32 {
         a as f32
     }
@@ -57,6 +65,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_double"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastFloat64ToInt32)]
     fn cast_int32_to_float64(a: i32) -> f64 {
         f64::from(a)
     }
@@ -65,6 +74,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_smallint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt16ToInt32)]
     fn cast_int32_to_int16(a: i32) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -73,6 +83,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_bigint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToInt32)]
     fn cast_int32_to_int64(a: i32) -> i64 {
         i64::from(a)
     }
@@ -81,6 +92,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToInt32)]
     fn cast_int32_to_string(a: i32) -> String {
         let mut buf = String::new();
         strconv::format_int32(&mut buf, a);
@@ -91,6 +103,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_uint2"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint16ToInt32)]
     fn cast_int32_to_uint16(a: i32) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -99,6 +112,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_uint4"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint32ToInt32)]
     fn cast_int32_to_uint32(a: i32) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -107,6 +121,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_uint8"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint64ToInt32)]
     fn cast_int32_to_uint64(a: i32) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -133,6 +148,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt32ToNumeric {
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToInt32)
+    }
 }
 
 impl fmt::Display for CastInt32ToNumeric {
@@ -144,6 +163,7 @@ impl fmt::Display for CastInt32ToNumeric {
 sqlfunc!(
     #[sqlname = "integer_to_oid"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastOidToInt32)]
     fn cast_int32_to_oid(a: i32) -> Oid {
         // For historical reasons in PostgreSQL, the bytes of the `i32` are
         // reinterpreted as a `u32` without bounds checks, so negative `i32`s
@@ -159,6 +179,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_\"char\""]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastPgLegacyCharToInt32)]
     fn cast_int32_to_pg_legacy_char(a: i32) -> Result<PgLegacyChar, EvalError> {
         // Per PostgreSQL, casts to `PgLegacyChar` are performed as if
         // `PgLegacyChar` is signed.

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -22,7 +22,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(NegInt32)]
+    #[inverse = to_unary!(NegInt32)]
     fn neg_int32(a: i32) -> Result<i32, EvalError> {
         a.checked_neg().ok_or(EvalError::Int32OutOfRange)
     }
@@ -31,7 +31,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(BitNotInt32)]
+    #[inverse = to_unary!(BitNotInt32)]
     fn bit_not_int32(a: i32) -> i32 {
         !a
     }
@@ -47,7 +47,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_boolean"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastBoolToInt32)]
+    #[inverse = to_unary!(super::CastBoolToInt32)]
     fn cast_int32_to_bool(a: i32) -> bool {
         a != 0
     }
@@ -56,7 +56,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToInt32)]
+    #[inverse = to_unary!(super::CastFloat32ToInt32)]
     fn cast_int32_to_float32(a: i32) -> f32 {
         a as f32
     }
@@ -65,7 +65,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_double"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastFloat64ToInt32)]
+    #[inverse = to_unary!(super::CastFloat64ToInt32)]
     fn cast_int32_to_float64(a: i32) -> f64 {
         f64::from(a)
     }
@@ -74,7 +74,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_smallint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt16ToInt32)]
+    #[inverse = to_unary!(super::CastInt16ToInt32)]
     fn cast_int32_to_int16(a: i32) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -83,7 +83,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToInt32)]
+    #[inverse = to_unary!(super::CastInt64ToInt32)]
     fn cast_int32_to_int64(a: i32) -> i64 {
         i64::from(a)
     }
@@ -92,7 +92,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToInt32)]
+    #[inverse = to_unary!(super::CastStringToInt32)]
     fn cast_int32_to_string(a: i32) -> String {
         let mut buf = String::new();
         strconv::format_int32(&mut buf, a);
@@ -103,7 +103,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_uint2"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint16ToInt32)]
+    #[inverse = to_unary!(super::CastUint16ToInt32)]
     fn cast_int32_to_uint16(a: i32) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -112,7 +112,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_uint4"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint32ToInt32)]
+    #[inverse = to_unary!(super::CastUint32ToInt32)]
     fn cast_int32_to_uint32(a: i32) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -121,7 +121,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_uint8"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint64ToInt32)]
+    #[inverse = to_unary!(super::CastUint64ToInt32)]
     fn cast_int32_to_uint64(a: i32) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -149,7 +149,7 @@ impl<'a> EagerUnaryFunc<'a> for CastInt32ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt32)
     }
 }
@@ -163,7 +163,7 @@ impl fmt::Display for CastInt32ToNumeric {
 sqlfunc!(
     #[sqlname = "integer_to_oid"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastOidToInt32)]
+    #[inverse = to_unary!(super::CastOidToInt32)]
     fn cast_int32_to_oid(a: i32) -> Oid {
         // For historical reasons in PostgreSQL, the bytes of the `i32` are
         // reinterpreted as a `u32` without bounds checks, so negative `i32`s
@@ -179,7 +179,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "integer_to_\"char\""]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastPgLegacyCharToInt32)]
+    #[inverse = to_unary!(super::CastPgLegacyCharToInt32)]
     fn cast_int32_to_pg_legacy_char(a: i32) -> Result<PgLegacyChar, EvalError> {
         // Per PostgreSQL, casts to `PgLegacyChar` are performed as if
         // `PgLegacyChar` is signed.

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -22,6 +22,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(NegInt64)]
     fn neg_int64(a: i64) -> Result<i64, EvalError> {
         a.checked_neg().ok_or(EvalError::Int64OutOfRange)
     }
@@ -30,6 +31,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(BitNotInt64)]
     fn bit_not_int64(a: i64) -> i64 {
         !a
     }
@@ -44,6 +46,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "bigint_to_boolean"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastBoolToInt64)]
     fn cast_int64_to_bool(a: i64) -> bool {
         a != 0
     }
@@ -52,6 +56,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_smallint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt16ToInt64)]
     fn cast_int64_to_int16(a: i64) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -60,6 +65,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_integer"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToInt64)]
     fn cast_int64_to_int32(a: i64) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -68,6 +74,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_oid"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastOidToInt64)]
     fn cast_int64_to_oid(a: i64) -> Result<Oid, EvalError> {
         // Unlike casting a 16-bit or 32-bit integers to OID, casting a 64-bit
         // integers to an OID rejects negative values.
@@ -78,6 +85,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_uint2"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint16ToInt64)]
     fn cast_int64_to_uint16(a: i64) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -86,6 +94,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_uint4"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint32ToInt64)]
     fn cast_int64_to_uint32(a: i64) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -94,6 +103,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_uint8"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint64ToInt64)]
     fn cast_int64_to_uint64(a: i64) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -120,6 +130,10 @@ impl<'a> EagerUnaryFunc<'a> for CastInt64ToNumeric {
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToInt64)
+    }
 }
 
 impl fmt::Display for CastInt64ToNumeric {
@@ -130,6 +144,8 @@ impl fmt::Display for CastInt64ToNumeric {
 
 sqlfunc!(
     #[sqlname = "bigint_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToInt64)]
     fn cast_int64_to_float32(a: i64) -> f32 {
         a as f32
     }
@@ -137,6 +153,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "bigint_to_double"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat64ToInt64)]
     fn cast_int64_to_float64(a: i64) -> f64 {
         a as f64
     }
@@ -145,6 +163,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToInt64)]
     fn cast_int64_to_string(a: i64) -> String {
         let mut buf = String::new();
         strconv::format_int64(&mut buf, a);

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -22,7 +22,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(NegInt64)]
+    #[inverse = to_unary!(NegInt64)]
     fn neg_int64(a: i64) -> Result<i64, EvalError> {
         a.checked_neg().ok_or(EvalError::Int64OutOfRange)
     }
@@ -31,7 +31,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(BitNotInt64)]
+    #[inverse = to_unary!(BitNotInt64)]
     fn bit_not_int64(a: i64) -> i64 {
         !a
     }
@@ -47,7 +47,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_boolean"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastBoolToInt64)]
+    #[inverse = to_unary!(super::CastBoolToInt64)]
     fn cast_int64_to_bool(a: i64) -> bool {
         a != 0
     }
@@ -56,7 +56,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_smallint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt16ToInt64)]
+    #[inverse = to_unary!(super::CastInt16ToInt64)]
     fn cast_int64_to_int16(a: i64) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -65,7 +65,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToInt64)]
+    #[inverse = to_unary!(super::CastInt32ToInt64)]
     fn cast_int64_to_int32(a: i64) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -74,7 +74,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_oid"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastOidToInt64)]
+    #[inverse = to_unary!(super::CastOidToInt64)]
     fn cast_int64_to_oid(a: i64) -> Result<Oid, EvalError> {
         // Unlike casting a 16-bit or 32-bit integers to OID, casting a 64-bit
         // integers to an OID rejects negative values.
@@ -85,7 +85,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_uint2"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint16ToInt64)]
+    #[inverse = to_unary!(super::CastUint16ToInt64)]
     fn cast_int64_to_uint16(a: i64) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -94,7 +94,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_uint4"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint32ToInt64)]
+    #[inverse = to_unary!(super::CastUint32ToInt64)]
     fn cast_int64_to_uint32(a: i64) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -103,7 +103,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_uint8"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint64ToInt64)]
+    #[inverse = to_unary!(super::CastUint64ToInt64)]
     fn cast_int64_to_uint64(a: i64) -> Result<u64, EvalError> {
         u64::try_from(a).or(Err(EvalError::UInt64OutOfRange))
     }
@@ -131,7 +131,7 @@ impl<'a> EagerUnaryFunc<'a> for CastInt64ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToInt64)
     }
 }
@@ -145,7 +145,7 @@ impl fmt::Display for CastInt64ToNumeric {
 sqlfunc!(
     #[sqlname = "bigint_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToInt64)]
+    #[inverse = to_unary!(super::CastFloat32ToInt64)]
     fn cast_int64_to_float32(a: i64) -> f32 {
         a as f32
     }
@@ -154,7 +154,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_double"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat64ToInt64)]
+    #[inverse = to_unary!(super::CastFloat64ToInt64)]
     fn cast_int64_to_float64(a: i64) -> f64 {
         a as f64
     }
@@ -163,7 +163,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "bigint_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToInt64)]
+    #[inverse = to_unary!(super::CastStringToInt64)]
     fn cast_int64_to_string(a: i64) -> String {
         let mut buf = String::new();
         strconv::format_int64(&mut buf, a);

--- a/src/expr/src/scalar/func/impls/interval.rs
+++ b/src/expr/src/scalar/func/impls/interval.rs
@@ -17,7 +17,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "interval_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToInterval)]
+    #[inverse = to_unary!(super::CastStringToInterval)]
     fn cast_interval_to_string(a: Interval) -> String {
         let mut buf = String::new();
         strconv::format_interval(&mut buf, a);
@@ -28,7 +28,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "interval_to_time"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastTimeToInterval)]
+    #[inverse = to_unary!(super::CastTimeToInterval)]
     fn cast_interval_to_time(mut i: Interval) -> NaiveTime {
         // Negative durations have their HH::MM::SS.NS values subtracted from 1 day.
         if i.is_negative() {
@@ -49,7 +49,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::NegInterval)]
+    #[inverse = to_unary!(super::NegInterval)]
     fn neg_interval(i: Interval) -> Result<Interval, EvalError> {
         i.checked_neg().ok_or(EvalError::IntervalOutOfRange)
     }

--- a/src/expr/src/scalar/func/impls/interval.rs
+++ b/src/expr/src/scalar/func/impls/interval.rs
@@ -17,6 +17,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "interval_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToInterval)]
     fn cast_interval_to_string(a: Interval) -> String {
         let mut buf = String::new();
         strconv::format_interval(&mut buf, a);
@@ -26,6 +27,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "interval_to_time"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastTimeToInterval)]
     fn cast_interval_to_time(mut i: Interval) -> NaiveTime {
         // Negative durations have their HH::MM::SS.NS values subtracted from 1 day.
         if i.is_negative() {
@@ -46,6 +49,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::NegInterval)]
     fn neg_interval(i: Interval) -> Result<Interval, EvalError> {
         i.checked_neg().ok_or(EvalError::IntervalOutOfRange)
     }

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -24,7 +24,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "jsonb_to_text"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastStringToJsonb)]
+    #[inverse = to_unary!(super::CastStringToJsonb)]
     fn cast_jsonb_to_string<'a>(a: JsonbRef<'a>) -> String {
         let mut buf = String::new();
         strconv::format_jsonb(&mut buf, a);

--- a/src/expr/src/scalar/func/impls/jsonb.rs
+++ b/src/expr/src/scalar/func/impls/jsonb.rs
@@ -23,6 +23,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "jsonb_to_text"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastStringToJsonb)]
     fn cast_jsonb_to_string<'a>(a: JsonbRef<'a>) -> String {
         let mut buf = String::new();
         strconv::format_jsonb(&mut buf, a);

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -56,6 +56,11 @@ impl LazyUnaryFunc for CastListToString {
     fn preserves_uniqueness(&self) -> bool {
         true
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        // TODO? if typeconv was in expr, we could determine this
+        None
+    }
 }
 
 impl fmt::Display for CastListToString {
@@ -113,6 +118,11 @@ impl LazyUnaryFunc for CastList1ToList2 {
     fn preserves_uniqueness(&self) -> bool {
         false
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        // TODO: this could be figured out--might be easier after enum dispatch?
+        None
+    }
 }
 
 impl fmt::Display for CastList1ToList2 {
@@ -157,6 +167,10 @@ impl LazyUnaryFunc for ListLength {
 
     fn preserves_uniqueness(&self) -> bool {
         false
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        None
     }
 }
 

--- a/src/expr/src/scalar/func/impls/list.rs
+++ b/src/expr/src/scalar/func/impls/list.rs
@@ -57,7 +57,7 @@ impl LazyUnaryFunc for CastListToString {
         true
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         // TODO? if typeconv was in expr, we could determine this
         None
     }
@@ -119,7 +119,7 @@ impl LazyUnaryFunc for CastList1ToList2 {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         // TODO: this could be figured out--might be easier after enum dispatch?
         None
     }
@@ -169,7 +169,7 @@ impl LazyUnaryFunc for ListLength {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
 }

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -57,7 +57,7 @@ impl LazyUnaryFunc for CastMapToString {
         true
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         // TODO? If we moved typeconv into expr, we could evaluate this
         None
     }
@@ -107,7 +107,7 @@ impl LazyUnaryFunc for MapLength {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
 }

--- a/src/expr/src/scalar/func/impls/map.rs
+++ b/src/expr/src/scalar/func/impls/map.rs
@@ -56,6 +56,11 @@ impl LazyUnaryFunc for CastMapToString {
     fn preserves_uniqueness(&self) -> bool {
         true
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        // TODO? If we moved typeconv into expr, we could evaluate this
+        None
+    }
 }
 
 impl fmt::Display for CastMapToString {
@@ -100,6 +105,10 @@ impl LazyUnaryFunc for MapLength {
 
     fn preserves_uniqueness(&self) -> bool {
         false
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        None
     }
 }
 

--- a/src/expr/src/scalar/func/impls/mz_timestamp.rs
+++ b/src/expr/src/scalar/func/impls/mz_timestamp.rs
@@ -24,7 +24,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "mz_timestamp_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToMzTimestamp)]
+    #[inverse = to_unary!(super::CastStringToMzTimestamp)]
     fn cast_mz_timestamp_to_string(a: Timestamp) -> String {
         let mut buf = String::new();
         strconv::format_mz_timestamp(&mut buf, a);
@@ -35,7 +35,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_mz_timestamp"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastMzTimestampToString)]
+    #[inverse = to_unary!(super::CastMzTimestampToString)]
     fn cast_string_to_mz_timestamp(a: String) -> Result<Timestamp, EvalError> {
         strconv::parse_mz_timestamp(&a).err_into()
     }

--- a/src/expr/src/scalar/func/impls/mz_timestamp.rs
+++ b/src/expr/src/scalar/func/impls/mz_timestamp.rs
@@ -24,6 +24,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "mz_timestamp_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToMzTimestamp)]
     fn cast_mz_timestamp_to_string(a: Timestamp) -> String {
         let mut buf = String::new();
         strconv::format_mz_timestamp(&mut buf, a);
@@ -33,6 +34,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_mz_timestamp"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastMzTimestampToString)]
     fn cast_string_to_mz_timestamp(a: String) -> Result<Timestamp, EvalError> {
         strconv::parse_mz_timestamp(&a).err_into()
     }

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -23,6 +23,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(NegNumeric)]
     fn neg_numeric(mut a: Numeric) -> Numeric {
         numeric::cx_datum().neg(&mut a);
         numeric::munge_numeric(&mut a).unwrap();
@@ -167,6 +168,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_smallint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt16ToNumeric(None))]
     fn cast_numeric_to_int16(mut a: Numeric) -> Result<i16, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -178,6 +181,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_integer"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt32ToNumeric(None))]
     fn cast_numeric_to_int32(mut a: Numeric) -> Result<i32, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -188,6 +193,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_bigint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt64ToNumeric(None))]
     fn cast_numeric_to_int64(mut a: Numeric) -> Result<i64, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -198,6 +205,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToNumeric(None))]
     fn cast_numeric_to_float32(a: Numeric) -> Result<f32, EvalError> {
         let i = a.to_string().parse::<f32>().unwrap();
         if i.is_infinite() {
@@ -210,6 +219,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_double"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat64ToNumeric(None))]
     fn cast_numeric_to_float64(a: Numeric) -> Result<f64, EvalError> {
         let i = a.to_string().parse::<f64>().unwrap();
         if i.is_infinite() {
@@ -222,6 +233,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_text"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastStringToNumeric(None))]
     fn cast_numeric_to_string(a: Numeric) -> String {
         let mut buf = String::new();
         strconv::format_numeric(&mut buf, &OrderedDecimal(a));
@@ -231,6 +244,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_uint2"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint16ToNumeric(None))]
     fn cast_numeric_to_uint16(mut a: Numeric) -> Result<u16, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -242,6 +257,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_uint4"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint32ToNumeric(None))]
     fn cast_numeric_to_uint32(mut a: Numeric) -> Result<u32, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -252,6 +269,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "numeric_to_uint8"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint64ToNumeric(None))]
     fn cast_numeric_to_uint64(mut a: Numeric) -> Result<u64, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -23,7 +23,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(NegNumeric)]
+    #[inverse = to_unary!(NegNumeric)]
     fn neg_numeric(mut a: Numeric) -> Numeric {
         numeric::cx_datum().neg(&mut a);
         numeric::munge_numeric(&mut a).unwrap();
@@ -169,7 +169,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_smallint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt16ToNumeric(None))]
+    #[inverse = to_unary!(super::CastInt16ToNumeric(None))]
     fn cast_numeric_to_int16(mut a: Numeric) -> Result<i16, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -182,7 +182,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_integer"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt32ToNumeric(None))]
+    #[inverse = to_unary!(super::CastInt32ToNumeric(None))]
     fn cast_numeric_to_int32(mut a: Numeric) -> Result<i32, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -194,7 +194,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_bigint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt64ToNumeric(None))]
+    #[inverse = to_unary!(super::CastInt64ToNumeric(None))]
     fn cast_numeric_to_int64(mut a: Numeric) -> Result<i64, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -206,7 +206,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToNumeric(None))]
+    #[inverse = to_unary!(super::CastFloat32ToNumeric(None))]
     fn cast_numeric_to_float32(a: Numeric) -> Result<f32, EvalError> {
         let i = a.to_string().parse::<f32>().unwrap();
         if i.is_infinite() {
@@ -220,7 +220,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_double"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat64ToNumeric(None))]
+    #[inverse = to_unary!(super::CastFloat64ToNumeric(None))]
     fn cast_numeric_to_float64(a: Numeric) -> Result<f64, EvalError> {
         let i = a.to_string().parse::<f64>().unwrap();
         if i.is_infinite() {
@@ -234,7 +234,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_text"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastStringToNumeric(None))]
+    #[inverse = to_unary!(super::CastStringToNumeric(None))]
     fn cast_numeric_to_string(a: Numeric) -> String {
         let mut buf = String::new();
         strconv::format_numeric(&mut buf, &OrderedDecimal(a));
@@ -245,7 +245,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_uint2"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint16ToNumeric(None))]
+    #[inverse = to_unary!(super::CastUint16ToNumeric(None))]
     fn cast_numeric_to_uint16(mut a: Numeric) -> Result<u16, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -258,7 +258,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_uint4"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint32ToNumeric(None))]
+    #[inverse = to_unary!(super::CastUint32ToNumeric(None))]
     fn cast_numeric_to_uint32(mut a: Numeric) -> Result<u32, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);
@@ -270,7 +270,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "numeric_to_uint8"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint64ToNumeric(None))]
+    #[inverse = to_unary!(super::CastUint64ToNumeric(None))]
     fn cast_numeric_to_uint64(mut a: Numeric) -> Result<u64, EvalError> {
         let mut cx = numeric::cx_datum();
         cx.round(&mut a);

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -14,7 +14,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "oid_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToOid)]
+    #[inverse = to_unary!(super::CastStringToOid)]
     fn cast_oid_to_string(a: Oid) -> String {
         let mut buf = String::new();
         strconv::format_uint32(&mut buf, a.0);
@@ -25,7 +25,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oid_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToOid)]
+    #[inverse = to_unary!(super::CastInt32ToOid)]
     fn cast_oid_to_int32(a: Oid) -> i32 {
         // For historical reasons in PostgreSQL, the bytes of the `u32` are
         // reinterpreted as an `i32` without bounds checks, so very large
@@ -40,7 +40,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oid_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToOid)]
+    #[inverse = to_unary!(super::CastInt64ToOid)]
     fn cast_oid_to_int64(a: Oid) -> i64 {
         i64::from(a.0)
     }
@@ -49,7 +49,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oidtoregclass"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastRegClassToOid)]
+    #[inverse = to_unary!(super::CastRegClassToOid)]
     fn cast_oid_to_reg_class(a: Oid) -> RegClass {
         RegClass(a.0)
     }
@@ -58,7 +58,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oidtoregproc"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastRegProcToOid)]
+    #[inverse = to_unary!(super::CastRegProcToOid)]
     fn cast_oid_to_reg_proc(a: Oid) -> RegProc {
         RegProc(a.0)
     }
@@ -67,7 +67,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oidtoregtype"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastRegTypeToOid)]
+    #[inverse = to_unary!(super::CastRegTypeToOid)]
     fn cast_oid_to_reg_type(a: Oid) -> RegType {
         RegType(a.0)
     }

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -14,6 +14,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "oid_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToOid)]
     fn cast_oid_to_string(a: Oid) -> String {
         let mut buf = String::new();
         strconv::format_uint32(&mut buf, a.0);
@@ -24,6 +25,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oid_to_integer"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToOid)]
     fn cast_oid_to_int32(a: Oid) -> i32 {
         // For historical reasons in PostgreSQL, the bytes of the `u32` are
         // reinterpreted as an `i32` without bounds checks, so very large
@@ -38,6 +40,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oid_to_bigint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToOid)]
     fn cast_oid_to_int64(a: Oid) -> i64 {
         i64::from(a.0)
     }
@@ -46,6 +49,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oidtoregclass"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastRegClassToOid)]
     fn cast_oid_to_reg_class(a: Oid) -> RegClass {
         RegClass(a.0)
     }
@@ -54,6 +58,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oidtoregproc"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastRegProcToOid)]
     fn cast_oid_to_reg_proc(a: Oid) -> RegProc {
         RegProc(a.0)
     }
@@ -62,6 +67,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "oidtoregtype"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastRegTypeToOid)]
     fn cast_oid_to_reg_type(a: Oid) -> RegType {
         RegType(a.0)
     }

--- a/src/expr/src/scalar/func/impls/pg_legacy_char.rs
+++ b/src/expr/src/scalar/func/impls/pg_legacy_char.rs
@@ -35,6 +35,7 @@ where
 sqlfunc!(
     #[sqlname = "\"char\"_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToPgLegacyChar)]
     fn cast_pg_legacy_char_to_string(a: PgLegacyChar) -> Result<String, EvalError> {
         let mut buf = String::new();
         format_pg_legacy_char(&mut buf, a.0)?;
@@ -45,6 +46,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "\"char\"_to_integer"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToPgLegacyChar)]
     fn cast_pg_legacy_char_to_int32(a: PgLegacyChar) -> i32 {
         // Per PostgreSQL, casts to `i32` are performed as if `PgLegacyChar` is
         // signed.

--- a/src/expr/src/scalar/func/impls/pg_legacy_char.rs
+++ b/src/expr/src/scalar/func/impls/pg_legacy_char.rs
@@ -35,7 +35,7 @@ where
 sqlfunc!(
     #[sqlname = "\"char\"_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToPgLegacyChar)]
+    #[inverse = to_unary!(super::CastStringToPgLegacyChar)]
     fn cast_pg_legacy_char_to_string(a: PgLegacyChar) -> Result<String, EvalError> {
         let mut buf = String::new();
         format_pg_legacy_char(&mut buf, a.0)?;
@@ -46,7 +46,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "\"char\"_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToPgLegacyChar)]
+    #[inverse = to_unary!(super::CastInt32ToPgLegacyChar)]
     fn cast_pg_legacy_char_to_int32(a: PgLegacyChar) -> i32 {
         // Per PostgreSQL, casts to `i32` are performed as if `PgLegacyChar` is
         // signed.

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -57,6 +57,11 @@ impl LazyUnaryFunc for CastRecordToString {
     fn preserves_uniqueness(&self) -> bool {
         true
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        // TODO? if we moved typeconv into expr, we could evaluate this
+        None
+    }
 }
 
 impl fmt::Display for CastRecordToString {
@@ -108,6 +113,11 @@ impl LazyUnaryFunc for CastRecord1ToRecord2 {
     fn preserves_uniqueness(&self) -> bool {
         false
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        // TODO: we could determine Record1's type from `cast_exprs`
+        None
+    }
 }
 
 impl fmt::Display for CastRecord1ToRecord2 {
@@ -157,6 +167,10 @@ impl LazyUnaryFunc for RecordGet {
 
     fn preserves_uniqueness(&self) -> bool {
         false
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        None
     }
 }
 

--- a/src/expr/src/scalar/func/impls/record.rs
+++ b/src/expr/src/scalar/func/impls/record.rs
@@ -58,7 +58,7 @@ impl LazyUnaryFunc for CastRecordToString {
         true
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         // TODO? if we moved typeconv into expr, we could evaluate this
         None
     }
@@ -114,7 +114,7 @@ impl LazyUnaryFunc for CastRecord1ToRecord2 {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         // TODO: we could determine Record1's type from `cast_exprs`
         None
     }
@@ -169,7 +169,7 @@ impl LazyUnaryFunc for RecordGet {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
 }

--- a/src/expr/src/scalar/func/impls/regproc.rs
+++ b/src/expr/src/scalar/func/impls/regproc.rs
@@ -12,7 +12,7 @@ use mz_repr::adt::system::{Oid, RegClass, RegProc, RegType};
 sqlfunc!(
     #[sqlname = "regclasstooid"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastOidToRegClass)]
+    #[inverse = to_unary!(super::CastOidToRegClass)]
     fn cast_reg_class_to_oid(a: RegClass) -> Oid {
         Oid(a.0)
     }
@@ -21,7 +21,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "regproctooid"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastOidToRegProc)]
+    #[inverse = to_unary!(super::CastOidToRegProc)]
     fn cast_reg_proc_to_oid(a: RegProc) -> Oid {
         Oid(a.0)
     }
@@ -30,7 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "regtypetooid"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastOidToRegType)]
+    #[inverse = to_unary!(super::CastOidToRegType)]
     fn cast_reg_type_to_oid(a: RegType) -> Oid {
         Oid(a.0)
     }

--- a/src/expr/src/scalar/func/impls/regproc.rs
+++ b/src/expr/src/scalar/func/impls/regproc.rs
@@ -12,6 +12,7 @@ use mz_repr::adt::system::{Oid, RegClass, RegProc, RegType};
 sqlfunc!(
     #[sqlname = "regclasstooid"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastOidToRegClass)]
     fn cast_reg_class_to_oid(a: RegClass) -> Oid {
         Oid(a.0)
     }
@@ -20,6 +21,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "regproctooid"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastOidToRegProc)]
     fn cast_reg_proc_to_oid(a: RegProc) -> Oid {
         Oid(a.0)
     }
@@ -28,6 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "regtypetooid"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastOidToRegType)]
     fn cast_reg_type_to_oid(a: RegType) -> Oid {
         Oid(a.0)
     }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -38,7 +38,7 @@ use crate::{like_pattern, EvalError, MirScalarExpr, UnaryFunc};
 sqlfunc!(
     #[sqlname = "text_to_boolean"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastBoolToString)]
+    #[inverse = to_unary!(super::CastBoolToString)]
     fn cast_string_to_bool<'a>(a: &'a str) -> Result<bool, EvalError> {
         strconv::parse_bool(a).err_into()
     }
@@ -47,7 +47,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_\"char\""]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastPgLegacyCharToString)]
+    #[inverse = to_unary!(super::CastPgLegacyCharToString)]
     fn cast_string_to_pg_legacy_char<'a>(a: &'a str) -> PgLegacyChar {
         PgLegacyChar(a.as_bytes().get(0).copied().unwrap_or(0))
     }
@@ -56,7 +56,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_bytea"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastBytesToString)]
+    #[inverse = to_unary!(super::CastBytesToString)]
     fn cast_string_to_bytes<'a>(a: &'a str) -> Result<Vec<u8>, EvalError> {
         strconv::parse_bytes(a).err_into()
     }
@@ -65,7 +65,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_smallint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt16ToString)]
+    #[inverse = to_unary!(super::CastInt16ToString)]
     fn cast_string_to_int16<'a>(a: &'a str) -> Result<i16, EvalError> {
         strconv::parse_int16(a).err_into()
     }
@@ -74,7 +74,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_integer"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt32ToString)]
+    #[inverse = to_unary!(super::CastInt32ToString)]
     fn cast_string_to_int32<'a>(a: &'a str) -> Result<i32, EvalError> {
         strconv::parse_int32(a).err_into()
     }
@@ -83,7 +83,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_bigint"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastInt64ToString)]
+    #[inverse = to_unary!(super::CastInt64ToString)]
     fn cast_string_to_int64<'a>(a: &'a str) -> Result<i64, EvalError> {
         strconv::parse_int64(a).err_into()
     }
@@ -92,7 +92,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToString)]
+    #[inverse = to_unary!(super::CastFloat32ToString)]
     fn cast_string_to_float32<'a>(a: &'a str) -> Result<f32, EvalError> {
         strconv::parse_float32(a).err_into()
     }
@@ -101,7 +101,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_double"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat64ToString)]
+    #[inverse = to_unary!(super::CastFloat64ToString)]
     fn cast_string_to_float64<'a>(a: &'a str) -> Result<f64, EvalError> {
         strconv::parse_float64(a).err_into()
     }
@@ -110,7 +110,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_oid"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastOidToString)]
+    #[inverse = to_unary!(super::CastOidToString)]
     fn cast_string_to_oid<'a>(a: &'a str) -> Result<Oid, EvalError> {
         Ok(Oid(strconv::parse_oid(a)?))
     }
@@ -119,7 +119,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_uint2"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint16ToString)]
+    #[inverse = to_unary!(super::CastUint16ToString)]
     fn cast_string_to_uint16(a: &'a str) -> Result<u16, EvalError> {
         strconv::parse_uint16(a).err_into()
     }
@@ -128,7 +128,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_uint4"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint32ToString)]
+    #[inverse = to_unary!(super::CastUint32ToString)]
     fn cast_string_to_uint32(a: &'a str) -> Result<u32, EvalError> {
         strconv::parse_uint32(a).err_into()
     }
@@ -137,7 +137,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_uint8"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUint64ToString)]
+    #[inverse = to_unary!(super::CastUint64ToString)]
     fn cast_string_to_uint64(a: &'a str) -> Result<u64, EvalError> {
         strconv::parse_uint64(a).err_into()
     }
@@ -166,7 +166,7 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToString)
     }
 }
@@ -180,7 +180,7 @@ impl fmt::Display for CastStringToNumeric {
 sqlfunc!(
     #[sqlname = "text_to_date"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastDateToString)]
+    #[inverse = to_unary!(super::CastDateToString)]
     fn cast_string_to_date<'a>(a: &'a str) -> Result<Date, EvalError> {
         strconv::parse_date(a).err_into()
     }
@@ -189,7 +189,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_time"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastTimeToString)]
+    #[inverse = to_unary!(super::CastTimeToString)]
     fn cast_string_to_time<'a>(a: &'a str) -> Result<NaiveTime, EvalError> {
         strconv::parse_time(a).err_into()
     }
@@ -198,7 +198,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_timestamp"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastTimestampToString)]
+    #[inverse = to_unary!(super::CastTimestampToString)]
     fn cast_string_to_timestamp<'a>(
         a: &'a str,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
@@ -209,7 +209,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_timestamp_with_time_zone"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastTimestampTzToString)]
+    #[inverse = to_unary!(super::CastTimestampTzToString)]
     fn cast_string_to_timestamp_tz<'a>(
         a: &'a str,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
@@ -220,7 +220,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_interval"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastIntervalToString)]
+    #[inverse = to_unary!(super::CastIntervalToString)]
     fn cast_string_to_interval<'a>(a: &'a str) -> Result<Interval, EvalError> {
         strconv::parse_interval(a).err_into()
     }
@@ -229,7 +229,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_uuid"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastUuidToString)]
+    #[inverse = to_unary!(super::CastUuidToString)]
     fn cast_string_to_uuid<'a>(a: &'a str) -> Result<Uuid, EvalError> {
         strconv::parse_uuid(a).err_into()
     }
@@ -290,7 +290,7 @@ impl LazyUnaryFunc for CastStringToArray {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastArrayToString {
             ty: self.return_ty.clone(),
         })
@@ -363,7 +363,7 @@ impl LazyUnaryFunc for CastStringToList {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastListToString {
             ty: self.return_ty.clone(),
         })
@@ -444,7 +444,7 @@ impl LazyUnaryFunc for CastStringToMap {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastMapToString {
             ty: self.return_ty.clone(),
         })
@@ -488,7 +488,7 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToChar {
         .nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastCharToString)
     }
 }
@@ -535,7 +535,7 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
         self.fail_on_len || self.length.is_none()
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastVarCharToString)
     }
 }
@@ -600,7 +600,7 @@ impl LazyUnaryFunc for CastStringToInt2Vector {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastInt2VectorToString)
     }
 }
@@ -614,7 +614,7 @@ impl fmt::Display for CastStringToInt2Vector {
 sqlfunc!(
     #[sqlname = "text_to_jsonb"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastJsonbToString)]
+    #[inverse = to_unary!(super::CastJsonbToString)]
     // TODO(jamii): it would be much more efficient to skip the intermediate repr::jsonb::Jsonb.
     fn cast_string_to_jsonb<'a>(a: &'a str) -> Result<Jsonb, EvalError> {
         Ok(strconv::parse_jsonb(a)?)
@@ -802,7 +802,7 @@ impl LazyUnaryFunc for RegexpMatch {
         false
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         None
     }
 }

--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -37,6 +37,8 @@ use crate::{like_pattern, EvalError, MirScalarExpr, UnaryFunc};
 
 sqlfunc!(
     #[sqlname = "text_to_boolean"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastBoolToString)]
     fn cast_string_to_bool<'a>(a: &'a str) -> Result<bool, EvalError> {
         strconv::parse_bool(a).err_into()
     }
@@ -45,6 +47,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_\"char\""]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastPgLegacyCharToString)]
     fn cast_string_to_pg_legacy_char<'a>(a: &'a str) -> PgLegacyChar {
         PgLegacyChar(a.as_bytes().get(0).copied().unwrap_or(0))
     }
@@ -53,6 +56,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "text_to_bytea"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastBytesToString)]
     fn cast_string_to_bytes<'a>(a: &'a str) -> Result<Vec<u8>, EvalError> {
         strconv::parse_bytes(a).err_into()
     }
@@ -60,6 +64,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_smallint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt16ToString)]
     fn cast_string_to_int16<'a>(a: &'a str) -> Result<i16, EvalError> {
         strconv::parse_int16(a).err_into()
     }
@@ -67,6 +73,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_integer"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt32ToString)]
     fn cast_string_to_int32<'a>(a: &'a str) -> Result<i32, EvalError> {
         strconv::parse_int32(a).err_into()
     }
@@ -74,6 +82,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_bigint"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastInt64ToString)]
     fn cast_string_to_int64<'a>(a: &'a str) -> Result<i64, EvalError> {
         strconv::parse_int64(a).err_into()
     }
@@ -81,6 +91,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToString)]
     fn cast_string_to_float32<'a>(a: &'a str) -> Result<f32, EvalError> {
         strconv::parse_float32(a).err_into()
     }
@@ -88,6 +100,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_double"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat64ToString)]
     fn cast_string_to_float64<'a>(a: &'a str) -> Result<f64, EvalError> {
         strconv::parse_float64(a).err_into()
     }
@@ -95,6 +109,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_oid"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastOidToString)]
     fn cast_string_to_oid<'a>(a: &'a str) -> Result<Oid, EvalError> {
         Ok(Oid(strconv::parse_oid(a)?))
     }
@@ -102,6 +118,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_uint2"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint16ToString)]
     fn cast_string_to_uint16(a: &'a str) -> Result<u16, EvalError> {
         strconv::parse_uint16(a).err_into()
     }
@@ -109,6 +127,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_uint4"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint32ToString)]
     fn cast_string_to_uint32(a: &'a str) -> Result<u32, EvalError> {
         strconv::parse_uint32(a).err_into()
     }
@@ -116,6 +136,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_uint8"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUint64ToString)]
     fn cast_string_to_uint64(a: &'a str) -> Result<u64, EvalError> {
         strconv::parse_uint64(a).err_into()
     }
@@ -143,6 +165,10 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToNumeric {
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToString)
+    }
 }
 
 impl fmt::Display for CastStringToNumeric {
@@ -153,6 +179,8 @@ impl fmt::Display for CastStringToNumeric {
 
 sqlfunc!(
     #[sqlname = "text_to_date"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastDateToString)]
     fn cast_string_to_date<'a>(a: &'a str) -> Result<Date, EvalError> {
         strconv::parse_date(a).err_into()
     }
@@ -160,6 +188,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_time"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastTimeToString)]
     fn cast_string_to_time<'a>(a: &'a str) -> Result<NaiveTime, EvalError> {
         strconv::parse_time(a).err_into()
     }
@@ -167,6 +197,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_timestamp"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastTimestampToString)]
     fn cast_string_to_timestamp<'a>(
         a: &'a str,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
@@ -176,6 +208,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_timestamp_with_time_zone"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastTimestampTzToString)]
     fn cast_string_to_timestamp_tz<'a>(
         a: &'a str,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
@@ -185,6 +219,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_interval"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastIntervalToString)]
     fn cast_string_to_interval<'a>(a: &'a str) -> Result<Interval, EvalError> {
         strconv::parse_interval(a).err_into()
     }
@@ -192,6 +228,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "text_to_uuid"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastUuidToString)]
     fn cast_string_to_uuid<'a>(a: &'a str) -> Result<Uuid, EvalError> {
         strconv::parse_uuid(a).err_into()
     }
@@ -250,6 +288,12 @@ impl LazyUnaryFunc for CastStringToArray {
     /// Whether this function preserves uniqueness
     fn preserves_uniqueness(&self) -> bool {
         false
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastArrayToString {
+            ty: self.return_ty.clone(),
+        })
     }
 }
 
@@ -317,6 +361,12 @@ impl LazyUnaryFunc for CastStringToList {
     /// Whether this function preserves uniqueness
     fn preserves_uniqueness(&self) -> bool {
         false
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastListToString {
+            ty: self.return_ty.clone(),
+        })
     }
 }
 
@@ -393,6 +443,12 @@ impl LazyUnaryFunc for CastStringToMap {
     fn preserves_uniqueness(&self) -> bool {
         false
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastMapToString {
+            ty: self.return_ty.clone(),
+        })
+    }
 }
 
 impl fmt::Display for CastStringToMap {
@@ -430,6 +486,10 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToChar {
             length: self.length,
         }
         .nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastCharToString)
     }
 }
 
@@ -473,6 +533,10 @@ impl<'a> EagerUnaryFunc<'a> for CastStringToVarChar {
 
     fn preserves_uniqueness(&self) -> bool {
         self.fail_on_len || self.length.is_none()
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastVarCharToString)
     }
 }
 
@@ -535,6 +599,10 @@ impl LazyUnaryFunc for CastStringToInt2Vector {
     fn preserves_uniqueness(&self) -> bool {
         false
     }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastInt2VectorToString)
+    }
 }
 
 impl fmt::Display for CastStringToInt2Vector {
@@ -545,6 +613,8 @@ impl fmt::Display for CastStringToInt2Vector {
 
 sqlfunc!(
     #[sqlname = "text_to_jsonb"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastJsonbToString)]
     // TODO(jamii): it would be much more efficient to skip the intermediate repr::jsonb::Jsonb.
     fn cast_string_to_jsonb<'a>(a: &'a str) -> Result<Jsonb, EvalError> {
         Ok(strconv::parse_jsonb(a)?)
@@ -730,6 +800,10 @@ impl LazyUnaryFunc for RegexpMatch {
     /// Whether this function preserves uniqueness
     fn preserves_uniqueness(&self) -> bool {
         false
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        None
     }
 }
 

--- a/src/expr/src/scalar/func/impls/time.rs
+++ b/src/expr/src/scalar/func/impls/time.rs
@@ -27,7 +27,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "time_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToTime)]
+    #[inverse = to_unary!(super::CastStringToTime)]
     fn cast_time_to_string(a: NaiveTime) -> String {
         let mut buf = String::new();
         strconv::format_time(&mut buf, a);
@@ -38,7 +38,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "time_to_interval"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastIntervalToTime)]
+    #[inverse = to_unary!(super::CastIntervalToTime)]
     fn cast_time_to_interval<'a>(t: NaiveTime) -> Interval {
         // wont overflow because value can't exceed 24 hrs + 1_000_000 ns = 86_400 seconds + 1_000_000 ns = 86_400_001_000 us
         let micros: i64 = Interval::convert_date_time_unit(

--- a/src/expr/src/scalar/func/impls/time.rs
+++ b/src/expr/src/scalar/func/impls/time.rs
@@ -27,6 +27,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "time_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToTime)]
     fn cast_time_to_string(a: NaiveTime) -> String {
         let mut buf = String::new();
         strconv::format_time(&mut buf, a);
@@ -37,6 +38,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "time_to_interval"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastIntervalToTime)]
     fn cast_time_to_interval<'a>(t: NaiveTime) -> Interval {
         // wont overflow because value can't exceed 24 hrs + 1_000_000 ns = 86_400 seconds + 1_000_000 ns = 86_400_001_000 us
         let micros: i64 = Interval::convert_date_time_unit(

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -28,6 +28,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "timestamp_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToTimestamp)]
     fn cast_timestamp_to_string(a: CheckedTimestamp<NaiveDateTime>) -> String {
         let mut buf = String::new();
         strconv::format_timestamp(&mut buf, &a);
@@ -38,6 +39,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToTimestampTz)]
     fn cast_timestamp_tz_to_string(a: CheckedTimestamp<DateTime<Utc>>) -> String {
         let mut buf = String::new();
         strconv::format_timestamptz(&mut buf, &a);
@@ -47,6 +49,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_to_date"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastDateToTimestamp)]
     fn cast_timestamp_to_date(a: CheckedTimestamp<NaiveDateTime>) -> Result<Date, EvalError> {
         Ok(a.date().try_into()?)
     }
@@ -54,6 +58,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_date"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastDateToTimestampTz)]
     fn cast_timestamp_tz_to_date(a: CheckedTimestamp<DateTime<Utc>>) -> Result<Date, EvalError> {
         Ok(a.naive_utc().date().try_into()?)
     }
@@ -62,6 +68,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "timestamp_to_timestamp_with_time_zone"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastTimestampTzToTimestamp)]
     fn cast_timestamp_to_timestamp_tz(
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
@@ -73,6 +80,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_timestamp"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastTimestampToTimestampTz)]
     fn cast_timestamp_tz_to_timestamp(
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
@@ -82,6 +91,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_to_time"]
+    #[preserves_uniqueness = false]
     fn cast_timestamp_to_time(a: CheckedTimestamp<NaiveDateTime>) -> NaiveTime {
         a.time()
     }
@@ -89,6 +99,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_time"]
+    #[preserves_uniqueness = false]
     fn cast_timestamp_tz_to_time(a: CheckedTimestamp<DateTime<Utc>>) -> NaiveTime {
         a.naive_utc().time()
     }

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -28,7 +28,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "timestamp_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToTimestamp)]
+    #[inverse = to_unary!(super::CastStringToTimestamp)]
     fn cast_timestamp_to_string(a: CheckedTimestamp<NaiveDateTime>) -> String {
         let mut buf = String::new();
         strconv::format_timestamp(&mut buf, &a);
@@ -39,7 +39,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToTimestampTz)]
+    #[inverse = to_unary!(super::CastStringToTimestampTz)]
     fn cast_timestamp_tz_to_string(a: CheckedTimestamp<DateTime<Utc>>) -> String {
         let mut buf = String::new();
         strconv::format_timestamptz(&mut buf, &a);
@@ -50,7 +50,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "timestamp_to_date"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastDateToTimestamp)]
+    #[inverse = to_unary!(super::CastDateToTimestamp)]
     fn cast_timestamp_to_date(a: CheckedTimestamp<NaiveDateTime>) -> Result<Date, EvalError> {
         Ok(a.date().try_into()?)
     }
@@ -59,7 +59,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_date"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastDateToTimestampTz)]
+    #[inverse = to_unary!(super::CastDateToTimestampTz)]
     fn cast_timestamp_tz_to_date(a: CheckedTimestamp<DateTime<Utc>>) -> Result<Date, EvalError> {
         Ok(a.naive_utc().date().try_into()?)
     }
@@ -68,7 +68,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "timestamp_to_timestamp_with_time_zone"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastTimestampTzToTimestamp)]
+    #[inverse = to_unary!(super::CastTimestampTzToTimestamp)]
     fn cast_timestamp_to_timestamp_tz(
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
@@ -80,8 +80,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "timestamp_with_time_zone_to_timestamp"]
-    #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastTimestampToTimestampTz)]
+    #[preserves_uniqueness = true]
+    #[inverse = to_unary!(super::CastTimestampToTimestampTz)]
     fn cast_timestamp_tz_to_timestamp(
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -21,7 +21,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::BitNotUint16)]
+    #[inverse = to_unary!(super::BitNotUint16)]
     fn bit_not_uint16(a: u16) -> u16 {
         !a
     }
@@ -30,7 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_real"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastFloat32ToUint16)]
+    #[inverse = to_unary!(super::CastFloat32ToUint16)]
     fn cast_uint16_to_float32(a: u16) -> f32 {
         f32::from(a)
     }
@@ -39,7 +39,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_double"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastFloat64ToUint16)]
+    #[inverse = to_unary!(super::CastFloat64ToUint16)]
     fn cast_uint16_to_float64(a: u16) -> f64 {
         f64::from(a)
     }
@@ -48,7 +48,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_uint4"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint32ToUint16)]
+    #[inverse = to_unary!(super::CastUint32ToUint16)]
     fn cast_uint16_to_uint32(a: u16) -> u32 {
         u32::from(a)
     }
@@ -57,7 +57,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_uint8"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint64ToUint16)]
+    #[inverse = to_unary!(super::CastUint64ToUint16)]
     fn cast_uint16_to_uint64(a: u16) -> u64 {
         u64::from(a)
     }
@@ -66,7 +66,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_smallint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt16ToUint16)]
+    #[inverse = to_unary!(super::CastInt16ToUint16)]
     fn cast_uint16_to_int16(a: u16) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -75,7 +75,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToUint16)]
+    #[inverse = to_unary!(super::CastInt32ToUint16)]
     fn cast_uint16_to_int32(a: u16) -> i32 {
         i32::from(a)
     }
@@ -83,7 +83,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToUint16)]
+    #[inverse = to_unary!(super::CastInt64ToUint16)]
     fn cast_uint16_to_int64(a: u16) -> i64 {
         i64::from(a)
     }
@@ -92,7 +92,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToUint16)]
+    #[inverse = to_unary!(super::CastStringToUint16)]
     fn cast_uint16_to_string(a: u16) -> String {
         let mut buf = String::new();
         strconv::format_uint16(&mut buf, a);
@@ -121,7 +121,7 @@ impl<'a> EagerUnaryFunc<'a> for CastUint16ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint16)
     }
 }

--- a/src/expr/src/scalar/func/impls/uint16.rs
+++ b/src/expr/src/scalar/func/impls/uint16.rs
@@ -20,6 +20,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "~"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::BitNotUint16)]
     fn bit_not_uint16(a: u16) -> u16 {
         !a
     }
@@ -28,6 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_real"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastFloat32ToUint16)]
     fn cast_uint16_to_float32(a: u16) -> f32 {
         f32::from(a)
     }
@@ -36,46 +39,60 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint2_to_double"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastFloat64ToUint16)]
     fn cast_uint16_to_float64(a: u16) -> f64 {
         f64::from(a)
     }
 );
 
 sqlfunc!(
-    #[sqlname = "uint2_to_integer"]
-    #[preserves_uniqueness = true]
-    fn cast_uint16_to_int32(a: u16) -> i32 {
-        i32::from(a)
-    }
-);
-
-sqlfunc!(
     #[sqlname = "uint2_to_uint4"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint32ToUint16)]
     fn cast_uint16_to_uint32(a: u16) -> u32 {
         u32::from(a)
     }
 );
 
 sqlfunc!(
-    #[sqlname = "uint2_to_bigint"]
-    #[preserves_uniqueness = true]
-    fn cast_uint16_to_int64(a: u16) -> i64 {
-        i64::from(a)
-    }
-);
-
-sqlfunc!(
     #[sqlname = "uint2_to_uint8"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint64ToUint16)]
     fn cast_uint16_to_uint64(a: u16) -> u64 {
         u64::from(a)
     }
 );
 
 sqlfunc!(
+    #[sqlname = "uint2_to_smallint"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt16ToUint16)]
+    fn cast_uint16_to_int16(a: u16) -> Result<i16, EvalError> {
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "uint2_to_integer"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToUint16)]
+    fn cast_uint16_to_int32(a: u16) -> i32 {
+        i32::from(a)
+    }
+);
+sqlfunc!(
+    #[sqlname = "uint2_to_bigint"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToUint16)]
+    fn cast_uint16_to_int64(a: u16) -> i64 {
+        i64::from(a)
+    }
+);
+
+sqlfunc!(
     #[sqlname = "uint2_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToUint16)]
     fn cast_uint16_to_string(a: u16) -> String {
         let mut buf = String::new();
         strconv::format_uint16(&mut buf, a);
@@ -102,6 +119,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint16ToNumeric {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToUint16)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -21,7 +21,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::BitNotUint32)]
+    #[inverse = to_unary!(super::BitNotUint32)]
     fn bit_not_uint32(a: u32) -> u32 {
         !a
     }
@@ -30,7 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToUint32)]
+    #[inverse = to_unary!(super::CastFloat32ToUint32)]
     fn cast_uint32_to_float32(a: u32) -> f32 {
         a as f32
     }
@@ -39,7 +39,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_double"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastFloat64ToUint32)]
+    #[inverse = to_unary!(super::CastFloat64ToUint32)]
     fn cast_uint32_to_float64(a: u32) -> f64 {
         f64::from(a)
     }
@@ -48,7 +48,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_uint2"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint16ToUint32)]
+    #[inverse = to_unary!(super::CastUint16ToUint32)]
     fn cast_uint32_to_uint16(a: u32) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -57,7 +57,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_uint8"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint64ToUint32)]
+    #[inverse = to_unary!(super::CastUint64ToUint32)]
     fn cast_uint32_to_uint64(a: u32) -> u64 {
         u64::from(a)
     }
@@ -66,7 +66,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_smallint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt16ToUint32)]
+    #[inverse = to_unary!(super::CastInt16ToUint32)]
     fn cast_uint32_to_int16(a: u32) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -75,7 +75,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToUint32)]
+    #[inverse = to_unary!(super::CastInt32ToUint32)]
     fn cast_uint32_to_int32(a: u32) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -84,7 +84,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToUint32)]
+    #[inverse = to_unary!(super::CastInt64ToUint32)]
     fn cast_uint32_to_int64(a: u32) -> i64 {
         i64::from(a)
     }
@@ -93,7 +93,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToUint32)]
+    #[inverse = to_unary!(super::CastStringToUint32)]
     fn cast_uint32_to_string(a: u32) -> String {
         let mut buf = String::new();
         strconv::format_uint32(&mut buf, a);
@@ -123,7 +123,7 @@ impl<'a> EagerUnaryFunc<'a> for CastUint32ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint32)
     }
 }

--- a/src/expr/src/scalar/func/impls/uint32.rs
+++ b/src/expr/src/scalar/func/impls/uint32.rs
@@ -20,6 +20,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "~"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::BitNotUint32)]
     fn bit_not_uint32(a: u32) -> u32 {
         !a
     }
@@ -27,6 +29,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "uint4_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToUint32)]
     fn cast_uint32_to_float32(a: u32) -> f32 {
         a as f32
     }
@@ -35,6 +39,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_double"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastFloat64ToUint32)]
     fn cast_uint32_to_float64(a: u32) -> f64 {
         f64::from(a)
     }
@@ -43,14 +48,34 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_uint2"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint16ToUint32)]
     fn cast_uint32_to_uint16(a: u32) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
 );
 
 sqlfunc!(
+    #[sqlname = "uint4_to_uint8"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint64ToUint32)]
+    fn cast_uint32_to_uint64(a: u32) -> u64 {
+        u64::from(a)
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "uint4_to_smallint"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt16ToUint32)]
+    fn cast_uint32_to_int16(a: u32) -> Result<i16, EvalError> {
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
+    }
+);
+
+sqlfunc!(
     #[sqlname = "uint4_to_integer"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToUint32)]
     fn cast_uint32_to_int32(a: u32) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -59,22 +84,16 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint4_to_bigint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToUint32)]
     fn cast_uint32_to_int64(a: u32) -> i64 {
         i64::from(a)
     }
 );
 
 sqlfunc!(
-    #[sqlname = "uint4_to_uint8"]
-    #[preserves_uniqueness = true]
-    fn cast_uint32_to_uint64(a: u32) -> u64 {
-        u64::from(a)
-    }
-);
-
-sqlfunc!(
     #[sqlname = "uint4_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToUint32)]
     fn cast_uint32_to_string(a: u32) -> String {
         let mut buf = String::new();
         strconv::format_uint32(&mut buf, a);
@@ -102,6 +121,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint32ToNumeric {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToUint32)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -21,7 +21,7 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "~"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::BitNotUint64)]
+    #[inverse = to_unary!(super::BitNotUint64)]
     fn bit_not_uint64(a: u64) -> u64 {
         !a
     }
@@ -30,7 +30,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_real"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat32ToUint64)]
+    #[inverse = to_unary!(super::CastFloat32ToUint64)]
     fn cast_uint64_to_float32(a: u64) -> f32 {
         a as f32
     }
@@ -39,7 +39,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_double"]
     #[preserves_uniqueness = false]
-    #[right_inverse = to_unary!(super::CastFloat64ToUint64)]
+    #[inverse = to_unary!(super::CastFloat64ToUint64)]
     fn cast_uint64_to_float64(a: u64) -> f64 {
         a as f64
     }
@@ -48,7 +48,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_uint2"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint16ToUint64)]
+    #[inverse = to_unary!(super::CastUint16ToUint64)]
     fn cast_uint64_to_uint16(a: u64) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
@@ -57,7 +57,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_uint4"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastUint32ToUint64)]
+    #[inverse = to_unary!(super::CastUint32ToUint64)]
     fn cast_uint64_to_uint32(a: u64) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
@@ -66,7 +66,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_smallint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt16ToUint64)]
+    #[inverse = to_unary!(super::CastInt16ToUint64)]
     fn cast_uint64_to_int16(a: u64) -> Result<i16, EvalError> {
         i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
     }
@@ -75,7 +75,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_integer"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt32ToUint64)]
+    #[inverse = to_unary!(super::CastInt32ToUint64)]
     fn cast_uint64_to_int32(a: u64) -> Result<i32, EvalError> {
         i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
     }
@@ -84,7 +84,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_bigint"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastInt64ToUint64)]
+    #[inverse = to_unary!(super::CastInt64ToUint64)]
     fn cast_uint64_to_int64(a: u64) -> Result<i64, EvalError> {
         i64::try_from(a).or(Err(EvalError::Int64OutOfRange))
     }
@@ -93,7 +93,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToUint64)]
+    #[inverse = to_unary!(super::CastStringToUint64)]
     fn cast_uint64_to_string(a: u64) -> String {
         let mut buf = String::new();
         strconv::format_uint64(&mut buf, a);
@@ -123,7 +123,7 @@ impl<'a> EagerUnaryFunc<'a> for CastUint64ToNumeric {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
     }
 
-    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
         to_unary!(super::CastNumericToUint64)
     }
 }

--- a/src/expr/src/scalar/func/impls/uint64.rs
+++ b/src/expr/src/scalar/func/impls/uint64.rs
@@ -20,6 +20,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "~"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::BitNotUint64)]
     fn bit_not_uint64(a: u64) -> u64 {
         !a
     }
@@ -27,6 +29,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "uint8_to_real"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat32ToUint64)]
     fn cast_uint64_to_float32(a: u64) -> f32 {
         a as f32
     }
@@ -34,6 +38,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "uint8_to_double"]
+    #[preserves_uniqueness = false]
+    #[right_inverse = to_unary!(super::CastFloat64ToUint64)]
     fn cast_uint64_to_float64(a: u64) -> f64 {
         a as f64
     }
@@ -42,30 +48,43 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_uint2"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint16ToUint64)]
     fn cast_uint64_to_uint16(a: u64) -> Result<u16, EvalError> {
         u16::try_from(a).or(Err(EvalError::UInt16OutOfRange))
     }
 );
 
 sqlfunc!(
-    #[sqlname = "uint8_to_integer"]
-    #[preserves_uniqueness = true]
-    fn cast_uint64_to_int32(a: u64) -> Result<i32, EvalError> {
-        i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
-    }
-);
-
-sqlfunc!(
     #[sqlname = "uint8_to_uint4"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastUint32ToUint64)]
     fn cast_uint64_to_uint32(a: u64) -> Result<u32, EvalError> {
         u32::try_from(a).or(Err(EvalError::UInt32OutOfRange))
     }
 );
 
 sqlfunc!(
+    #[sqlname = "uint8_to_smallint"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt16ToUint64)]
+    fn cast_uint64_to_int16(a: u64) -> Result<i16, EvalError> {
+        i16::try_from(a).or(Err(EvalError::Int16OutOfRange))
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "uint8_to_integer"]
+    #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt32ToUint64)]
+    fn cast_uint64_to_int32(a: u64) -> Result<i32, EvalError> {
+        i32::try_from(a).or(Err(EvalError::Int32OutOfRange))
+    }
+);
+
+sqlfunc!(
     #[sqlname = "uint8_to_bigint"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastInt64ToUint64)]
     fn cast_uint64_to_int64(a: u64) -> Result<i64, EvalError> {
         i64::try_from(a).or(Err(EvalError::Int64OutOfRange))
     }
@@ -74,6 +93,7 @@ sqlfunc!(
 sqlfunc!(
     #[sqlname = "uint8_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToUint64)]
     fn cast_uint64_to_string(a: u64) -> String {
         let mut buf = String::new();
         strconv::format_uint64(&mut buf, a);
@@ -101,6 +121,10 @@ impl<'a> EagerUnaryFunc<'a> for CastUint64ToNumeric {
 
     fn output_type(&self, input: ColumnType) -> ColumnType {
         ScalarType::Numeric { max_scale: self.0 }.nullable(input.nullable)
+    }
+
+    fn right_inverse(&self) -> Option<crate::UnaryFunc> {
+        to_unary!(super::CastNumericToUint64)
     }
 }
 

--- a/src/expr/src/scalar/func/impls/uuid.rs
+++ b/src/expr/src/scalar/func/impls/uuid.rs
@@ -14,6 +14,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "uuid_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToUuid)]
     fn cast_uuid_to_string(u: Uuid) -> String {
         let mut buf = String::with_capacity(36);
         strconv::format_uuid(&mut buf, u);

--- a/src/expr/src/scalar/func/impls/uuid.rs
+++ b/src/expr/src/scalar/func/impls/uuid.rs
@@ -14,7 +14,7 @@ use mz_repr::strconv;
 sqlfunc!(
     #[sqlname = "uuid_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToUuid)]
+    #[inverse = to_unary!(super::CastStringToUuid)]
     fn cast_uuid_to_string(u: Uuid) -> String {
         let mut buf = String::with_capacity(36);
         strconv::format_uuid(&mut buf, u);

--- a/src/expr/src/scalar/func/impls/varchar.rs
+++ b/src/expr/src/scalar/func/impls/varchar.rs
@@ -13,7 +13,7 @@ use mz_repr::adt::varchar::VarChar;
 sqlfunc!(
     #[sqlname = "varchar_to_text"]
     #[preserves_uniqueness = true]
-    #[right_inverse = to_unary!(super::CastStringToVarChar {
+    #[inverse = to_unary!(super::CastStringToVarChar {
         length: None,
         fail_on_len: false,
     })]

--- a/src/expr/src/scalar/func/impls/varchar.rs
+++ b/src/expr/src/scalar/func/impls/varchar.rs
@@ -13,6 +13,10 @@ use mz_repr::adt::varchar::VarChar;
 sqlfunc!(
     #[sqlname = "varchar_to_text"]
     #[preserves_uniqueness = true]
+    #[right_inverse = to_unary!(super::CastStringToVarChar {
+        length: None,
+        fail_on_len: false,
+    })]
     fn cast_var_char_to_string<'a>(a: VarChar<&'a str>) -> &'a str {
         a.0
     }

--- a/src/expr/src/scalar/func/macros.rs
+++ b/src/expr/src/scalar/func/macros.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// Convenience macro for generating `right_inverse` values.
+// Convenience macro for generating `inverse` values.
 macro_rules! to_unary {
     ($f:expr) => {
         Some(crate::UnaryFunc::from($f))
@@ -25,7 +25,7 @@ macro_rules! sqlfunc {
         );
     };
 
-    // Add both uniqueness + right_inverse attributes if they were omitted
+    // Add both uniqueness + inverse attributes if they were omitted
     (
         #[sqlname = $name:expr]
         fn $fn_name:ident $($tail:tt)*
@@ -33,12 +33,12 @@ macro_rules! sqlfunc {
         sqlfunc!(
             #[sqlname = $name]
             #[preserves_uniqueness = false]
-            #[right_inverse = None]
+            #[inverse = None]
             fn $fn_name $($tail)*
         );
     };
 
-    // Add the right_inverse attribute if it was omitted
+    // Add the inverse attribute if it was omitted
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
@@ -47,7 +47,7 @@ macro_rules! sqlfunc {
         sqlfunc!(
             #[sqlname = $name]
             #[preserves_uniqueness = $preserves_uniqueness]
-            #[right_inverse = None]
+            #[inverse = None]
             fn $fn_name $($tail)*
         );
     };
@@ -56,13 +56,13 @@ macro_rules! sqlfunc {
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
-        #[right_inverse = $right_inverse:expr]
+        #[inverse = $inverse:expr]
         fn $fn_name:ident ($($params:tt)*) $($tail:tt)*
     ) => {
         sqlfunc!(
             #[sqlname = $name]
             #[preserves_uniqueness = $preserves_uniqueness]
-            #[right_inverse = $right_inverse]
+            #[inverse = $inverse]
             fn $fn_name<'a>($($params)*) $($tail)*
         );
     };
@@ -71,14 +71,14 @@ macro_rules! sqlfunc {
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
-        #[right_inverse = $right_inverse:expr]
+        #[inverse = $inverse:expr]
         fn $fn_name:ident<$lt:lifetime>(mut $param_name:ident: $input_ty:ty $(,)?) -> $output_ty:ty
             $body:block
     ) => {
         sqlfunc!(
             #[sqlname = $name]
             #[preserves_uniqueness = $preserves_uniqueness]
-            #[right_inverse = $right_inverse]
+            #[inverse = $inverse]
             fn $fn_name<$lt>($param_name: $input_ty) -> $output_ty {
                 let mut $param_name = $param_name;
                 $body
@@ -89,7 +89,7 @@ macro_rules! sqlfunc {
     (
         #[sqlname = $name:expr]
         #[preserves_uniqueness = $preserves_uniqueness:expr]
-        #[right_inverse = $right_inverse:expr]
+        #[inverse = $inverse:expr]
         fn $fn_name:ident<$lt:lifetime>($param_name:ident: $input_ty:ty $(,)?) -> $output_ty:ty
             $body:block
     ) => {
@@ -119,8 +119,8 @@ macro_rules! sqlfunc {
                     $preserves_uniqueness
                 }
 
-                fn right_inverse(&self) -> Option<crate::UnaryFunc> {
-                    $right_inverse
+                fn inverse(&self) -> Option<crate::UnaryFunc> {
+                    $inverse
                 }
             }
 
@@ -310,9 +310,9 @@ macro_rules! derive_unary {
                     $(Self::$name(f) => LazyUnaryFunc::preserves_uniqueness(f),)*
                 }
             }
-            pub fn right_inverse(&self) -> Option<UnaryFunc> {
+            pub fn inverse(&self) -> Option<UnaryFunc> {
                 match self {
-                    $(Self::$name(f) => LazyUnaryFunc::right_inverse(f),)*
+                    $(Self::$name(f) => LazyUnaryFunc::inverse(f),)*
                 }
             }
         }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -452,7 +452,7 @@ impl MirScalarExpr {
             expr: inner_expr,
         } = expr
         {
-            if let Some(inverse_func) = func.invert() {
+            if let Some(inverse_func) = func.right_inverse() {
                 // We don't want to insert a function call that doesn't preserve
                 // uniqueness. E.g., if `a` has an integer type, we don't want to do
                 // a surprise rounding for `WHERE a = 3.14`.
@@ -506,7 +506,7 @@ impl MirScalarExpr {
         };
 
         if let MirScalarExpr::CallUnary { func, .. } = other_side {
-            if let Some(inverse_func) = func.invert() {
+            if let Some(inverse_func) = func.right_inverse() {
                 if inverse_func.preserves_uniqueness()
                     && eval(&MirScalarExpr::CallUnary {
                         func: inverse_func,

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -452,7 +452,7 @@ impl MirScalarExpr {
             expr: inner_expr,
         } = expr
         {
-            if let Some(inverse_func) = func.right_inverse() {
+            if let Some(inverse_func) = func.inverse() {
                 // We don't want to insert a function call that doesn't preserve
                 // uniqueness. E.g., if `a` has an integer type, we don't want to do
                 // a surprise rounding for `WHERE a = 3.14`.
@@ -506,7 +506,7 @@ impl MirScalarExpr {
         };
 
         if let MirScalarExpr::CallUnary { func, .. } = other_side {
-            if let Some(inverse_func) = func.right_inverse() {
+            if let Some(inverse_func) = func.inverse() {
                 if inverse_func.preserves_uniqueness()
                     && eval(&MirScalarExpr::CallUnary {
                         func: inverse_func,

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3552,9 +3552,15 @@ static OP_IMPLS: Lazy<HashMap<&'static str, Func>> = Lazy::new(|| {
             params!(RecordAny, RecordAny) => BinaryFunc::Gte => Bool, 2993;
             params!(MzTimestamp, MzTimestamp)=>BinaryFunc::Gte =>Bool, oid::FUNC_MZ_TIMESTAMP_GTE_MZ_TIMESTAMP_OID;
         },
-        // Warning! If you are writing functions here that do not simply use
-        // `BinaryFunc::Eq`, you will break row equality (used e.g. DISTINCT
-        // operations).
+        // Warning!
+        // - If you are writing functions here that do not simply use
+        //   `BinaryFunc::Eq`, you will break row equality (used in e.g.
+        //   DISTINCT operations and JOINs). In short, this is totally verboten.
+        // - The implementation of `BinaryFunc::Eq` is byte equality on two
+        //   datums, and we enforce that both inputs to the function are of the
+        //   same type in planning. However, it's possible that we will perform
+        //   equality on types not listed here (e.g. `Varchar`) due to decisions
+        //   made in the optimizer.
         "=" => Scalar {
             params!(Numeric, Numeric) => BinaryFunc::Eq, 1752;
             params!(Bool, Bool) => BinaryFunc::Eq, 91;

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -140,6 +140,7 @@ static VALID_CASTS: Lazy<HashMap<(ScalarBaseType, ScalarBaseType), CastImpl>> = 
     casts! {
         // BOOL
         (Bool, Int32) => Explicit: CastBoolToInt32(func::CastBoolToInt32),
+        (Bool, Int64) => Explicit: CastBoolToInt64(func::CastBoolToInt64),
         (Bool, String) => Assignment: CastBoolToString(func::CastBoolToString),
 
         //INT16
@@ -235,6 +236,7 @@ static VALID_CASTS: Lazy<HashMap<(ScalarBaseType, ScalarBaseType), CastImpl>> = 
         // UINT16
         (UInt16, UInt32) => Implicit: CastUint16ToUint32(func::CastUint16ToUint32),
         (UInt16, UInt64) => Implicit: CastUint16ToUint64(func::CastUint16ToUint64),
+        (UInt16, Int16) => Implicit: CastUint16ToInt16(func::CastUint16ToInt16),
         (UInt16, Int32) => Implicit: CastUint16ToInt32(func::CastUint16ToInt32),
         (UInt16, Int64) => Implicit: CastUint16ToInt64(func::CastUint16ToInt64),
         (UInt16, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
@@ -248,6 +250,7 @@ static VALID_CASTS: Lazy<HashMap<(ScalarBaseType, ScalarBaseType), CastImpl>> = 
         // UINT32
         (UInt32, UInt16) => Assignment: CastUint32ToUint16(func::CastUint32ToUint16),
         (UInt32, UInt64) => Implicit: CastUint32ToUint64(func::CastUint32ToUint64),
+        (UInt32, Int16) => Assignment: CastUint32ToInt16(func::CastUint32ToInt16),
         (UInt32, Int32) => Assignment: CastUint32ToInt32(func::CastUint32ToInt32),
         (UInt32, Int64) => Implicit: CastUint32ToInt64(func::CastUint32ToInt64),
         (UInt32, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {
@@ -261,6 +264,7 @@ static VALID_CASTS: Lazy<HashMap<(ScalarBaseType, ScalarBaseType), CastImpl>> = 
         // UINT64
         (UInt64, UInt16) => Assignment: CastUint64ToUint16(func::CastUint64ToUint16),
         (UInt64, UInt32) => Assignment: CastUint64ToUint32(func::CastUint64ToUint32),
+        (UInt64, Int16) => Assignment: CastUint64ToInt16(func::CastUint64ToInt16),
         (UInt64, Int32) => Assignment: CastUint64ToInt32(func::CastUint64ToInt32),
         (UInt64, Int64) => Assignment: CastUint64ToInt64(func::CastUint64ToInt64),
         (UInt64, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -412,8 +412,10 @@ SELECT 1::bigint::bigint;
 ----
 1
 
-query error CAST does not support casting from boolean to bigint
+query T
 SELECT TRUE::boolean::bigint
+----
+1
 
 query error CAST does not support casting from date to bigint
 SELECT '2001 02-03'::date::bigint


### PR DESCRIPTION
The optimizer would like to use the right inverse of cast functions to make index selection more powerful, e.g. if a column reference is cast to some type to make it comparable to a literal, we can instead cast the literal to the column's type, making it possible to an index on that column.

### Motivation

This PR adds a known-desirable feature. Discussed in #15476

### Tips for reviewer

@petrosagg Tagging you just because you worked on the macro; if you see any areas to clean that up, very welcome to suggestions.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Improve Materialize's ability to use indexes when comparing column expressions to literal values, e.g. `SELECT * FROM table_foo WHERE col_a = 'hello'`, particularly cases where `col_a` was of type `VARCHAR`.