### PR TITLE
coord: Log timestamp selected for every query

### DIFF
--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -98,7 +98,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // assured that the answer will be correct.
         if since.less_equal(&candidate) {
             event!(
-                Level::TRACE,
+                Level::DEBUG,
                 conn_id = format!("{}", session.conn_id()),
                 since = format!("{since:?}"),
                 upper = format!("{upper}"),

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -11,7 +11,7 @@
 
 use differential_dataflow::lattice::Lattice;
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
-use tracing::event;
+use tracing::{event, Level};
 
 use mz_compute_client::controller::ComputeInstanceId;
 use mz_expr::MirScalarExpr;
@@ -99,7 +99,7 @@ impl<S: Append + 'static> Coordinator<S> {
             event!(
                 Level::TRACE,
                 conn_id = format!("{}", session.conn_id()),
-                timestamp = format!("{timestamp}")
+                timestamp = format!("{candidate}")
             );
             Ok(candidate)
         } else {

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -11,6 +11,7 @@
 
 use differential_dataflow::lattice::Lattice;
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
+use tracing::event;
 
 use mz_compute_client::controller::ComputeInstanceId;
 use mz_expr::MirScalarExpr;
@@ -95,6 +96,11 @@ impl<S: Append + 'static> Coordinator<S> {
         // If the timestamp is greater or equal to some element in `since` we are
         // assured that the answer will be correct.
         if since.less_equal(&candidate) {
+            event!(
+                Level::TRACE,
+                conn_id = format!("{}", session.conn_id()),
+                timestamp = format!("{timestamp}")
+            );
             Ok(candidate)
         } else {
             coord_bail!(self.generate_timestamp_not_valid_error_msg(

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -70,6 +70,8 @@ impl<S: Append + 'static> Coordinator<S> {
             && timeline.is_some()
             && when.advance_to_global_ts();
 
+        let upper = self.largest_not_in_advance_of_upper(id_bundle);
+
         if use_timestamp_oracle {
             let timeline = timeline.expect("checked that timeline exists above");
             let timestamp_oracle = self.get_timestamp_oracle_mut(&timeline);
@@ -79,7 +81,6 @@ impl<S: Append + 'static> Coordinator<S> {
                 candidate.advance_by(since.borrow());
             }
             if when.advance_to_upper() {
-                let upper = self.largest_not_in_advance_of_upper(id_bundle);
                 candidate.join_assign(&upper);
             }
         }
@@ -99,6 +100,8 @@ impl<S: Append + 'static> Coordinator<S> {
             event!(
                 Level::TRACE,
                 conn_id = format!("{}", session.conn_id()),
+                since = format!("{since:?}"),
+                upper = format!("{upper}"),
                 timestamp = format!("{candidate}")
             );
             Ok(candidate)


### PR DESCRIPTION
Closes #14915

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
