### PR TITLE
zippy: Add a scenario using parallel Kafka inserts

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -32,6 +32,7 @@ steps:
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
+          - { value: zippy-kafka-parallel-insert }
           - { value: zippy-user-tables }
           - { value: zippy-debezium-postgres }
           - { value: zippy-postgres-cdc }
@@ -253,6 +254,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=1000]
+
+  - id: zippy-kafka-parallel-insert
+    label: "Zippy Kafka Parallel Insert"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=1000]
 
   - id: zippy-user-tables
     label: "Zippy User Tables"

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -11,7 +11,12 @@ from typing import Dict, List, Type
 
 from materialize.zippy.debezium_actions import CreateDebeziumSource, DebeziumStart
 from materialize.zippy.framework import Action, Scenario
-from materialize.zippy.kafka_actions import CreateTopic, Ingest, KafkaStart
+from materialize.zippy.kafka_actions import (
+    CreateTopic,
+    Ingest,
+    KafkaInsertParallel,
+    KafkaStart,
+)
 from materialize.zippy.mz_actions import KillComputed, KillStoraged, MzStart, MzStop
 from materialize.zippy.pg_cdc_actions import CreatePostgresCdcTable
 from materialize.zippy.postgres_actions import (
@@ -29,7 +34,7 @@ from materialize.zippy.replica_actions import (
 from materialize.zippy.sink_actions import CreateSink
 from materialize.zippy.source_actions import CreateSource
 from materialize.zippy.table_actions import DML, CreateTable, ValidateTable
-from materialize.zippy.view_actions import CreateView, ValidateView
+from materialize.zippy.view_actions import CreateView, CreateViewSimple, ValidateView
 
 
 class KafkaSources(Scenario):
@@ -49,7 +54,7 @@ class KafkaSources(Scenario):
             CreateView: 5,
             CreateSink: 5,
             ValidateView: 10,
-            Ingest: 50,
+            Ingest: 100,
         }
 
 
@@ -87,7 +92,7 @@ class DebeziumPostgres(Scenario):
             KillComputed: 15,
             CreateView: 10,
             ValidateView: 20,
-            PostgresDML: 30,
+            PostgresDML: 100,
         }
 
 
@@ -106,7 +111,7 @@ class PostgresCdc(Scenario):
             PostgresRestart: 10,
             CreateView: 10,
             ValidateView: 20,
-            PostgresDML: 30,
+            PostgresDML: 100,
         }
 
 
@@ -130,6 +135,24 @@ class ClusterReplicas(Scenario):
             CreateView: 20,
             CreateSink: 10,
             ValidateView: 20,
-            Ingest: 25,
-            DML: 25,
+            Ingest: 50,
+            DML: 50,
+        }
+
+
+class KafkaParallelInsert(Scenario):
+    """A Zippy test using simple views over Kafka sources with parallel insertion."""
+
+    def bootstrap(self) -> List[Type[Action]]:
+        return [KafkaStart, MzStart]
+
+    def config(self) -> Dict[Type[Action], float]:
+        return {
+            KillStoraged: 5,
+            KillComputed: 5,
+            CreateTopic: 10,
+            CreateSource: 10,
+            CreateViewSimple: 5,
+            ValidateView: 10,
+            KafkaInsertParallel: 50,
         }

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -38,7 +38,9 @@ class CreateSink(Action):
             self.new_sink = True
             self.source_view = random.choice(capabilities.get(ViewExists))
             self.dest_view = ViewExists(
-                name=f"{sink_name}_view", froms=[self.source_view]
+                name=f"{sink_name}_view",
+                froms=[self.source_view],
+                expensive_aggregates=True,
             )
         elif len(existing_sinks) == 1:
             self.new_sink = False
@@ -72,11 +74,11 @@ class CreateSink(Action):
                 # from the 'before' and the 'after'
 
                 > CREATE MATERIALIZED VIEW {self.dest_view.name} AS
-                  SELECT SUM(min)::int AS min, SUM(max)::int AS max, SUM(c1)::int AS c1, SUM(c2)::int AS c2 FROM (
-                    SELECT (after).min, (after).max, (after).c1, (after).c2 FROM {self.sink.name}_source
-                    UNION ALL
-                    SELECT - (before).min, - (before).max, -(before).c1, -(before).c2 FROM {self.sink.name}_source
-                  );
+                    SELECT SUM(c1)::int AS c1, SUM(c2)::int AS c2, SUM(min)::int AS min, SUM(max)::int AS max FROM (
+                      SELECT (after).c1, (after).c2, (after).min, (after).max FROM {self.sink.name}_source
+                      UNION ALL
+                      SELECT -(before).c1, -(before).c2, -(before).min, -(before).max FROM {self.sink.name}_source
+                    );
             """
             )
         )

--- a/misc/python/materialize/zippy/view_capabilities.py
+++ b/misc/python/materialize/zippy/view_capabilities.py
@@ -30,9 +30,15 @@ WatermarkedObjects = List[
 class ViewExists(Capability):
     """A view exists in Materialize."""
 
-    def __init__(self, name: str, froms: Optional[WatermarkedObjects] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        froms: Optional[WatermarkedObjects] = None,
+        expensive_aggregates: Optional[bool] = None,
+    ) -> None:
         self.name = name
         self.froms = froms if froms is not None else []
+        self.expensive_aggregates = expensive_aggregates
 
     def get_watermarks(self) -> Watermarks:
         """Calculate the intersection of the mins/maxs of the inputs. The result from the view should match the calculation."""


### PR DESCRIPTION
A somewhat more stressful Kafka sources test:
 - perform `$ kafka-ingest` in concurrent threads in order to get more data for a given unit of time
 - use only simplified views that do not have aggregates or joins in order to avoid OOMs of computed
 - use 'serializable' and not 'strict serializable' as the isolation level
 - do not kill the entire Mz instance during the test in order to reduce the total time the test does not make much progress

### Motivation

  * This PR adds a feature that has not yet been specified.
Zippy was running strictly sequential actions, which limits the total concurrency possible in the system.