### PR TITLE
ci: Run CI with SIZE '4-4' by default

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -28,7 +28,7 @@ steps:
           - { value: testdrive-partitions-5 }
           - { value: testdrive-replicas-4}
           - { value: testdrive-size-1}
-          - { value: testdrive-size-16}
+          - { value: testdrive-size-8}
           - { value: testdrive-in-cloudtest}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
@@ -222,10 +222,10 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --size=1]
+          args: [--aws-region=us-east-2, --default-size=1]
 
-  - id: testdrive-size-16
-    label: ":racing_car: testdrive with SIZE 16"
+  - id: testdrive-size-8
+    label: ":racing_car: testdrive with SIZE 8"
     timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
@@ -233,7 +233,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          args: [--aws-region=us-east-2, --size=16]
+          args: [--aws-region=us-east-2, --default-size=8]
 
   - id: testdrive-in-cloudtest
     label: Full Testdrive in Cloudtest (K8s)

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -15,7 +15,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import Optional
+from typing import List, Optional
 
 from materialize.checks.actions import Action
 from materialize.checks.executors import Executor
@@ -35,15 +35,22 @@ class StartMz(MzcomposeAction):
         ]
     )
 
-    def __init__(self, tag: Optional[str] = None) -> None:
+    def __init__(
+        self, tag: Optional[str] = None, environment_extra: List[str] = []
+    ) -> None:
         self.tag = tag
+        self.environment_extra = environment_extra
 
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
 
         image = f"materialize/materialized:{self.tag}" if self.tag is not None else None
         print(f"Starting Mz using image {image}")
-        mz = Materialized(image=image, options=StartMz.DEFAULT_MZ_OPTIONS)
+        mz = Materialized(
+            image=image,
+            options=StartMz.DEFAULT_MZ_OPTIONS,
+            environment_extra=self.environment_extra,
+        )
 
         with c.override(mz):
             # Work around https://github.com/MaterializeInc/materialize/issues/15725

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -27,8 +27,16 @@ from materialize.checks.mzcompose_actions import (
     UseComputed,
 )
 from materialize.checks.scenarios import Scenario
+from materialize.mzcompose.services import Materialized
 
 LAST_RELEASED_VERSION = f"v{util.released_materialize_versions()[0]}"
+
+# Older Mz versions are not configured to know SIZE '4-4' clusters by default
+size = Materialized.Size.DEFAULT_SIZE
+environment_extra = [
+    f'MZ_STORAGE_HOST_SIZES={{"{size}":{{"workers":{size}}}}}',
+    f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
+]
 
 
 class UpgradeEntireMz(Scenario):
@@ -36,7 +44,7 @@ class UpgradeEntireMz(Scenario):
 
     def actions(self) -> List[Action]:
         return [
-            StartMz(tag=LAST_RELEASED_VERSION),
+            StartMz(tag=LAST_RELEASED_VERSION, environment_extra=environment_extra),
             Initialize(self.checks),
             Manipulate(self.checks, phase=1),
             KillMz(),
@@ -60,7 +68,7 @@ class UpgradeComputedLast(Scenario):
 
     def actions(self) -> List[Action]:
         return [
-            StartMz(tag=LAST_RELEASED_VERSION),
+            StartMz(tag=LAST_RELEASED_VERSION, environment_extra=environment_extra),
             StartComputed(tag=LAST_RELEASED_VERSION),
             UseComputed(),
             Initialize(self.checks),
@@ -85,7 +93,7 @@ class UpgradeComputedFirst(Scenario):
 
     def actions(self) -> List[Action]:
         return [
-            StartMz(tag=LAST_RELEASED_VERSION),
+            StartMz(tag=LAST_RELEASED_VERSION, environment_extra=environment_extra),
             StartComputed(tag=LAST_RELEASED_VERSION),
             UseComputed(),
             Initialize(self.checks),

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -67,7 +67,8 @@ class Testdrive(K8sPod):
                 "--schema-registry-url=http://redpanda:8081",
                 "--default-timeout=300s",
                 "--var=replicas=1",
-                "--var=size=1",
+                "--var=default-storage-size=1",
+                "--var=default-replica-size=1",
                 *([f"--aws-region={self.aws_region}"] if self.aws_region else []),
                 # S3 sources are not compatible with Minio unfortunately
                 # "--aws-endpoint=http://minio-service.default:9000",

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -45,15 +45,20 @@ class CreateReplica(Action):
         if len(existing_replicas) == 0:
             self.new_replica = True
 
-            size_types = [ReplicaSizeType.Nodes, ReplicaSizeType.Workers]
-            type_weights = [0.75, 0.25]
-            size_type = random.choices(size_types, weights=type_weights, k=1)[0]
+            size_types = [
+                ReplicaSizeType.Nodes,
+                ReplicaSizeType.Workers,
+                ReplicaSizeType.Both,
+            ]
+            size_type = random.choice(size_types)
 
             size = str(random.choice([2, 4]))
             if size_type is ReplicaSizeType.Nodes:
                 this_replica.size = size + "-1"
             elif size_type is ReplicaSizeType.Workers:
                 this_replica.size = size
+            elif size_type is ReplicaSizeType.Both:
+                this_replica.size = f"{size}-{size}"
             else:
                 assert False
 

--- a/misc/python/materialize/zippy/replica_capabilities.py
+++ b/misc/python/materialize/zippy/replica_capabilities.py
@@ -15,6 +15,7 @@ from materialize.zippy.framework import Capability
 class ReplicaSizeType(Enum):
     Nodes = 1
     Workers = 2
+    Both = 3
 
 
 class ReplicaExists(Capability):

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -69,12 +69,14 @@ impl Default for ClusterReplicaSizeMap {
         //     "4": {"scale": 1, "workers": 4},
         //     /// ...
         //     "32": {"scale": 1, "workers": 32}
-        //     /// Testing with multiple processes on a single machine is a novelty, so
-        //     /// we don't bother providing many options.
-        //     "2-2": {"scale": 2, "workers": 2},
+        //     /// Testing with multiple processes on a single machine
         //     "2-4": {"scale": 2, "workers": 4},
+        //     /// Used in mzcompose tests
+        //     "2-2": {"scale": 2, "workers": 2},
+        //     ...
+        //     "16-16": {"scale": 16, "workers": 16},
         //     /// Used in the shared_fate cloudtest tests
-        //     "1-1": {"scale": 1, "workers": 1},
+        //     "2-1": {"scale": 2, "workers": 1},
         //     ...
         //     "16-1": {"scale": 16, "workers": 1},
         // }
@@ -104,17 +106,18 @@ impl Default for ClusterReplicaSizeMap {
                     workers: NonZeroUsize::new(1).unwrap(),
                 },
             );
+
+            inner.insert(
+                format!("{scale}-{scale}"),
+                ComputeReplicaAllocation {
+                    memory_limit: None,
+                    cpu_limit: None,
+                    scale: NonZeroUsize::new(scale).unwrap(),
+                    workers: NonZeroUsize::new(scale).unwrap(),
+                },
+            );
         }
 
-        inner.insert(
-            "2-2".to_string(),
-            ComputeReplicaAllocation {
-                memory_limit: None,
-                cpu_limit: None,
-                scale: NonZeroUsize::new(2).unwrap(),
-                workers: NonZeroUsize::new(2).unwrap(),
-            },
-        );
         inner.insert(
             "2-4".to_string(),
             ComputeReplicaAllocation {

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -376,6 +376,7 @@ def workflow_test_builtin_migration(c: Composition) -> None:
         # Random commit before pg_proc was updated.
         Materialized(
             image="materialize/materialized:devel-aa4128c9c485322f90ab0af2b9cb4d16e1c470c0",
+            default_size=1,
         ),
         Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True),
     ):

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1220,7 +1220,9 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Materialized(memory="8G"),
+    # We create all sources, sinks and dataflows by default with SIZE '1'
+    # The workflow_instance_size workflow is testing multi-process clusters
+    Materialized(memory="8G", default_size=1),
     Testdrive(default_timeout="120s"),
 ]
 

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -152,7 +152,7 @@ id price
 
 # The ouput of SUBSCRIBE is dependent on the replica size
 $ skip-if
-SELECT ${arg.size} > 1;
+SELECT '${arg.default-replica-size}' != '4-4';
 
 > BEGIN
 

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -11,19 +11,15 @@
 
 > CREATE SOURCE demo FROM LOAD GENERATOR AUCTION (TICK INTERVAL '50ms') FOR ALL TABLES
 
-$ set-regex match=\d+ replacement=<SIZE>
-
 > SHOW SOURCES
 name          type           size
 ----------------------------------
-demo          load-generator <SIZE>
+demo          load-generator ${arg.default-storage-size}
 accounts      subsource      <null>
 auctions      subsource      <null>
 bids          subsource      <null>
 organizations subsource      <null>
 users         subsource      <null>
-
-$ unset-regex
 
 > SHOW COLUMNS FROM auctions
 end_time false "timestamp with time zone"

--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -11,7 +11,7 @@
 
 # The contents of the introspection tables depend on the replica size
 $ skip-if
-SELECT ${arg.size} > 1
+SELECT '${arg.default-replica-size}' != '4-4'
 
 # In case the environment has other replicas
 > SET cluster_replica = r1
@@ -23,7 +23,7 @@ SELECT ${arg.size} > 1
 # Note: We rely on testdrive's retry behavior here, as it takes some time for
 # the logging to catch up.
 
-> SELECT time > 0
+> SELECT COUNT(*)
   FROM
     mz_materialized_views AS views,
     mz_internal.mz_compute_exports AS compute_exports,
@@ -31,5 +31,6 @@ SELECT ${arg.size} > 1
   WHERE
     views.name = 'mv' AND
     views.id = compute_exports.export_id AND
-    compute_exports.export_id = frontiers.export_id
-true
+    compute_exports.export_id = frontiers.export_id AND
+    time > 0
+16

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -17,7 +17,7 @@
 
 # The contents of the introspection tables depend on the replica size
 $ skip-if
-SELECT ${arg.size} > 1
+SELECT '${arg.default-replica-size}' != '4-4'
 
 # In case the environment has other replicas
 > SET cluster_replica = r1
@@ -38,7 +38,7 @@ SELECT ${arg.size} > 1
             compute_exports.export_id = delays.export_id)
 true
 
-> SELECT time > 0
+> SELECT COUNT(*)
   FROM
     mz_materialized_views AS views,
     mz_internal.mz_compute_exports AS compute_exports,
@@ -46,8 +46,9 @@ true
   WHERE
     views.name = 'mv' AND
     views.id = compute_exports.export_id AND
-    compute_exports.export_id = import_frontiers.export_id
-true
+    compute_exports.export_id = import_frontiers.export_id AND
+    time > 0
+16
 
 > CREATE VIEW vv AS SELECT * FROM t
 
@@ -91,7 +92,7 @@ true
             compute_exports.export_id = delays.export_id)
 true
 
-> SELECT time > 0
+> SELECT COUNT(*)
   FROM
     mz_views AS views,
     mz_indexes AS indexes,
@@ -101,8 +102,9 @@ true
     views.name = 'vv' AND
     views.id = indexes.on_id AND
     indexes.id = compute_exports.export_id AND
-    compute_exports.export_id = import_frontiers.export_id
-true
+    compute_exports.export_id = import_frontiers.export_id AND
+    time > 0
+16
 
 > DROP INDEX vv_primary_idx
 

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -9,17 +9,13 @@
 
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
 
-$ set-regex match=\d+ replacement=<SIZE>
-
 > SHOW SOURCES
 accounts      subsource      <null>
-auction_house load-generator <SIZE>
+auction_house load-generator ${arg.default-storage-size}
 auctions      subsource      <null>
 bids          subsource      <null>
 organizations subsource      <null>
 users         subsource      <null>
-
-$ unset-regex
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -334,15 +334,11 @@ a  b
 3  4
 1  2
 
-$ set-regex match=\d+ replacement=<SIZE>
-
 > SHOW SOURCES
 name     type    size
 ---------------------
-data     kafka   <SIZE>
-mat_data kafka   <SIZE>
-
-$ unset-regex
+data     kafka   ${arg.default-storage-size}
+mat_data kafka   ${arg.default-storage-size}
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -162,21 +162,17 @@ renamed_sink
 # Clean up temp view
 > DROP VIEW public_objects;
 
-$ set-regex match=\d+ replacement=<SIZE>
-
 # Source was successfully renamed
 > SHOW SOURCES;
 name               type   size
 ------------------------------
-renamed_mz_data    kafka  <SIZE>
+renamed_mz_data    kafka  ${arg.default-storage-size}
 
 # Sink was successfully renamed
 > SHOW SINKS
 name               type   size
 ------------------------------
-renamed_sink       kafka  <SIZE>
-
-$ set-regex match=u\d+|cluster1|default replacement=<VARIABLE_OUTPUT>
+renamed_sink       kafka  ${arg.default-storage-size}
 
 # View was successfully renamed
 > SHOW VIEWS

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -106,16 +106,12 @@ name               type   size
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
-$ set-regex match=\d+ replacement=<D>
-
 > SHOW SINKS
 name               type   size
 ------------------------------
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-
-$ unset-regex
+snk1             kafka  ${arg.default-storage-size}
+snk2             kafka  ${arg.default-storage-size}
+snk3             kafka  ${arg.default-storage-size}
 
 $ kafka-verify-data format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
@@ -204,22 +200,18 @@ $ kafka-verify-data format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"column1": 2}}}
 {"before": null, "after": {"row":{"column1": 3}}}
 
-$ set-regex match=\d+ replacement=<D>
-
 > SHOW SINKS
 name               type   size
 ------------------------------
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk<D>             kafka  <D>
-snk_unsigned       kafka  <D>
-
-$ unset-regex
+snk1             kafka  ${arg.default-storage-size}
+snk2             kafka  ${arg.default-storage-size}
+snk3             kafka  ${arg.default-storage-size}
+snk4             kafka  ${arg.default-storage-size}
+snk5             kafka  ${arg.default-storage-size}
+snk6             kafka  ${arg.default-storage-size}
+snk7             kafka  ${arg.default-storage-size}
+snk8             kafka  ${arg.default-storage-size}
+snk_unsigned       kafka  ${arg.default-storage-size}
 
 # test explicit partition count
 > CREATE SINK snk9 FROM foo
@@ -287,30 +279,27 @@ $ kafka-create-topic topic=snk15 partitions=4
 
 # Including for sinks with default size
 > SELECT size FROM mz_sinks WHERE name = 'snk13'
-"${arg.size}"
-
-$ skip-if
-SELECT ${arg.size} != 1
+"${arg.default-storage-size}"
 
 # Check that SHOW SINKS shows the size correctly
 > SHOW SINKS
 name               type   size
 ------------------------------
-snk1               kafka  1
-snk2               kafka  1
-snk3               kafka  1
-snk4               kafka  1
-snk5               kafka  1
-snk6               kafka  1
-snk7               kafka  1
-snk8               kafka  1
-snk9               kafka  1
-snk10              kafka  1
-snk11              kafka  1
-snk12              kafka  1
-snk13              kafka  1
-snk14              kafka  1
-snk15              kafka  1
+snk1               kafka  ${arg.default-storage-size}
+snk2               kafka  ${arg.default-storage-size}
+snk3               kafka  ${arg.default-storage-size}
+snk4               kafka  ${arg.default-storage-size}
+snk5               kafka  ${arg.default-storage-size}
+snk6               kafka  ${arg.default-storage-size}
+snk7               kafka  ${arg.default-storage-size}
+snk8               kafka  ${arg.default-storage-size}
+snk9               kafka  ${arg.default-storage-size}
+snk10              kafka  ${arg.default-storage-size}
+snk11              kafka  ${arg.default-storage-size}
+snk12              kafka  ${arg.default-storage-size}
+snk13              kafka  ${arg.default-storage-size}
+snk14              kafka  ${arg.default-storage-size}
+snk15              kafka  ${arg.default-storage-size}
 sink_with_size     kafka  2
 sink_with_options  kafka  2
-snk_unsigned       kafka  1
+snk_unsigned       kafka  ${arg.default-storage-size}

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -67,7 +67,7 @@ INSERT INTO temp SELECT * FROM temp
 2
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 ${arg.size}
+mz_system r1 1
 
 $ postgres-execute connection=mz_system
 DROP CLUSTER REPLICA mz_system.r1
@@ -75,7 +75,7 @@ DROP CLUSTER REPLICA mz_system.r1
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
 
 $ postgres-execute connection=mz_system
-CREATE CLUSTER REPLICA mz_system.r1 SIZE '${arg.size}';
+CREATE CLUSTER REPLICA mz_system.r1 SIZE '${arg.default-replica-size}';
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 ${arg.size}
+mz_system r1 ${arg.default-replica-size}


### PR DESCRIPTION
    ci: Run CI with SIZE '4-4' by default
    
    - Extend the default ClusterReplicaSizeMap with 2-2, 4-4, 8-8, 16-16 options
    - Do not store any SIZE defaults in test/testdrive/mzcompose.py
    - Consolidate all SIZE defaults to a single location in services.py
      so that there is no ambiguity as to what SIZE is in effect in a given
      test
    - use the default_size int = X to get clusters to start as SIZE 'X-X',
      that is, as X-process clusters with X workers per process
    - use the default_size int = X to get sources and sinks to start as SIZE 'X',
      that is, a single process with X workers
    - remove unnecessary use of set-regex in certain tests
    - refactor the skip-if directives that skip tests or portions thereof
      based on the default cluster or storage SIZE.
    - extend the ClusterReplicas Zippy scenario to use 2-2 and 4-4 replicas as well
    - fix the upgrade tests to pass appropriate options to older Mz versions to
      define what a SIZE '4-4' cluster is and what a SIZE '4' storaged is.
    - set a Nightly job with SIZE '8-8'

### Motivation


  * This PR adds a feature that has not yet been specified.

Running CI with SIZE 1 or even SIZE '4-1' does not cause all possible forms of concurrency to be exercised on a regular basis. So we are going directly for SIZE '4-4' by default.

cloudtest is being left out on purpose until the issues around spawning/respawning large clusters in K8s have been resolved.

### Tips for reviewer
@benesch if you could review the changes I had to make to the rust code and do misc/materialize/mzcompose , that would be very much appreciated.