### PR TITLE
storage: restore panic when reclock compaction goes backwards

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -312,19 +312,11 @@ impl ReclockFollower {
 impl ReclockFollowerInner {
     pub fn compact(&mut self, new_since: Antichain<Timestamp>) {
         if !PartialOrder::less_equal(&self.since, &new_since) {
-            // As long as the assertion about `as_of` and `since` on creation
-            // are correct, it is fine to ignore these compaction requests if
-            // they don't advance the since. Note that if the `new_since` and
-            // old `since` are equal, we still attempt to compact the
-            // in-memory trace.
-            tracing::error!(
-                ?new_since,
-                ?self.since,
-                "ReclockFollower: We are forced to skip the compaction \
-                because the `new_since` was not beyond the `since`. \
-                This is a bug that should be fixed."
+            panic!(
+                "ReclockFollower: `new_since` ({:?}) is not beyond \
+                `self.since` ({:?}).",
+                new_since, self.since,
             );
-            return;
         }
 
         for bindings in self.remap_trace.values_mut() {
@@ -516,21 +508,11 @@ impl ReclockOperator {
     /// Compacts the internal state
     pub async fn compact(&mut self, new_since: Antichain<Timestamp>) {
         if !PartialOrder::less_equal(&self.since, &new_since) {
-            // As long as the assertion about `as_of` and `since` on creation
-            // are correct, it is fine to ignore these compaction requests if
-            // they don't advance the since. Note that if the `new_since` and
-            // old `since` are equal, we still attempt to compact the
-            // in-memory trace.
-            tracing::error!(
-                ?new_since,
-                ?self.since,
-                ?self.read_handle,
-                ?self.listener,
-                "ReclockOperator: We are forced to skip the compaction \
-                because the `new_since` was not beyond the `since`. \
-                This is a bug that should be fixed."
+            panic!(
+                "ReclockOperator: `new_since` ({:?}) is not beyond \
+                `self.since` ({:?}), using {:?} and {:?}",
+                new_since, self.since, self.read_handle, self.listener
             );
-            return;
         }
 
         for bindings in self.remap_trace.values_mut() {


### PR DESCRIPTION
Both issues originally related to this (https://sentry.io/organizations/materializeinc/issues/3684198607/?query=as_of&referrer=issue-stream&statsPeriod=14d and https://sentry.io/organizations/materializeinc/issues/3693151052/?query=is%3Aunresolved+was+not+beyond&referrer=issue-stream&statsPeriod=14d) are resolved, incident 11 is closed, and its been 3 days since https://github.com/MaterializeInc/materialize/pull/15656 was pushed, so we should not be confident to once again require _strict_ behavior in this

related to https://github.com/MaterializeInc/materialize/issues/15402, technically we need to discuss closing that, as https://github.com/MaterializeInc/materialize/pull/15645 is considered _medium-term_ until we have critical read handles.


### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

