### PR TITLE
storage: when rehydrating, retry connecting much more eagerly

### DIFF
--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -154,7 +154,7 @@ where
     async fn step_rehydrate(&mut self) -> RehydrationTaskState {
         // Reconnect to the storage host.
         let client = Retry::default()
-            .clamp_backoff(Duration::from_secs(32))
+            .clamp_backoff(Duration::from_secs(1))
             .retry_async(|_| {
                 let addr = self.addr.clone();
                 let version = self.build_info.semver_version();


### PR DESCRIPTION
Before, the 32 second retry interval was making tests quite slow because the `storaged` pod is usually not available on the first try, so we were always waiting at least 32 seconds.

Fixes #13958

@philip-stoev I think this is what's causing #13958, just from looking at it. Could you please double-check? We might use an even lower retry interval but that might be too aggressive.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
