### PR TITLE
platform checks: Allow parallel execution of Checks

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -44,6 +44,13 @@ steps:
           - { value: checks-oneatatime-kill-storaged }
           - { value: checks-oneatatime-restart-postgres-backend }
           - { value: checks-oneatatime-restart-redpanda }
+          - { value: checks-parallel-drop-create-default-replica }
+          - { value: checks-parallel-restart-computed }
+          - { value: checks-parallel-restart-entire-mz }
+          - { value: checks-parallel-restart-environmentd-storaged }
+          - { value: checks-parallel-kill-storaged }
+          - { value: checks-parallel-restart-postgres-backend }
+          - { value: checks-parallel-restart-redpanda }
           - { value: checks-upgrade-entire-mz }
           - { value: checks-upgrade-computed-first }
           - { value: checks-upgrade-computed-last }
@@ -365,6 +372,76 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartRedpanda, --execution-mode=oneatatime]
+
+  - id: checks-parallel-drop-create-default-replica
+    label: "Checks parallel + DROP/CREATE replica"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel]
+
+  - id: checks-parallel-restart-computed
+    label: "Checks parallel + restart computed"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartComputed, --execution-mode=parallel]
+
+  - id: checks-parallel-restart-entire-mz
+    label: "Checks parallel + restart of the entire Mz"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEntireMz, --execution-mode=parallel]
+
+  - id: checks-parallel-restart-environmentd-storaged
+    label: "Checks parallel + restart of environmentd & storaged"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEnvironmentdStoraged, --execution-mode=parallel]
+
+  - id: checks-parallel-kill-storaged
+    label: "Checks parallel + kill storaged"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=KillStoraged, --execution-mode=parallel]
+
+  - id: checks-parallel-restart-postgres-backend
+    label: "Checks parallel + restart Postgres backend"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartPostgresBackend, --execution-mode=parallel]
+
+  - id: checks-parallel-restart-redpanda
+    label: "Checks parallel + restart Redpanda"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartRedpanda, --execution-mode=parallel]
 
   - id: checks-upgrade-entire-mz
     label: "Platform checks upgrade, whole-Mz restart"

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -36,14 +36,23 @@ class Check:
     def validate(self) -> Testdrive:
         assert False
 
-    def run_initialize(self, e: Executor) -> None:
+    def start_initialize(self, e: Executor) -> None:
         self._initialize.execute(e)
 
-    def run_manipulate(self, e: Executor, phase: int) -> None:
+    def join_initialize(self, e: Executor) -> None:
+        self._initialize.join(e)
+
+    def start_manipulate(self, e: Executor, phase: int) -> None:
         self._manipulate[phase].execute(e)
 
-    def run_validate(self, e: Executor) -> None:
+    def join_manipulate(self, e: Executor, phase: int) -> None:
+        self._manipulate[phase].join(e)
+
+    def start_validate(self, e: Executor) -> None:
         self._validate.execute(e)
+
+    def join_validate(self, e: Executor) -> None:
+        self._validate.join(e)
 
 
 class CheckDisabled(Check):


### PR DESCRIPTION
As each check is independent, they can be run in parallel to put extra stress on the system.

- modify Executor to allow for concurrent execution where an Action is started first and then join()-ed later
- provide a MzcomposeParallel Executor that performs 'docker run testdrive' in a separate Python thread and passes any exceptions upstream
- add a Nightly CI jobs that runs the existing Scenarios with parallel Checks

### Motivation
  * This PR adds a feature that has not yet been specified.

I am trying to beef up Nightly by adding as many tests as possible. The lowest-hanging fruit is running existing tests concurrently to place extra stress on the system.