### PR TITLE
doc/user: add example for flattening `jsonb` array

### DIFF
--- a/doc/user/content/sql/types/jsonb.md
+++ b/doc/user/content/sql/types/jsonb.md
@@ -585,7 +585,7 @@ SELECT jsonb_strip_nulls('[{"1":"a","2":null},"b",null,"c"]'::jsonb);
 
 <hr/>
 
-#### `to_jsonb` {#ex-to-jsonb}
+#### `to_jsonb`
 
 ```sql
 SELECT to_jsonb('hello');

--- a/doc/user/content/sql/types/jsonb.md
+++ b/doc/user/content/sql/types/jsonb.md
@@ -382,6 +382,8 @@ SELECT '{"1": 2, "a": ["b", "c"]}'::jsonb ? 'b' AS search_for_key;
 
 #### `jsonb_array_elements`
 
+##### Expanding a JSON array
+
 ```sql
 SELECT * FROM jsonb_array_elements('[true, 1, "a", {"b": 2}, null]'::jsonb);
 ```
@@ -395,7 +397,34 @@ SELECT * FROM jsonb_array_elements('[true, 1, "a", {"b": 2}, null]'::jsonb);
  null
 ```
 
-Note that the `value` column is `jsonb`.
+##### Flattening a JSON array
+
+```sql
+SELECT * FROM flatten_json;
+```
+
+```nofmt
+ id |           json_col
+----+-------------------------------
+  1 | [{"a":1,"b":2},{"a":3,"b":4}]
+  2 | [{"a":5,"b":6},{"a":7,"b":8}]
+```
+
+```sql
+SELECT id,
+       obj->>'a' AS a,
+       obj->>'b' AS b
+FROM flatten_json, jsonb_array_elements(json_col) obj;
+```
+
+```nofmt
+ id | a | b
+----+---+---
+  1 | 1 | 2
+  1 | 3 | 4
+  2 | 5 | 6
+  2 | 7 | 8
+```
 
 <hr/>
 
@@ -414,8 +443,6 @@ SELECT * FROM jsonb_array_elements_text('[true, 1, "a", {"b": 2}, null]'::jsonb)
  {"b":2.0}
  null
 ```
-
-Note that the `value` column is `string`.
 
 <hr/>
 
@@ -558,7 +585,7 @@ SELECT jsonb_strip_nulls('[{"1":"a","2":null},"b",null,"c"]'::jsonb);
 
 <hr/>
 
-#### `to_jsonb`
+#### `to_jsonb` {#ex-to-jsonb}
 
 ```sql
 SELECT to_jsonb('hello');

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -507,55 +507,55 @@
   functions:
   - signature: 'jsonb_array_elements(j: jsonb) -> Col<jsonb>'
     description: "`j`'s elements if `j` is an array."
-    url: "/sql/types/jsonb/#jsonb_array_elements"
+    url: "/docs/sql/types/jsonb/#jsonb_array_elements"
 
   - signature: 'jsonb_array_elements_text(j: jsonb) -> Col<string>'
     description: "`j`'s elements if `j` is an array."
-    url: "/sql/types/jsonb/#jsonb_array_elements_text"
+    url: "/docs/sql/types/jsonb/#jsonb_array_elements_text"
 
   - signature: 'jsonb_array_length(j: jsonb) -> int'
     description: Number of elements in `j`'s outermost array.
-    url: "/sql/types/jsonb/#jsonb_array_length"
+    url: "/docs/sql/types/jsonb/#jsonb_array_length"
 
   - signature: 'jsonb_build_array(x: ...) -> jsonb'
     description: The elements of `x` in a `jsonb` array. Elements can be of heterogenous
       types.
-    url: "/sql/types/jsonb/#jsonb_build_array"
+    url: "/docs/sql/types/jsonb/#jsonb_build_array"
 
   - signature: 'jsonb_build_object(x: ...) -> jsonb'
     description: The elements of x as a `jsonb` object. The argument list alternates
       between keys and values.
-    url: "/sql/types/jsonb/#jsonb_build_object"
+    url: "/docs/sql/types/jsonb/#jsonb_build_object"
 
   - signature: 'jsonb_each(j: jsonb) -> Col<(key: string, value: jsonb)>'
     description: "`j`'s outermost elements if `j` is an object."
-    url: "/sql/types/jsonb/#jsonb_each"
+    url: "/docs/sql/types/jsonb/#jsonb_each"
 
   - signature: 'jsonb_each_text(j: jsonb) -> Col<(key: string, value: string)>'
     description: "`j`'s outermost elements if `j` is an object."
-    url: "/sql/types/jsonb/#jsonb_each_text"
+    url: "/docs/sql/types/jsonb/#jsonb_each_text"
 
   - signature: 'jsonb_object_keys(j: jsonb) -> Col<string>'
     description: "`j`'s outermost keys if `j` is an object."
-    url: "/sql/types/jsonb/#jsonb_object_keys"
+    url: "/docs/sql/types/jsonb/#jsonb_object_keys"
 
   - signature: 'jsonb_pretty(j: jsonb) -> string'
     description: Pretty printed (i.e. indented) `j`.
-    url: "/sql/types/jsonb/#jsonb_pretty"
+    url: "/docs/sql/types/jsonb/#jsonb_pretty"
 
   - signature: 'jsonb_typeof(j: jsonb) -> string'
     description: Type of `j`'s outermost value. One of `object`, `array`, `string`,
       `number`, `boolean`, and `null`.
-    url: "/sql/types/jsonb/#jsonb_typeof"
+    url: "/docs/sql/types/jsonb/#jsonb_typeof"
 
   - signature: 'jsonb_strip_nulls(j: jsonb) -> jsonb'
     description: "`j` with all object fields with a value of `null` removed. Other
       `null` values remain."
-    url: "/sql/types/jsonb/#jsonb_strip_nulls"
+    url: "/docs/sql/types/jsonb/#jsonb_strip_nulls"
 
   - signature: 'to_jsonb(v: T) -> jsonb'
     description: "`v` as `jsonb`"
-    url: "/sql/types/jsonb/#to_jsonb"
+    url: "/docs/sql/types/jsonb/#to_jsonb"
 
 - type: Table
   description: Table functions evaluate to a set of rows, rather than a single expression.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -507,55 +507,55 @@
   functions:
   - signature: 'jsonb_array_elements(j: jsonb) -> Col<jsonb>'
     description: "`j`'s elements if `j` is an array."
-    url: "/docs/sql/types/jsonb/#jsonb_array_elements"
+    url: "/sql/types/jsonb/#jsonb_array_elements"
 
   - signature: 'jsonb_array_elements_text(j: jsonb) -> Col<string>'
     description: "`j`'s elements if `j` is an array."
-    url: "/docs/sql/types/jsonb/#jsonb_array_elements_text"
+    url: "/sql/types/jsonb/#jsonb_array_elements_text"
 
   - signature: 'jsonb_array_length(j: jsonb) -> int'
     description: Number of elements in `j`'s outermost array.
-    url: "/docs/sql/types/jsonb/#jsonb_array_length"
+    url: "/sql/types/jsonb/#jsonb_array_length"
 
   - signature: 'jsonb_build_array(x: ...) -> jsonb'
     description: The elements of `x` in a `jsonb` array. Elements can be of heterogenous
       types.
-    url: "/docs/sql/types/jsonb/#jsonb_build_array"
+    url: "/sql/types/jsonb/#jsonb_build_array"
 
   - signature: 'jsonb_build_object(x: ...) -> jsonb'
     description: The elements of x as a `jsonb` object. The argument list alternates
       between keys and values.
-    url: "/docs/sql/types/jsonb/#jsonb_build_object"
+    url: "/sql/types/jsonb/#jsonb_build_object"
 
   - signature: 'jsonb_each(j: jsonb) -> Col<(key: string, value: jsonb)>'
     description: "`j`'s outermost elements if `j` is an object."
-    url: "/docs/sql/types/jsonb/#jsonb_each"
+    url: "/sql/types/jsonb/#jsonb_each"
 
   - signature: 'jsonb_each_text(j: jsonb) -> Col<(key: string, value: string)>'
     description: "`j`'s outermost elements if `j` is an object."
-    url: "/docs/sql/types/jsonb/#jsonb_each_text"
+    url: "/sql/types/jsonb/#jsonb_each_text"
 
   - signature: 'jsonb_object_keys(j: jsonb) -> Col<string>'
     description: "`j`'s outermost keys if `j` is an object."
-    url: "/docs/sql/types/jsonb/#jsonb_object_keys"
+    url: "/sql/types/jsonb/#jsonb_object_keys"
 
   - signature: 'jsonb_pretty(j: jsonb) -> string'
     description: Pretty printed (i.e. indented) `j`.
-    url: "/docs/sql/types/jsonb/#jsonb_pretty"
+    url: "/sql/types/jsonb/#jsonb_pretty"
 
   - signature: 'jsonb_typeof(j: jsonb) -> string'
     description: Type of `j`'s outermost value. One of `object`, `array`, `string`,
       `number`, `boolean`, and `null`.
-    url: "/docs/sql/types/jsonb/#jsonb_typeof"
+    url: "/sql/types/jsonb/#jsonb_typeof"
 
   - signature: 'jsonb_strip_nulls(j: jsonb) -> jsonb'
     description: "`j` with all object fields with a value of `null` removed. Other
       `null` values remain."
-    url: "/docs/sql/types/jsonb/#jsonb_strip_nulls"
+    url: "/sql/types/jsonb/#jsonb_strip_nulls"
 
   - signature: 'to_jsonb(v: T) -> jsonb'
     description: "`v` as `jsonb`"
-    url: "/docs/sql/types/jsonb/#to_jsonb"
+    url: "/sql/types/jsonb/#to_jsonb"
 
 - type: Table
   description: Table functions evaluate to a set of rows, rather than a single expression.

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -27,7 +27,7 @@
     {{/*  Extract the function's name from its signature and use it as the ID
           to facilitate deeplinking. The `docsearch_l3` class is a special
           class that is scraped by our Algolia DocSearch configuration.  */}}
-    <td class="docsearch_l3" id="{{ index (split .signature "(") 0 | urlize }}">
+    <td {{ if (ne ($.Get 0) .type "JSON") }} class="docsearch_l3" id="{{ index (split .signature "(") 0 | urlize }}" {{end}}>
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}


### PR DESCRIPTION
Documenting a recent example [trapped in Slack](https://materializeinc.slack.com/archives/C03V4PADVC3/p1664815111499829?thread_ts=1664810908.477389&cid=C03V4PADVC3) that teaches how to flatten a JSON array. 

While working this in, I realized that the intra-page links from the function table to the examples were self-referencing, rather than linking to the corresponding function examples. This can be traced back to #11184, and the fact that `jsonb` functions aren't broken out into dedicated function pages (which borks the referencing). Unless there's a strong reason to not have documented these extensively in the first place, I'll open a follow-up issue to get things sorted!