### PR TITLE
stash: log postgres errors to sentry

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -23,7 +23,7 @@ use timely::progress::Antichain;
 use timely::PartialOrder;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::{Client, Statement, Transaction};
-use tracing::{event, warn, Level};
+use tracing::{error, event, warn, Level};
 
 use mz_ore::retry::Retry;
 
@@ -433,7 +433,7 @@ impl Postgres {
                             }
                         }
                         attempt += 1;
-                        warn!("tokio-postgres stash error, retry attempt {attempt}: {pgerr}");
+                        error!("tokio-postgres stash error, retry attempt {attempt}: {pgerr}");
                         self.client = None;
                         retry.next().await;
                     }


### PR DESCRIPTION
The error macro will log to sentry.

See #15655

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a