### PR TITLE
compute-client: faster rehydration of failed replicas

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -269,33 +269,35 @@ where
 
     /// Receives the next response from any replica of this instance.
     ///
+    /// Returns `Err` if receiving from a replica has failed, to signal that it is in need of
+    /// rehydration.
+    ///
     /// This method is cancellation safe.
-    pub async fn recv(&mut self) -> (ReplicaId, ComputeResponse<T>) {
+    pub async fn recv(&mut self) -> Result<(ReplicaId, ComputeResponse<T>), ReplicaId> {
         // Receive responses from any of the replicas, and take appropriate
         // action.
-        loop {
-            let response = self
-                .replicas
-                .iter_mut()
-                .map(|(id, replica)| async { (*id, replica.recv().await) })
-                .collect::<FuturesUnordered<_>>()
-                .next()
-                .await;
+        let response = self
+            .replicas
+            .iter_mut()
+            .map(|(id, replica)| async { (*id, replica.recv().await) })
+            .collect::<FuturesUnordered<_>>()
+            .next()
+            .await;
 
-            match response {
-                None => {
-                    // There were no replicas in the set. Block forever to
-                    // communicate that no response is ready.
-                    future::pending().await
-                }
-                Some((replica_id, None)) => {
-                    // A replica has failed and requires rehydration.
-                    self.failed_replicas.insert(replica_id);
-                }
-                Some((replica_id, Some(response))) => {
-                    // A replica has produced a response. Return it.
-                    return (replica_id, response);
-                }
+        match response {
+            None => {
+                // There were no replicas in the set. Block forever to
+                // communicate that no response is ready.
+                future::pending().await
+            }
+            Some((replica_id, None)) => {
+                // A replica has failed and requires rehydration.
+                self.failed_replicas.insert(replica_id);
+                Err(replica_id)
+            }
+            Some((replica_id, Some(response))) => {
+                // A replica has produced a response. Return it.
+                Ok((replica_id, response))
             }
         }
     }


### PR DESCRIPTION
If a replica fails during waiting for responses in `ComputeController::ready`, we now return immediately to signal the caller that there is work to do (namely rehydrating the replica).

Previously we would wait until something else happened to interrupt `ready` and re-enter it again, which would needlessly delay rehydration.

### Motivation

   * This PR refactors existing code.

This was raised by @brennanvincent [in Slack](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1666827730272599).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
