### PR TITLE
storage: downgrade potentially alarming error logs to trace logs

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1927,7 +1927,7 @@ mod persist_read_handles {
             match self.tx.send((tracing::Span::current(), cmd)) {
                 Ok(()) => (), // All good!
                 Err(e) => {
-                    tracing::error!("could not forward command: {:?}", e);
+                    tracing::trace!("could not forward command: {:?}", e);
                 }
             }
         }
@@ -2296,7 +2296,7 @@ mod persist_write_handles {
             match self.tx.send((tracing::Span::current(), cmd)) {
                 Ok(()) => (), // All good!
                 Err(e) => {
-                    tracing::error!("could not forward command: {:?}", e);
+                    tracing::trace!("could not forward command: {:?}", e);
                 }
             }
         }


### PR DESCRIPTION
During shutdown, it can frequently happen that the other end of the channel goes down first. And these logs statement might lead folks down the wrong path when trying to debug issues.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
