### PR TITLE
storage: in rehydrating client, be lenient about extra upper updates

### DIFF
--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -331,12 +331,15 @@ where
                             new_uppers.push((id, new_upper));
                         }
                     } else {
-                        // We should have initialized the uppers when we first absorbed
-                        // a command, if storaged has restarted since then.
+                        // It can happen during source shutdown that we remove
+                        // the tracked upper from our state but a
+                        // `FrontierUppers` response is still on the wire.
                         //
-                        // If the controller has restarted since then, we should have
-                        // initialized them in the initial `step_rehydrate`.
-                        panic!("RehydratingStorageClient received FrontierUppers response for absent identifier {id}");
+                        // This is very fine to ignore, especially now that
+                        // these upper updates are plain `Antichains`, and not
+                        // `ChangeBatches` where we need to be extra careful
+                        // about not messing up our state.
+                        tracing::info!("RehydratingStorageClient received FrontierUppers response {new_upper:?} for absent identifier {id}");
                     }
                 }
                 if !new_uppers.is_empty() {


### PR DESCRIPTION
It can happen during source shutdown that we remove the tracked upper from our state but a `FrontierUppers` response is still on the wire.

This is very fine to ignore, especially now that these upper updates are plain `Antichains`, and not `ChangeBatches` where we need to be extra careful about not messing up our state.

Fixes #14746

### Tips for review peeps

Initial analysis suggested that some more complicated interplay was involved. See discussion on https://github.com/MaterializeInc/materialize/issues/14746.

I managed to tickle this locally just by rigging `storaged` up to report uppers as fast as it can, even when there is no progress (which we normally don't do). With that, it will panic when just dropping a source, which I think is also what's happening in those ci failures.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
