### PR TITLE
adapter: de-duplicate identical notices

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -88,6 +88,7 @@ pub struct Session<T = mz_repr::Timestamp> {
     drop_sinks: Vec<ComputeSinkId>,
     notices_tx: mpsc::UnboundedSender<AdapterNotice>,
     notices_rx: mpsc::UnboundedReceiver<AdapterNotice>,
+    prev_notice: Option<AdapterNotice>,
 }
 
 impl<T: TimestampManipulation> Session<T> {
@@ -123,6 +124,7 @@ impl<T: TimestampManipulation> Session<T> {
             drop_sinks: vec![],
             notices_tx,
             notices_rx,
+            prev_notice: None,
         }
     }
 
@@ -348,6 +350,12 @@ impl<T: TimestampManipulation> Session<T> {
                     continue;
                 }
             }
+            // De-duplicate identical notices. This routinely happens for
+            // ClusterReplicaStatusChanged messages.
+            if Some(&notice) == self.prev_notice.as_ref() {
+                continue;
+            }
+            self.prev_notice = Some(notice.clone());
             return notice;
         }
     }


### PR DESCRIPTION
See https://github.com/MaterializeInc/materialize/issues/15692#issuecomment-1292420449

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a