### PR TITLE
[sources] Fix merge skew: pick up the source_errors rename

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -753,7 +753,7 @@ where
 
                 for (message_batch, source_upper) in buffer.drain(..) {
                     if let Some(batch) = &*message_batch.borrow() {
-                        let has_errors = batch.non_definite_errors.first();
+                        let has_errors = batch.source_errors.first();
                         let has_messages = batch.messages.values().any(|vs| !vs.is_empty());
 
                         let maybe_health = match (has_errors, has_messages) {


### PR DESCRIPTION
### Motivation

Rather embarassingly, caused by merge skew between two recent PRs: #15510 and #15200.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
