### PR TITLE
persist: be more lenient when applying compaction diffs to state

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -875,6 +875,8 @@ impl CodecMetrics {
 pub struct StateMetrics {
     pub(crate) apply_spine_fast_path: IntCounter,
     pub(crate) apply_spine_slow_path: IntCounter,
+    pub(crate) apply_spine_slow_path_lenient: IntCounter,
+    pub(crate) apply_spine_slow_path_lenient_adjustment: IntCounter,
     pub(crate) apply_spine_slow_path_with_reconstruction: IntCounter,
     pub(crate) update_state_fast_path: IntCounter,
     pub(crate) update_state_slow_path: IntCounter,
@@ -891,6 +893,14 @@ impl StateMetrics {
             apply_spine_slow_path: registry.register(metric!(
                 name: "mz_persist_state_apply_spine_slow_path",
                 help: "count of spine diff applications that hit the slow path",
+            )),
+            apply_spine_slow_path_lenient: registry.register(metric!(
+                name: "mz_persist_state_apply_spine_slow_path_lenient",
+                help: "count of spine diff applications that hit the lenient compaction apply path",
+            )),
+            apply_spine_slow_path_lenient_adjustment: registry.register(metric!(
+                name: "mz_persist_state_apply_spine_slow_path_lenient_adjustment",
+                help: "count of adjustments made by the lenient compaction apply path",
             )),
             apply_spine_slow_path_with_reconstruction: registry.register(metric!(
                 name: "mz_persist_state_apply_spine_slow_path_with_reconstruction",


### PR DESCRIPTION
Because of the way Spine internally optimizes only _some_ empty batches (immediately merges them in), we can end up in a situation where a compaction res applied on another copy of state, but when we replay all of the state diffs against a new Spine locally, it merges empty batches differently in-mem and we can't exactly apply the compaction diff. Example:

- compact: [1,2),[2,3) -> [1,3)
- this spine: [0,2),[2,3) (0,1 is empty)

Ideally, we'd figure out a way to avoid this, but nothing immediately comes to mind. In the meantime, force the application (otherwise the shard is stuck and we can't do anything with it) by manually splitting the empty batch back out. For the example above:

- [0,1),[1,3) (0,1 is empty)

This can only happen when the batch needing to be split is empty, so error out if it isn't because that means something unexpected is going on.

This commit also contains an (unsuccessful) attempt to get Maelstrom to tickle this bug. Seemed worth merging anyway.

Touches #15493

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
