### PR TITLE
doc/developer: add an error message example

### DIFF
--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -104,9 +104,9 @@ For error message style, we strive to adhere to the [guidelines](https://www.pos
 - **Hint message**: suggestions about what to do to fix the problem. This should be actionable, and can provide a shortlink to direct the user to more information. Use complete sentences, each of which starts with a capitalized letter and ends with a period. Separate sentences with two spaces.
 
 ```
-Primary: could not parse column "foo"
-Detail: Column "foo" in table "bar" contains an unsupported type.
-Hint: Try using CAST in the CREATE SOURCE statement.
+Primary: could not parse column "bar.foo"
+Detail: Column "bar.foo" contains an unsupported type.
+Hint: Try using CAST in the CREATE SOURCE statement or excluding this column from replcation.
 ```
 
 To use a shortlink in a Hint, add the shortlink to this [file](https://github.com/MaterializeInc/materialize/blob/3efb2c933e4e6c8e694afb1e794c7d8dae368e7d/ci/deploy/website.sh#L29) in your PR to add/modify the hint message. Be mindful that we are committed to the upkeep of the referenced link.

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -97,13 +97,19 @@ _Portions of this section are copied from the PostgreSQL documentation and subje
 
 For error message style, we strive to adhere to the [guidelines](https://www.postgresql.org/docs/current/error-style-guide.html) in the PostgreSQL manual, and use a format that consists of a **required** _primary_ message followed by **optional** _detail_ and _hint_ messages.
 
-**Primary message**: short, factual, and avoids reference to implementation details. Lowercase the first letter and do not end with any punctuation.
+- **Primary message**: short, factual, and avoids reference to implementation details. Lowercase the first letter and do not end with any punctuation.
 
-**Detail message**: factual, use if needed to keep the primary message short or to mention implementation details. Use complete sentences, each of which starts with a capitalized letter and ends with a period. Separate sentences with two spaces.
+- **Detail message**: factual, use if needed to keep the primary message short or to mention implementation details. Use complete sentences, each of which starts with a capitalized letter and ends with a period. Separate sentences with two spaces.
 
-**Hint message**: suggestions about what to do to fix the problem. This should be actionable, and can provide a shortlink to direct the user to more information. Use complete sentences, each of which starts with a capitalized letter and ends with a period. Separate sentences with two spaces.
+- **Hint message**: suggestions about what to do to fix the problem. This should be actionable, and can provide a shortlink to direct the user to more information. Use complete sentences, each of which starts with a capitalized letter and ends with a period. Separate sentences with two spaces.
 
-To use a shortlink in a Hint, add the shortlink to this [file](https://github.com/MaterializeInc/materialize/blob/3efb2c933e4e6c8e694afb1e794c7d8dae368e7d/ci/deploy/website.sh#L29) in your PR to add/modify the hint mesage. Be mindful that we are committed to the upkeep of the referenced link.
+```
+Primary: could not parse column "foo"
+Detail: Column "foo" in table "bar" contains an unsupported type.
+Hint: Try using CAST in the CREATE SOURCE statement.
+```
+
+To use a shortlink in a Hint, add the shortlink to this [file](https://github.com/MaterializeInc/materialize/blob/3efb2c933e4e6c8e694afb1e794c7d8dae368e7d/ci/deploy/website.sh#L29) in your PR to add/modify the hint message. Be mindful that we are committed to the upkeep of the referenced link.
 
 Some key principles to highlight are:
 * Do not put any formatting into message texts, such as newlines.
@@ -115,6 +121,7 @@ Some key principles to highlight are:
 * Tricky words to avoid: unable, bad, illegal, unknown.
 * Avoid contractions and spell out words in full.
 * Word choices to be mindful of: find vs. exists, may vs. can vs. might.
+
 
 ## Rust style
 

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -106,7 +106,7 @@ For error message style, we strive to adhere to the [guidelines](https://www.pos
 ```
 Primary: could not parse column "bar.foo"
 Detail: Column "bar.foo" contains an unsupported type.
-Hint: Try using CAST in the CREATE SOURCE statement or excluding this column from replcation.
+Hint: Try using CAST in the CREATE SOURCE statement or excluding this column from replication.
 ```
 
 To use a shortlink in a Hint, add the shortlink to this [file](https://github.com/MaterializeInc/materialize/blob/3efb2c933e4e6c8e694afb1e794c7d8dae368e7d/ci/deploy/website.sh#L29) in your PR to add/modify the hint message. Be mindful that we are committed to the upkeep of the referenced link.


### PR DESCRIPTION
Added an error message example and some formatting cleanup to internal style guide.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
