### PR TITLE
ore: configure sentry to attach stack traces

### DIFF
--- a/src/ore/src/tracing/mod.rs
+++ b/src/ore/src/tracing/mod.rs
@@ -317,7 +317,10 @@ where
     };
 
     let sentry_guard = if let Some(sentry_config) = config.sentry {
-        let mut sentry_client_options = sentry::ClientOptions::default();
+        let mut sentry_client_options = sentry::ClientOptions {
+            attach_stacktrace: true,
+            ..Default::default()
+        };
         sentry_client_options.release = Some(Cow::Owned(build_version.to_string()));
 
         let guard = sentry::init((sentry_config.dsn, sentry_client_options));


### PR DESCRIPTION
By default Sentry won't attach stack traces to `error!` logs.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
