### PR TITLE
doc: Remove redundant lines in python examples

### DIFF
--- a/doc/user/content/integrations/python.md
+++ b/doc/user/content/integrations/python.md
@@ -80,7 +80,6 @@ import sys
 dsn = "user=MATERIALIZE_USERNAME password=MATERIALIZE_PASSWORD host=MATERIALIZE_HOST port=6875 dbname=materialize sslmode=require"
 conn = psycopg3.connect(dsn)
 
-conn = psycopg3.connect(dsn)
 with conn.cursor() as cur:
     for row in cur.stream("SUBSCRIBE t"):
         print(row)
@@ -157,8 +156,6 @@ dsn = "user=MATERIALIZE_USERNAME password=MATERIALIZE_PASSWORD host=MATERIALIZE_
 conn = psycopg2.connect(dsn)
 conn.autocommit = True
 
-cur = conn.cursor()
-
 with conn.cursor() as cur:
     cur.execute("CREATE SOURCE counter FROM LOAD GENERATOR COUNTER;")
 
@@ -180,8 +177,6 @@ import sys
 dsn = "user=MATERIALIZE_USERNAME password=MATERIALIZE_PASSWORD host=MATERIALIZE_HOST port=6875 dbname=materialize sslmode=require"
 conn = psycopg2.connect(dsn)
 conn.autocommit = True
-
-cur = conn.cursor()
 
 with conn.cursor() as cur:
     cur.execute("CREATE VIEW market_orders_2 AS " \


### PR DESCRIPTION
Some of the python examples contain redundant lines.

### Motivation

  * This PR fixes a previously unreported bug.

    Redundant lines in python examples


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
