### PR TITLE
sql: resolve function names as all other objects

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1367,6 +1367,7 @@ impl CatalogState {
         search_path: &Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)>,
         name: &PartialItemName,
         conn_id: ConnectionId,
+        err_gen: fn(String) -> SqlCatalogError,
     ) -> Result<&CatalogEntry, SqlCatalogError> {
         // If a schema name was specified, just try to find the item in that
         // schema. If no schema was specified, try to find the item in the connection's
@@ -1405,7 +1406,7 @@ impl CatalogState {
                 return Ok(&self.entry_by_id[id]);
             }
         }
-        Err(SqlCatalogError::UnknownItem(name.to_string()))
+        Err(err_gen(name.to_string()))
     }
 
     /// Resolves `name` to a non-function [`CatalogEntry`].
@@ -1422,6 +1423,7 @@ impl CatalogState {
             search_path,
             name,
             conn_id,
+            SqlCatalogError::UnknownItem,
         )
     }
 
@@ -1439,6 +1441,7 @@ impl CatalogState {
             search_path,
             name,
             conn_id,
+            SqlCatalogError::UnknownFunction,
         )
     }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -8157,7 +8157,11 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", VarInput::Flat("pg_catalog"), false)
+                .set(
+                    "search_path",
+                    VarInput::Flat(mz_repr::namespaces::PG_CATALOG_SCHEMA),
+                    false,
+                )
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(
@@ -8184,7 +8188,11 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", VarInput::Flat("mz_catalog"), false)
+                .set(
+                    "search_path",
+                    VarInput::Flat(mz_repr::namespaces::MZ_CATALOG_SCHEMA),
+                    false,
+                )
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(
@@ -8211,7 +8219,11 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", VarInput::Flat("mz_temp"), false)
+                .set(
+                    "search_path",
+                    VarInput::Flat(mz_repr::namespaces::MZ_TEMP_SCHEMA),
+                    false,
+                )
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -49,6 +49,9 @@ use mz_ore::soft_assert;
 use mz_persist_client::cfg::{PersistParameters, RetryParameters};
 use mz_pgrepr::oid::FIRST_USER_OID;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
+use mz_repr::namespaces::{
+    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
+};
 use mz_repr::role_id::RoleId;
 use mz_repr::{explain::ExprHumanizer, Diff, GlobalId, RelationDesc, ScalarType};
 use mz_secrets::InMemorySecretsController;
@@ -93,8 +96,7 @@ use mz_transform::Optimizer;
 
 use crate::catalog::builtin::{
     Builtin, BuiltinLog, BuiltinRole, BuiltinTable, BuiltinType, Fingerprint, BUILTINS,
-    BUILTIN_PREFIXES, INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA,
-    MZ_INTROSPECTION_CLUSTER, MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
+    BUILTIN_PREFIXES, MZ_INTROSPECTION_CLUSTER,
 };
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
 pub use crate::catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap, Config};

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1441,7 +1441,10 @@ impl CatalogState {
             search_path,
             name,
             conn_id,
-            SqlCatalogError::UnknownFunction,
+            |name| SqlCatalogError::UnknownFunction {
+                name,
+                alternative: None,
+            },
         )
     }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -486,7 +486,11 @@ impl CatalogState {
         }
     }
 
-    fn ensure_no_unstable_uses(&self, item: &CatalogItem) -> Result<(), AdapterError> {
+    fn check_unstable_dependencies(&self, item: &CatalogItem) -> Result<(), AdapterError> {
+        if self.system_config().allow_unstable_dependencies() {
+            return Ok(());
+        }
+
         let unstable_dependencies: Vec<_> = item
             .uses()
             .iter()
@@ -5440,7 +5444,7 @@ impl Catalog {
                     item,
                     owner_id,
                 } => {
-                    state.ensure_no_unstable_uses(&item)?;
+                    state.check_unstable_dependencies(&item)?;
 
                     if let Some(id @ ClusterId::System(_)) = item.cluster_id() {
                         let cluster_name = state.clusters_by_id[&id].name.clone();

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -30,6 +30,9 @@ use serde::Serialize;
 use mz_compute_client::logging::{ComputeLog, DifferentialLog, LogVariant, TimelyLog};
 use mz_pgrepr::oid;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
+use mz_repr::namespaces::{
+    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, PG_CATALOG_SCHEMA,
+};
 use mz_repr::role_id::RoleId;
 use mz_repr::{RelationDesc, RelationType, ScalarType};
 use mz_sql::catalog::{
@@ -43,12 +46,6 @@ use mz_storage_client::healthcheck::{MZ_SINK_STATUS_HISTORY_DESC, MZ_SOURCE_STAT
 use crate::catalog::storage::{MZ_INTROSPECTION_ROLE_ID, MZ_SYSTEM_ROLE_ID};
 use crate::catalog::DEFAULT_CLUSTER_REPLICA_NAME;
 use crate::rbac;
-
-pub const MZ_TEMP_SCHEMA: &str = "mz_temp";
-pub const MZ_CATALOG_SCHEMA: &str = "mz_catalog";
-pub const PG_CATALOG_SCHEMA: &str = "pg_catalog";
-pub const MZ_INTERNAL_SCHEMA: &str = "mz_internal";
-pub const INFORMATION_SCHEMA: &str = "information_schema";
 
 pub static BUILTIN_PREFIXES: Lazy<Vec<&str>> = Lazy::new(|| vec!["mz_", "pg_"]);
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -624,7 +624,7 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let create_sql = mz_sql::parse::parse(&view.create_sql)
-            .expect("create_sql cannot be invalid")
+            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", view.create_sql))
             .into_element();
         let query = match create_sql {
             Statement::CreateView(stmt) => stmt.definition.query,
@@ -663,7 +663,7 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let create_sql = mz_sql::parse::parse(&mview.create_sql)
-            .expect("create_sql cannot be invalid")
+            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", mview.create_sql))
             .into_element();
         let query = match create_sql {
             Statement::CreateMaterializedView(stmt) => stmt.query,
@@ -754,7 +754,7 @@ impl CatalogState {
         let mut updates = vec![];
 
         let key_sqls = match mz_sql::parse::parse(&index.create_sql)
-            .expect("create_sql cannot be invalid")
+            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", index.create_sql))
             .into_element()
         {
             Statement::CreateIndex(CreateIndexStatement { key_parts, .. }) => {
@@ -791,7 +791,7 @@ impl CatalogState {
             let key_sql = key_sqls
                 .get(i)
                 .expect("missing sql information for index key")
-                .to_string();
+                .to_ast_string();
             let (field_number, expression) = match key {
                 MirScalarExpr::Column(col) => {
                     (Datum::UInt64(u64::cast_from(*col + 1)), Datum::Null)

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -236,7 +236,7 @@ async fn migrate(
                 SchemaValue {
                     database_id: None,
                     database_ns: None,
-                    name: "mz_catalog".into(),
+                    name: mz_repr::namespaces::MZ_CATALOG_SCHEMA.into(),
                     owner_id: MZ_SYSTEM_ROLE_ID,
                     privileges: Some(vec![
                         rbac::default_catalog_privilege(mz_sql_parser::ast::ObjectType::Schema),
@@ -255,7 +255,7 @@ async fn migrate(
                 SchemaValue {
                     database_id: None,
                     database_ns: None,
-                    name: "pg_catalog".into(),
+                    name: mz_repr::namespaces::PG_CATALOG_SCHEMA.into(),
                     owner_id: MZ_SYSTEM_ROLE_ID,
                     privileges: Some(vec![
                         rbac::default_catalog_privilege(mz_sql_parser::ast::ObjectType::Schema),
@@ -316,7 +316,7 @@ async fn migrate(
                 SchemaValue {
                     database_id: None,
                     database_ns: None,
-                    name: "mz_internal".into(),
+                    name: mz_repr::namespaces::MZ_INTERNAL_SCHEMA.into(),
                     owner_id: MZ_SYSTEM_ROLE_ID,
                     privileges: Some(vec![
                         rbac::default_catalog_privilege(mz_sql_parser::ast::ObjectType::Schema),
@@ -335,7 +335,7 @@ async fn migrate(
                 SchemaValue {
                     database_id: None,
                     database_ns: None,
-                    name: "information_schema".into(),
+                    name: mz_repr::namespaces::INFORMATION_SCHEMA.into(),
                     owner_id: MZ_SYSTEM_ROLE_ID,
                     privileges: Some(vec![
                         rbac::default_catalog_privilege(mz_sql_parser::ast::ObjectType::Schema),

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -290,6 +290,7 @@ impl AdapterError {
                     .to_string(),
             ),
             AdapterError::Catalog(c) => c.hint(),
+            AdapterError::SqlCatalog(e) => e.hint(),
             AdapterError::Eval(e) => e.hint(),
             AdapterError::InvalidClusterReplicaAz { expected, az: _ } => {
                 Some(if expected.is_empty() {

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -19,6 +19,7 @@ use mz_repr::adt::numeric::{
     InvalidNumericMaxScaleError, NumericMaxScale, NUMERIC_DATUM_MAX_PRECISION,
 };
 use mz_repr::adt::varchar::{InvalidVarCharMaxLengthError, VarCharMaxLength};
+use mz_repr::namespaces::MZ_CATALOG_SCHEMA;
 use mz_repr::ScalarType;
 
 use crate::oid;
@@ -358,7 +359,7 @@ pub static LIST: Lazy<postgres_types::Type> = Lazy::new(|| {
         // https://www.postgresql.org/docs/current/system-catalog-initial-data.html#SYSTEM-CATALOG-OID-ASSIGNMENT
         oid::TYPE_LIST_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -369,7 +370,7 @@ pub static MAP: Lazy<postgres_types::Type> = Lazy::new(|| {
         // OID chosen to follow our "LIST" type.
         oid::TYPE_MAP_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -379,7 +380,7 @@ pub static ANYCOMPATIBLELIST: Lazy<postgres_types::Type> = Lazy::new(|| {
         "anycompatiblelist".to_owned(),
         oid::TYPE_ANYCOMPATIBLELIST_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -389,7 +390,7 @@ pub static ANYCOMPATIBLEMAP: Lazy<postgres_types::Type> = Lazy::new(|| {
         "anycompatiblemap".to_owned(),
         oid::TYPE_ANYCOMPATIBLEMAP_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -399,7 +400,7 @@ pub static UINT2: Lazy<postgres_types::Type> = Lazy::new(|| {
         "uint2".to_owned(),
         oid::TYPE_UINT2_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -409,7 +410,7 @@ pub static UINT4: Lazy<postgres_types::Type> = Lazy::new(|| {
         "uint4".to_owned(),
         oid::TYPE_UINT4_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -419,7 +420,7 @@ pub static UINT8: Lazy<postgres_types::Type> = Lazy::new(|| {
         "uint8".to_owned(),
         oid::TYPE_UINT8_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -429,7 +430,7 @@ pub static UINT2_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
         "uint2_array".to_owned(),
         oid::TYPE_UINT2_ARRAY_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -439,7 +440,7 @@ pub static UINT4_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
         "uint4_array".to_owned(),
         oid::TYPE_UINT4_ARRAY_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -449,7 +450,7 @@ pub static UINT8_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
         "uint8_array".to_owned(),
         oid::TYPE_UINT8_ARRAY_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -459,7 +460,7 @@ pub static MZ_TIMESTAMP: Lazy<postgres_types::Type> = Lazy::new(|| {
         "mz_timestamp".to_owned(),
         oid::TYPE_MZ_TIMESTAMP_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -469,7 +470,7 @@ pub static MZ_TIMESTAMP_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
         "mz_timestamp_array".to_owned(),
         oid::TYPE_MZ_TIMESTAMP_ARRAY_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -479,7 +480,7 @@ pub static MZ_ACL_ITEM: Lazy<postgres_types::Type> = Lazy::new(|| {
         "mz_aclitem".to_owned(),
         oid::TYPE_MZ_ACL_ITEM_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 
@@ -489,7 +490,7 @@ pub static MZ_ACL_ITEM_ARRAY: Lazy<postgres_types::Type> = Lazy::new(|| {
         "mz_aclitem_array".to_owned(),
         oid::TYPE_MZ_ACL_ITEM_ARRAY_OID,
         postgres_types::Kind::Pseudo,
-        "mz_catalog".to_owned(),
+        MZ_CATALOG_SCHEMA.to_owned(),
     )
 });
 

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -101,6 +101,7 @@ pub mod antichain;
 pub mod chrono;
 pub mod explain;
 pub mod global_id;
+pub mod namespaces;
 pub mod role_id;
 pub mod stats;
 pub mod strconv;

--- a/src/repr/src/namespaces.rs
+++ b/src/repr/src/namespaces.rs
@@ -1,0 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Namespace constants to share between high- and low-levels of the system.
+
+// TODO: define default database, schema names
+
+pub const MZ_TEMP_SCHEMA: &str = "mz_temp";
+pub const MZ_CATALOG_SCHEMA: &str = "mz_catalog";
+pub const PG_CATALOG_SCHEMA: &str = "pg_catalog";
+pub const MZ_INTERNAL_SCHEMA: &str = "mz_internal";
+pub const INFORMATION_SCHEMA: &str = "information_schema";

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -585,9 +585,9 @@ impl<T: AstInfo> Expr<T> {
         }
     }
 
-    pub fn call(name: Vec<&str>, args: Vec<Expr<T>>) -> Expr<T> {
+    pub fn call(name: T::ItemName, args: Vec<Expr<T>>) -> Expr<T> {
         Expr::Function(Function {
-            name: UnresolvedItemName(name.into_iter().map(Into::into).collect()),
+            name,
             args: FunctionArgs::args(args),
             filter: None,
             over: None,
@@ -595,11 +595,11 @@ impl<T: AstInfo> Expr<T> {
         })
     }
 
-    pub fn call_nullary(name: Vec<&str>) -> Expr<T> {
+    pub fn call_nullary(name: T::ItemName) -> Expr<T> {
         Expr::call(name, vec![])
     }
 
-    pub fn call_unary(self, name: Vec<&str>) -> Expr<T> {
+    pub fn call_unary(self, name: T::ItemName) -> Expr<T> {
         Expr::call(name, vec![self])
     }
 
@@ -796,7 +796,7 @@ impl_display!(WindowFrameBound);
 /// A function call
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Function<T: AstInfo> {
-    pub name: UnresolvedItemName,
+    pub name: T::ItemName,
     pub args: FunctionArgs<T>,
     // aggregate functions may specify e.g. `COUNT(DISTINCT X) FILTER (WHERE ...)`
     pub filter: Option<Box<Expr<T>>>,

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -23,9 +23,7 @@ use std::hash::Hash;
 use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{
-    AstInfo, Expr, FunctionArgs, Ident, ShowStatement, UnresolvedItemName, WithOptionValue,
-};
+use crate::ast::{AstInfo, Expr, FunctionArgs, Ident, ShowStatement, WithOptionValue};
 
 /// The most complete variant of a `SELECT` query expression, optionally
 /// including `WITH`, `UNION` / other set operations, and `ORDER BY`.
@@ -625,7 +623,7 @@ impl_display_t!(TableFactor);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TableFunction<T: AstInfo> {
-    pub name: UnresolvedItemName,
+    pub name: T::ItemName,
     pub args: FunctionArgs<T>,
 }
 impl<T: AstInfo> AstDisplay for TableFunction<T> {

--- a/src/sql-parser/src/ast/fold.rs
+++ b/src/sql-parser/src/ast/fold.rs
@@ -26,7 +26,7 @@
 //! by invoking the right folder method on each of its fields.
 //!
 //! ```
-//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedItemName, WindowSpec, Raw, AstInfo};
+//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, WindowSpec, Raw, AstInfo};
 //! #
 //! pub trait Fold<T: AstInfo, T2: AstInfo> {
 //!     /* ... */
@@ -36,7 +36,7 @@
 //!     }
 //!
 //!     /* ... */
-//!     # fn fold_unresolved_item_name(&mut self, node: UnresolvedItemName) -> UnresolvedItemName;
+//!     # fn fold_item_name(&mut self, node: <T as AstInfo>::ItemName) -> <T2 as AstInfo>::ItemName;
 //!     # fn fold_function_args(&mut self, node: FunctionArgs<T>) -> FunctionArgs<T2>;
 //!     # fn fold_expr(&mut self, node: Expr<T>) -> Expr<T2>;
 //!     # fn fold_window_spec(&mut self, node: WindowSpec<T>) -> WindowSpec<T2>;
@@ -47,7 +47,7 @@
 //!     F: Fold<T, T2> + ?Sized,
 //! {
 //!     Function {
-//!         name: folder.fold_unresolved_item_name(node.name),
+//!         name: folder.fold_item_name(node.name),
 //!         args: folder.fold_function_args(node.args),
 //!         filter: node.filter.map(|filter| Box::new(folder.fold_expr(*filter))),
 //!         over: node.over.map(|over| folder.fold_window_spec(over)),

--- a/src/sql-parser/src/ast/visit.rs
+++ b/src/sql-parser/src/ast/visit.rs
@@ -26,7 +26,7 @@
 //! by invoking the right visitor method of each of its fields.
 //!
 //! ```
-//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedItemName, WindowSpec, Raw, AstInfo};
+//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, WindowSpec, Raw, AstInfo};
 //! #
 //! pub trait Visit<'ast, T: AstInfo> {
 //!     /* ... */
@@ -36,7 +36,7 @@
 //!     }
 //!
 //!     /* ... */
-//!     # fn visit_unresolved_item_name(&mut self, node: &'ast UnresolvedItemName);
+//!     # fn visit_item_name(&mut self, node: &'ast <T as AstInfo>::ItemName);
 //!     # fn visit_function_args(&mut self, node: &'ast FunctionArgs<T>);
 //!     # fn visit_expr(&mut self, node: &'ast Expr<T>);
 //!     # fn visit_window_spec(&mut self, node: &'ast WindowSpec<T>);
@@ -46,7 +46,7 @@
 //! where
 //!     V: Visit<'ast, T> + ?Sized,
 //! {
-//!     visitor.visit_unresolved_item_name(&node.name);
+//!     visitor.visit_item_name(&node.name);
 //!     visitor.visit_function_args(&node.args);
 //!     if let Some(filter) = &node.filter {
 //!         visitor.visit_expr(&*filter);

--- a/src/sql-parser/src/ast/visit_mut.rs
+++ b/src/sql-parser/src/ast/visit_mut.rs
@@ -25,7 +25,7 @@
 //! invoking the right visitor method of each of its fields.
 //!
 //! ```
-//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, UnresolvedItemName, WindowSpec, AstInfo};
+//! # use mz_sql_parser::ast::{Expr, Function, FunctionArgs, WindowSpec, AstInfo};
 //! #
 //! pub trait VisitMut<'ast, T: AstInfo> {
 //!     /* ... */
@@ -35,7 +35,7 @@
 //!     }
 //!
 //!     /* ... */
-//!     # fn visit_unresolved_item_name_mut(&mut self, node: &'ast mut UnresolvedItemName);
+//!     # fn visit_item_name_mut(&mut self, node: &'ast mut <T as AstInfo>::ItemName);
 //!     # fn visit_function_args_mut(&mut self, node: &'ast mut FunctionArgs<T>);
 //!     # fn visit_expr_mut(&mut self, node: &'ast mut Expr<T>);
 //!     # fn visit_window_spec_mut(&mut self, node: &'ast mut WindowSpec<T>);
@@ -45,7 +45,7 @@
 //! where
 //!     V: VisitMut<'ast, T> + ?Sized,
 //! {
-//!     visitor.visit_unresolved_item_name_mut(&mut node.name);
+//!     visitor.visit_item_name_mut(&mut node.name);
 //!     visitor.visit_function_args_mut(&mut node.args);
 //!     if let Some(filter) = &mut node.filter {
 //!         visitor.visit_expr_mut(&mut *filter);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5392,21 +5392,20 @@ impl<'a> Parser<'a> {
             Ok(self.parse_rows_from()?)
         } else {
             let name = self.parse_raw_name()?;
-            match name {
-                name @ RawItemName::Name(..) if self.consume_token(&Token::LParen) => {
-                    let args = self.parse_optional_args(false)?;
-                    let alias = self.parse_optional_table_alias()?;
-                    let with_ordinality = self.parse_keywords(&[WITH, ORDINALITY]);
-                    Ok(TableFactor::Function {
-                        function: TableFunction { name, args },
-                        alias,
-                        with_ordinality,
-                    })
-                }
-                _ => Ok(TableFactor::Table {
+            if self.consume_token(&Token::LParen) {
+                let args = self.parse_optional_args(false)?;
+                let alias = self.parse_optional_table_alias()?;
+                let with_ordinality = self.parse_keywords(&[WITH, ORDINALITY]);
+                Ok(TableFactor::Function {
+                    function: TableFunction { name, args },
+                    alias,
+                    with_ordinality,
+                })
+            } else {
+                Ok(TableFactor::Table {
                     name,
                     alias: self.parse_optional_table_alias()?,
-                }),
+                })
             }
         }
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -134,7 +134,7 @@ CREATE TEMPORARY TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) 
 ----
 CREATE TEMPORARY TABLE foo (id int4, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: Op { namespace: [], op: "<>" }, expr1: Function(Function { name: UnresolvedItemName([Ident("rtrim")]), args: Args { args: [Function(Function { name: UnresolvedItemName([Ident("ltrim")]), args: Args { args: [Identifier([Ident("ref_code")])], order_by: [] }, filter: None, over: None, distinct: false })], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedItemName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedItemName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: Op { namespace: [], op: "<>" }, expr1: Function(Function { name: Name(UnresolvedItemName([Ident("rtrim")])), args: Args { args: [Function(Function { name: Name(UnresolvedItemName([Ident("ltrim")])), args: Args { args: [Identifier([Ident("ref_code")])], order_by: [] }, filter: None, over: None, distinct: false })], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
@@ -541,7 +541,7 @@ CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop W
 ----
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("baz")])), key_parts: Some([Function(Function { name: UnresolvedItemName([Ident("ascii")]), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }), IsExpr { expr: Identifier([Ident("a")]), construct: Null, negated: true }, Nested(Exists(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("boop")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), in_cluster: None, on_name: Name(UnresolvedItemName([Ident("baz")])), key_parts: Some([Function(Function { name: Name(UnresolvedItemName([Ident("ascii")])), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }), IsExpr { expr: Identifier([Ident("a")]), construct: Null, negated: true }, Nested(Exists(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("boop")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX ind ON tab ((col + 1))
@@ -772,14 +772,14 @@ SUBSCRIBE foo.bar AS OF now()
 ----
 SUBSCRIBE foo.bar AS OF now()
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None, output: Diffs })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None, output: Diffs })
 
 parse-statement
 SUBSCRIBE foo.bar WITH (SNAPSHOT) AS OF now()
 ----
 SUBSCRIBE foo.bar WITH (SNAPSHOT) AS OF now()
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None, output: Diffs })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None, output: Diffs })
 
 parse-statement
 SUBSCRIBE foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
@@ -807,14 +807,14 @@ SUBSCRIBE foo.bar AS OF now() UP TO now() + interval '1' day
 ----
 SUBSCRIBE foo.bar AS OF now() UP TO now() + INTERVAL '1' DAY
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }), output: Diffs })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }), output: Diffs })
 
 parse-statement
 SUBSCRIBE foo.bar UP TO now() + interval '1' day
 ----
 SUBSCRIBE foo.bar UP TO now() + INTERVAL '1' DAY
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }), output: Diffs })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedItemName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }), output: Diffs })
 
 parse-statement
 SUBSCRIBE foo.bar ENVELOPE UPSERT KEY (a)
@@ -1289,14 +1289,14 @@ CREATE SECRET secret AS decode('c2VjcmV0Cg==', 'base64')
 ----
 CREATE SECRET secret AS decode('c2VjcmV0Cg==', 'base64')
 =>
-CreateSecret(CreateSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_not_exists: false, value: Function(Function { name: UnresolvedItemName([Ident("decode")]), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+CreateSecret(CreateSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_not_exists: false, value: Function(Function { name: Name(UnresolvedItemName([Ident("decode")])), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
 CREATE SECRET IF NOT EXISTS secret AS decode('c2VjcmV0Cg==', 'base64')
 ----
 CREATE SECRET IF NOT EXISTS secret AS decode('c2VjcmV0Cg==', 'base64')
 =>
-CreateSecret(CreateSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_not_exists: true, value: Function(Function { name: UnresolvedItemName([Ident("decode")]), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+CreateSecret(CreateSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_not_exists: true, value: Function(Function { name: Name(UnresolvedItemName([Ident("decode")])), args: Args { args: [Value(String("c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
 DROP SECRET secret
@@ -1331,7 +1331,7 @@ ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 ----
 ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 =>
-AlterSecret(AlterSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_exists: false, value: Function(Function { name: UnresolvedItemName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+AlterSecret(AlterSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_exists: false, value: Function(Function { name: Name(UnresolvedItemName([Ident("decode")])), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
 CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux';

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -201,9 +201,9 @@ SELECT E'\u&&&&'
 parse-statement
 SELECT [1, 2]
 ----
-error: Expected an expression, found left square bracket
+error: expected id
 SELECT [1, 2]
-       ^
+        ^
 
 # Subscripts must have values
 parse-statement

--- a/src/sql-parser/tests/testdata/id
+++ b/src/sql-parser/tests/testdata/id
@@ -21,6 +21,13 @@ SELECT * FROM [u123 AS materialize.public.foo]
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
+SELECT [u123 AS materialize.public.foo](1)
+----
+SELECT [u123 AS materialize.public.foo](1)
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Id("u123", UnresolvedItemName([Ident("materialize"), Ident("public"), Ident("foo")])), args: Args { args: [Value(Number("1"))], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
 SELECT * FROM [u123 AS foo]
 ----
 error: table name in square brackets must be fully qualified

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -199,214 +199,214 @@ id::numeric
 parse-scalar
 EXTRACT(YEAR FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MILLENIUM FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("millenium")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("millenium")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(CENTURY FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("century")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("century")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(YEAR FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("year")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(ISOYEAR FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("isoyear")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("isoyear")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(QUARTER FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("quarter")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("quarter")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MONTH FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("month")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("month")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(DAY FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("day")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("day")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(HOUR FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MINUTE FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(SECOND FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("second")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("second")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MILLISECONDS FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("milliseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("milliseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(MICROSECONDS FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("microseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("microseconds")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(TIMEZONE FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("timezone")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("timezone")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(TIMEZONE_HOUR FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("timezone_hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("timezone_hour")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(TIMEZONE_MINUTE FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("timezone_minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("timezone_minute")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(WEEK FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("week")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("week")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(DOY FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("doy")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("doy")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(DOW FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("dow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("dow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(ISODOW FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("isodow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("isodow")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 EXTRACT(EPOCH FROM d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("extract")]), args: Args { args: [Value(String("epoch")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Args { args: [Value(String("epoch")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 # date_part
 
 parse-scalar
 DATE_PART('YEAR', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MILLENIUM', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MILLENIUM")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("MILLENIUM")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('CENTURY', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("CENTURY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("CENTURY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('YEAR', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("YEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('ISOYEAR', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("ISOYEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("ISOYEAR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('QUARTER', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("QUARTER")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("QUARTER")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MONTH', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MONTH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("MONTH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('DAY', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("DAY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("DAY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('HOUR', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MINUTE', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('SECOND', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("SECOND")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("SECOND")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MILLISECONDS', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MILLISECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("MILLISECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('MICROSECONDS', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("MICROSECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("MICROSECONDS")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('TIMEZONE', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("TIMEZONE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('TIMEZONE_HOUR', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE_HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("TIMEZONE_HOUR")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('TIMEZONE_MINUTE', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("TIMEZONE_MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("TIMEZONE_MINUTE")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('WEEK', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("WEEK")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("WEEK")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('DOY', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("DOY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("DOY")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('DOW', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("DOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("DOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('ISODOW', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("ISODOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("ISODOW")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 DATE_PART('EPOCH', d)
 ----
-Function(Function { name: UnresolvedItemName([Ident("date_part")]), args: Args { args: [Value(String("EPOCH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("date_part")])), args: Args { args: [Value(String("EPOCH")), Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 COALESCE(foo, bar)
@@ -424,7 +424,7 @@ COALESCE()
 parse-scalar
 sqrt(id)
 ----
-Function(Function { name: UnresolvedItemName([Ident("sqrt")]), args: Args { args: [Identifier([Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("sqrt")])), args: Args { args: [Identifier([Ident("id")])], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar roundtrip
 (a + b) - (c + d)
@@ -454,7 +454,7 @@ AnySubquery { left: Value(Number("1")), op: Op { namespace: [], op: "<" }, right
 parse-scalar
 1 < ANY (fn())
 ----
-AnyExpr { left: Value(Number("1")), op: Op { namespace: [], op: "<" }, right: Function(Function { name: UnresolvedItemName([Ident("fn")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }
+AnyExpr { left: Value(Number("1")), op: Op { namespace: [], op: "<" }, right: Function(Function { name: Name(UnresolvedItemName([Ident("fn")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }) }
 
 parse-scalar
 LIST[]
@@ -700,12 +700,12 @@ Nested(WildcardAccess(WildcardAccess(Nested(Identifier([Ident("x")])))))
 parse-scalar
 position('om' IN 'Thomas')
 ----
-Function(Function { name: UnresolvedItemName([Ident("position")]), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("position")])), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 "position"('om', 'Thomas')
 ----
-Function(Function { name: UnresolvedItemName([Ident("position")]), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
+Function(Function { name: Name(UnresolvedItemName([Ident("position")])), args: Args { args: [Value(String("om")), Value(String("Thomas"))], order_by: [] }, filter: None, over: None, distinct: false })
 
 parse-scalar
 position('om', 'Thomas')

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -319,14 +319,14 @@ SELECT count(*) FILTER (WHERE foo) FROM customer
 ----
 SELECT count(*) FILTER (WHERE foo) FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Star, filter: Some(Identifier([Ident("foo")])), over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("count")])), args: Star, filter: Some(Identifier([Ident("foo")])), over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT count(DISTINCT + x) FROM customer
 ----
 SELECT count(DISTINCT + x) FROM customer
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Args { args: [Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("x")]), expr2: None }], order_by: [] }, filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("count")])), args: Args { args: [Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("x")]), expr2: None }], order_by: [] }, filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT count(ALL + x) FROM customer
@@ -358,7 +358,7 @@ SELECT array_agg(b ORDER BY a)
 ----
 SELECT array_agg(b ORDER BY a)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: UnresolvedItemName([Ident("array_agg")]), args: Args { args: [Identifier([Ident("b")])], order_by: [OrderByExpr { expr: Identifier([Ident("a")]), asc: None, nulls_last: None }] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("array_agg")])), args: Args { args: [Identifier([Ident("b")])], order_by: [OrderByExpr { expr: Identifier([Ident("a")]), asc: None, nulls_last: None }] }, filter: None, over: None, distinct: false }), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 
 # Parameters
@@ -506,14 +506,14 @@ SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: Name(UnresolvedItemName([Ident("count")])), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: UnresolvedItemName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("bar")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(Op { op: Op { namespace: [], op: ">" }, expr1: Function(Function { name: Name(UnresolvedItemName([Ident("count")])), args: Star, filter: None, over: None, distinct: false }), expr2: Some(Value(Number("1"))) }), options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING 1 = 1
@@ -894,7 +894,7 @@ SELECT foo FROM LATERAL bar(1)
 ----
 SELECT foo FROM bar(1)
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedItemName([Ident("bar")]), args: Args { args: [Value(Number("1"))], order_by: [] } }, alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { function: TableFunction { name: Name(UnresolvedItemName([Ident("bar")])), args: Args { args: [Value(Number("1"))], order_by: [] } }, alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar
@@ -1095,28 +1095,28 @@ SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) ON true
 ----
 SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) ON true
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] } }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("customer")])), alias: None }, joins: [Join { relation: Function { function: TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Identifier([Ident("customer"), Ident("id")])], order_by: [] } }, alias: None, with_ordinality: false }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM LATERAL ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) AS alias
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: Some(TableAlias { name: Ident("alias"), columns: [], strict: false }), with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 ----
 SELECT * FROM generate_series(1, 2) WITH ORDINALITY
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Function { function: TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2) WITH ORDINALITY)
@@ -1130,14 +1130,14 @@ SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDI
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5)) WITH ORDINALITY
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: true }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 ----
 SELECT * FROM ROWS FROM (generate_series(1, 2), generate_series(3, 5))
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: UnresolvedItemName([Ident("generate_series")]), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: RowsFrom { functions: [TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("1")), Value(Number("2"))], order_by: [] } }, TableFunction { name: Name(UnresolvedItemName([Ident("generate_series")])), args: Args { args: [Value(Number("3")), Value(Number("5"))], order_by: [] } }], alias: None, with_ordinality: false }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # Ensure parsing AS OF is case-insensitive
 parse-statement
@@ -1145,14 +1145,14 @@ SELECT * FROM data as of now()
 ----
 SELECT * FROM data AS OF now()
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
 
 parse-statement
 SELECT * FROM data AS OF now()
 ----
 SELECT * FROM data AS OF now()
 =>
-Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: UnresolvedItemName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("data")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: Some(At(Function(Function { name: Name(UnresolvedItemName([Ident("now")])), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
 
 
 parse-statement

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1103,7 +1103,8 @@ impl fmt::Display for CatalogError {
 }
 
 impl CatalogError {
-    pub(crate) fn hint(&self) -> Option<String> {
+    /// Returns any applicable hints for [`CatalogError`].
+    pub fn hint(&self) -> Option<String> {
         match self {
             CatalogError::UnknownFunction { alternative, .. } => {
                 match alternative {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -296,6 +296,10 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
 
     /// Returns the name of `object_id`. For use only in error messages and notices.
     fn get_object_name(&self, object_id: &ObjectId) -> String;
+
+    /// Returns the minimal qualification required to unambiguously specify
+    /// `qualified_name`.
+    fn minimal_qualification(&self, qualified_name: &QualifiedItemName) -> PartialItemName;
 }
 
 /// Configuration associated with a catalog.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -939,34 +939,6 @@ where
     let name = spec.to_string();
     let ecx = &ecx.with_name(&name);
     let types: Vec<_> = args.iter().map(|e| ecx.scalar_type(e)).collect();
-    //     select_impl_inner(ecx, impls, args, &types, order_by).map_err(|e| {
-    //         let types: Vec<_> = types
-    //             .into_iter()
-    //             .map(|ty| match ty {
-    //                 Some(ty) => ecx.humanize_scalar_type(&ty),
-    //                 None => "unknown".to_string(),
-    //             })
-    //             .collect();
-    //         let context = match (spec, types.as_slice()) {
-    //             (FuncSpec::Func(name), _) => {
-    //                 format!(
-    //                     "Cannot call function {}({})",
-    //                     ecx.qcx
-    //                         .scx
-    //                         .humanize_resolved_name(name)
-    //                         .expect("resolved to object"),
-    //                     types.join(", ")
-    //                 )
-    //             }
-    //             (FuncSpec::Op(name), [typ]) => format!("no overload for {} {}", name, typ),
-    //             (FuncSpec::Op(name), [ltyp, rtyp]) => {
-    //                 format!("no overload for {} {} {}", ltyp, name, rtyp)
-    //             }
-    //             (FuncSpec::Op(_), [..]) => unreachable!("non-unary non-binary operator"),
-    //         };
-    //         sql_err!("{}: {}", context, e)
-    //     })
-    // }
 
     // 4.a. Discard candidate functions for which the input types do not
     // match and cannot be converted (using an implicit conversion) to
@@ -989,7 +961,12 @@ where
         if candidates == 0 {
             match spec {
                 FuncSpec::Func(name) => PlanError::UnknownFunction {
-                    name: name.to_string(),
+                    name: ecx
+                        .qcx
+                        .scx
+                        .humanize_resolved_name(name)
+                        .expect("resolved to object")
+                        .to_string(),
                     arg_types,
                 },
                 FuncSpec::Op(name) => PlanError::UnknownOperator {
@@ -1000,7 +977,12 @@ where
         } else {
             match spec {
                 FuncSpec::Func(name) => PlanError::IndistinctFunction {
-                    name: name.to_string(),
+                    name: ecx
+                        .qcx
+                        .scx
+                        .humanize_resolved_name(name)
+                        .expect("resolved to object")
+                        .to_string(),
                     arg_types,
                 },
                 FuncSpec::Op(name) => PlanError::IndistinctOperator {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1795,6 +1795,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                 current_settings(name, missing_ok)
             }) => ScalarType::String, 3294;
         },
+        "current_timestamp" => Scalar {
+            params!() => UnmaterializableFunc::CurrentTimestamp => TimestampTz, oid::FUNC_CURRENT_TIMESTAMP_OID;
+        },
         "current_user" => Scalar {
             params!() => UnmaterializableFunc::CurrentUser => String, 745;
         },
@@ -2899,9 +2902,6 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         },
         "concat_agg" => Aggregate {
             params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("concat_agg")) => String, oid::FUNC_CONCAT_AGG_OID;
-        },
-        "current_timestamp" => Scalar {
-            params!() => UnmaterializableFunc::CurrentTimestamp => TimestampTz, oid::FUNC_CURRENT_TIMESTAMP_OID;
         },
         "list_agg" => Aggregate {
             params!(Any) => Operation::unary_ordered(|ecx, e, order_by| {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -24,7 +24,7 @@ use mz_repr::{ColumnName, ColumnType, Datum, RelationType, Row, ScalarBaseType, 
 
 use crate::ast::{SelectStatement, Statement};
 use crate::catalog::{CatalogType, TypeCategory, TypeReference};
-use crate::names::{self, PartialItemName};
+use crate::names::{self, ResolvedItemName};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AggregateFunc, BinaryFunc, CoercibleScalarExpr, ColumnOrder, HirRelationExpr, HirScalarExpr,
@@ -39,7 +39,7 @@ use crate::plan::typeconv::{self, CastContext};
 #[derive(Clone, Copy, Debug)]
 pub enum FuncSpec<'a> {
     /// A function name.
-    Func(&'a PartialItemName),
+    Func(&'a ResolvedItemName),
     /// An operator name.
     Op(&'a str),
 }
@@ -963,7 +963,6 @@ where
                 FuncSpec::Func(name) => PlanError::UnknownFunction {
                     name: name.to_string(),
                     arg_types,
-                    alternative_hint: None,
                 },
                 FuncSpec::Op(name) => PlanError::UnknownOperator {
                     name: name.to_string(),

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -939,6 +939,34 @@ where
     let name = spec.to_string();
     let ecx = &ecx.with_name(&name);
     let types: Vec<_> = args.iter().map(|e| ecx.scalar_type(e)).collect();
+    //     select_impl_inner(ecx, impls, args, &types, order_by).map_err(|e| {
+    //         let types: Vec<_> = types
+    //             .into_iter()
+    //             .map(|ty| match ty {
+    //                 Some(ty) => ecx.humanize_scalar_type(&ty),
+    //                 None => "unknown".to_string(),
+    //             })
+    //             .collect();
+    //         let context = match (spec, types.as_slice()) {
+    //             (FuncSpec::Func(name), _) => {
+    //                 format!(
+    //                     "Cannot call function {}({})",
+    //                     ecx.qcx
+    //                         .scx
+    //                         .humanize_resolved_name(name)
+    //                         .expect("resolved to object"),
+    //                     types.join(", ")
+    //                 )
+    //             }
+    //             (FuncSpec::Op(name), [typ]) => format!("no overload for {} {}", name, typ),
+    //             (FuncSpec::Op(name), [ltyp, rtyp]) => {
+    //                 format!("no overload for {} {} {}", ltyp, name, rtyp)
+    //             }
+    //             (FuncSpec::Op(_), [..]) => unreachable!("non-unary non-binary operator"),
+    //         };
+    //         sql_err!("{}: {}", context, e)
+    //     })
+    // }
 
     // 4.a. Discard candidate functions for which the input types do not
     // match and cannot be converted (using an implicit conversion) to

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -397,6 +397,13 @@ impl ResolvedItemName {
             ResolvedItemName::Error => "error in name resolution".to_string(),
         }
     }
+
+    pub fn full_item_name(&self) -> &FullItemName {
+        match self {
+            ResolvedItemName::Item { full_name, .. } => full_name,
+            _ => panic!("cannot call object_full_name on non-object"),
+        }
+    }
 }
 
 impl AstDisplay for ResolvedItemName {
@@ -1054,6 +1061,66 @@ impl<'a> NameResolver<'a> {
             }
         }
     }
+
+    fn fold_raw_object_name_name_internal(
+        &mut self,
+        name: RawItemName,
+        consider_function: bool,
+    ) -> ResolvedItemName {
+        match name {
+            RawItemName::Name(raw_name) => {
+                let raw_name = match normalize::unresolved_item_name(raw_name) {
+                    Ok(raw_name) => raw_name,
+                    Err(e) => {
+                        if self.status.is_ok() {
+                            self.status = Err(e);
+                        }
+                        return ResolvedItemName::Error;
+                    }
+                };
+
+                // Check if unqualified name refers to a CTE.
+                if raw_name.database.is_none() && raw_name.schema.is_none() {
+                    let norm_name = normalize::ident(Ident::new(&raw_name.item));
+                    if let Some(id) = self.ctes.get(&norm_name) {
+                        return ResolvedItemName::Cte {
+                            id: *id,
+                            name: norm_name,
+                        };
+                    }
+                }
+
+                let r = if consider_function {
+                    self.catalog.resolve_function(&raw_name)
+                } else {
+                    self.catalog.resolve_item(&raw_name)
+                };
+
+                match r {
+                    Ok(item) => {
+                        self.ids.insert(item.id());
+                        let print_id = !matches!(
+                            item.item_type(),
+                            CatalogItemType::Func | CatalogItemType::Type
+                        );
+                        ResolvedItemName::Item {
+                            id: item.id(),
+                            qualifiers: item.name().qualifiers.clone(),
+                            full_name: self.catalog.resolve_full_name(item.name()),
+                            print_id,
+                        }
+                    }
+                    Err(e) => {
+                        if self.status.is_ok() {
+                            self.status = Err(e.into());
+                        }
+                        ResolvedItemName::Error
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
@@ -1174,50 +1241,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
         item_name: <Raw as AstInfo>::ItemName,
     ) -> <Aug as AstInfo>::ItemName {
         match item_name {
-            RawItemName::Name(raw_name) => {
-                let raw_name = match normalize::unresolved_item_name(raw_name) {
-                    Ok(raw_name) => raw_name,
-                    Err(e) => {
-                        if self.status.is_ok() {
-                            self.status = Err(e);
-                        }
-                        return ResolvedItemName::Error;
-                    }
-                };
-
-                // Check if unqualified name refers to a CTE.
-                if raw_name.database.is_none() && raw_name.schema.is_none() {
-                    let norm_name = normalize::ident(Ident::new(&raw_name.item));
-                    if let Some(id) = self.ctes.get(&norm_name) {
-                        return ResolvedItemName::Cte {
-                            id: *id,
-                            name: norm_name,
-                        };
-                    }
-                }
-
-                match self.catalog.resolve_item(&raw_name) {
-                    Ok(item) => {
-                        self.ids.insert(item.id());
-                        let print_id = !matches!(
-                            item.item_type(),
-                            CatalogItemType::Func | CatalogItemType::Type
-                        );
-                        ResolvedItemName::Item {
-                            id: item.id(),
-                            qualifiers: item.name().qualifiers.clone(),
-                            full_name: self.catalog.resolve_full_name(item.name()),
-                            print_id,
-                        }
-                    }
-                    Err(e) => {
-                        if self.status.is_ok() {
-                            self.status = Err(e.into());
-                        }
-                        ResolvedItemName::Error
-                    }
-                }
-            }
+            name @ RawItemName::Name(..) => self.fold_raw_object_name_name_internal(name, false),
             RawItemName::Id(id, raw_name) => {
                 let gid: GlobalId = match id.parse() {
                     Ok(id) => id,
@@ -1481,6 +1505,204 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
             UnresolvedObjectName::Item(name) => {
                 ResolvedObjectName::Item(self.fold_item_name(RawItemName::Name(name)))
             }
+        }
+    }
+
+    fn fold_expr(&mut self, node: mz_sql_parser::ast::Expr<Raw>) -> mz_sql_parser::ast::Expr<Aug> {
+        use mz_sql_parser::ast::Expr::*;
+        match node {
+            mz_sql_parser::ast::Expr::Identifier(i) => {
+                Identifier(i.into_iter().map(|i| self.fold_ident(i)).collect())
+            }
+            mz_sql_parser::ast::Expr::QualifiedWildcard(i) => {
+                QualifiedWildcard(i.into_iter().map(|i| self.fold_ident(i)).collect())
+            }
+            mz_sql_parser::ast::Expr::FieldAccess { expr, field } => FieldAccess {
+                expr: Box::new(self.fold_expr(*expr)),
+                field: self.fold_ident(field),
+            },
+            mz_sql_parser::ast::Expr::WildcardAccess(expr) => {
+                WildcardAccess(Box::new(self.fold_expr(*expr)))
+            }
+            mz_sql_parser::ast::Expr::Parameter(p) => Parameter(p),
+            mz_sql_parser::ast::Expr::Not { expr } => Not {
+                expr: Box::new(self.fold_expr(*expr)),
+            },
+            mz_sql_parser::ast::Expr::And { left, right } => And {
+                left: Box::new(self.fold_expr(*left)),
+                right: Box::new(self.fold_expr(*right)),
+            },
+            mz_sql_parser::ast::Expr::Or { left, right } => Or {
+                left: Box::new(self.fold_expr(*left)),
+                right: Box::new(self.fold_expr(*right)),
+            },
+            mz_sql_parser::ast::Expr::IsExpr {
+                expr,
+                construct,
+                negated,
+            } => IsExpr {
+                expr: Box::new(self.fold_expr(*expr)),
+                construct: self.fold_is_expr_construct(construct),
+                negated,
+            },
+            mz_sql_parser::ast::Expr::InList {
+                expr,
+                list,
+                negated,
+            } => InList {
+                expr: Box::new(self.fold_expr(*expr)),
+                list: list.into_iter().map(|l| self.fold_expr(l)).collect(),
+                negated,
+            },
+            mz_sql_parser::ast::Expr::InSubquery {
+                expr,
+                subquery,
+                negated,
+            } => InSubquery {
+                expr: Box::new(self.fold_expr(*expr)),
+                subquery: Box::new(self.fold_query(*subquery)),
+                negated,
+            },
+            mz_sql_parser::ast::Expr::Like {
+                expr,
+                pattern,
+                escape,
+                case_insensitive,
+                negated,
+            } => Like {
+                expr: Box::new(self.fold_expr(*expr)),
+                pattern: Box::new(self.fold_expr(*pattern)),
+                escape: escape.map(|expr| Box::new(self.fold_expr(*expr))),
+                case_insensitive,
+                negated,
+            },
+            mz_sql_parser::ast::Expr::Between {
+                expr,
+                negated,
+                low,
+                high,
+            } => Between {
+                expr: Box::new(self.fold_expr(*expr)),
+                negated,
+                low: Box::new(self.fold_expr(*low)),
+                high: Box::new(self.fold_expr(*high)),
+            },
+            mz_sql_parser::ast::Expr::Op { op, expr1, expr2 } => Op {
+                op: self.fold_op(op),
+                expr1: Box::new(self.fold_expr(*expr1)),
+                expr2: expr2.map(|expr2| Box::new(self.fold_expr(*expr2))),
+            },
+            mz_sql_parser::ast::Expr::Cast { expr, data_type } => Cast {
+                expr: Box::new(self.fold_expr(*expr)),
+                data_type: self.fold_data_type(data_type),
+            },
+            mz_sql_parser::ast::Expr::Collate { expr, collation } => Collate {
+                expr: Box::new(self.fold_expr(*expr)),
+                collation: self.fold_unresolved_item_name(collation),
+            },
+            mz_sql_parser::ast::Expr::HomogenizingFunction { function, exprs } => {
+                HomogenizingFunction {
+                    function: self.fold_homogenizing_function(function),
+                    exprs: exprs.into_iter().map(|expr| self.fold_expr(expr)).collect(),
+                }
+            }
+            mz_sql_parser::ast::Expr::NullIf { l_expr, r_expr } => NullIf {
+                l_expr: Box::new(self.fold_expr(*l_expr)),
+                r_expr: Box::new(self.fold_expr(*r_expr)),
+            },
+            mz_sql_parser::ast::Expr::Nested(expr) => Nested(Box::new(self.fold_expr(*expr))),
+            mz_sql_parser::ast::Expr::Row { exprs } => Row {
+                exprs: exprs.into_iter().map(|expr| self.fold_expr(expr)).collect(),
+            },
+            mz_sql_parser::ast::Expr::Value(value) => Value(self.fold_value(value)),
+            mz_sql_parser::ast::Expr::Function(mz_sql_parser::ast::Function {
+                name,
+                args,
+                filter,
+                over,
+                distinct,
+            }) => Function(mz_sql_parser::ast::Function {
+                name: match name {
+                    name @ RawItemName::Name(..) => {
+                        self.fold_raw_object_name_name_internal(name, true)
+                    }
+                    _ => self.fold_item_name(name),
+                },
+                args: self.fold_function_args(args),
+                filter: filter.map(|expr| Box::new(self.fold_expr(*expr))),
+                over: over.map(|over| self.fold_window_spec(over)),
+                distinct,
+            }),
+            mz_sql_parser::ast::Expr::Case {
+                operand,
+                conditions,
+                results,
+                else_result,
+            } => Case {
+                operand: operand.map(|expr| Box::new(self.fold_expr(*expr))),
+                conditions: conditions
+                    .into_iter()
+                    .map(|expr| self.fold_expr(expr))
+                    .collect(),
+                results: results
+                    .into_iter()
+                    .map(|expr| self.fold_expr(expr))
+                    .collect(),
+                else_result: else_result.map(|expr| Box::new(self.fold_expr(*expr))),
+            },
+            mz_sql_parser::ast::Expr::Exists(query) => Exists(Box::new(self.fold_query(*query))),
+            mz_sql_parser::ast::Expr::Subquery(subquery) => {
+                Subquery(Box::new(self.fold_query(*subquery)))
+            }
+            mz_sql_parser::ast::Expr::AnySubquery { left, op, right } => AnySubquery {
+                left: Box::new(self.fold_expr(*left)),
+                op: self.fold_op(op),
+                right: Box::new(self.fold_query(*right)),
+            },
+            mz_sql_parser::ast::Expr::AnyExpr { left, op, right } => AnyExpr {
+                left: Box::new(self.fold_expr(*left)),
+                op: self.fold_op(op),
+                right: Box::new(self.fold_expr(*right)),
+            },
+            mz_sql_parser::ast::Expr::AllSubquery { left, op, right } => AllSubquery {
+                left: Box::new(self.fold_expr(*left)),
+                op: self.fold_op(op),
+                right: Box::new(self.fold_query(*right)),
+            },
+            mz_sql_parser::ast::Expr::AllExpr { left, op, right } => AllExpr {
+                left: Box::new(self.fold_expr(*left)),
+                op: self.fold_op(op),
+                right: Box::new(self.fold_expr(*right)),
+            },
+            mz_sql_parser::ast::Expr::Array(exprs) => {
+                Array(exprs.into_iter().map(|expr| self.fold_expr(expr)).collect())
+            }
+            mz_sql_parser::ast::Expr::ArraySubquery(subquery) => {
+                ArraySubquery(Box::new(self.fold_query(*subquery)))
+            }
+            mz_sql_parser::ast::Expr::List(exprs) => {
+                List(exprs.into_iter().map(|expr| self.fold_expr(expr)).collect())
+            }
+            mz_sql_parser::ast::Expr::ListSubquery(subquery) => {
+                ListSubquery(Box::new(self.fold_query(*subquery)))
+            }
+            mz_sql_parser::ast::Expr::Subscript { expr, positions } => Subscript {
+                expr: Box::new(self.fold_expr(*expr)),
+                positions: positions
+                    .into_iter()
+                    .map(|p| self.fold_subscript_position(p))
+                    .collect(),
+            },
+        }
+    }
+
+    fn fold_table_function(
+        &mut self,
+        node: mz_sql_parser::ast::TableFunction<Raw>,
+    ) -> mz_sql_parser::ast::TableFunction<Aug> {
+        mz_sql_parser::ast::TableFunction {
+            name: self.fold_raw_object_name_name_internal(node.name, true),
+            args: self.fold_function_args(node.args),
         }
     }
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1118,7 +1118,8 @@ impl<'a> NameResolver<'a> {
                     }
                 }
             }
-            _ => unreachable!(),
+            // We don't want to hit this code path, but immaterial if we do
+            name @ RawItemName::Id(..) => self.fold_item_name(name),
         }
     }
 }
@@ -1701,7 +1702,10 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
         node: mz_sql_parser::ast::TableFunction<Raw>,
     ) -> mz_sql_parser::ast::TableFunction<Aug> {
         mz_sql_parser::ast::TableFunction {
-            name: self.fold_raw_object_name_name_internal(node.name, true),
+            name: match &node.name {
+                RawItemName::Name(..) => self.fold_raw_object_name_name_internal(node.name, true),
+                RawItemName::Id(..) => self.fold_item_name(node.name),
+            },
             args: self.fold_function_args(node.args),
         }
     }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1734,7 +1734,13 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
     ) -> mz_sql_parser::ast::TableFunction<Aug> {
         mz_sql_parser::ast::TableFunction {
             name: match &node.name {
-                RawItemName::Name(..) => self.fold_raw_object_name_name_internal(node.name, true),
+                RawItemName::Name(name) => {
+                    if *name == UnresolvedItemName::unqualified("values") && self.status.is_ok() {
+                        self.status = Err(PlanError::FromValueRequiresParen);
+                    }
+
+                    self.fold_raw_object_name_name_internal(node.name, true)
+                }
                 RawItemName::Id(..) => self.fold_item_name(node.name),
             },
             args: self.fold_function_args(node.args),

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -90,7 +90,8 @@ pub fn unresolved_schema_name(
 /// Qualified operators outside of the pg_catalog schema are rejected.
 pub fn op(op: &Op) -> Result<&str, PlanError> {
     if !op.namespace.is_empty()
-        && (op.namespace.len() != 1 || op.namespace[0].as_str() != "pg_catalog")
+        && (op.namespace.len() != 1
+            || op.namespace[0].as_str() != mz_repr::namespaces::PG_CATALOG_SCHEMA)
     {
         sql_bail!(
             "operator does not exist: {}.{}",

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -180,32 +180,21 @@ pub fn create_statement(
         )))
     };
 
-    fn normalize_function_name(
-        scx: &StatementContext,
-        name: &mut UnresolvedItemName,
-    ) -> Result<(), PlanError> {
-        let item = scx.resolve_function(name.clone())?;
-        *name = unresolve(scx.catalog.resolve_full_name(item.name()));
-        Ok(())
-    }
-
-    struct QueryNormalizer<'a> {
-        scx: &'a StatementContext<'a>,
+    struct QueryNormalizer {
         ctes: Vec<Ident>,
         err: Option<PlanError>,
     }
 
-    impl<'a> QueryNormalizer<'a> {
-        fn new(scx: &'a StatementContext<'a>) -> QueryNormalizer<'a> {
+    impl QueryNormalizer {
+        fn new() -> QueryNormalizer {
             QueryNormalizer {
-                scx,
                 ctes: vec![],
                 err: None,
             }
         }
     }
 
-    impl<'a, 'ast> VisitMut<'ast, Aug> for QueryNormalizer<'a> {
+    impl<'ast> VisitMut<'ast, Aug> for QueryNormalizer {
         fn visit_query_mut(&mut self, query: &'ast mut Query<Aug>) {
             let n = self.ctes.len();
             match &query.ctes {
@@ -225,11 +214,6 @@ pub fn create_statement(
         }
 
         fn visit_function_mut(&mut self, func: &'ast mut Function<Aug>) {
-            if let Err(e) = normalize_function_name(self.scx, &mut func.name) {
-                self.err = Some(e);
-                return;
-            }
-
             match &mut func.args {
                 FunctionArgs::Star => (),
                 FunctionArgs::Args { args, order_by } => {
@@ -247,11 +231,6 @@ pub fn create_statement(
         }
 
         fn visit_table_function_mut(&mut self, func: &'ast mut TableFunction<Aug>) {
-            if let Err(e) = normalize_function_name(self.scx, &mut func.name) {
-                self.err = Some(e);
-                return;
-            }
-
             match &mut func.args {
                 FunctionArgs::Star => (),
                 FunctionArgs::Args { args, order_by } => {
@@ -317,7 +296,7 @@ pub fn create_statement(
             with_options: _,
         }) => {
             *name = allocate_name(name)?;
-            let mut normalizer = QueryNormalizer::new(scx);
+            let mut normalizer = QueryNormalizer::new();
             for c in columns {
                 normalizer.visit_column_def_mut(c);
             }
@@ -339,7 +318,7 @@ pub fn create_statement(
             } else {
                 allocate_name(name)?
             };
-            let mut normalizer = QueryNormalizer::new(scx);
+            let mut normalizer = QueryNormalizer::new();
             for c in columns {
                 normalizer.visit_column_def_mut(c);
             }
@@ -378,7 +357,7 @@ pub fn create_statement(
                 allocate_name(name)?
             };
             {
-                let mut normalizer = QueryNormalizer::new(scx);
+                let mut normalizer = QueryNormalizer::new();
                 normalizer.visit_query_mut(query);
                 if let Some(err) = normalizer.err {
                     return Err(err);
@@ -396,7 +375,7 @@ pub fn create_statement(
         }) => {
             *name = allocate_name(name)?;
             {
-                let mut normalizer = QueryNormalizer::new(scx);
+                let mut normalizer = QueryNormalizer::new();
                 normalizer.visit_query_mut(query);
                 if let Some(err) = normalizer.err {
                     return Err(err);
@@ -413,7 +392,7 @@ pub fn create_statement(
             if_not_exists,
             ..
         }) => {
-            let mut normalizer = QueryNormalizer::new(scx);
+            let mut normalizer = QueryNormalizer::new();
             if let Some(key_parts) = key_parts {
                 for key_part in key_parts {
                     normalizer.visit_expr_mut(key_part);
@@ -427,7 +406,7 @@ pub fn create_statement(
 
         Statement::CreateType(CreateTypeStatement { name, as_type }) => {
             *name = allocate_name(name)?;
-            let mut normalizer = QueryNormalizer::new(scx);
+            let mut normalizer = QueryNormalizer::new();
             normalizer.visit_create_type_as_mut(as_type);
             if let Some(err) = normalizer.err {
                 return Err(err);

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -277,6 +277,7 @@ impl PlanError {
             Self::InvalidOrderByInSubscribeWithinTimestampOrderBy => {
                 Some("All order bys must be output columns.".into())
             }
+            Self::Catalog(e) => e.hint(),
             _ => None,
         }
     }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -181,6 +181,7 @@ pub enum PlanError {
     InvalidKeysInSubscribeEnvelopeUpsert,
     InvalidKeysInSubscribeEnvelopeDebezium,
     InvalidOrderByInSubscribeWithinTimestampOrderBy,
+    FromValueRequiresParen,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -469,6 +470,9 @@ impl fmt::Display for PlanError {
             Self::InvalidOrderByInSubscribeWithinTimestampOrderBy => {
                 write!(f, "invalid ORDER BY in SUBSCRIBE WITHIN TIMESTAMP ORDER BY")
             }
+            Self::FromValueRequiresParen => f.write_str(
+                "VALUES expression in FROM clause must be surrounded by parentheses"
+            ),
         }
     }
 }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -144,7 +144,6 @@ pub enum PlanError {
     UnknownFunction {
         name: String,
         arg_types: Vec<String>,
-        alternative_hint: Option<String>,
     },
     IndistinctFunction {
         name: String,
@@ -252,12 +251,7 @@ impl PlanError {
                 None
             }
             Self::InvalidOptionValue { err, .. } => err.hint(),
-            Self::UnknownFunction { alternative_hint, ..} => {
-                match alternative_hint {
-                    Some(_) => alternative_hint.clone(),
-                    None => Some("No function matches the given name and argument types. You might need to add explicit type casts.".into()),
-                }
-            }
+            Self::UnknownFunction { ..} => Some("No function matches the given name and argument types. You might need to add explicit type casts.".into()),
             Self::IndistinctFunction {..} => {
                 Some("Could not choose a best candidate function. You might need to add explicit type casts.".into())
             }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4234,7 +4234,10 @@ fn plan_aggregate(
             if args.is_empty() {
                 sql_bail!(
                     "{}(*) must be used to call a parameterless aggregate function",
-                    name
+                    ecx.qcx
+                        .scx
+                        .humanize_resolved_name(name)
+                        .expect("name actually resolved")
                 );
             }
             let args = plan_exprs(ecx, args)?;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2778,7 +2778,10 @@ fn invent_column_name(
                         .qcx
                         .scx
                         .catalog
-                        .resolve_schema(Some("materialize"), "mz_internal")
+                        .resolve_schema(
+                            Some("materialize"),
+                            mz_repr::namespaces::MZ_INTERNAL_SCHEMA,
+                        )
                         .expect("mz_internal schema must exist")
                         .id()
                 {
@@ -3954,7 +3957,7 @@ fn plan_collate(
     collation: &UnresolvedItemName,
 ) -> Result<CoercibleScalarExpr, PlanError> {
     if collation.0.len() == 2
-        && collation.0[0] == Ident::new("pg_catalog")
+        && collation.0[0] == Ident::new(mz_repr::namespaces::PG_CATALOG_SCHEMA)
         && collation.0[1] == Ident::new("default")
     {
         plan_expr(ecx, expr)

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2588,12 +2588,6 @@ fn plan_table_function_internal(
     with_ordinality: bool,
     table_name: Option<FullItemName>,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
-    // if *name == UnresolvedItemName::unqualified("values") {
-    //     // Produce a nice error message for the common typo
-    //     // `SELECT * FROM VALUES (1)`.
-    //     sql_bail!("VALUES expression in FROM clause must be surrounded by parentheses");
-    // }
-
     let ecx = &ExprContext {
         qcx,
         name: "table function arguments",

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4480,25 +4480,40 @@ fn plan_function<'a>(
     if *distinct {
         sql_bail!(
             "DISTINCT specified, but {} is not an aggregate function",
-            name
+            ecx.qcx
+                .scx
+                .humanize_resolved_name(name)
+                .expect("already resolved")
         );
     }
     if filter.is_some() {
         sql_bail!(
             "FILTER specified, but {} is not an aggregate function",
-            name
+            ecx.qcx
+                .scx
+                .humanize_resolved_name(name)
+                .expect("already resolved")
         );
     }
 
     let scalar_args = match &args {
         FunctionArgs::Star => {
-            sql_bail!("* argument is invalid with non-aggregate function {}", name)
+            sql_bail!(
+                "* argument is invalid with non-aggregate function {}",
+                ecx.qcx
+                    .scx
+                    .humanize_resolved_name(name)
+                    .expect("already resolved")
+            )
         }
         FunctionArgs::Args { args, order_by } => {
             if !order_by.is_empty() {
                 sql_bail!(
                     "ORDER BY specified, but {} is not an aggregate function",
-                    name
+                    ecx.qcx
+                        .scx
+                        .humanize_resolved_name(name)
+                        .expect("already resolved")
                 );
             }
             plan_exprs(ecx, args)?

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -69,7 +69,7 @@ use mz_sql_parser::ast::{
 
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
-use crate::names::{Aug, PartialItemName, ResolvedDataType, ResolvedItemName};
+use crate::names::{Aug, FullItemName, PartialItemName, ResolvedDataType, ResolvedItemName};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
@@ -2094,7 +2094,10 @@ fn plan_scalar_table_funcs(
     let rows_from_qcx = qcx.derived_context(from_scope.clone(), qcx.relation_type(relation_expr));
 
     for (table_func, id) in table_funcs.iter() {
-        table_func_names.insert(id.clone(), table_func.name.0.last().unwrap().clone());
+        table_func_names.insert(
+            id.clone(),
+            table_func.name.full_item_name().item.clone().into(),
+        );
     }
     // If there's only a single table function, we can skip generating
     // ordinality columns.
@@ -2408,8 +2411,11 @@ fn plan_rows_from(
     // Per PostgreSQL, all scope items take the name of the first function
     // (unless aliased).
     // See: https://github.com/postgres/postgres/blob/639a86e36/src/backend/parser/parse_relation.c#L1701-L1705
-    let (expr, mut scope, num_cols) =
-        plan_rows_from_internal(qcx, functions, Some(&functions[0].name))?;
+    let (expr, mut scope, num_cols) = plan_rows_from_internal(
+        qcx,
+        functions,
+        Some(functions[0].name.full_item_name().clone()),
+    )?;
 
     // Columns tracks the set of columns we will keep in the projection.
     let mut columns = Vec::new();
@@ -2465,7 +2471,7 @@ fn plan_rows_from(
 fn plan_rows_from_internal<'a>(
     qcx: &QueryContext,
     functions: impl IntoIterator<Item = &'a TableFunction<Aug>>,
-    table_name: Option<&UnresolvedItemName>,
+    table_name: Option<FullItemName>,
 ) -> Result<(HirRelationExpr, Scope, Vec<usize>), PlanError> {
     let mut functions = functions.into_iter();
     let mut num_cols = Vec::new();
@@ -2474,7 +2480,7 @@ fn plan_rows_from_internal<'a>(
     // always the column to join against and is maintained to be the coalescence
     // of the row number column for all prior functions.
     let (mut left_expr, mut left_scope) =
-        plan_table_function_internal(qcx, functions.next().unwrap(), true, table_name)?;
+        plan_table_function_internal(qcx, functions.next().unwrap(), true, table_name.clone())?;
     num_cols.push(left_scope.len() - 1);
     // Create the coalesced ordinality column.
     left_expr = left_expr.map(vec![HirScalarExpr::column(left_scope.len() - 1)]);
@@ -2486,7 +2492,7 @@ fn plan_rows_from_internal<'a>(
         // The right hand side of a join must be planned in a new scope.
         let qcx = qcx.empty_derived_context();
         let (right_expr, mut right_scope) =
-            plan_table_function_internal(&qcx, function, true, table_name)?;
+            plan_table_function_internal(&qcx, function, true, table_name.clone())?;
         num_cols.push(right_scope.len() - 1);
         let left_col = left_scope.len() - 1;
         let right_col = left_scope.len() + right_scope.len() - 1;
@@ -2580,13 +2586,13 @@ fn plan_table_function_internal(
     qcx: &QueryContext,
     TableFunction { name, args }: &TableFunction<Aug>,
     with_ordinality: bool,
-    table_name: Option<&UnresolvedItemName>,
+    table_name: Option<FullItemName>,
 ) -> Result<(HirRelationExpr, Scope), PlanError> {
-    if *name == UnresolvedItemName::unqualified("values") {
-        // Produce a nice error message for the common typo
-        // `SELECT * FROM VALUES (1)`.
-        sql_bail!("VALUES expression in FROM clause must be surrounded by parentheses");
-    }
+    // if *name == UnresolvedItemName::unqualified("values") {
+    //     // Produce a nice error message for the common typo
+    //     // `SELECT * FROM VALUES (1)`.
+    //     sql_bail!("VALUES expression in FROM clause must be surrounded by parentheses");
+    // }
 
     let ecx = &ExprContext {
         qcx,
@@ -2610,11 +2616,12 @@ fn plan_table_function_internal(
             plan_exprs(ecx, args)?
         }
     };
-    let resolved_name = normalize::unresolved_item_name(name.clone())?;
+
     let table_name = match table_name {
-        Some(table_name) => normalize::unresolved_item_name(table_name.clone())?.item,
-        None => resolved_name.item.clone(),
+        Some(table_name) => table_name.item,
+        None => name.full_item_name().item.clone(),
     };
+
     let scope_name = Some(PartialItemName {
         database: None,
         schema: None,
@@ -2623,13 +2630,7 @@ fn plan_table_function_internal(
 
     let (mut expr, mut scope) = match resolve_func(ecx, name, args)? {
         Func::Table(impls) => {
-            let tf = func::select_impl(
-                ecx,
-                FuncSpec::Func(&resolved_name),
-                impls,
-                scalar_args,
-                vec![],
-            )?;
+            let tf = func::select_impl(ecx, FuncSpec::Func(name), impls, scalar_args, vec![])?;
             let scope = Scope::from_source(scope_name.clone(), tf.column_names);
             (tf.expr, scope)
         }
@@ -2769,11 +2770,27 @@ fn invent_column_name(
                 _ => None,
             },
             Expr::Function(func) => {
-                let name = normalize::unresolved_item_name(func.name.clone()).ok()?;
-                if name.schema.as_deref() == Some("mz_internal") {
+                let (schema, item) = match &func.name {
+                    ResolvedItemName::Item {
+                        qualifiers,
+                        full_name,
+                        ..
+                    } => (&qualifiers.schema_spec, full_name.item.clone()),
+                    _ => unreachable!(),
+                };
+
+                if schema
+                    == ecx
+                        .qcx
+                        .scx
+                        .catalog
+                        .resolve_schema(Some("materialize"), "mz_internal")
+                        .expect("mz_internal schema must exist")
+                        .id()
+                {
                     None
                 } else {
-                    Some((name.item.into(), NameQuality::High))
+                    Some((item.into(), NameQuality::High))
                 }
             }
             Expr::HomogenizingFunction { function, .. } => Some((
@@ -4203,8 +4220,6 @@ fn plan_aggregate(
         bail_unsupported!("aggregate window functions");
     }
 
-    let name = normalize::unresolved_item_name(name.clone())?;
-
     // We follow PostgreSQL's rule here for mapping `count(*)` into the
     // generalized function selection framework. The rule is simple: the user
     // must type `count(*)`, but the function selection framework sees an empty
@@ -4229,7 +4244,7 @@ fn plan_aggregate(
 
     let (order_by_exprs, col_orders) = plan_function_order_by(ecx, &order_by)?;
 
-    let (mut expr, func) = func::select_impl(ecx, FuncSpec::Func(&name), impls, args, col_orders)?;
+    let (mut expr, func) = func::select_impl(ecx, FuncSpec::Func(name), impls, args, col_orders)?;
     if let Some(filter) = &filter {
         // If a filter is present, as in
         //
@@ -4394,8 +4409,6 @@ fn plan_function<'a>(
         distinct,
     }: &'a Function<Aug>,
 ) -> Result<HirScalarExpr, PlanError> {
-    let unresolved_name = normalize::unresolved_item_name(name.clone())?;
-
     let impls = match resolve_func(ecx, name, args)? {
         Func::Aggregate(_) if ecx.allow_aggregates => {
             // should already have been caught by `scope.resolve_expr` in `plan_expr`
@@ -4408,27 +4421,21 @@ fn plan_function<'a>(
             sql_bail!(
                 "aggregate functions are not allowed in {} (function {})",
                 ecx.name,
-                unresolved_name
+                name
             );
         }
         Func::Table(_) => {
             sql_bail!(
                 "table functions are not allowed in {} (function {})",
                 ecx.name,
-                unresolved_name
+                name
             );
         }
         Func::Scalar(impls) => impls,
         Func::ScalarWindow(impls) => {
             let (window_spec, _, scalar_args, partition) = validate_window_function_plan(ecx, f)?;
 
-            let func = func::select_impl(
-                ecx,
-                FuncSpec::Func(&unresolved_name),
-                impls,
-                scalar_args,
-                vec![],
-            )?;
+            let func = func::select_impl(ecx, FuncSpec::Func(name), impls, scalar_args, vec![])?;
 
             let (order_by, col_orders) = plan_function_order_by(ecx, &window_spec.order_by)?;
 
@@ -4445,13 +4452,8 @@ fn plan_function<'a>(
             let (window_spec, window_frame, scalar_args, partition) =
                 validate_window_function_plan(ecx, f)?;
 
-            let (expr, func) = func::select_impl(
-                ecx,
-                FuncSpec::Func(&unresolved_name),
-                impls,
-                scalar_args,
-                vec![],
-            )?;
+            let (expr, func) =
+                func::select_impl(ecx, FuncSpec::Func(name), impls, scalar_args, vec![])?;
 
             let (order_by, col_orders) = plan_function_order_by(ecx, &window_spec.order_by)?;
 
@@ -4500,13 +4502,7 @@ fn plan_function<'a>(
         }
     };
 
-    func::select_impl(
-        ecx,
-        FuncSpec::Func(&unresolved_name),
-        impls,
-        scalar_args,
-        vec![],
-    )
+    func::select_impl(ecx, FuncSpec::Func(name), impls, scalar_args, vec![])
 }
 
 /// Resolves the name to a set of function implementations.
@@ -4514,10 +4510,10 @@ fn plan_function<'a>(
 /// If the name does not specify a known built-in function, returns an error.
 pub fn resolve_func(
     ecx: &ExprContext,
-    name: &UnresolvedItemName,
+    name: &ResolvedItemName,
     args: &mz_sql_parser::ast::FunctionArgs<Aug>,
 ) -> Result<&'static Func, PlanError> {
-    if let Ok(i) = ecx.qcx.scx.resolve_function(name.clone()) {
+    if let Ok(i) = ecx.qcx.scx.get_item_by_resolved_name(name) {
         if let Ok(f) = i.func() {
             return Ok(f);
         }
@@ -4546,24 +4542,9 @@ pub fn resolve_func(
         })
         .collect();
 
-    // Suggest using the `jsonb_` version of `json_` functions if they exist.
-    let alternative_hint = match name.0.split_last() {
-        Some((i, q)) if i.as_str().starts_with("json_") => {
-            let mut jsonb_version = q.to_vec();
-            jsonb_version.push(Ident::new(i.as_str().replace("json_", "jsonb_")));
-            let jsonb_version = UnresolvedItemName(jsonb_version);
-            match resolve_func(ecx, &jsonb_version, args) {
-                Ok(_) => Some(format!("Try using {}", jsonb_version)),
-                Err(_) => None,
-            }
-        }
-        _ => None,
-    };
-
     Err(PlanError::UnknownFunction {
         name: name.to_string(),
         arg_types,
-        alternative_hint,
     })
 }
 
@@ -5103,7 +5084,7 @@ impl<'a> AggregateTableFuncVisitor<'a> {
 
 impl<'a> VisitMut<'_, Aug> for AggregateTableFuncVisitor<'a> {
     fn visit_function_mut(&mut self, func: &mut Function<Aug>) {
-        let item = match self.scx.resolve_function(func.name.clone()) {
+        let item = match self.scx.get_item_by_resolved_name(&func.name) {
             Ok(i) => i,
             // Catching missing functions later in planning improves error messages.
             Err(_) => return,
@@ -5160,7 +5141,7 @@ impl<'a> VisitMut<'_, Aug> for AggregateTableFuncVisitor<'a> {
                 // If we're in a SELECT list, replace table functions with a uuid identifier
                 // and save the table func so it can be planned elsewhere.
                 let mut table_func = None;
-                if let Ok(item) = self.scx.resolve_function(func.name.clone()) {
+                if let Ok(item) = self.scx.get_item_by_resolved_name(&func.name) {
                     if let Ok(Func::Table { .. }) = item.func() {
                         if let Some(context) = self.table_disallowed_context.last() {
                             self.err = Some(sql_err!(

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -506,7 +506,9 @@ impl<'a> StatementContext<'a> {
     pub fn allocate_temporary_full_name(&self, name: PartialItemName) -> FullItemName {
         FullItemName {
             database: RawDatabaseSpecifier::Ambient,
-            schema: name.schema.unwrap_or_else(|| "mz_temp".to_owned()),
+            schema: name
+                .schema
+                .unwrap_or_else(|| mz_repr::namespaces::MZ_TEMP_SCHEMA.to_owned()),
             item: name.item,
         }
     }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -905,4 +905,27 @@ impl<'a> StatementContext<'a> {
     pub fn get_owner_id(&self, id: &ObjectId) -> Option<RoleId> {
         self.catalog.get_owner_id(id)
     }
+
+    /// WARNING! This style of name resolution assumes the referred-to objects exists (i.e. panics
+    /// if objects do not exist) so should never be used to handle user input.
+    pub fn dangerous_resolve_name(&self, name: Vec<&str>) -> ResolvedItemName {
+        tracing::trace!("dangerous_resolve_name {:?}", name);
+        let name = UnresolvedItemName::qualified(&name);
+        let entry = match self.resolve_item(RawItemName::Name(name.clone())) {
+            Ok(entry) => entry,
+            Err(_) => self
+                .resolve_function(name.clone())
+                .expect("name referred to an existing object"),
+        };
+
+        let partial = normalize::unresolved_item_name(name).unwrap();
+        let full_name = self.allocate_full_name(partial).unwrap();
+
+        ResolvedItemName::Item {
+            id: entry.id(),
+            qualifiers: entry.name().qualifiers.clone(),
+            full_name,
+            print_id: true,
+        }
+    }
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -906,6 +906,14 @@ impl<'a> StatementContext<'a> {
         self.catalog.get_owner_id(id)
     }
 
+    pub fn humanize_resolved_name(
+        &self,
+        name: &ResolvedItemName,
+    ) -> Result<PartialItemName, PlanError> {
+        let item = self.get_item_by_resolved_name(name)?;
+        Ok(self.catalog.minimal_qualification(item.name()))
+    }
+
     /// WARNING! This style of name resolution assumes the referred-to objects exists (i.e. panics
     /// if objects do not exist) so should never be used to handle user input.
     pub fn dangerous_resolve_name(&self, name: Vec<&str>) -> ResolvedItemName {

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -16,6 +16,7 @@
 use uuid::Uuid;
 
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
+use mz_repr::namespaces::PG_CATALOG_SCHEMA;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut, VisitMutNode};
 use mz_sql_parser::ast::{
     Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Select, SelectItem, TableAlias,
@@ -298,7 +299,7 @@ impl<'a> FuncRewriter<'a> {
                             != self
                                 .scx
                                 .catalog
-                                .resolve_schema(None, "pg_catalog")
+                                .resolve_schema(None, PG_CATALOG_SCHEMA)
                                 .expect("pg_catalog schema exists")
                                 .id()
                         {

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -19,10 +19,10 @@ use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_sql_parser::ast::visit_mut::{self, VisitMut, VisitMutNode};
 use mz_sql_parser::ast::{
     Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Select, SelectItem, TableAlias,
-    TableFactor, TableFunction, TableWithJoins, UnresolvedItemName, Value,
+    TableFactor, TableFunction, TableWithJoins, Value,
 };
 
-use crate::names::{Aug, PartialItemName, ResolvedDataType};
+use crate::names::{Aug, PartialItemName, ResolvedDataType, ResolvedItemName};
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
 
@@ -34,7 +34,7 @@ where
     node.visit_mut(&mut func_rewriter);
     func_rewriter.status?;
 
-    let mut desugarer = Desugarer::new();
+    let mut desugarer = Desugarer::new(scx);
     node.visit_mut(&mut desugarer);
     desugarer.status
 }
@@ -108,7 +108,8 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn plan_agg(
-        name: UnresolvedItemName,
+        &self,
+        name: ResolvedItemName,
         expr: Expr<Aug>,
         order_by: Vec<OrderByExpr<Aug>>,
         filter: Option<Box<Expr<Aug>>>,
@@ -126,17 +127,26 @@ impl<'a> FuncRewriter<'a> {
         })
     }
 
-    fn plan_avg(expr: Expr<Aug>, filter: Option<Box<Expr<Aug>>>, distinct: bool) -> Expr<Aug> {
-        let sum = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
-            expr.clone(),
-            vec![],
-            filter.clone(),
-            distinct,
-        )
-        .call_unary(vec!["mz_internal", "mz_avg_promotion"]);
-        let count = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "count"]),
+    fn plan_avg(
+        &self,
+        expr: Expr<Aug>,
+        filter: Option<Box<Expr<Aug>>>,
+        distinct: bool,
+    ) -> Expr<Aug> {
+        let sum = self
+            .plan_agg(
+                self.scx.dangerous_resolve_name(vec!["pg_catalog", "sum"]),
+                expr.clone(),
+                vec![],
+                filter.clone(),
+                distinct,
+            )
+            .call_unary(
+                self.scx
+                    .dangerous_resolve_name(vec!["mz_internal", "mz_avg_promotion"]),
+            );
+        let count = self.plan_agg(
+            self.scx.dangerous_resolve_name(vec!["pg_catalog", "count"]),
             expr,
             vec![],
             filter,
@@ -146,6 +156,7 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn plan_variance(
+        &self,
         expr: Expr<Aug>,
         filter: Option<Box<Expr<Aug>>>,
         distinct: bool,
@@ -165,25 +176,28 @@ impl<'a> FuncRewriter<'a> {
         //
         //     (sum(x²) - sum(x)² / count(x)) / count(x)
         //
-        let expr = expr.call_unary(vec!["mz_internal", "mz_avg_promotion"]);
+        let expr = expr.call_unary(
+            self.scx
+                .dangerous_resolve_name(vec!["mz_internal", "mz_avg_promotion"]),
+        );
         let expr_squared = expr.clone().multiply(expr.clone());
-        let sum_squares = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
+        let sum_squares = self.plan_agg(
+            self.scx.dangerous_resolve_name(vec!["pg_catalog", "sum"]),
             expr_squared,
             vec![],
             filter.clone(),
             distinct,
         );
-        let sum = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
+        let sum = self.plan_agg(
+            self.scx.dangerous_resolve_name(vec!["pg_catalog", "sum"]),
             expr.clone(),
             vec![],
             filter.clone(),
             distinct,
         );
         let sum_squared = sum.clone().multiply(sum);
-        let count = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "count"]),
+        let count = self.plan_agg(
+            self.scx.dangerous_resolve_name(vec!["pg_catalog", "count"]),
             expr,
             vec![],
             filter,
@@ -200,12 +214,14 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn plan_stddev(
+        &self,
         expr: Expr<Aug>,
         filter: Option<Box<Expr<Aug>>>,
         distinct: bool,
         sample: bool,
     ) -> Expr<Aug> {
-        Self::plan_variance(expr, filter, distinct, sample).call_unary(vec!["sqrt"])
+        self.plan_variance(expr, filter, distinct, sample)
+            .call_unary(self.scx.dangerous_resolve_name(vec!["pg_catalog", "sqrt"]))
     }
 
     fn plan_bool_and(
@@ -225,8 +241,8 @@ impl<'a> FuncRewriter<'a> {
         // to `bool`. We intentionally do not write `NOT x::bool`, because that
         // would perform an explicit cast, and to match PostgreSQL we must
         // perform only an implicit cast.
-        let sum = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
+        let sum = self.plan_agg(
+            self.scx.dangerous_resolve_name(vec!["pg_catalog", "sum"]),
             expr.negate().cast(self.int32_data_type()),
             vec![],
             filter,
@@ -241,7 +257,7 @@ impl<'a> FuncRewriter<'a> {
         filter: Option<Box<Expr<Aug>>>,
         distinct: bool,
     ) -> Expr<Aug> {
-        // The code below converts `bool_or(x)` into:
+        // The code below converts `bool_or(x)`z into:
         //
         //     sum((x OR false)::int4) > 0
         //
@@ -252,8 +268,8 @@ impl<'a> FuncRewriter<'a> {
         // changing its logical value. It is tempting to use `x::bool` instead,
         // but that performs an explicit cast, and to match PostgreSQL we must
         // perform only an implicit cast.
-        let sum = Self::plan_agg(
-            UnresolvedItemName::qualified(&["pg_catalog", "sum"]),
+        let sum = self.plan_agg(
+            self.scx.dangerous_resolve_name(vec!["pg_catalog", "sum"]),
             expr.or(Expr::Value(Value::Boolean(false)))
                 .cast(self.int32_data_type()),
             vec![],
@@ -272,43 +288,55 @@ impl<'a> FuncRewriter<'a> {
                 distinct,
                 over: None,
             }) => {
-                let name = normalize::unresolved_item_name(name.clone()).ok()?;
-                if let Some(database) = &name.database {
-                    // If a database name is provided, we need only verify that
-                    // the database exists, as presently functions can only
-                    // exist in ambient schemas.
-                    if let Err(e) = self.scx.catalog.resolve_database(database) {
-                        self.status = Err(e.into());
+                let name = match name {
+                    ResolvedItemName::Item {
+                        qualifiers,
+                        full_name,
+                        ..
+                    } => {
+                        if &qualifiers.schema_spec
+                            != self
+                                .scx
+                                .catalog
+                                .resolve_schema(None, "pg_catalog")
+                                .expect("pg_catalog schema exists")
+                                .id()
+                        {
+                            return None;
+                        }
+                        full_name.item.clone()
                     }
-                }
-                if name.schema.is_some() && name.schema.as_deref() != Some("pg_catalog") {
-                    return None;
-                }
+                    _ => unreachable!(),
+                };
+
                 let filter = filter.clone();
                 let distinct = *distinct;
                 let expr = if args.len() == 1 {
                     let arg = args[0].clone();
-                    match name.item.as_str() {
-                        "avg" => Self::plan_avg(arg, filter, distinct),
-                        "variance" | "var_samp" => Self::plan_variance(arg, filter, distinct, true),
-                        "var_pop" => Self::plan_variance(arg, filter, distinct, false),
-                        "stddev" | "stddev_samp" => Self::plan_stddev(arg, filter, distinct, true),
-                        "stddev_pop" => Self::plan_stddev(arg, filter, distinct, false),
+                    match name.as_str() {
+                        "avg" => self.plan_avg(arg, filter, distinct),
+                        "variance" | "var_samp" => self.plan_variance(arg, filter, distinct, true),
+                        "var_pop" => self.plan_variance(arg, filter, distinct, false),
+                        "stddev" | "stddev_samp" => self.plan_stddev(arg, filter, distinct, true),
+                        "stddev_pop" => self.plan_stddev(arg, filter, distinct, false),
                         "bool_and" => self.plan_bool_and(arg, filter, distinct),
                         "bool_or" => self.plan_bool_or(arg, filter, distinct),
                         _ => return None,
                     }
                 } else if args.len() == 2 {
                     let (lhs, rhs) = (args[0].clone(), args[1].clone());
-                    match name.item.as_str() {
+                    match name.as_str() {
                         "mod" => lhs.modulo(rhs),
-                        "pow" => Expr::call(vec!["pg_catalog", "power"], vec![lhs, rhs]),
+                        "pow" => Expr::call(
+                            self.scx.dangerous_resolve_name(vec!["pg_catalog", "power"]),
+                            vec![lhs, rhs],
+                        ),
                         _ => return None,
                     }
                 } else {
                     return None;
                 };
-                Some((Ident::new(name.item), expr))
+                Some((Ident::new(name), expr))
             }
             // Rewrites special keywords that SQL considers to be function calls
             // to actual function calls. For example, `SELECT current_timestamp`
@@ -325,7 +353,10 @@ impl<'a> FuncRewriter<'a> {
                 match fn_ident {
                     None => None,
                     Some(fn_ident) => {
-                        let expr = Expr::call_nullary(vec![fn_ident]);
+                        let expr = Expr::call_nullary(
+                            self.scx
+                                .dangerous_resolve_name(vec!["pg_catalog", fn_ident]),
+                        );
                         Some((Ident::new(ident), expr))
                     }
                 }
@@ -362,24 +393,25 @@ impl<'ast> VisitMut<'ast, Aug> for FuncRewriter<'_> {
 ///
 /// For example, `<expr> NOT IN (<subquery>)` is rewritten to `expr <> ALL
 /// (<subquery>)`.
-struct Desugarer {
+struct Desugarer<'a> {
+    scx: &'a StatementContext<'a>,
     status: Result<(), PlanError>,
     recursion_guard: RecursionGuard,
 }
 
-impl CheckedRecursion for Desugarer {
+impl<'a> CheckedRecursion for Desugarer<'a> {
     fn recursion_guard(&self) -> &RecursionGuard {
         &self.recursion_guard
     }
 }
 
-impl<'ast> VisitMut<'ast, Aug> for Desugarer {
+impl<'a, 'ast> VisitMut<'ast, Aug> for Desugarer<'a> {
     fn visit_expr_mut(&mut self, expr: &'ast mut Expr<Aug>) {
         self.visit_internal(Self::visit_expr_mut_internal, expr);
     }
 }
 
-impl Desugarer {
+impl<'a> Desugarer<'a> {
     fn visit_internal<F, X>(&mut self, f: F, x: X)
     where
         F: Fn(&mut Self, X) -> Result<(), PlanError>,
@@ -394,8 +426,9 @@ impl Desugarer {
         }
     }
 
-    fn new() -> Desugarer {
+    fn new(scx: &'a StatementContext) -> Desugarer<'a> {
         Desugarer {
+            scx,
             status: Ok(()),
             recursion_guard: RecursionGuard::with_limit(1024), // chosen arbitrarily
         }
@@ -459,10 +492,9 @@ impl Desugarer {
                     .from(TableWithJoins {
                         relation: TableFactor::Function {
                             function: TableFunction {
-                                name: UnresolvedItemName(vec![
-                                    Ident::new("mz_catalog"),
-                                    Ident::new("unnest"),
-                                ]),
+                                name: self
+                                    .scx
+                                    .dangerous_resolve_name(vec!["mz_catalog", "unnest"]),
                                 args: FunctionArgs::args(vec![right.take()]),
                             },
                             alias: Some(TableAlias {
@@ -542,11 +574,11 @@ impl Desugarer {
                                     .collect(),
                             },
                         )
-                        .call_unary(match expr {
+                        .call_unary(self.scx.dangerous_resolve_name(match expr {
                             Expr::AnySubquery { .. } => vec!["mz_internal", "mz_any"],
                             Expr::AllSubquery { .. } => vec!["mz_internal", "mz_all"],
                             _ => unreachable!(),
-                        }),
+                        })),
                     alias: None,
                 });
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -848,6 +848,15 @@ const KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
     safe: true,
 };
 
+pub const ALLOW_UNSTABLE_DEPENDENCIES: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("allow_unstable_dependencies"),
+    value: &false,
+    description:
+        "Whether to allow catalog objects to depend on unstable items, e.g. those in the `mz_internal` schema (Materialize).",
+    internal: true,
+    safe: false,
+};
+
 /// Represents the input to a variable.
 ///
 /// Each variable has different rules for how it handles each style of input.
@@ -1596,6 +1605,7 @@ impl Default for SystemVars {
             .with_var(&ENABLE_WITHIN_TIMESTAMP_ORDER_BY_IN_SUBSCRIBE)
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
+            .with_var(&ALLOW_UNSTABLE_DEPENDENCIES)
     }
 }
 
@@ -2013,6 +2023,11 @@ impl SystemVars {
 
     pub fn keep_n_source_status_history_entries(&self) -> usize {
         *self.expect_value(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
+    }
+
+    /// Returns the `enable_rbac_checks` configuration parameter.
+    pub fn allow_unstable_dependencies(&self) -> bool {
+        *self.expect_value(&ALLOW_UNSTABLE_DEPENDENCIES)
     }
 }
 

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -137,6 +137,15 @@ def test_crash_environmentd(mz: MaterializeApplication) -> None:
 
 def test_crash_clusterd(mz: MaterializeApplication) -> None:
     populate(mz, 3)
+    mz.testdrive.run(
+        input=dedent(
+            """
+            $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            ALTER SYSTEM SET allow_unstable_dependencies = true;
+            """
+        ),
+        no_reset=True,
+    )
     mz.environmentd.sql("CREATE TABLE crash_table (f1 TEXT)")
     mz.environmentd.sql(
         "CREATE MATERIALIZED VIEW crash_view AS SELECT mz_internal.mz_panic(f1) FROM crash_table"

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -49,6 +49,9 @@ disruptions = [
         name="pause-in-materialized-view",
         disruption=lambda c: c.testdrive(
             """
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET allow_unstable_dependencies = true;
+
 > SET cluster=cluster1
 
 > CREATE TABLE sleep_table (sleep INTEGER);

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -223,7 +223,7 @@ SELECT avg(a) FROM t2
 
 # avg of an explicit NULL should return an error.
 
-query error db error: ERROR: function pg_catalog\.sum\(unknown\) is not unique
+query error db error: ERROR: function sum\(unknown\) is not unique
 SELECT avg(NULL)
 
 statement error

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -15,7 +15,7 @@ CREATE TABLE t (a int, b int)
 statement ok
 INSERT INTO t (a, b) VALUES (1, 1), (1, 2), (2, 3), (3, 1)
 
-query error aggregate functions are not allowed in WHERE clause \(function sum\)
+query error aggregate functions are not allowed in WHERE clause \(function pg_catalog.sum\)
 SELECT a FROM t WHERE sum(b) = 3 GROUP BY a
 
 query error column "t.b" must appear in the GROUP BY clause or be used in an aggregate function
@@ -283,7 +283,7 @@ SELECT abs(1) FILTER (WHERE false)
 query error Expected end of statement, found left parenthesis
 SELECT column1 FILTER (WHERE column1 = 1) FROM (VALUES (1))
 
-query error aggregate functions are not allowed in FILTER \(function count\)
+query error db error: ERROR: aggregate functions are not allowed in FILTER \(function pg_catalog\.count\)
 SELECT v, count(*) FILTER (WHERE count(1) > 5) FROM filter_test GROUP BY v
 
 # These filter tests are Materialize-specific.

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -47,7 +47,7 @@ SELECT array_agg(1) FROM kv
 ----
 NULL
 
-statement error db error: ERROR: function json_agg\(integer\) does not exist
+statement error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(1) FROM kv
 ----
 NULL
@@ -77,7 +77,7 @@ SELECT array_agg(v) FROM kv
 ----
 NULL
 
-statement error db error: ERROR: function json_agg\(integer\) does not exist
+statement error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(v) FROM kv
 ----
 NULL
@@ -99,7 +99,7 @@ SELECT array_agg(1)
 ----
 {1}
 
-statement error db error: ERROR: function json_agg\(integer\) does not exist
+statement error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(1)
 
 query T
@@ -114,7 +114,7 @@ SELECT count(NULL)
 ----
 0
 
-statement error db error: ERROR: function json_agg\(unknown\) does not exist
+statement error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(NULL)
 
 query T
@@ -186,7 +186,7 @@ SELECT array_agg(1) FROM kv
 ----
 {1,1,1,1,1,1}
 
-statement error db error: ERROR: function json_agg\(integer\) does not exist
+statement error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(1) FROM kv
 
 query T
@@ -596,7 +596,7 @@ SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
 {NULL}
 
-query error db error: ERROR: function json_agg\(text\) does not exist
+query error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(s) FROM kv WHERE s IS NULL
 
 query T
@@ -693,13 +693,13 @@ SELECT avg(b), sum(b) FROM abc
 # ----
 # 3 years 5 mons 7 days 00:00:19
 
-query error db error: ERROR: function pg_catalog\.sum\(character varying\) does not exist
+query error db error: ERROR: function sum\(character varying\) does not exist
 SELECT avg(a) FROM abc
 
-query error db error: ERROR: function pg_catalog\.sum\(boolean\) does not exist
+query error db error: ERROR: function sum\(boolean\) does not exist
 SELECT avg(c) FROM abc
 
-query error db error: ERROR: function pg_catalog\.sum\(record\(f1: character varying,f2: boolean\?\)\) does not exist
+query error db error: ERROR: function sum\(record\(f1: character varying,f2: boolean\?\)\) does not exist
 SELECT avg((a,c)) FROM abc
 
 query error db error: ERROR: function sum\(character varying\) does not exist
@@ -903,7 +903,7 @@ false false
 query error concat_agg not yet supported
 SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 
-query error db error: ERROR: function json_agg\(text\) does not exist
+query error db error: ERROR: function "json_agg" does not exist
 SELECT json_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 
 # This is arguably wrong--we don't respect the inner ORDER BY--because we don't

--- a/test/sqllogictest/errors.slt
+++ b/test/sqllogictest/errors.slt
@@ -16,10 +16,10 @@ SELECT * FROM VALUES (1)
 query error Expected identifier, found number
 SELECT * FROM VALUES (1), (2)
 
-query error function noexist\(\) does not exist
+query error db error: ERROR: function "noexist" does not exist
 SELECT noexist()
 
-query error function noexist\(\) does not exist
+query error db error: ERROR: function "noexist" does not exist
 SELECT * FROM noexist()
 
 statement error Expected DATABASE, SCHEMA, ROLE, TYPE, INDEX, SINK, SOURCE, TABLE, SECRET, \[OR REPLACE\] \[TEMPORARY\] VIEW, or \[OR REPLACE\] MATERIALIZED VIEW after CREATE, found identifier "material"

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -784,7 +784,7 @@ SELECT materialize.pg_catalog.abs(1)
 ----
 1
 
-query error function mz_catalog.abs\(integer\) does not exist
+query error db error: ERROR: function "mz_catalog\.abs" does not exist
 SELECT mz_catalog.abs(1)
 
 query error unknown database 'noexist'
@@ -803,7 +803,7 @@ SELECT pg_catalog.mod(7, 4)
 ----
 3
 
-query error function mz_catalog.mod\(integer, integer\) does not exist
+query error db error: ERROR: function "mz_catalog\.mod" does not exist
 SELECT mz_catalog.mod(7, 4)
 
 query error unknown database 'noexist'

--- a/test/sqllogictest/returning.slt
+++ b/test/sqllogictest/returning.slt
@@ -90,10 +90,10 @@ INSERT INTO t VALUES (7, 8) RETURNING 1/0
 statement error column "z" does not exist
 INSERT INTO t VALUES (7, 8) RETURNING z
 
-statement error aggregate functions are not allowed in RETURNING clause \(function count\)
+statement error db error: ERROR: aggregate functions are not allowed in RETURNING clause \(function pg_catalog\.count\)
 INSERT INTO t VALUES (7, 8) RETURNING count(*)
 
-statement error window functions are not allowed in RETURNING clause \(function row_number\)
+statement error db error: ERROR: window functions are not allowed in RETURNING clause \(function pg_catalog\.row_number\)
 INSERT INTO t VALUES (7, 8) RETURNING row_number()
 
 statement error RETURNING clause does not allow subqueries

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -12,7 +12,7 @@
 
 mode cockroach
 
-statement error window function row_number requires an OVER clause
+statement error db error: ERROR: window function pg_catalog\.row_number requires an OVER clause
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT row_number() FROM t
 

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -59,10 +59,10 @@ known_errors = [
     "list_agg on char not yet supported",
     "does not allow subqueries",
     "range constructor flags argument must not be null",  # expected after https://github.com/MaterializeInc/materialize/issues/18036 has been fixed
-    "function pg_catalog.array_remove(",
-    "function pg_catalog.array_cat(",
-    "function mz_catalog.list_append(",
-    "function mz_catalog.list_prepend(",
+    "function array_remove(",
+    "function array_cat(",
+    "function list_append(",
+    "function list_prepend(",
     "does not support implicitly casting from",
     "aggregate functions that refer exclusively to outer columns not yet supported",  # https://github.com/MaterializeInc/materialize/issues/3720
     "range lower bound must be less than or equal to range upper bound",

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -272,10 +272,9 @@ sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 > SET CLUSTER TO default
 > DROP INDEX sys_ind
 
-# TODO: re-enable test once we can run testdrive tests _not_ in unsafe mode.
-# # Test that creating indexes on objects in the mz_internal schema fails
-# ! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
-# contains:cannot create index with unstable dependencies
+# Test that creating indexes on objects in the mz_internal schema fails
+! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
+contains:cannot create index with unstable dependencies
 
 > SHOW INDEXES IN CLUSTER mz_introspection
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_introspection    {id,worker_id}

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -272,9 +272,10 @@ sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 > SET CLUSTER TO default
 > DROP INDEX sys_ind
 
-# Test that creating indexes on objects in the mz_internal schema fails
-! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
-contains:cannot create index with unstable dependencies
+# TODO: re-enable test once we can run testdrive tests _not_ in unsafe mode.
+# # Test that creating indexes on objects in the mz_internal schema fails
+# ! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
+# contains:cannot create index with unstable dependencies
 
 > SHOW INDEXES IN CLUSTER mz_introspection
 mz_active_peeks_per_worker_s2_primary_idx                   mz_active_peeks_per_worker                   mz_introspection    {id,worker_id}


### PR DESCRIPTION
Ultimately, we need to be able to track functions as objects that users depend on. This is necessary for:
- [UDFs](https://github.com/MaterializeInc/materialize/pull/7346#discussion_r668954450)
- Preventing users from creating objects that depend on unstable catalog objects without having a flag set
 
To be able to track functions as dependencies, we can resolve functions as all other objects (this is currently where we track all dependencies).

Other approaches considered included determining these dependencies _after_ planning, however that meant that we needed to return the `GlobalId`s in the plans and that seemed crazy.

One cost to this change is that we lose "nice error messages" when trying to find functions that do not exist--the new error messages in this case will not include the arguments' types. I'd argue that this is a net improvement because it more clearly delineates between a "catalog error" and a "function resolution" error, but it does diverge from PG's error strategy.

One last note: this PR is fairly ancient and from a different era when design docs were less prevalent, so I never wrote a design doc for this. However, I was able to get this green with a very narrowly defined change in behavior so hope I can get away without writing one.

### Motivation

This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/pull/7346#discussion_r668954450

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
