### PR TITLE
zippy: Reduce the number of rows in the UserTables scenario

### DIFF
--- a/misc/python/materialize/zippy/table_actions.py
+++ b/misc/python/materialize/zippy/table_actions.py
@@ -15,6 +15,8 @@ from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.table_capabilities import TableExists
 
+MAX_ROWS_PER_ACTION = 10000
+
 
 class CreateTable(Action):
     """Creates a table on the Mz instance. 50% of the tables have a default index."""
@@ -85,7 +87,7 @@ class DML(Action):
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.table = random.choice(capabilities.get(TableExists))
-        self.delta = random.randint(1, 100000)
+        self.delta = random.randint(1, MAX_ROWS_PER_ACTION)
 
 
 class Insert(DML):


### PR DESCRIPTION
The UserTables scenario takes too long to complete and is prone to OOMs.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly Zippy UserTables was timing out.