### PR TITLE
Update docs for pre push hook

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -419,7 +419,7 @@ To ensure each code change passes all style nits before pushing to GitHub,
 symlink `pre-push` into your local git hooks:
 
 ```sh
-ln -s ./misc/githooks/pre-push .git/hooks/pre-push
+ln -s ../../misc/githooks/pre-push .git/hooks/pre-push
 ```
 
 ### Shell completion


### PR DESCRIPTION
The current command in the developer docs didn't work for me. This update
matches the command in the header of `misc/githooks/pre-push`.

### Motivation

  * This PR fixes a previously unreported bug.

Copy and pasting the command from the documentation creates a soft
link at `.git/hooks/pre-push`. When I try to `cat .git/hooks/pre-push` it
fails because the created link is invalid.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
