### PR TITLE
doc: specify anchor targets for ambiguous links

### DIFF
--- a/doc/user/content/integrations/postgres-bastion.md
+++ b/doc/user/content/integrations/postgres-bastion.md
@@ -23,7 +23,7 @@ Before following the steps, check meeting the next items:
 
 ### Steps
 
-1. Create in Materialize the [SSH connection](/sql/create-connection/#example-4) to the bastion server:
+1. Create in Materialize the [SSH connection](/sql/create-connection/#postgres-ssh-example) to the bastion server:
     ```sql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (
         HOST '<SSH_BASTION_HOST>',
@@ -47,7 +47,7 @@ Before following the steps, check meeting the next items:
     echo "ssh-ed25519 AAAA...76RH materialize" >> ~/.ssh/authorized_keys
     ```
 
-1. Create in Materialize the [Postgres connection](/sql/create-connection/#example-3):
+1. Create in Materialize the [Postgres connection](/sql/create-connection/#postgres-example):
     ```sql
     CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
 
@@ -62,7 +62,7 @@ Before following the steps, check meeting the next items:
         SSH TUNNEL ssh_connection;
     ```
 
-1. Create in Materialize the [Postgres source](/sql/create-source/postgres/#creating-a-source-1):
+1. Create in Materialize the [Postgres source](/sql/create-source/postgres/#create-source-example):
     ```sql
     CREATE SOURCE mz_source
     FROM POSTGRES

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -134,7 +134,7 @@ Field                       | Value            | Required | Description
 `SSL KEY`                   | secret           |          | Client SSL key in PEM format.
 `USER`                      | `text`           | ✓        | Database username.
 
-##### Example
+##### Example {#postgres-example}
 
 ```sql
 CREATE SECRET pgpass AS '<POSTGRES_PASSWORD>';
@@ -159,7 +159,7 @@ Field                       | Value            | Required | Description
 `PORT`                      | `int4`           | ✓        | Port for the connection.
 `USER`                      | `text`           | ✓        | Username for the connection.
 
-##### Example
+##### Example {#postgres-ssh-example}
 
 ```sql
     CREATE CONNECTION ssh_connection TO SSH TUNNEL (

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -139,7 +139,7 @@ CREATE CONNECTION pg_connection TO POSTGRES (
 );
 ```
 
-### Creating a source
+### Creating a source {#create-source-example}
 
 ```sql
 CREATE SOURCE mz_source


### PR DESCRIPTION
This should fix some recent CI failures for the `Lint docs` test.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a