### PR TITLE
environmentd: deflake test_auth_expiry

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -512,8 +512,8 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
     )]);
     let encoding_key = EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap())?;
 
-    const EXPIRES_IN_SECS: u64 = 2;
-    const REFRESH_BEFORE_SECS: u64 = 1;
+    const EXPIRES_IN_SECS: u64 = 5;
+    const REFRESH_BEFORE_SECS: u64 = 4;
     let frontegg_server = start_mzcloud(
         encoding_key,
         tenant_id,
@@ -591,7 +591,7 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
         .store(false, Ordering::Relaxed);
     wait_for_refresh();
     // Sleep until the expiry future should resolve.
-    std::thread::sleep(Duration::from_secs(EXPIRES_IN_SECS - REFRESH_BEFORE_SECS));
+    std::thread::sleep(Duration::from_secs(EXPIRES_IN_SECS + 1));
     assert!(pg_client.query_one("SELECT current_user", &[]).is_err());
 
     Ok(())


### PR DESCRIPTION
Increase the expiry time to allow slow things more leniency. Correct the sleep at the end which needs to wait the full expiry time, not just the refresh time.

Fixes #15718

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a