### PR TITLE
compute: don't report empty frontiers during reconciliation

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -512,6 +512,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {
                 compute_state.report_compute_frontiers();
+                compute_state.report_dropped_collections();
             }
 
             // Handle any received commands.
@@ -563,6 +564,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     sink_write_frontiers: HashMap::new(),
                     pending_peeks: Vec::new(),
                     reported_frontiers: HashMap::new(),
+                    dropped_collections: Vec::new(),
                     compute_logger: None,
                     persist_clients: Arc::clone(&self.persist_clients),
                     command_history: ComputeCommandHistory::default(),


### PR DESCRIPTION
This commit moves the reporting of dropped dataflows from the `AllowCompaction` command handler into a separate step that runs after the stepping of the timely runtime.

The effects of this are:
 * We stop reporting the dropping of collections that are re-created during reconciliation.
 * We only report the dropping of collections after the timely operators had opportunity to observe the associated tokens/traces and shut down in response.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/15535.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
