### PR TITLE
[testing] Switch to a version of the DBZ image with ARM support

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/debezium.py
+++ b/misc/python/materialize/cloudtest/k8s/debezium.py
@@ -58,7 +58,7 @@ class DebeziumDeployment(K8sDeployment):
         ]
 
         container = V1Container(
-            name="debezium", image="debezium/connect:1.9.5.Final", env=env, ports=ports
+            name="debezium", image="debezium/connect:1.9.6.Final", env=env, ports=ports
         )
 
         template = V1PodTemplateSpec(

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -20,7 +20,7 @@ DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.5"
 # Be sure to use a `X.Y.Z.Final` tag here; `X.Y` tags refer to the latest
 # minor version in the release series, and minor versions have been known to
 # introduce breakage.
-DEFAULT_DEBEZIUM_VERSION = "1.9.5.Final"
+DEFAULT_DEBEZIUM_VERSION = "1.9.6.Final"
 
 LINT_DEBEZIUM_VERSIONS = ["1.4", "1.5", "1.6"]
 


### PR DESCRIPTION
### Motivation

Debezium 1.9.6 is compatible with ARM and therefore Apple's M1. While the previous build would run, the debezium image was flaky and would sometimes hang; this should give a better default experience.

### Tips for reviewer

Other than CI and local runs, I don't know if there's anything else we test or investigate when bumping the image version?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
