### PR TITLE
Clean up peeks that are no longer pending from compute command history 

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -1011,9 +1011,13 @@ pub struct ComputeCommandHistory<T = mz_repr::Timestamp> {
 
 impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
     /// Add a command to the history.
-    pub fn push(&mut self, command: ComputeCommand<T>) {
+    ///
+    /// This action will reduce the history every time it doubles, while retaining the
+    /// provided peeks.
+    pub fn push<V>(&mut self, command: ComputeCommand<T>, peeks: &std::collections::HashMap<uuid::Uuid, V>) {
         self.commands.push(command);
         if self.commands.len() > 2 * self.reduced_count {
+            self.retain_peeks(peeks);
             self.reduce();
         }
     }

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -1012,9 +1012,13 @@ pub struct ComputeCommandHistory<T = mz_repr::Timestamp> {
 impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
     /// Add a command to the history.
     ///
-    /// This action will reduce the history every time it doubles, while retaining the
+    /// This action will reduce the history every time it doubles while retaining the
     /// provided peeks.
-    pub fn push<V>(&mut self, command: ComputeCommand<T>, peeks: &std::collections::HashMap<uuid::Uuid, V>) {
+    pub fn push<V>(
+        &mut self,
+        command: ComputeCommand<T>,
+        peeks: &std::collections::HashMap<uuid::Uuid, V>,
+    ) {
         self.commands.push(command);
         if self.commands.len() > 2 * self.reduced_count {
             self.retain_peeks(peeks);

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -244,7 +244,7 @@ where
         }
 
         // Record the command so that new replicas can be brought up to speed.
-        self.history.push(cmd.clone());
+        self.history.push(cmd.clone(), &self.peeks);
 
         // Clone the command for each active replica.
         for (id, replica) in self.replicas.iter_mut() {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -105,7 +105,9 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         use ComputeCommand::*;
-        self.compute_state.command_history.push(cmd.clone(), &self.compute_state.pending_peeks);
+        self.compute_state
+            .command_history
+            .push(cmd.clone(), &self.compute_state.pending_peeks);
         match cmd {
             CreateTimely(_) => panic!("CreateTimely must be captured before"),
             CreateInstance(config) => self.handle_create_instance(config),
@@ -267,7 +269,9 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             self.send_peek_response(peek, response);
         } else {
             peek.span = span!(parent: &peek.span, Level::DEBUG, "pending peek");
-            self.compute_state.pending_peeks.insert(peek.peek.uuid, peek);
+            self.compute_state
+                .pending_peeks
+                .insert(peek.peek.uuid, peek);
         }
     }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -25,6 +25,7 @@ use timely::progress::frontier::Antichain;
 use timely::progress::reachability::logging::TrackerEvent;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, Mutex};
+use uuid::Uuid;
 
 use mz_compute_client::command::{
     ComputeCommand, ComputeCommandHistory, DataflowDescription, InstanceConfig, Peek, ReplicaId,
@@ -67,7 +68,7 @@ pub struct ComputeState {
     /// equal to this frontier)
     pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
     /// Peek commands that are awaiting fulfillment.
-    pub pending_peeks: Vec<PendingPeek>,
+    pub pending_peeks: HashMap<Uuid, PendingPeek>,
     /// Tracks the frontier information that has been sent over `response_tx`.
     pub reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
     /// The logger, from Timely's logging framework, if logs are enabled.
@@ -104,7 +105,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         use ComputeCommand::*;
-        self.compute_state.command_history.push(cmd.clone());
+        self.compute_state.command_history.push(cmd.clone(), &self.compute_state.pending_peeks);
         match cmd {
             CreateTimely(_) => panic!("CreateTimely must be captured before"),
             CreateInstance(config) => self.handle_create_instance(config),
@@ -266,7 +267,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             self.send_peek_response(peek, response);
         } else {
             peek.span = span!(parent: &peek.span, Level::DEBUG, "pending peek");
-            self.compute_state.pending_peeks.push(peek);
+            self.compute_state.pending_peeks.insert(peek.peek.uuid, peek);
         }
     }
 
@@ -274,13 +275,13 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let pending_peeks_len = self.compute_state.pending_peeks.len();
         let mut pending_peeks = std::mem::replace(
             &mut self.compute_state.pending_peeks,
-            Vec::with_capacity(pending_peeks_len),
+            HashMap::with_capacity(pending_peeks_len),
         );
-        for peek in pending_peeks.drain(..) {
-            if uuids.contains(&peek.peek.uuid) {
+        for (uuid, peek) in pending_peeks.drain() {
+            if uuids.contains(&uuid) {
                 self.send_peek_response(peek, PeekResponse::Canceled);
             } else {
-                self.compute_state.pending_peeks.push(peek);
+                self.compute_state.pending_peeks.insert(uuid, peek);
             }
         }
     }
@@ -610,16 +611,16 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let pending_peeks_len = self.compute_state.pending_peeks.len();
         let mut pending_peeks = std::mem::replace(
             &mut self.compute_state.pending_peeks,
-            Vec::with_capacity(pending_peeks_len),
+            HashMap::with_capacity(pending_peeks_len),
         );
-        for mut peek in pending_peeks.drain(..) {
+        for (uuid, mut peek) in pending_peeks.drain() {
             if let Some(response) =
                 peek.seek_fulfillment(&mut upper, self.compute_state.max_result_size)
             {
                 let _span = tracing::info_span!(parent: &peek.span,  "process_peek").entered();
                 self.send_peek_response(peek, response);
             } else {
-                self.compute_state.pending_peeks.push(peek);
+                self.compute_state.pending_peeks.insert(uuid, peek);
             }
         }
     }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -561,7 +561,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         std::cell::RefCell::new(Vec::new()),
                     ),
                     sink_write_frontiers: HashMap::new(),
-                    pending_peeks: Vec::new(),
+                    pending_peeks: HashMap::new(),
                     reported_frontiers: HashMap::new(),
                     compute_logger: None,
                     persist_clients: Arc::clone(&self.persist_clients),
@@ -811,7 +811,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
         if let Some(compute_state) = &mut self.compute_state {
             let mut command_history = ComputeCommandHistory::default();
             for command in new_commands.iter() {
-                command_history.push(command.clone());
+                command_history.push(command.clone(), &compute_state.pending_peeks);
             }
             compute_state.command_history = command_history;
         }


### PR DESCRIPTION
Currently, the compute command history can grow without bounds as peeks are processed, given that peeks that are no longer pending never get cleaned up. This effect happens both at the compute controller side as well as on the replica side.

This PR fixes this unbounded growth by retaining only pending peeks in the compute command history every time the history is reduced upon doubling via `ComputeCommandHistory::push`. Since this reduction upon `push` happens only when the size of the history doubles, we expect the overheads of tagging peek cleanup along with reduction to be manageable. 

Advances #15531. While the present PR resolves the current command leak into the history, it would be ideal that we expose the size of the compute command history externally, so that we can avoid peek leaks from sneaking in again in the future. Perhaps we could even introduce automated testing that can check this property. So I am delaying resolution of the peek cleanup issue until we add this testing or determine that it is too hard to do so. 

In more detail, the following changes are part of this PR:

- Add an extra parameter to `ComputeCommandHistory::push` to receive a map of currently pending peeks, which are to be retained with a call to `ComputeCommandHistory::retain_peeks`, as well as adjust the implementation accordingly.
- Ensure that calls to `ComputeCommandHistory::push` to provide the extra parameter required.
- As a consequence of the above, change the representation of the pending peeks in `ComputeState` from a `Vec` to a `HashMap`, thus matching the representation used in `Instance`. Note that the map representation is useful also on the replica side given that we now conceptually join the pending peeks against the compute command history every time the history doubles.

### Motivation

  * This PR fixes a recognized bug.
  https://github.com/MaterializeInc/materialize/issues/15531

### Tips for reviewer

There have been changes in the codebase to move away from `HashMap` to `BTreeMap`. This PR adds another use of `HashMap` in place of a `Vec` in `ComputeState`, since I presumed by looking at the code that iteration order was not a material issue. If we feel this should be different, then we should probably iterate during the review phase. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
   Since it is hard to externalize the size of the compute command history at present, tests were carried out locally by printing the history sizes to the screen upon doublings, and verifying that the fix keeps the history short on a workload of 100K peeks over an indexed table. Future PRs should focus on externalizing this metric and hopefully adding tests that monitor it.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
