### PR TITLE
persist: ensure handle heartbeats are monotonic

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -273,7 +273,11 @@ where
         debug_assert_eq!(self.trace.upper(), batch.desc.upper());
 
         // Also use this as an opportunity to heartbeat the writer
-        self.writer(writer_id).last_heartbeat_timestamp_ms = heartbeat_timestamp_ms;
+        let writer_state = self.writer(writer_id);
+        writer_state.last_heartbeat_timestamp_ms = std::cmp::max(
+            heartbeat_timestamp_ms,
+            writer_state.last_heartbeat_timestamp_ms,
+        );
 
         Continue(merge_reqs)
     }
@@ -298,7 +302,10 @@ where
 
         // Also use this as an opportunity to heartbeat the reader and downgrade
         // the seqno capability.
-        reader_state.last_heartbeat_timestamp_ms = heartbeat_timestamp_ms;
+        reader_state.last_heartbeat_timestamp_ms = std::cmp::max(
+            heartbeat_timestamp_ms,
+            reader_state.last_heartbeat_timestamp_ms,
+        );
 
         let seqno = match outstanding_seqno {
             Some(outstanding_seqno) => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Our handles are still expiring on prod, and after pulling down state transitions from CRDB's changefeed, we are surprisingly seeing handle heartbeats go backwards rather significantly (like backwards by 10+ min in the example I found). The time we use comes from our `NowFn`, so maybe something to follow up on?

In the mean time, we shouldn't let handle heartbeats go backwards from `downgrade_since` and `compare_and_append` calls. `heartbeat_reader|writer` already have the correct logic.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
