### PR TITLE
compute controller: don't remove cancelled peeks immediately

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -90,7 +90,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 conn_id,
                 secret_key,
             } => {
-                self.handle_cancel(conn_id, secret_key).await;
+                self.handle_cancel(conn_id, secret_key);
             }
 
             Command::DumpCatalog { session, tx } => {
@@ -470,7 +470,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
     /// Instruct the dataflow layer to cancel any ongoing, interactive work for
     /// the named `conn_id`.
-    async fn handle_cancel(&mut self, conn_id: ConnectionId, secret_key: u32) {
+    fn handle_cancel(&mut self, conn_id: ConnectionId, secret_key: u32) {
         if let Some(conn_meta) = self.active_conns.get(&conn_id) {
             // If the secret key specified by the client doesn't match the
             // actual secret key for the target connection, we treat this as a
@@ -518,7 +518,7 @@ impl<S: Append + 'static> Coordinator<S> {
             for PendingPeek {
                 sender: rows_tx,
                 conn_id: _,
-            } in self.cancel_pending_peeks(conn_id).await
+            } in self.cancel_pending_peeks(conn_id)
             {
                 // Cancel messages can be sent after the connection has hung
                 // up, but before the connection's state has been cleaned up.
@@ -540,6 +540,6 @@ impl<S: Append + 'static> Coordinator<S> {
             .expect("unable to drop temporary schema");
         self.metrics.active_sessions.dec();
         self.active_conns.remove(&session.conn_id());
-        self.cancel_pending_peeks(session.conn_id()).await;
+        self.cancel_pending_peeks(session.conn_id());
     }
 }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -68,7 +68,7 @@ impl<S: Append + 'static> Coordinator<S> {
             // in any situation where you use it, you must also have a code
             // path that responds to the client (e.g. reporting an error).
             Message::RemovePendingPeeks { conn_id } => {
-                self.cancel_pending_peeks(conn_id).await;
+                self.cancel_pending_peeks(conn_id);
             }
             Message::LinearizeReads(pending_read_txns) => {
                 self.message_linearize_reads(pending_read_txns).await;

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -479,7 +479,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
 
     /// Cancel and remove all pending peeks that were initiated by the client with `conn_id`.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) async fn cancel_pending_peeks(&mut self, conn_id: u32) -> Vec<PendingPeek> {
+    pub(crate) fn cancel_pending_peeks(&mut self, conn_id: u32) -> Vec<PendingPeek> {
         // The peek is present on some specific compute instance.
         // Allow dataflow to cancel any pending peeks.
         if let Some(uuids) = self.client_pending_peeks.remove(&conn_id) {
@@ -491,7 +491,6 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 self.controller
                     .active_compute()
                     .cancel_peeks(compute_instance, uuids)
-                    .await
                     .unwrap();
             }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -620,12 +620,13 @@ where
     ///   * A `PeekResponse::Canceled` affirming that the peek was canceled.
     ///
     ///   * No `PeekResponse` at all.
-    pub async fn cancel_peeks(
+    pub fn cancel_peeks(
         &mut self,
         instance_id: ComputeInstanceId,
         uuids: BTreeSet<Uuid>,
     ) -> Result<(), ComputeError> {
-        self.instance(instance_id)?.cancel_peeks(uuids).await
+        self.instance(instance_id)?.cancel_peeks(uuids);
+        Ok(())
     }
 
     /// Assign a read policy to specific identifiers.

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -677,9 +677,7 @@ where
     }
 
     /// Cancels existing peek requests.
-    pub async fn cancel_peeks(&mut self, uuids: BTreeSet<Uuid>) -> Result<(), ComputeError> {
-        self.remove_peeks(&uuids).await?;
-
+    pub fn cancel_peeks(&mut self, uuids: BTreeSet<Uuid>) {
         // Enqueue the response to the cancelation.
         for uuid in &uuids {
             let otel_ctx = self
@@ -704,7 +702,6 @@ where
         }
 
         self.compute.send(ComputeCommand::CancelPeeks { uuids });
-        Ok(())
     }
 
     /// Assigns a read policy to specific identifiers.


### PR DESCRIPTION
Instead of dropping the pending peek (and thereby its read hold) immediately upon receiving a cancel command, the compute controller needs to wait for all replicas to confirm that they are done with the peek.

### Motivation

  * This PR fixes a recognized bug.

Fixes #15693.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
