### PR TITLE
sql: Include system indexes in SHOW INDEXES

### DIFF
--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -17,7 +17,7 @@ menu:
 Field | Use
 ------|-----
 _on&lowbar;name_ | The name of the object whose indexes you want to show. If omitted, all indexes in the cluster are shown.
-_schema&lowbar;name_ | The schema to show objects from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+_schema&lowbar;name_ | The schema to show objects from. Defaults to `public` in the current database if neither on&lowbar;name nor cluster&lowbar;name are specified. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
 _cluster&lowbar;name_ | The cluster to show indexes from. If omitted, indexes from all clusters are shown.
 
 ## Details

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -423,6 +423,18 @@ pub enum ResolvedSchemaName {
     Error,
 }
 
+impl ResolvedSchemaName {
+    /// Panics if this is `Self::Error`.
+    pub fn schema_spec(&self) -> &SchemaSpecifier {
+        match self {
+            ResolvedSchemaName::Schema { schema_spec, .. } => &schema_spec,
+            ResolvedSchemaName::Error => {
+                unreachable!("should have been handled by name resolution")
+            }
+        }
+    }
+}
+
 impl AstDisplay for ResolvedSchemaName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -427,7 +427,7 @@ impl ResolvedSchemaName {
     /// Panics if this is `Self::Error`.
     pub fn schema_spec(&self) -> &SchemaSpecifier {
         match self {
-            ResolvedSchemaName::Schema { schema_spec, .. } => &schema_spec,
+            ResolvedSchemaName::Schema { schema_spec, .. } => schema_spec,
             ResolvedSchemaName::Error => {
                 unreachable!("should have been handled by name resolution")
             }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -122,7 +122,7 @@ statement ok
 CREATE DEFAULT INDEX foo_v_idx IN CLUSTER foo ON v
 
 query TTTT
-SHOW INDEXES IN CLUSTER bar;
+SHOW INDEXES IN CLUSTER bar WHERE name NOT LIKE 'mz_%';
 ----
 v_primary_idx v bar {?column?}
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -271,3 +271,39 @@ sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 # Test that creating indexes on objects in the mz_internal schema fails
 ! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
 contains:cannot create index with unstable dependencies
+
+> SHOW INDEXES IN CLUSTER mz_introspection
+mz_active_peeks_s2_primary_idx                              mz_active_peeks                             mz_introspection    {id,worker_id}
+mz_arrangement_batches_internal_s2_primary_idx              mz_arrangement_batches_internal             mz_introspection    {operator_id,worker_id}
+mz_arrangement_records_internal_s2_primary_idx              mz_arrangement_records_internal             mz_introspection    {operator_id,worker_id}
+mz_arrangement_sharing_internal_s2_primary_idx              mz_arrangement_sharing_internal             mz_introspection    {operator_id,worker_id}
+mz_compute_exports_s2_primary_idx                           mz_compute_exports                          mz_introspection    {export_id,worker_id}
+mz_dataflow_addresses_s2_primary_idx                        mz_dataflow_addresses                       mz_introspection    {id,worker_id}
+mz_dataflow_channels_s2_primary_idx                         mz_dataflow_channels                        mz_introspection    {id,worker_id}
+mz_dataflow_operator_reachability_internal_s2_primary_idx   mz_dataflow_operator_reachability_internal  mz_introspection    {address,port,worker_id,update_type,timestamp}
+mz_dataflow_operators_s2_primary_idx                        mz_dataflow_operators                       mz_introspection    {id,worker_id}
+mz_message_counts_received_internal_s2_primary_idx          mz_message_counts_received_internal         mz_introspection    {channel_id,from_worker_id,to_worker_id}
+mz_message_counts_sent_internal_s2_primary_idx              mz_message_counts_sent_internal             mz_introspection    {channel_id,from_worker_id,to_worker_id}
+mz_raw_compute_operator_durations_internal_s2_primary_idx   mz_raw_compute_operator_durations_internal  mz_introspection    {id,worker_id,duration_ns}
+mz_raw_peek_durations_s2_primary_idx                        mz_raw_peek_durations                       mz_introspection    {worker_id,duration_ns}
+mz_raw_worker_compute_delays_s2_primary_idx                 mz_raw_worker_compute_delays                mz_introspection    {export_id,import_id,worker_id,delay_ns}
+mz_scheduling_elapsed_internal_s2_primary_idx               mz_scheduling_elapsed_internal              mz_introspection    {id,worker_id}
+mz_scheduling_parks_internal_s2_primary_idx                 mz_scheduling_parks_internal                mz_introspection    {worker_id,slept_for,requested}
+mz_show_all_objects_ind                                     mz_objects                                  mz_introspection    {schema_id}
+mz_show_cluster_replicas_ind                                mz_show_cluster_replicas                    mz_introspection    {cluster,replica,size}
+mz_show_clusters_ind                                        mz_clusters                                 mz_introspection    {name}
+mz_show_columns_ind                                         mz_columns                                  mz_introspection    {id}
+mz_show_connections_ind                                     mz_connections                              mz_introspection    {schema_id}
+mz_show_databases_ind                                       mz_databases                                mz_introspection    {name}
+mz_show_indexes_ind                                         mz_show_indexes                             mz_introspection    {on_id,schema_id,cluster_id}
+mz_show_materialized_views_ind                              mz_show_materialized_views                  mz_introspection    {schema_id,cluster_id}
+mz_show_schemas_ind                                         mz_schemas                                  mz_introspection    {database_id}
+mz_show_secrets_ind                                         mz_secrets                                  mz_introspection    {schema_id}
+mz_show_sinks_ind                                           mz_sinks                                    mz_introspection    {schema_id}
+mz_show_sources_ind                                         mz_sources                                  mz_introspection    {schema_id}
+mz_show_tables_ind                                          mz_tables                                   mz_introspection    {schema_id}
+mz_show_types_ind                                           mz_types                                    mz_introspection    {schema_id}
+mz_show_views_ind                                           mz_views                                    mz_introspection    {schema_id}
+mz_worker_compute_dependencies_s2_primary_idx               mz_worker_compute_dependencies              mz_introspection    {export_id,import_id,worker_id}
+mz_worker_compute_frontiers_s2_primary_idx                  mz_worker_compute_frontiers                 mz_introspection    {export_id,worker_id,time}
+mz_worker_compute_import_frontiers_s2_primary_idx           mz_worker_compute_import_frontiers          mz_introspection    {export_id,import_id,worker_id,time}


### PR DESCRIPTION
Previously, system indexes were excluded when running SHOW INDEXES if the cluster was specified. This commit updates this logic so that system indexes are included when the cluster is specified.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Include system indexes when running `SHOW INDEXES IN CLUSTER <X>`
