### PR TITLE
persist: stop recomputing since in expire_reader (for now)

### DIFF
--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -268,8 +268,8 @@ where
             .await
             .unwrap_or_else(|e| {
                 panic!(
-                    "{source_id}: cannot serve requested as_of {:?}: {:?}",
-                    as_of_stream, e
+                    "{source_id}: {} cannot serve requested as_of {:?}: {:?}",
+                    data_shard, as_of_stream, e
                 )
             });
 


### PR DESCRIPTION
Temporarily disabling this because we think it might be the cause of the remap since bug. Specifically, a storaged process has a ReadHandle for maintaining the once and one inside a Listen. If we crash and stay down for longer than the read lease duration, it's possible that an expiry of them both in quick succession jumps the since forward to the Listen one.

This is okay because since is always allowed to be behind (we take advantage of this in maybe_downgrade_since, for example). It will jump ahead on the next explicit downgrade_since call.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
