### PR TITLE
Protect `Subscribe` against computed-based OOMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,6 +3227,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytesize",
  "chrono",
  "differential-dataflow",
  "futures",

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.65"
 async-trait = "0.1.57"
+bytesize = "1.1.0"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.24"

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -972,7 +972,9 @@ where
                         self.compute.subscribes.insert(subscribe_id, upper.clone());
                     }
 
-                    updates.retain(|(time, _data, _diff)| lower.less_equal(time));
+                    if let Ok(updates) = updates.as_mut() {
+                        updates.retain(|(time, _data, _diff)| lower.less_equal(time));
+                    }
                     Some(ComputeControllerResponse::SubscribeResponse(
                         subscribe_id,
                         SubscribeResponse::Batch(SubscribeBatch {

--- a/src/compute-client/src/response.proto
+++ b/src/compute-client/src/response.proto
@@ -69,7 +69,19 @@ message ProtoSubscribeBatch {
         int64 diff = 3;
     }
 
+    message ProtoSubscribeBatchContents {
+         oneof kind {
+             ProtoSubscribeUpdates updates = 1;
+             string error = 2;
+         }
+     }
+
+     message ProtoSubscribeUpdates {
+         repeated ProtoUpdate updates = 1;
+     }
+
     mz_repr.antichain.ProtoU64Antichain lower = 1;
     mz_repr.antichain.ProtoU64Antichain upper = 2;
-    repeated ProtoUpdate updates = 3;
+    reserved 3;
+    ProtoSubscribeBatchContents updates = 4;
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -674,7 +674,9 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     /// Scan the shared subscribe response buffer, and forward results along.
     pub fn process_subscribes(&mut self) {
         let mut subscribe_responses = self.compute_state.subscribe_response_buffer.borrow_mut();
-        for (sink_id, response) in subscribe_responses.drain(..) {
+        for (sink_id, mut response) in subscribe_responses.drain(..) {
+            response
+                .to_error_if_exceeds(usize::try_from(self.compute_state.max_result_size).unwrap());
             self.send_compute_response(ComputeResponse::SubscribeResponse(sink_id, response));
         }
     }

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -140,7 +140,7 @@ impl SubscribeProtocol {
                 SubscribeResponse::Batch(SubscribeBatch {
                     lower: self.prev_upper.clone(),
                     upper: upper.clone(),
-                    updates: ship,
+                    updates: Ok(ship),
                 }),
             ));
             self.prev_upper = upper;

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -38,6 +38,18 @@ contains:result exceeds max size of 128 B
 ! INSERT INTO t1 SELECT * FROM t1;
 contains:result exceeds max size of 128 B
 
+> INSERT INTO t1 SELECT * FROM generate_series(1, 100);
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SUBSCRIBE t1;
+
+# No output should be produced. Instead an error .. notice?
+! FETCH 1 c;
+contains:result exceeds max size of 128 B
+
+> ROLLBACK;
+
 # Constants with less than or equal to 10,000 rows will be evaluated in environmentd. Anything in excess of this will
 # be sent to computed to be executed. Therefore, we need to set the size high enough such that it will be evaluated by
 # computed to test the computed side of things.


### PR DESCRIPTION
A revised version of #15347 that avoids a gnarly rebase.

---

Prevent environmentd OOMs when using SUBSCRIBE.

This PR modifies computed to only return SubscribeResponse with at most a specified limit on the number of bytes in records. This allows environmentd to safely receive the results, and move forward with them or report an error if the response did not fit in the bounds.

Fixes https://github.com/MaterializeInc/materialize/issues/15202

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

This PR is identical to #15347 which has undergone review and had some amount of testing done (at least, it failed tests for a while, and was fixed). It introduces a new test, but could plausibly also use additional tests if @philip-stoev can imagine further cases that would make sense.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
