### PR TITLE
[sinks] [status] Put sink status collection behind unsafe

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -453,9 +453,9 @@ impl<S: Append + 'static> Coordinator<S> {
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.collection(sink.from)?;
 
-        // This is disabled for the moment because we want to attempt to roll out the change slowly as we're
+        // This is in unsafe mode for the moment because we want to attempt to roll out the change slowly as we're
         // stressing persist in a new way.
-        let status_id = if false {
+        let status_id = if self.catalog.config().unsafe_mode {
             Some(self.catalog.resolve_builtin_storage_collection(
                 &crate::catalog::builtin::MZ_SINK_STATUS_HISTORY,
             ))

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -8,9 +8,55 @@
 # by the Apache License, Version 2.0.
 
 # Specify the behaviour of the status history tables
+$ set-regex match="\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)?" replacement="<TIMESTAMP>"
 
 # History starts out empty when there are no sources
 > select * from mz_internal.mz_source_status_history
 
-# History starts out empty when there are no sinks
-> select * from mz_internal.mz_sink_status_history
+$ kafka-create-topic topic=status-history
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE SOURCE kafka_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
+  FORMAT TEXT
+
+> CREATE SINK kafka_sink FROM kafka_source
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ set-from-sql var=sink_id
+SELECT id FROM mz_sinks WHERE name = 'kafka_sink'
+
+# Verify we get a starting -- it's possible we move to running by the time this query runs.
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' AND status = 'starting' ORDER BY occurred_at;
+"<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
+
+$ kafka-ingest format=bytes topic=status-history
+a
+b
+c
+d
+
+
+> SELECT * FROM kafka_source ORDER BY 1;
+a
+b
+c
+d
+
+$ kafka-verify-data format=avro sink=materialize.public.kafka_sink sort-messages=true
+{"before": null, "after": {"row":{"text": "a"}}}
+{"before": null, "after": {"row":{"text": "b"}}}
+{"before": null, "after": {"row":{"text": "c"}}}
+{"before": null, "after": {"row":{"text": "d"}}}
+
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at;
+"<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
+"<TIMESTAMP> UTC" ${sink_id} running <null> <null>


### PR DESCRIPTION
Change the temporary `if false` to a more robust `if unsafe_mode`.  Also add some actual tests now that it's running in tests!

### Motivation
Per a discussion among the storage team, we want to put this behind unsafe mode so that:
1) it continues to be tested by our testing infrastructure
2) it's not turned on in production, adding load to persist

### Tips for reviewer
Similar tests to #15633.  I couldn't think of anything sink-specific that was worth adding -- though please give a shout if so!

Stacked on top of #15586.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - none (unsafe mode doesn't make release notes I believe?)
