### PR TITLE
persist: add since preserving `next` functions to `ListenHandle`

### DIFF
--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -117,7 +117,7 @@ async fn bench_write_to_listen_one_iter(
     let listen = task::spawn(|| "listen", async move {
         loop {
             let events = tokio::select! {
-                x = listen.next() => x,
+                x = listen.next_and_downgrade() => x,
                 _ = tx.closed() => break,
             };
             for event in events {

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -299,7 +299,7 @@ impl Transactor {
     > {
         let mut ret = Vec::new();
         loop {
-            for event in listen.next().await {
+            for event in listen.next_and_downgrade().await {
                 match event {
                     ListenEvent::Progress(x) => {
                         // NB: Unlike the snapshot as_of, a listener frontier is
@@ -328,7 +328,7 @@ impl Transactor {
         i64,
     )> {
         while PartialOrder::less_equal(self.long_lived_listen.frontier(), as_of) {
-            for event in self.long_lived_listen.next().await {
+            for event in self.long_lived_listen.next_and_downgrade().await {
                 match event {
                     ListenEvent::Updates(mut updates) => {
                         self.long_lived_updates.append(&mut updates)

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -636,7 +636,7 @@ mod raw_persist_benchmark {
             // record with the record count to avoid having to actually count
             // the number of records..
             let mut count = 0;
-            let events = self.next().await;
+            let events = self.next_and_downgrade().await;
 
             for event in events {
                 if let ListenEvent::Progress(t) = event {

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -1390,7 +1390,7 @@ mod reader {
                 .expect("invalid as_of");
 
             'outer: loop {
-                let next = listen.next().await;
+                let next = listen.next_and_downgrade().await;
 
                 for event in next {
                     match event {

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1215,7 +1215,7 @@ pub mod datadriven {
         let listen = datadriven.listens.get_mut(input).expect("unknown listener");
         let mut s = String::new();
         loop {
-            for event in listen.next().await {
+            for event in listen.next_and_downgrade().await {
                 match event {
                     ListenEvent::Updates(x) => {
                         for ((k, _v), t, d) in x.iter() {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1619,7 +1619,7 @@ mod tests {
 
         // Grab a listener as_of (aka gt) 1, which is not yet closed out.
         let mut listen = read.clone().await.expect_listen(1).await;
-        let mut listen_next = Box::pin(listen.next());
+        let mut listen_next = Box::pin(listen.next_and_downgrade());
         // Intentionally don't await the listen_next, but instead manually poke
         // it for a while and assert that it doesn't resolve yet. See below for
         // discussion of some alternative ways of writing this unit test.


### PR DESCRIPTION
### Motivation

Persist `ListenHandle`s are automatically downgrading the since frontier of the shard as data is being consumed. While this is sometimes convenient, there are times that a user wants to read the contents of a shard but leave its since intact for future readers.

This PR leaves the auto-advancing functionality as-is under the `next_and_downgrade` and `next_parts_and_downgrade` methods and provides two extra functions on a `ListenHandle` that only return the next batch of data.

Using this new functionality I removed the workarounds in reclocking. Additionally, as I was working on this I discovered that we had [another dormant bug](https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/source/healthcheck.rs#L159) in our healthcheck handling code, probably because whoever wrote it wasn't aware downgrades are happening implicitly.

I don't have strong opinions on the naming of these functions, someone from the persist team should chime in if they prefer to have a different one. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
