### PR TITLE
[sources] Write source errors to persist

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -544,13 +544,9 @@ impl<S: Append + 'static> Coordinator<S> {
         // This is disabled for the moment because it has unusual upper
         // advancement behavior.
         // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
-        let source_status_collection_id = if false {
-            Some(self.catalog.resolve_builtin_storage_collection(
-                &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
-            ))
-        } else {
-            None
-        };
+        let source_status_history_shard = self
+            .catalog
+            .resolve_builtin_storage_collection(&crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY);
 
         info!("coordinator init: installing existing objects in catalog");
         let mut privatelink_connections = HashMap::new();
@@ -567,7 +563,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // using a single dataflow, we have to make sure the rebuild process re-runs
                 // the same multiple-build dataflow.
                 CatalogItem::Source(source) => {
-                    let data_source = match &source.data_source {
+                    let (data_source, status_collection_id) = match &source.data_source {
                         // Re-announce the source description.
                         DataSourceDesc::Ingestion(ingestion) => {
                             let mut source_imports = BTreeMap::new();
@@ -590,17 +586,20 @@ impl<S: Append + 'static> Coordinator<S> {
                                 source_exports.insert(subsource, export);
                             }
 
-                            DataSource::Ingestion(IngestionDescription {
-                                desc: ingestion.desc.clone(),
-                                ingestion_metadata: (),
-                                source_imports,
-                                source_exports,
-                                host_config: ingestion.host_config.clone(),
-                            })
+                            (
+                                DataSource::Ingestion(IngestionDescription {
+                                    desc: ingestion.desc.clone(),
+                                    ingestion_metadata: (),
+                                    source_imports,
+                                    source_exports,
+                                    host_config: ingestion.host_config.clone(),
+                                }),
+                                Some(source_status_history_shard),
+                            )
                         }
-                        DataSourceDesc::Source => DataSource::Other,
+                        DataSourceDesc::Source => (DataSource::Other, None),
                         DataSourceDesc::Introspection(introspection) => {
-                            DataSource::Introspection(*introspection)
+                            (DataSource::Introspection(*introspection), None)
                         }
                     };
 
@@ -612,7 +611,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 desc: source.desc.clone(),
                                 data_source,
                                 since: None,
-                                status_collection_id: source_status_collection_id,
+                                status_collection_id,
                             },
                         )])
                         .await

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -544,7 +544,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // This is disabled for the moment because it has unusual upper
         // advancement behavior.
         // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
-        let source_status_history_shard = if self.catalog.config().unsafe_mode {
+        let source_status_collection_id = if self.catalog.config().unsafe_mode {
             Some(self.catalog.resolve_builtin_storage_collection(
                 &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
             ))
@@ -598,7 +598,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                     source_exports,
                                     host_config: ingestion.host_config.clone(),
                                 }),
-                                source_status_history_shard,
+                                source_status_collection_id,
                             )
                         }
                         DataSourceDesc::Source => (DataSource::Other, None),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -507,7 +507,7 @@ impl<S: Append + 'static> Coordinator<S> {
         {
             Ok(()) => {
                 for (source_id, source) in sources {
-                    let source_status_history_shard = if self.catalog.config().unsafe_mode {
+                    let source_status_collection_id = if self.catalog.config().unsafe_mode {
                         Some(self.catalog.resolve_builtin_storage_collection(
                             &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
                         ))
@@ -545,7 +545,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                     source_exports,
                                     host_config: ingestion.host_config,
                                 }),
-                                source_status_history_shard,
+                                source_status_collection_id,
                             )
                         }
                         DataSourceDesc::Source => (DataSource::Other, None),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -510,15 +510,12 @@ impl<S: Append + 'static> Coordinator<S> {
                     // This is disabled for the moment because it has unusual upper
                     // advancement behavior.
                     // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
-                    let status_collection_id = if false {
-                        Some(self.catalog.resolve_builtin_storage_collection(
+                    let source_status_history_shard =
+                        self.catalog.resolve_builtin_storage_collection(
                             &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
-                        ))
-                    } else {
-                        None
-                    };
+                        );
 
-                    let data_source = match source.data_source {
+                    let (data_source, status_collection_id) = match source.data_source {
                         DataSourceDesc::Ingestion(ingestion) => {
                             let mut source_imports = BTreeMap::new();
                             for source_import in ingestion.source_imports {
@@ -540,15 +537,18 @@ impl<S: Append + 'static> Coordinator<S> {
                                 source_exports.insert(subsource, export);
                             }
 
-                            DataSource::Ingestion(IngestionDescription {
-                                desc: ingestion.desc,
-                                ingestion_metadata: (),
-                                source_imports,
-                                source_exports,
-                                host_config: ingestion.host_config,
-                            })
+                            (
+                                DataSource::Ingestion(IngestionDescription {
+                                    desc: ingestion.desc,
+                                    ingestion_metadata: (),
+                                    source_imports,
+                                    source_exports,
+                                    host_config: ingestion.host_config,
+                                }),
+                                Some(source_status_history_shard),
+                            )
                         }
-                        DataSourceDesc::Source => DataSource::Other,
+                        DataSourceDesc::Source => (DataSource::Other, None),
                         DataSourceDesc::Introspection(_) => {
                             unreachable!("cannot create sources with introspection data sources")
                         }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -856,7 +856,7 @@ where
             {
                 Some(
                     durable_metadata
-                        .remove(&status_collection_id)
+                        .get(&status_collection_id)
                         .ok_or(StorageError::IdentifierMissing(status_collection_id))?
                         .data_shard,
                 )

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -26,6 +26,33 @@ use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::sources::SourceData;
 
+pub fn pack_status_row(
+    source_id: GlobalId,
+    status_name: &str,
+    error: Option<&str>,
+    ts: u64,
+) -> Row {
+    let timestamp = NaiveDateTime::from_timestamp(
+        (ts / 1000)
+            .try_into()
+            .expect("timestamp seconds does not fit into i64"),
+        (ts % 1000 * 1_000_000)
+            .try_into()
+            .expect("timestamp millis does not fit into a u32"),
+    );
+    let timestamp = Datum::TimestampTz(
+        DateTime::from_utc(timestamp, Utc)
+            .try_into()
+            .expect("must fit"),
+    );
+    let source_id = source_id.to_string();
+    let source_id = Datum::String(&source_id);
+    let status = Datum::String(status_name);
+    let error = error.as_deref().into();
+    let metadata = Datum::Null;
+    Row::pack_slice(&[timestamp, source_id, status, error, metadata])
+}
+
 /// The Healthchecker is responsible for tracking the current state
 /// of a Timely worker for a source, as well as updating the relevant
 /// state collection based on it.
@@ -229,25 +256,12 @@ impl Healthchecker {
         status_update: &SourceStatusUpdate,
         ts: u64,
     ) -> Vec<((SourceData, ()), Timestamp, i64)> {
-        let timestamp = NaiveDateTime::from_timestamp(
-            (ts / 1000)
-                .try_into()
-                .expect("timestamp seconds does not fit into i64"),
-            (ts % 1000 * 1_000_000)
-                .try_into()
-                .expect("timestamp millis does not fit into a u32"),
+        let row = pack_status_row(
+            self.source_id,
+            status_update.status.name(),
+            status_update.error.as_deref(),
+            ts,
         );
-        let timestamp = Datum::TimestampTz(
-            DateTime::from_utc(timestamp, Utc)
-                .try_into()
-                .expect("must fit"),
-        );
-        let source_id = self.source_id.to_string();
-        let source_id = Datum::String(&source_id);
-        let status = Datum::String(status_update.status.name());
-        let error = status_update.error.as_deref().into();
-        let metadata = Datum::Null;
-        let row = Row::pack_slice(&[timestamp, source_id, status, error, metadata]);
 
         vec![(
             (SourceData(Ok(row)), ()),

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -39,7 +39,7 @@ mod antichain;
 mod commit;
 mod delimited_value_reader;
 pub mod generator;
-mod healthcheck;
+pub mod healthcheck;
 mod kafka;
 mod kinesis;
 pub mod metrics;

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -904,7 +904,7 @@ where
                 let mut append_ts = timestamp;
                 'retry_loop: loop {
                     // We don't actually care so much about the timestamp we append at; it's best-effort.
-                    // Ensure that the append timestamp is past the current upper, and the new upper
+                    // Ensure that the append timestamp is not less than the current upper, and the new upper
                     // is past that timestamp. (Unless we've advanced to the empty antichain, but in
                     // that case we're already in trouble.)
                     for t in recent_upper.elements() {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -30,6 +30,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
 use futures::future::Either;
 use itertools::Itertools;
@@ -52,21 +53,21 @@ use mz_expr::PartitionId;
 use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
-use mz_repr::{GlobalId, Timestamp};
+use mz_persist_client::Upper;
+use mz_repr::{GlobalId, Row, Timestamp};
 use mz_storage_client::controller::{CollectionMetadata, ResumptionFrontierCalculator};
 use mz_storage_client::source::util::async_source;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::SourceError;
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
-use mz_storage_client::types::sources::{AsyncSourceToken, MzOffset, SourceToken};
+use mz_storage_client::types::sources::{AsyncSourceToken, MzOffset, SourceData, SourceToken};
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 use mz_timely_util::operator::StreamExt as _;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
-use crate::controller::{CollectionMetadata, ResumptionFrontierCalculator};
 use crate::source::antichain::{MutableOffsetAntichain, OffsetAntichain};
 use crate::source::healthcheck;
-use crate::source::healthcheck::Healthchecker;
+
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::{ReclockBatch, ReclockFollower, ReclockOperator};
 use crate::source::types::{
@@ -437,6 +438,23 @@ pub enum HealthStatus {
     Starting,
     Running,
     StalledWithError(String),
+}
+
+impl HealthStatus {
+    fn name(&self) -> &'static str {
+        match self {
+            HealthStatus::Starting => "starting",
+            HealthStatus::Running => "running",
+            HealthStatus::StalledWithError(_) => "stalled",
+        }
+    }
+
+    fn error(&self) -> Option<&str> {
+        match self {
+            HealthStatus::Starting | HealthStatus::Running => None,
+            HealthStatus::StalledWithError(e) => Some(e),
+        }
+    }
 }
 
 type WorkerId = usize;
@@ -822,6 +840,8 @@ where
         worker_id: healthcheck_worker_id,
         worker_count,
         id: source_id,
+        storage_metadata,
+        persist_clients,
         ..
     } = config;
 
@@ -853,7 +873,70 @@ where
         scope.clone(),
         move |mut _capabilities, _frontiers, scheduler| async move {
             let mut buffer = Vec::new();
+
+            let mut persist_clients = persist_clients.lock().await;
+            let persist_client = persist_clients
+                .open(storage_metadata.persist_location.clone())
+                .await
+                .expect("error creating persist client for Healthchecker");
+            drop(persist_clients);
+
+            let client_ref = &persist_client;
+
+            let write_to_persist = |row: Row, timestamp: Timestamp| async move {
+                let status_shard = match storage_metadata.status_shard {
+                    Some(s) => s,
+                    None => return,
+                };
+                let handle = client_ref
+                    .open_writer(status_shard)
+                    .await;
+
+                let mut handle = match handle {
+                    Ok(stuff) => stuff,
+                    Err(e) => {
+                        panic!("Invalid usage of the persist client for source {source_id} status history shard: {e:?}");
+                    }
+                };
+
+                let mut recent_upper = handle.upper().clone();
+                let mut append_ts = timestamp;
+                'retry_loop: loop {
+                    // We don't actually care so much about the timestamp we append at; it's best-effort.
+                    // Ensure that the append timestamp is past the current upper, and the new upper
+                    // is past that timestamp. (Unless we've advanced to the empty antichain, but in
+                    // that case we're already in trouble.)
+                    for t in recent_upper.elements() {
+                        append_ts.join_assign(t);
+                    }
+                    let mut new_upper = Antichain::from_elem(append_ts.step_forward());
+                    new_upper.join_assign(&recent_upper);
+
+                    let updates = vec![
+                        ((SourceData(Ok(row.clone())), ()), append_ts, 1i64)
+                    ];
+                    let cas_result = handle.compare_and_append(updates, recent_upper.clone(), new_upper).await;
+                    match cas_result {
+                        Ok(Ok(Ok(()))) => break 'retry_loop,
+                        Ok(Ok(Err(Upper(upper)))) => {
+                            recent_upper = upper;
+                        }
+                        Ok(Err(e)) => {
+                            panic!("Invalid usage of the persist client for source {source_id} status history shard: {e:?}");
+                        }
+                        Err(e) => {
+                            trace!("compare_and_append in update_status failed: {e}");
+                        }
+                    }
+                }
+
+                handle.expire().await
+            };
+
             info!("Health for source {source_id} initialized to: {last_reported_status:?}");
+            let row = healthcheck::pack_status_row(source_id, last_reported_status.name(), last_reported_status.error(), 0);
+            write_to_persist(row, Timestamp::MIN).await;
+
             while scheduler.notified().await {
                 if weak_token.upgrade().is_none() {
                     return;
@@ -865,17 +948,18 @@ where
                         if !is_active_worker {
                             warn!("Health messages for source {source_id} passed to an unexpected worker id: {healthcheck_worker_id}")
                         }
-                        let prev_health = &healths[worker_id];
-                        if prev_health != &health_event {
-                            healths[worker_id] = health_event;
-                            let new_status = overall_status(&healths);
-                            if &last_reported_status != new_status {
-                                info!("Health transition for source {source_id}: {last_reported_status:?} -> {new_status:?}");
-                                last_reported_status = new_status.clone();
-                            }
-                        }
+                        healths[worker_id] = health_event;
                     }
-                })
+                });
+
+                let new_status = overall_status(&healths);
+                if &last_reported_status != new_status {
+                    info!("Health transition for source {source_id}: {last_reported_status:?} -> {new_status:?}");
+                    let row = healthcheck::pack_status_row(source_id, new_status.name(), new_status.error(), 0);
+                    write_to_persist(row, Timestamp::MIN).await;
+
+                    last_reported_status = new_status.clone();
+                }
             }
         },
     );

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -842,6 +842,7 @@ where
         id: source_id,
         storage_metadata,
         persist_clients,
+        now,
         ..
     } = config;
 
@@ -934,8 +935,9 @@ where
             };
 
             info!("Health for source {source_id} initialized to: {last_reported_status:?}");
-            let row = healthcheck::pack_status_row(source_id, last_reported_status.name(), last_reported_status.error(), 0);
-            write_to_persist(row, Timestamp::MIN).await;
+            let now_ms = now();
+            let row = healthcheck::pack_status_row(source_id, last_reported_status.name(), last_reported_status.error(), now_ms);
+            write_to_persist(row, Timestamp::from(now_ms)).await;
 
             while scheduler.notified().await {
                 if weak_token.upgrade().is_none() {
@@ -955,8 +957,9 @@ where
                 let new_status = overall_status(&healths);
                 if &last_reported_status != new_status {
                     info!("Health transition for source {source_id}: {last_reported_status:?} -> {new_status:?}");
-                    let row = healthcheck::pack_status_row(source_id, new_status.name(), new_status.error(), 0);
-                    write_to_persist(row, Timestamp::MIN).await;
+                    let now_ms = now();
+                    let row = healthcheck::pack_status_row(source_id, new_status.name(), new_status.error(), now_ms);
+                    write_to_persist(row, Timestamp::from(now_ms)).await;
 
                     last_reported_status = new_status.clone();
                 }

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -934,10 +934,12 @@ where
                 handle.expire().await
             };
 
-            info!("Health for source {source_id} initialized to: {last_reported_status:?}");
-            let now_ms = now();
-            let row = healthcheck::pack_status_row(source_id, last_reported_status.name(), last_reported_status.error(), now_ms);
-            write_to_persist(row, Timestamp::from(now_ms)).await;
+            if is_active_worker {
+                info!("Health for source {source_id} initialized to: {last_reported_status:?}");
+                let now_ms = now();
+                let row = healthcheck::pack_status_row(source_id, last_reported_status.name(), last_reported_status.error(), now_ms);
+                write_to_persist(row, Timestamp::from(now_ms)).await;
+            }
 
             while scheduler.notified().await {
                 if weak_token.upgrade().is_none() {

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -10,9 +10,6 @@
 # Specify the behaviour of the status history tables
 $ set-regex match="\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)?" replacement="<TIMESTAMP>"
 
-# History starts out empty when there are no sources
-> select * from mz_internal.mz_source_status_history
-
 $ kafka-create-topic topic=status-history
 
 > CREATE CONNECTION kafka_conn
@@ -31,6 +28,12 @@ $ kafka-create-topic topic=status-history
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
+$ set-from-sql var=source_id
+SELECT id FROM mz_sources WHERE name = 'kafka_source'
+
+> select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id} starting <null> <null>
+
 $ set-from-sql var=sink_id
 SELECT id FROM mz_sinks WHERE name = 'kafka_sink'
 
@@ -43,7 +46,6 @@ a
 b
 c
 d
-
 
 > SELECT * FROM kafka_source ORDER BY 1;
 a
@@ -60,3 +62,7 @@ $ kafka-verify-data format=avro sink=materialize.public.kafka_sink sort-messages
 > SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at;
 "<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
 "<TIMESTAMP> UTC" ${sink_id} running <null> <null>
+
+> select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id} starting <null> <null>
+"<TIMESTAMP> UTC" ${source_id} running <null> <null>


### PR DESCRIPTION
This puts a little meat on the skeleton from #15510:
- Add a one-shot persist append in the health operator, and invoke it whenever health changes.
- Thread the history shard ID through from the coordinator.

This reuses some code from the existing healthcheck implementation, but not the whole thing, which is no longer invoked.

### Motivation

Known-desirable feature: #15162.

### Tips for reviewer

Unlike my last PR, the implementation here is expected to be more or less complete. Feel free to point out if I'm missing something important.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
