### PR TITLE
sql: adjust required cast context for uint16 -> int16

### DIFF
--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -236,7 +236,7 @@ static VALID_CASTS: Lazy<HashMap<(ScalarBaseType, ScalarBaseType), CastImpl>> = 
         // UINT16
         (UInt16, UInt32) => Implicit: CastUint16ToUint32(func::CastUint16ToUint32),
         (UInt16, UInt64) => Implicit: CastUint16ToUint64(func::CastUint16ToUint64),
-        (UInt16, Int16) => Implicit: CastUint16ToInt16(func::CastUint16ToInt16),
+        (UInt16, Int16) => Assignment: CastUint16ToInt16(func::CastUint16ToInt16),
         (UInt16, Int32) => Implicit: CastUint16ToInt32(func::CastUint16ToInt32),
         (UInt16, Int64) => Implicit: CastUint16ToInt64(func::CastUint16ToInt64),
         (UInt16, Numeric) => Implicit: CastTemplate::new(|_ecx, _ccx, _from_type, to_type| {


### PR DESCRIPTION
4c3b585115 had the wrong cast context for uint16 to int16 casts, which got revealed in 36612952de; fixing

### Motivation

This PR fixes a previously unreported bug. https://buildkite.com/materialize/tests/builds/44019

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a