### PR TITLE
platform checks: remove erroneous assert in test framework

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -45,7 +45,6 @@ class Testdrive(Action):
         self.handle = e.testdrive(self.input)
 
     def join(self, e: Executor) -> None:
-        assert self.handle is not None
         e.join(self.handle)
 
 


### PR DESCRIPTION
An assert was added to satisfy mypy , but it was not valid in the case where platform checks is run inside cloudtest, and was not required anyway.

### Motivation

  * This PR fixes a previously unreported bug.
The cloudtest upgrade test started failing in Nightly after #15626