### PR TITLE
[sinks] Add sink status history collection

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1416,6 +1416,18 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
         .with_column("details", ScalarType::Jsonb.nullable(true)),
 });
 
+pub static MZ_SINK_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_sink_status_history",
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::SinkStatusHistory),
+    desc: RelationDesc::empty()
+        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
+        .with_column("sink_id", ScalarType::String.nullable(false))
+        .with_column("status", ScalarType::String.nullable(false))
+        .with_column("error", ScalarType::String.nullable(true))
+        .with_column("details", ScalarType::Jsonb.nullable(true)),
+});
+
 pub static MZ_STORAGE_USAGE_BY_SHARD: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_storage_usage_by_shard",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2682,6 +2694,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_INHERITS),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
+        Builtin::Source(&MZ_SINK_STATUS_HISTORY),
         Builtin::Source(&MZ_SOURCE_STATUS_HISTORY),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::View(&MZ_STORAGE_USAGE),

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -98,6 +98,7 @@ impl MetadataExport<mz_repr::Timestamp> for MetadataExportFetcher {
 pub enum IntrospectionType {
     /// We're not responsible for appending to this collection automatically, but we should
     /// automatically bump the write frontier from time to time.
+    SinkStatusHistory,
     SourceStatusHistory,
     ShardMapping,
 }
@@ -950,8 +951,9 @@ where
                             self.truncate_managed_collection(id).await;
                             self.initialize_shard_mapping().await;
                         }
-                        IntrospectionType::SourceStatusHistory => {
-                            // nothing to do: only storaged writes rows to the collection
+                        IntrospectionType::SourceStatusHistory
+                        | IntrospectionType::SinkStatusHistory => {
+                            // nothing to do: only storaged writes rows to these collections
                         }
                     }
                 }

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -21,7 +21,7 @@ mode cockroach
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name LIKE '%_1');
 ----
-2
+3
 
 # This test checks if the views in mz_catalog are also present in a postfixed
 # way. If this test fails and you added new view that uses introspection

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -516,6 +516,7 @@ mz_active_peeks                                 log   <null>
 mz_scheduling_elapsed_internal                  log   <null>
 mz_raw_compute_operator_durations_internal      log   <null>
 mz_scheduling_parks_internal                    log   <null>
+mz_sink_status_history                          source <null>
 mz_source_status_history                        source <null>
 mz_storage_shards                               source <null>
 mz_worker_compute_frontiers                     log   <null>

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -11,3 +11,6 @@
 
 # History starts out empty when there are no sources
 > select * from mz_internal.mz_source_status_history
+
+# History starts out empty when there are no sinks
+> select * from mz_internal.mz_sink_status_history


### PR DESCRIPTION
Create a sink status history collection that can be queried as other introspection sources such as the source status history collection.  Laying the groundwork for other in-progress surfacing work since we'll want to make sure that the output format of the in-progress sink healthchecker works with this collection

### Motivation
surfacing source / sink errors as tracked in in #12864 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - none yet
