### PR TITLE
compute-controller: Fix race between replica crash and drop

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -325,6 +325,11 @@ where
             .remove(&id)
             .expect("replica not found");
 
+        // In case the replica crashes and we receive a drop replica request
+        // at the same time, the cleanup request will race with the rehydration.
+        // Hence we also have to stop a pending rehydration request.
+        self.compute.failed_replicas.remove(&id);
+
         Ok(())
     }
 


### PR DESCRIPTION
When a replica crashes and at the same time a `DROP REPLICA` is requested, environmentd can crash when it tries to rehydrate the newly removed replica.

When we notice a connection problem with a replica, we delay the rehydration (because of cancellation safety in `.recv()`). We keep a list of dysfunctional replicas in `failed_replicas`. If we remove a replica, we do not remove it from this list.

I probably introduced this bug in #15467 and the failing nightlies  #15735 (zippy create replica ) might be related to this issue.

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR fixes a known bug.

Fixes #15735.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
