### PR TITLE
pg-cdc: Fix merge skew in test/pg-cdc/pg-cdc.td

### DIFF
--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -192,12 +192,14 @@ contains:publication "no_such_publication" does not exist
     "space table"
   );
 
+$ set-regex match=\d+ replacement=<NUMBER>
+
 > SHOW SOURCES
 conflict_table        subsource <null>
 escaped_text_table    subsource <null>
 large_text            subsource <null>
 multipart_pk          subsource <null>
-mz_source             postgres  1
+mz_source             postgres  <NUMBER>
 no_replica_identity   subsource <null>
 nonpk_table           subsource <null>
 nulls_table           subsource <null>
@@ -206,8 +208,10 @@ pk_table              subsource <null>
 trailing_space_nopk   subsource <null>
 trailing_space_pk     subsource <null>
 types_table           subsource <null>
-utf8_table            subsource <null>
+utf<NUMBER>_table     subsource <null>
 таблица               subsource <null>
+
+$ unset-regex
 
 # Dependency graph is that mz_source depends on all subsources
 ! DROP SOURCE conflict_table


### PR DESCRIPTION
SHOW SOURCES now includes a SIZE column so a regexp needs to be used to make sure the expected result is valid for all values of SIZE

### Motivation

  * This PR fixes a previously unreported bug.

CI was failing