### PR TITLE
storage: in reclock_operator, make capability downgrading more lenient

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -43,6 +43,7 @@ use crate::types::sources::{MzOffset, SourceData};
 /// produces messages with their associated timestamps.
 ///
 /// Shareable with `.share()`
+#[derive(Debug)]
 pub struct ReclockFollower {
     inner: Rc<RefCell<ReclockFollowerInner>>,
 }
@@ -133,6 +134,7 @@ fn integrate<'a>(
     })
 }
 
+#[derive(Debug)]
 struct ReclockFollowerInner {
     /// A dTVC trace of the remap collection containing all consolidated updates at
     /// `t` such that `since <= t < upper` indexed by partition and sorted by time.


### PR DESCRIPTION
The `remap_operator` will only hand out capabilities (with remap trace updates) for timestamps that are beyond the reclocked frontier. When this here `reclock_operator` is starting up, it can happen that the frontier (as far as we are aware of) is still at `[0]`, meaning we cannot downgrade our capabilities. This is perfectly fine, though, and we will eventually downgrade the capabilities that we have when the reclocked frontier advances sufficiently.

I also added some more trace logging that should make it easier to debug future issues, if any.

Fixes #15558

@philip-stoev I believe this fixes the bug, but there might be another thing. When I was running the test in a loop, it got stuck once. Might have been https://github.com/MaterializeInc/materialize/issues/15155, for which Petros has a fix open: https://github.com/MaterializeInc/materialize/pull/15538. Could you at least check if at least the "cannot downgrade ..." bug is fixed, please?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
