### PR TITLE
doc/user: update documentation about default cluster

### DIFF
--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -47,6 +47,7 @@ _replica_name_ | A name for this replica.
 
 Valid `size` options are:
 
+- `2xsmall`
 - `xsmall`
 - `small`
 - `medium`

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -21,12 +21,17 @@ Materialize has several pre-installed clusters.
 
 ### Default cluster
 
-A cluster named `default` with a single [replica](/overview/key-concepts/#cluster-replicas) named `r1` will exist in every environment; this cluster can be dropped at any time.
+When you enable a Materialize region, we automatically create a cluster named
+`default` with a single [replica](/overview/key-concepts/#cluster-replicas)
+named `r1` of size `xsmall`. You can modify or drop this cluster or its
+replicas at any time.
 
-The `default` cluster is the default value for the `cluster` session parameter.
-If you drop the default cluster, each connection to Materialize will need to run
-[`SET CLUSTER`](/sql/select/#ad-hoc-queries) to choose a valid cluster in order
-to run `SELECT` queries.
+{{< note >}}
+The default value for the `cluster` session parameter is `default`. If you do
+not have a cluster named `default`, each connection to Materialize will need to
+run [`SET cluster`](/sql/select/#ad-hoc-queries) to choose a valid cluster in
+order to run `SELECT` queries.
+{{< /note >}}
 
 ### `mz_introspection` system cluster
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -21,17 +21,14 @@ Materialize has several pre-installed clusters.
 
 ### Default cluster
 
-When you enable a Materialize region, we automatically create a cluster named
-`default` with a single [replica](/overview/key-concepts/#cluster-replicas)
-named `r1` of size `xsmall`. You can modify or drop this cluster or its
-replicas at any time.
+When you enable a Materialize region, a cluster named `default` with a single
+`xsmall` [replica](/overview/key-concepts/#cluster-replicas) named `r1` will be
+pre-installed. You can modify or drop this cluster or its replicas at any
+time.
 
-{{< note >}}
-The default value for the `cluster` session parameter is `default`. If you do
-not have a cluster named `default`, each connection to Materialize will need to
-run [`SET cluster`](/sql/select/#ad-hoc-queries) to choose a valid cluster in
-order to run `SELECT` queries.
-{{< /note >}}
+{{< note >}} The default value for the `cluster` session parameter is `default`.
+If the `default` cluster is dropped, you must run [`SET cluster`](/sql/select/#ad-hoc-queries)
+to choose a valid cluster in order to run `SELECT` queries.{{< /note >}}
 
 ### `mz_introspection` system cluster
 


### PR DESCRIPTION
Note that the default cluster has size `xsmall`, and note that `2xsmall` is a valid cluster size.


### Motivation

* This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
