### PR TITLE
coord: Restrict mz_introspection user privileges

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3111,7 +3111,10 @@ impl<S: Append> Catalog<S> {
         // TODO(benesch): this check here is not sufficiently protective. It'd
         // be very easy for a code path to accidentally avoid this check by
         // calling `resolve_compute_instance(session.vars().cluster()`.
-        if session.user().name != SYSTEM_USER.name && session.vars().cluster() == SYSTEM_USER.name {
+        if session.user().name != SYSTEM_USER.name
+            && session.user().name != INTROSPECTION_USER.name
+            && session.vars().cluster() == SYSTEM_USER.name
+        {
             coord_bail!(
                 "system cluster '{}' cannot execute user queries",
                 SYSTEM_USER.name

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -56,6 +56,10 @@ use mz_storage::controller::{CollectionDescription, DataSource, ReadPolicy, Stor
 use mz_storage::types::sinks::StorageSinkConnectionBuilder;
 use mz_storage::types::sources::{IngestionDescription, SourceExport};
 
+use crate::catalog::builtin::{
+    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_INTROSPECTION_COMPUTE_INSTANCE,
+    MZ_INTROSPECTION_ROLE, MZ_SYSTEM_COMPUTE_INSTANCE, PG_CATALOG_SCHEMA,
+};
 use crate::catalog::{
     self, Catalog, CatalogItem, ComputeInstance, Connection, DataSourceDesc, Ingestion,
     SerializedComputeReplicaLocation, StorageSinkConnectionState, SYSTEM_USER,
@@ -91,6 +95,13 @@ impl<S: Append + 'static> Coordinator<S> {
         event!(Level::TRACE, plan = format!("{:?}", plan));
         let responses = ExecuteResponse::generated_from(PlanKind::from(&plan));
         tx.set_allowed(responses);
+
+        if session.user().name == MZ_INTROSPECTION_ROLE.name {
+            if let Err(e) = self.mz_introspection_user_privilege_hack(&session, &plan, &depends_on)
+            {
+                return tx.send(Err(e), session);
+            }
+        }
 
         match plan {
             Plan::CreateSource(plan) => {
@@ -3385,6 +3396,116 @@ impl<S: Append + 'static> Coordinator<S> {
         }
         self.transient_id_counter += 1;
         Ok(GlobalId::Transient(id))
+    }
+
+    /// TODO(jkosh44) This function will verify the privileges for the mz_introspection user.
+    ///  All of the privileges are hard coded into this function. In the future if we ever add
+    ///  a more robust privileges framework, then this function should be replaced with that
+    ///  framework.
+    fn mz_introspection_user_privilege_hack(
+        &self,
+        session: &Session,
+        plan: &Plan,
+        depends_on: &Vec<GlobalId>,
+    ) -> Result<(), AdapterError> {
+        if session.user().name != MZ_INTROSPECTION_ROLE.name {
+            return Ok(());
+        }
+
+        match plan {
+            Plan::Subscribe(_)
+            | Plan::Peek(_)
+            | Plan::CopyFrom(_)
+            | Plan::SendRows(_)
+            | Plan::Explain(_)
+            | Plan::ShowAllVariables
+            | Plan::ShowVariable(_)
+            | Plan::SetVariable(_)
+            | Plan::ResetVariable(_)
+            | Plan::StartTransaction(_)
+            | Plan::CommitTransaction
+            | Plan::AbortTransaction
+            | Plan::EmptyQuery
+            | Plan::Declare(_)
+            | Plan::Fetch(_)
+            | Plan::Close(_)
+            | Plan::Prepare(_)
+            | Plan::Execute(_)
+            | Plan::Deallocate(_) => {}
+
+            Plan::CreateConnection(_)
+            | Plan::CreateDatabase(_)
+            | Plan::CreateSchema(_)
+            | Plan::CreateRole(_)
+            | Plan::CreateComputeInstance(_)
+            | Plan::CreateComputeReplica(_)
+            | Plan::CreateSource(_)
+            | Plan::CreateSecret(_)
+            | Plan::CreateSink(_)
+            | Plan::CreateTable(_)
+            | Plan::CreateView(_)
+            | Plan::CreateMaterializedView(_)
+            | Plan::CreateIndex(_)
+            | Plan::CreateType(_)
+            | Plan::DiscardTemp
+            | Plan::DiscardAll
+            | Plan::DropDatabase(_)
+            | Plan::DropSchema(_)
+            | Plan::DropRoles(_)
+            | Plan::DropComputeInstances(_)
+            | Plan::DropComputeReplicas(_)
+            | Plan::DropItems(_)
+            | Plan::SendDiffs(_)
+            | Plan::Insert(_)
+            | Plan::AlterNoop(_)
+            | Plan::AlterIndexSetOptions(_)
+            | Plan::AlterIndexResetOptions(_)
+            | Plan::AlterSink(_)
+            | Plan::AlterSource(_)
+            | Plan::AlterItemRename(_)
+            | Plan::AlterSecret(_)
+            | Plan::AlterSystemSet(_)
+            | Plan::AlterSystemReset(_)
+            | Plan::AlterSystemResetAll(_)
+            | Plan::ReadThenWrite(_)
+            | Plan::Raise(_)
+            | Plan::RotateKeys(_) => {
+                return Err(AdapterError::Unauthorized(
+                    "user 'mz_introspection' is unauthorized to perform this action".into(),
+                ))
+            }
+        }
+
+        if let Ok(active_compute_instance) = self.catalog.active_compute_instance(session) {
+            let active_compute_instance = active_compute_instance.name();
+            if (matches!(plan, Plan::Peek(_)) || matches!(plan, Plan::Subscribe(_)))
+                && active_compute_instance != MZ_INTROSPECTION_COMPUTE_INSTANCE.name
+                && active_compute_instance != MZ_SYSTEM_COMPUTE_INSTANCE.name
+            {
+                return Err(AdapterError::Unauthorized(format!(
+                    "user 'mz_introspection' is unauthorized to use cluster {active_compute_instance}",
+                )));
+            }
+        }
+
+        for id in depends_on {
+            let entry = self.catalog.get_entry(id);
+            let full_name = self
+                .catalog
+                .resolve_full_name(entry.name(), Some(session.conn_id()));
+            let schema = &full_name.schema;
+            if schema != MZ_CATALOG_SCHEMA
+                && schema != PG_CATALOG_SCHEMA
+                && schema != MZ_INTERNAL_SCHEMA
+                && schema != INFORMATION_SCHEMA
+            {
+                return Err(AdapterError::Unauthorized(format!(
+                    "user 'mz_introspection' is unauthorized to interact with object {full_name}",
+                )));
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes #15520

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
