### PR TITLE
doc(user): pattern for single parsing

### DIFF
--- a/doc/user/content/sql/patterns/single-parsing.md
+++ b/doc/user/content/sql/patterns/single-parsing.md
@@ -1,0 +1,63 @@
+---
+title: "Single parsing"
+description: "Parse a source once and save resources."
+aliases:
+  - /guides/single-parsing/
+menu:
+  main:
+    parent: 'sql-patterns'
+---
+
+<!-- Use a single materialized view to parse a Kafka/Redpanda source **only once** and save resources. -->
+Avoid parsing **more than once** a Kafka/Redpanda source. Using a single materialized view for parsing leads you to multiple benefits:
+* Faster and reusable access to data
+* Lesser resources processing data
+* Cleaner code
+
+## Details
+
+Materialized views process data and store the results in durable storage. Re-doing the parsing step, as a subquery, on every view consuming from a source will multiply the processing effort.
+
+#### Multi-parsing
+
+The following scenario reflects how two different materialized views increase the processing **overhead** by doing the same parsing step in the subqueries:
+
+```sql
+CREATE MATERIALIZED VIEW paid_customers AS
+SELECT ...
+FROM (
+    -- Parse
+    SELECT CONVERT_FROM(data, 'utf8')::jsonb AS data
+    FROM kafka_source
+)
+WHERE type = 'paid';
+
+
+CREATE MATERIALIZED VIEW free_customers AS
+SELECT ...
+FROM (
+    -- Parse
+    SELECT CONVERT_FROM(data, 'utf8')::jsonb AS data
+    FROM kafka_source
+)
+WHERE type = 'free';
+```
+
+#### Single-parsing
+
+A single parsing materialized view **reduces the processing overhead** and **makes the results reusable**:
+
+```sql
+-- Parse once
+CREATE MATERIALIZED VIEW customers AS
+  SELECT
+    ...
+  FROM (SELECT CONVERT_FROM(data, 'utf8')::jsonb AS data FROM kafka_source);
+
+-- Reuse
+CREATE MATERIALIZED VIEW paid_customers AS
+SELECT * FROM customers WHERE type ='paid';
+
+CREATE MATERIALIZED VIEW free_customers AS
+SELECT * FROM customers WHERE type = 'free';
+```


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Many Materialize users do the parsing step multiple times. If the throughput is huge leads to overhead. A straightforward way to reduce the overhead is to create a single materialized view to do the job. The pattern tries to encapsulate that.
 
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
