### PR TITLE
sql: refactor subsource AST handling

### DIFF
--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -21,6 +21,7 @@
 use std::fmt;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
+use crate::ast::AstInfo;
 use crate::keywords::Keyword;
 
 /// An identifier.
@@ -161,3 +162,21 @@ impl AstDisplay for UnresolvedDatabaseName {
     }
 }
 impl_display!(UnresolvedDatabaseName);
+
+// The name of an object not yet created during name resolution, which should be
+// resolveable as an object name later.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum DeferredObjectName<T: AstInfo> {
+    Named(T::ObjectName),
+    Deferred(UnresolvedObjectName),
+}
+
+impl<T: AstInfo> AstDisplay for DeferredObjectName<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            DeferredObjectName::Named(o) => f.write_node(o),
+            DeferredObjectName::Deferred(o) => f.write_node(o),
+        }
+    }
+}
+impl_display_t!(DeferredObjectName);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3998,7 +3998,7 @@ impl<'a> Parser<'a> {
     fn parse_deferred_object_name(&mut self) -> Result<DeferredObjectName<Raw>, ParserError> {
         Ok(match self.parse_raw_name()? {
             named @ RawObjectName::Id(..) => DeferredObjectName::Named(named),
-            RawObjectName::Name(deferred) => DeferredObjectName::Deferred(deferred),
+            RawObjectName::Name(name) => DeferredObjectName::Deferred(name),
         })
     }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2257,21 +2257,11 @@ impl<'a> Parser<'a> {
 
         let subsources = if self.parse_keywords(&[FOR, TABLES]) {
             self.expect_token(&Token::LParen)?;
-            let subsources = self.parse_comma_separated(|parser| {
-                let name = parser.parse_object_name()?;
-                let subsource = if parser.parse_keyword(INTO) {
-                    CreateSourceSubsource::Resolved(name, parser.parse_raw_name()?)
-                } else if parser.parse_keyword(AS) {
-                    CreateSourceSubsource::Aliased(name, parser.parse_object_name()?)
-                } else {
-                    CreateSourceSubsource::Bare(name)
-                };
-                Ok(subsource)
-            })?;
+            let subsources = self.parse_comma_separated(Parser::parse_subsource_references)?;
             self.expect_token(&Token::RParen)?;
-            Some(CreateSourceSubsources::Subset(subsources))
+            Some(CreateReferencedSubsources::Subset(subsources))
         } else if self.parse_keywords(&[FOR, ALL, TABLES]) {
-            Some(CreateSourceSubsources::All)
+            Some(CreateReferencedSubsources::All)
         } else {
             None
         };
@@ -2298,6 +2288,20 @@ impl<'a> Parser<'a> {
             with_options,
             subsources,
         }))
+    }
+
+    fn parse_subsource_references(&mut self) -> Result<CreateSourceSubsource<Raw>, ParserError> {
+        let reference = self.parse_object_name()?;
+        let subsource = if self.parse_one_of_keywords(&[AS, INTO]).is_some() {
+            Some(self.parse_deferred_object_name()?)
+        } else {
+            None
+        };
+
+        Ok(CreateSourceSubsource {
+            reference,
+            subsource,
+        })
     }
 
     /// Parses the column section of a CREATE SOURCE statement which can be
@@ -3989,6 +3993,13 @@ impl<'a> Parser<'a> {
             }
             None => Ok(None),
         }
+    }
+
+    fn parse_deferred_object_name(&mut self) -> Result<DeferredObjectName<Raw>, ParserError> {
+        Ok(match self.parse_raw_name()? {
+            named @ RawObjectName::Id(..) => DeferredObjectName::Named(named),
+            RawObjectName::Name(deferred) => DeferredObjectName::Deferred(deferred),
+        })
     }
 
     fn parse_raw_name(&mut self) -> Result<RawObjectName, ParserError> {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1441,13 +1441,40 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') 
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [], subsources: Some(All) })
 
-
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES WITH (SIZE = 'small');
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR ALL TABLES WITH (SIZE = 'small')
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], subsources: Some(All) })
+
+parse-statement
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (foo, bar as qux, baz into zop) WITH (SIZE = 'small');
+----
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (foo, bar AS qux, baz AS zop) WITH (SIZE = 'small')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedObjectName([Ident("foo")]), subsource: None }, CreateSourceSubsource { reference: UnresolvedObjectName([Ident("bar")]), subsource: Some(Deferred(UnresolvedObjectName([Ident("qux")]))) }, CreateSourceSubsource { reference: UnresolvedObjectName([Ident("baz")]), subsource: Some(Deferred(UnresolvedObjectName([Ident("zop")]))) }])) })
+
+parse-statement
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar]) WITH (SIZE = 'small');
+----
+error: Expected identifier, found left square bracket
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar]) WITH (SIZE = 'small');
+                                                                                          ^
+
+parse-statement
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar]) WITH (SIZE = 'small');
+----
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (baz AS [s1 AS foo.bar]) WITH (SIZE = 'small')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], subsources: Some(Subset([CreateSourceSubsource { reference: UnresolvedObjectName([Ident("baz")]), subsource: Some(Named(Id("s1", UnresolvedObjectName([Ident("foo"), Ident("bar")])))) }])) })
+
+parse-statement
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar] AS baz) WITH (SIZE = 'small');
+----
+error: Expected identifier, found left square bracket
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES ([s1 AS foo.bar] AS baz) WITH (SIZE = 'small');
+                                                                                          ^
 
 parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') WITH (SIZE = 'small') FOR ALL TABLES;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -39,7 +39,7 @@ use mz_sql_parser::ast::{
     AlterSinkAction, AlterSinkStatement, AlterSourceAction, AlterSourceStatement,
     AlterSystemResetAllStatement, AlterSystemResetStatement, AlterSystemSetStatement,
     CreateTypeListOption, CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName,
-    SetVariableValue, SshConnectionOption,
+    DeferredObjectName, SetVariableValue, SshConnectionOption,
 };
 use mz_storage::source::generator::as_generator;
 use mz_storage::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
@@ -69,10 +69,10 @@ use crate::ast::{
     AwsConnectionOptionName, ClusterOption, ClusterOptionName, ColumnOption, Compression,
     CreateClusterReplicaStatement, CreateClusterStatement, CreateConnection,
     CreateConnectionStatement, CreateDatabaseStatement, CreateIndexStatement,
-    CreateMaterializedViewStatement, CreateRoleOption, CreateRoleStatement, CreateSchemaStatement,
-    CreateSecretStatement, CreateSinkConnection, CreateSinkOption, CreateSinkOptionName,
-    CreateSinkStatement, CreateSourceConnection, CreateSourceFormat, CreateSourceOption,
-    CreateSourceOptionName, CreateSourceStatement, CreateSourceSubsource, CreateSourceSubsources,
+    CreateMaterializedViewStatement, CreateReferencedSubsources, CreateRoleOption,
+    CreateRoleStatement, CreateSchemaStatement, CreateSecretStatement, CreateSinkConnection,
+    CreateSinkOption, CreateSinkOptionName, CreateSinkStatement, CreateSourceConnection,
+    CreateSourceFormat, CreateSourceOption, CreateSourceOptionName, CreateSourceStatement,
     CreateSubsourceStatement, CreateTableStatement, CreateTypeAs, CreateTypeStatement,
     CreateViewStatement, CsrConfigOption, CsrConfigOptionName, CsrConnection, CsrConnectionAvro,
     CsrConnectionOption, CsrConnectionOptionName, CsrConnectionProtobuf, CsrSeedProtobuf,
@@ -856,18 +856,24 @@ pub fn plan_create_source(
     };
 
     let (available_subsources, requested_subsources) = match (available_subsources, subsources) {
-        (Some(available_subsources), Some(CreateSourceSubsources::Subset(subsources))) => {
+        (Some(available_subsources), Some(CreateReferencedSubsources::Subset(subsources))) => {
             let mut requested_subsources = vec![];
             for subsource in subsources {
-                let (name, target) = match subsource {
-                    CreateSourceSubsource::Resolved(name, target) => (name, target),
-                    CreateSourceSubsource::Aliased(_, _) | CreateSourceSubsource::Bare(_) => {
-                        sql_bail!(
-                            "[internal error] subsources should be resolved during purification"
-                        )
+                let name = subsource.reference.clone();
+
+                let target = match &subsource.subsource {
+                    Some(subsource) => match subsource {
+                        DeferredObjectName::Named(target) => target,
+                        DeferredObjectName::Deferred(_) => sql_bail!(
+                            "[internal error] subsources must be named during purification"
+                        ),
+                    },
+                    None => {
+                        sql_bail!("[internal error] subsources must be named during purification")
                     }
                 };
-                requested_subsources.push((name.clone(), target));
+
+                requested_subsources.push((name, target));
             }
             (available_subsources, requested_subsources)
         }
@@ -875,7 +881,7 @@ pub fn plan_create_source(
             // Multi-output sources must have a table selection clause
             sql_bail!("This is a multi-output source. Use `FOR TABLE (..)` or `FOR ALL TABLES` to select which ones to ingest");
         }
-        (None, Some(_)) | (Some(_), Some(CreateSourceSubsources::All)) => {
+        (None, Some(_)) | (Some(_), Some(CreateReferencedSubsources::All)) => {
             sql_bail!("[internal error] subsources should be resolved during purification")
         }
         (None, None) => (HashMap::<FullObjectName, usize>::new(), vec![]),
@@ -895,6 +901,7 @@ pub fn plan_create_source(
                 sql_bail!("[internal error] invalid target id")
             }
         };
+
         // TODO(petrosagg): This is the point where we would normally look into the catalog for the
         // item with ID `target` and verify that its RelationDesc is identical to the type of the
         // dataflow output. We can't do that here however because the subsources are created in the

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -33,17 +33,17 @@ use mz_repr::{strconv, GlobalId};
 use mz_secrets::SecretsReader;
 use mz_sql_parser::ast::{
     ColumnDef, ColumnOption, ColumnOptionDef, CsrConnection, CsrSeedAvro, CsrSeedProtobuf,
-    CsrSeedProtobufSchema, DbzMode, Envelope, Ident, KafkaConfigOption, KafkaConfigOptionName,
-    KafkaConnection, KafkaSourceConnection, PgConfigOption, PgConfigOptionName,
-    ReaderSchemaSelectionStrategy, TableConstraint, UnresolvedObjectName,
+    CsrSeedProtobufSchema, DbzMode, DeferredObjectName, Envelope, Ident, KafkaConfigOption,
+    KafkaConfigOptionName, KafkaConnection, KafkaSourceConnection, PgConfigOption,
+    PgConfigOptionName, ReaderSchemaSelectionStrategy, TableConstraint, UnresolvedObjectName,
 };
 use mz_storage::types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
 use mz_storage::types::connections::{Connection, ConnectionContext};
 use mz_storage::types::sources::PostgresSourceDetails;
 
 use crate::ast::{
-    AvroSchema, CreateSourceConnection, CreateSourceFormat, CreateSourceStatement,
-    CreateSourceSubsource, CreateSourceSubsources, CreateSubsourceStatement, CsrConnectionAvro,
+    AvroSchema, CreateReferencedSubsources, CreateSourceConnection, CreateSourceFormat,
+    CreateSourceStatement, CreateSourceSubsource, CreateSubsourceStatement, CsrConnectionAvro,
     CsrConnectionProtobuf, CsvColumns, Format, ProtobufSchema, Value, WithOptionValue,
 };
 use crate::catalog::SessionCatalog;
@@ -61,17 +61,18 @@ fn subsource_gen<'a, T>(
     let mut validated_requested_subsources = vec![];
 
     for subsource in selected_subsources {
-        let (upstream_name, subsource_name) = match subsource.clone() {
-            CreateSourceSubsource::Bare(name) => {
-                let upstream_name = normalize::unresolved_object_name(name)?;
-                let subsource_name = UnresolvedObjectName::unqualified(&upstream_name.item);
-                (upstream_name, subsource_name)
-            }
-            CreateSourceSubsource::Aliased(name, alias) => {
-                (normalize::unresolved_object_name(name)?, alias)
-            }
-            CreateSourceSubsource::Resolved(_, _) => {
-                bail!("Cannot alias subsource using `INTO`, use `AS` instead")
+        let upstream_name = normalize::unresolved_object_name(subsource.reference.clone())?;
+
+        let subsource_name = match &subsource.subsource {
+            Some(name) => match name {
+                DeferredObjectName::Deferred(name) => name.clone(),
+                DeferredObjectName::Named(_) => bail!("Cannot manually ID qualify subsources"),
+            },
+            None => {
+                // Use the entered name as the upstream reference, and then use
+                // the item as the subsource name to ensure it's created in the
+                // current schema, not mirroring the schema of the reference.
+                UnresolvedObjectName::unqualified(&upstream_name.item)
             }
         };
 
@@ -144,10 +145,14 @@ pub async fn purify_create_source(
     } = &mut stmt;
 
     // Disallow manually targetting subsources, this syntax is reserved for purification only
-    if let Some(CreateSourceSubsources::Subset(subsources)) = requested_subsources {
-        for subsource in subsources {
-            if matches!(subsource, CreateSourceSubsource::Resolved(_, _)) {
-                bail!("Cannot alias subsource using `INTO`, use `AS` instead");
+    if let Some(CreateReferencedSubsources::Subset(subsources)) = requested_subsources {
+        for CreateSourceSubsource {
+            subsource,
+            reference: _,
+        } in subsources
+        {
+            if let Some(DeferredObjectName::Named(_)) = subsource {
+                bail!("Cannot manually ID qualify subsources");
             }
         }
     }
@@ -292,7 +297,7 @@ pub async fn purify_create_source(
 
             let mut validated_requested_subsources = vec![];
             match requested_subsources {
-                Some(CreateSourceSubsources::All) => {
+                Some(CreateReferencedSubsources::All) => {
                     for table in &tables {
                         let upstream_name = UnresolvedObjectName::qualified(&[
                             &connection.database,
@@ -303,7 +308,7 @@ pub async fn purify_create_source(
                         validated_requested_subsources.push((upstream_name, subsource_name, table));
                     }
                 }
-                Some(CreateSourceSubsources::Subset(subsources)) => {
+                Some(CreateReferencedSubsources::Subset(subsources)) => {
                     // The user manually selected a subset of upstream tables so we need to
                     // validate that the names actually exist and are not ambiguous
 
@@ -353,15 +358,15 @@ pub async fn purify_create_source(
                 let qualified_subsource_name =
                     scx.allocate_qualified_name(partial_subsource_name.clone())?;
                 let full_subsource_name = scx.allocate_full_name(partial_subsource_name)?;
-                targeted_subsources.push(CreateSourceSubsource::Resolved(
-                    upstream_name,
-                    ResolvedObjectName::Object {
+                targeted_subsources.push(CreateSourceSubsource {
+                    reference: upstream_name,
+                    subsource: Some(DeferredObjectName::Named(ResolvedObjectName::Object {
                         id: transient_id,
                         qualifiers: qualified_subsource_name.qualifiers,
                         full_name: full_subsource_name,
-                        print_id: false,
-                    },
-                ));
+                        print_id: true,
+                    })),
+                });
 
                 // Create the subsource statement
                 let subsource = CreateSubsourceStatement {
@@ -380,7 +385,7 @@ pub async fn purify_create_source(
                 };
                 subsources.push((transient_id, subsource));
             }
-            *requested_subsources = Some(CreateSourceSubsources::Subset(targeted_subsources));
+            *requested_subsources = Some(CreateReferencedSubsources::Subset(targeted_subsources));
 
             // Remove any old detail references
             options.retain(|PgConfigOption { name, .. }| name != &PgConfigOptionName::Details);
@@ -408,7 +413,7 @@ pub async fn purify_create_source(
 
             let mut validated_requested_subsources = vec![];
             match requested_subsources {
-                Some(CreateSourceSubsources::All) => {
+                Some(CreateReferencedSubsources::All) => {
                     let available_subsources = match &available_subsources {
                         Some(available_subsources) => available_subsources,
                         None => bail!("FOR ALL TABLES is only valid for multi-output sources"),
@@ -419,7 +424,7 @@ pub async fn purify_create_source(
                         validated_requested_subsources.push((upstream_name, subsource_name, desc));
                     }
                 }
-                Some(CreateSourceSubsources::Subset(selected_subsources)) => {
+                Some(CreateReferencedSubsources::Subset(selected_subsources)) => {
                     let available_subsources = match &available_subsources {
                         Some(available_subsources) => available_subsources,
                         None => bail!("FOR TABLES (..) is only valid for multi-output sources"),
@@ -502,15 +507,15 @@ pub async fn purify_create_source(
                 let qualified_subsource_name =
                     scx.allocate_qualified_name(partial_subsource_name.clone())?;
                 let full_subsource_name = scx.allocate_full_name(partial_subsource_name)?;
-                targeted_subsources.push(CreateSourceSubsource::Resolved(
-                    upstream_name,
-                    ResolvedObjectName::Object {
+                targeted_subsources.push(CreateSourceSubsource {
+                    reference: upstream_name,
+                    subsource: Some(DeferredObjectName::Named(ResolvedObjectName::Object {
                         id: transient_id,
                         qualifiers: qualified_subsource_name.qualifiers,
                         full_name: full_subsource_name,
-                        print_id: false,
-                    },
-                ));
+                        print_id: true,
+                    })),
+                });
 
                 // Create the subsource statement
                 let subsource = CreateSubsourceStatement {
@@ -526,7 +531,8 @@ pub async fn purify_create_source(
                 subsources.push((transient_id, subsource));
             }
             if available_subsources.is_some() {
-                *requested_subsources = Some(CreateSourceSubsources::Subset(targeted_subsources));
+                *requested_subsources =
+                    Some(CreateReferencedSubsources::Subset(targeted_subsources));
             }
         }
     }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -66,7 +66,7 @@ fn subsource_gen<'a, T>(
         let subsource_name = match &subsource.subsource {
             Some(name) => match name {
                 DeferredObjectName::Deferred(name) => name.clone(),
-                DeferredObjectName::Named(_) => bail!("Cannot manually ID qualify subsources"),
+                DeferredObjectName::Named(..) => bail!("Cannot manually ID qualify subsources"),
             },
             None => {
                 // Use the entered name as the upstream reference, and then use

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -192,6 +192,27 @@ contains:publication "no_such_publication" does not exist
     "space table"
   );
 
+> SHOW SOURCES
+conflict_table        subsource <null>
+escaped_text_table    subsource <null>
+large_text            subsource <null>
+multipart_pk          subsource <null>
+mz_source             postgres  1
+no_replica_identity   subsource <null>
+nonpk_table           subsource <null>
+nulls_table           subsource <null>
+pk_table              subsource <null>
+"space table"         subsource <null>
+trailing_space_nopk   subsource <null>
+trailing_space_pk     subsource <null>
+types_table           subsource <null>
+utf8_table            subsource <null>
+таблица               subsource <null>
+
+# Dependency graph is that mz_source depends on all subsources
+! DROP SOURCE conflict_table
+contains: cannot drop materialize.public.conflict_table: still depended upon by catalog item 'materialize.public.mz_source'
+
 > SELECT * FROM no_replica_identity;
 1
 2


### PR DESCRIPTION
Our AST nodes did not have a generalized means of naming an objects that would be created after the first name resolution pass, but that were guaranteed to exist forever afterward. Stated another way, you could not generally have one DML statement create multiple objects with dependencies between them.

This commit introduces a generalized AST node to serve this purpose.

### Motivation

This PR refactors existing code. Discussed in the ["Queryable remap collections" design doc](https://www.notion.so/materialize/Queryable-remap-collections-8c0b8ee5953643599c7267a9d89867ae#9875492f7c364c6d8ab12008bec3bdde).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a