### PR TITLE
storage: in relock.rs, improve information content of as_of assert

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -471,7 +471,10 @@ impl ReclockOperator {
         // initialize our `self.since` is a more conservative option.
         assert!(
             PartialOrder::less_equal(since, &as_of),
-            "invalid as_of: as_of({as_of:?}) < since({since:?})"
+            "invalid as_of: as_of({as_of:?}) < since({since:?}), \
+            source {id}, \
+            remap_shard: {}",
+            metadata.remap_shard
         );
 
         assert!(


### PR DESCRIPTION
Should make future debugging easier.

@danhhz I think you meant to print more information for this one in your earlier PR.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
