### PR TITLE
storage: restore aggressive remap shard compaction behavior

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -329,8 +329,8 @@ impl ReclockFollowerInner {
             tracing::error!(
                 ?new_since,
                 ?self.since,
-                "We are forced to skip the compaction in \
-                the _ReclockFollower_ because the `new_since` was not beyond the `since`. \
+                "ReclockFollower: We are forced to skip the compaction \
+                because the `new_since` was not beyond the `since`. \
                 This is a bug that should be fixed."
             );
             return;
@@ -570,8 +570,10 @@ impl ReclockOperator {
             tracing::error!(
                 ?new_since,
                 ?self.since,
-                "We are forced to skip the compaction in \
-                the _ReclockOperator_ because the `new_since` was not beyond the `since`. \
+                ?self.read_handle,
+                ?self.listener,
+                "ReclockOperator: We are forced to skip the compaction \
+                because the `new_since` was not beyond the `since`. \
                 This is a bug that should be fixed."
             );
             return;

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -181,6 +181,7 @@ where
 
     let reclock_follower = {
         let upper_ts = config.resume_upper.as_option().copied().unwrap();
+        // Same value as our use of `derive_new_compaction_since`.
         let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
         ReclockFollower::new(as_of)
     };
@@ -970,13 +971,7 @@ where
 
             let upper_ts = resume_upper.as_option().copied().unwrap();
 
-            // NOTE: Below, we allow compaction only up to around 3 days before
-            // the resumption frontier. We still restart from right before the
-            // upper which is a) perfectly safe to do, and b) will make extra
-            // certain that the `as_of` is valid with regards to the since. If
-            // we pick the same time that we compact up to, we might run into
-            // the same (alleged/potential) off-by-one bug that this
-            // three-day-bandaid below is trying to paper over.
+            // Same value as our use of `derive_new_compaction_since`.
             let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
             let mut timestamper = match ReclockOperator::new(
                 Arc::clone(&persist_clients),
@@ -1082,8 +1077,8 @@ where
                 if let Some(new_compaction_since) = derive_new_compaction_since(
                     resumption_frontier,
                     &last_compaction_since,
-                    // 3 days in milliseconds
-                    1000 * 60 * 24 * 3,
+                    // Choose a `since` as aggresively as possible
+                    1,
                     id,
                     "remap",
                     worker_id,


### PR DESCRIPTION
As part of https://github.com/MaterializeInc/materialize/issues/15402, we want to restore the old aggressive compaction behavior, to ensure that https://github.com/MaterializeInc/materialize/pull/15645 actually fixes the issue. **Note that we do not restore the panic-on-lagging `new_since` behavior that was changed in https://github.com/MaterializeInc/materialize/pull/15526, as this is unsafe until at least 3 days past the release of this commit, so we don't accidentally trigger some other bug (this is mostly out of abundance of caution, and the change for that will be https://github.com/MaterializeInc/materialize/pull/15657)

### Motivation
  * This PR _is related to_ a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

