### PR TITLE
[storage] Filter the InvalidUppers error to only relevant ids

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -2208,7 +2208,7 @@ mod persist_write_handles {
                                                 Err(StorageError::InvalidUppers(filtered))
                                             }
                                         }
-                                        _ => Ok(()),
+                                        Ok(()) => Ok(()),
                                     };
                                     // It is not an error for the other end to hang up.
                                     let _ = response.send(result);


### PR DESCRIPTION
### Motivation

A previously-unreported bug, found while implementing #15162.

The append machinery in the storage controller batches writes, and then returns error or success based on all of the batches. However, this means a failed write to collection A can fail unrelated writes to collection B.

This branch only fails a write request if the write to the collection it attempts to write to actually failed, by filtering down the list of relevant ids in the error and only returning failure upward if that list is nonempty.

### Tips for reviewer

I don't have a reproducer for this bug that's easily separable from the source errors work, so no additional tests here. Please let me know if you have ideas!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None.
