### PR TITLE
Add feature to save/load flamegraph traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ dependencies = [
  "mz-build-info",
  "mz-http-util",
  "mz-npm",
+ "mz-ore",
  "once_cell",
  "pprof",
  "serde",

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.15.0"
 mime = "0.3.16"
 mz-build-info = { path = "../build-info" }
 mz-http-util = { path = "../http-util" }
+mz-ore = { path = "../ore" }
 pprof = { git = "https://github.com/MaterializeInc/pprof-rs.git" }
 serde = { version = "1.0.145", features = ["derive"] }
 tempfile = "3.2.0"

--- a/src/prof/src/http/mod.rs
+++ b/src/prof/src/http/mod.rs
@@ -307,7 +307,7 @@ mod enabled {
                     .stats()
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
                 let stats_rendered = render_jemalloc_stats(&stats);
-                let  stats_rendered = stats_rendered
+                let stats_rendered = stats_rendered
                     .iter()
                     .map(|(k, v)| (*k, v.as_str()))
                     .collect::<Vec<_>>();

--- a/src/prof/src/http/mod.rs
+++ b/src/prof/src/http/mod.rs
@@ -9,9 +9,7 @@
 
 //! Profiling HTTP endpoints.
 
-use std::cell::RefCell;
 use std::env;
-use std::fmt::Write;
 use std::time::Duration;
 
 use askama::Template;
@@ -82,9 +80,7 @@ struct ProfTemplate<'a> {
 struct FlamegraphTemplate<'a> {
     version: &'a str,
     title: &'a str,
-    data_json: &'a str,
-    display_bytes: bool,
-    extras: &'a [&'a str],
+    mzfg: &'a str,
 }
 
 #[allow(clippy::drop_copy)]
@@ -123,35 +119,21 @@ fn flamegraph(
     stacks: StackProfile,
     title: &str,
     display_bytes: bool,
-    extras: &[&str],
+    extras: &[(&str, &str)],
     build_info: &BuildInfo,
 ) -> impl IntoResponse {
-    let collated = crate::collate_stacks(stacks);
-    let data_json = RefCell::new(String::new());
-    collated.dfs(
-        |node| {
-            write!(
-                data_json.borrow_mut(),
-                "{{\"name\": \"{}\",\"value\":{},\"children\":[",
-                node.name,
-                node.weight
-            )
-            .unwrap(); // String's `std::fmt::Write` implementation never fails
-        },
-        |_node, is_last| {
-            data_json.borrow_mut().push_str("]}");
-            if !is_last {
-                data_json.borrow_mut().push(',');
-            }
-        },
-    );
-    let data_json = &*data_json.borrow();
+    let mut header_extra = vec![];
+    if display_bytes {
+        header_extra.push(("display_bytes", "1"));
+    }
+    for (k, v) in extras {
+        header_extra.push((k, v));
+    }
+    let mzfg = stacks.to_mzfg(true, &header_extra);
     mz_http_util::template_response(FlamegraphTemplate {
         version: build_info.version,
         title,
-        data_json,
-        display_bytes,
-        extras,
+        mzfg: &mzfg,
     })
 }
 
@@ -208,8 +190,6 @@ mod disabled {
 
 #[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
 mod enabled {
-    use std::borrow::Cow;
-    use std::fmt::Write;
     use std::io::{BufReader, Read};
     use std::sync::Arc;
 
@@ -222,8 +202,7 @@ mod enabled {
     use serde::Deserialize;
     use tokio::sync::Mutex;
 
-    use crate::jemalloc::{parse_jeheap, JemallocProfCtl, PROF_CTL};
-    use crate::symbolicate;
+    use crate::jemalloc::{parse_jeheap, JemallocProfCtl, JemallocStats, PROF_CTL};
 
     use super::{flamegraph, time_prof, MemProfilingStatus, ProfTemplate};
     use mz_build_info::BuildInfo;
@@ -256,6 +235,30 @@ mod enabled {
     ) -> impl IntoResponse {
         let prof_ctl = PROF_CTL.as_ref().unwrap();
         let merge_threads = threads.as_deref() == Some("merge");
+
+        fn render_jemalloc_stats(stats: &JemallocStats) -> Vec<(&str, String)> {
+            vec![
+                (
+                    "Allocated",
+                    HumanFormattedBytes(stats.allocated).to_string(),
+                ),
+                (
+                    "In active pages",
+                    HumanFormattedBytes(stats.active).to_string(),
+                ),
+                (
+                    "Allocated for allocator metadata",
+                    HumanFormattedBytes(stats.metadata).to_string(),
+                ),
+                // Don't print `stats.resident` since it is a bit hard to interpret;
+                // see `man jemalloc` for details.
+                (
+                    "Bytes unused, but retained by allocator",
+                    HumanFormattedBytes(stats.retained).to_string(),
+                ),
+            ]
+        }
+
         match action.as_str() {
             "activate" => {
                 {
@@ -275,7 +278,7 @@ mod enabled {
                 };
                 Ok(render_template(prof_ctl, build_info).await.into_response())
             }
-            "dump_file" => {
+            "dump_jeheap" => {
                 let mut borrow = prof_ctl.lock().await;
                 let mut f = borrow
                     .dump()
@@ -292,7 +295,7 @@ mod enabled {
                 )
                     .into_response())
             }
-            "dump_symbolicated_file" => {
+            "dump_sym_mzfg" => {
                 let mut borrow = prof_ctl.lock().await;
                 let f = borrow
                     .dump()
@@ -300,35 +303,21 @@ mod enabled {
                 let r = BufReader::new(f);
                 let stacks = parse_jeheap(r)
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-                let syms = symbolicate(&stacks);
-                let mut s = String::new();
-                // Emitting the format expected by Brendan Gregg's flamegraph tool.
-                //
-                // foo;bar;quux 30
-                // foo;bar;asdf 40
-                //
-                // etc.
-                for (stack, _anno) in stacks.iter() {
-                    for (i, addr) in stack.addrs.iter().enumerate() {
-                        let syms = match syms.get(addr) {
-                            Some(syms) => Cow::Borrowed(syms),
-                            None => Cow::Owned(vec!["???".to_string()]),
-                        };
-                        for (j, sym) in syms.iter().enumerate() {
-                            if j != 0 || i != 0 {
-                                s.push_str(";");
-                            }
-                            s.push_str(&*sym);
-                        }
-                    }
-                    writeln!(&mut s, " {}", stack.weight).unwrap();
-                }
+                let stats = borrow
+                    .stats()
+                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                let stats_rendered = render_jemalloc_stats(&stats);
+                let  stats_rendered = stats_rendered
+                    .iter()
+                    .map(|(k, v)| (*k, v.as_str()))
+                    .collect::<Vec<_>>();
+                let mzfg = stacks.to_mzfg(true, &stats_rendered);
                 Ok((
                     HeaderMap::from_iter([(
                         CONTENT_DISPOSITION,
-                        HeaderValue::from_static("attachment; filename=\"mz.fg\""),
+                        HeaderValue::from_static("attachment; filename=\"trace.mzfg\""),
                     )]),
-                    s,
+                    mzfg,
                 )
                     .into_response())
             }
@@ -343,23 +332,10 @@ mod enabled {
                 let stats = borrow
                     .stats()
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-                let stats_rendered = &[
-                    format!("Allocated: {}", HumanFormattedBytes(stats.allocated)),
-                    format!("In active pages: {}", HumanFormattedBytes(stats.active)),
-                    format!(
-                        "Allocated for allocator metadata: {}",
-                        HumanFormattedBytes(stats.metadata)
-                    ),
-                    // Don't print `stats.resident` since it is a bit hard to interpret;
-                    // see `man jemalloc` for details.
-                    format!(
-                        "Bytes unused, but retained by allocator: {}",
-                        HumanFormattedBytes(stats.retained)
-                    ),
-                ];
+                let stats_rendered = render_jemalloc_stats(&stats);
                 let stats_rendered = stats_rendered
                     .iter()
-                    .map(String::as_str)
+                    .map(|(k, v)| (*k, v.as_str()))
                     .collect::<Vec<_>>();
                 Ok(
                     flamegraph(stacks, "Heap Flamegraph", true, &stats_rendered, build_info)

--- a/src/prof/src/http/static/js/flamegraph.js
+++ b/src/prof/src/http/static/js/flamegraph.js
@@ -36,30 +36,30 @@ function toHumanBytes(n) {
 /// as of this writing, that only applies to separate threads, for CPU profiles.
 function collateStacks(profile, symbols, anyAnnotation) {
     function trieStep(node, name) {
-	for (const child of node.children) {
-	    if (child.name == name) {
-		return child;
-	    }
-	}
-	node.children.push({name: name, value: 0, children: []});
-	return node.children[node.children.length - 1];
+        for (const child of node.children) {
+            if (child.name == name) {
+                return child;
+            }
+        }
+        node.children.push({name: name, value: 0, children: []});
+        return node.children[node.children.length - 1];
     }
     let root = {name: "", value: 0, children: []};
     for (let stack of profile) {
-	let curNode = root;
-	curNode.value += stack.weight;
-	if (anyAnnotation) {
-	    const anno = stack.annotation || "unknown";
-	    curNode = trieStep(curNode, anno);
-	    curNode.value += stack.weight;
-	}
-	for (let addr of stack.addresses) {
-	    const path = symbols[addr] || [addr];
-	    for (const name of path) {
-		curNode = trieStep(curNode, name);
-		curNode.value += stack.weight;
-	    }
-	}
+        let curNode = root;
+        curNode.value += stack.weight;
+        if (anyAnnotation) {
+            const anno = stack.annotation || "unknown";
+            curNode = trieStep(curNode, anno);
+            curNode.value += stack.weight;
+        }
+        for (let addr of stack.addresses) {
+            const path = symbols[addr] || [addr];
+            for (const name of path) {
+                curNode = trieStep(curNode, name);
+                curNode.value += stack.weight;
+            }
+        }
     }
     return root;
 }
@@ -95,33 +95,33 @@ function collateStacks(profile, symbols, anyAnnotation) {
 function parseMzfg(input) {
     let lines = input.split('\n');
     if (lines.length != 0 && lines[lines.length - 1] == "") {
-	// ignore trailing newline
-	lines.pop();
+        // ignore trailing newline
+        lines.pop();
     }
     let i = 0;
     
     // parse header
     let header = {};
     while (i < lines.length) {
-	const line = lines[i];
-	++i;
-	if (line.length == 0) {
-	    break;
-	}
-	
-	const separatorIdx = line.indexOf(': ');
-	if (separatorIdx == -1) {
-	    throw "Invalid header line: " + line;
-	}
-	const fieldName = line.slice(0, separatorIdx);
-	const fieldValue = line.slice(separatorIdx + 2);
-	header[fieldName] = fieldValue;
+        const line = lines[i];
+        ++i;
+        if (line.length == 0) {
+            break;
+        }
+        
+        const separatorIdx = line.indexOf(': ');
+        if (separatorIdx == -1) {
+            throw "Invalid header line: " + line;
+        }
+        const fieldName = line.slice(0, separatorIdx);
+        const fieldValue = line.slice(separatorIdx + 2);
+        header[fieldName] = fieldValue;
     }
 
     // validate header
     const version = header["mz_fg_version"];
     if (version != 1) {
-	throw "Unrecognized version: " + version;
+        throw "Unrecognized version: " + version;
     }
 
     // parse stacks
@@ -129,28 +129,28 @@ function parseMzfg(input) {
     let anyAnnotation = false;
     const stackRegex = /^(?<addresses>(0x[\da-fA-F]{1,16};)*) (?<weight>\d+(\.\d*)?)( (?<annotation>.*))?$/;
     while (i < lines.length) {
-	const line = lines[i];
-	++i;
-	if (line.length == 0) {
-	    break;
-	}
+        const line = lines[i];
+        ++i;
+        if (line.length == 0) {
+            break;
+        }
 
-	const parsedLine = stackRegex.exec(line);
-	if (!parsedLine) {
-	    throw "Invalid stack trace line: " + line;
-	}
-	
-	let addresses = parsedLine.groups['addresses'].split(';');
-	// ignore the trailing semicolon
-	addresses.pop();
-	const weight = parseFloat(parsedLine.groups['weight']);
-	let annotation = null;
-	if (parsedLine.groups['annotation']) {
-	    annotation = parsedLine.groups['annotation'];
-	    anyAnnotation = true;
-	}
+        const parsedLine = stackRegex.exec(line);
+        if (!parsedLine) {
+            throw "Invalid stack trace line: " + line;
+        }
+        
+        let addresses = parsedLine.groups['addresses'].split(';');
+        // ignore the trailing semicolon
+        addresses.pop();
+        const weight = parseFloat(parsedLine.groups['weight']);
+        let annotation = null;
+        if (parsedLine.groups['annotation']) {
+            annotation = parsedLine.groups['annotation'];
+            anyAnnotation = true;
+        }
 
-	stacks.push({annotation: annotation, addresses: addresses, weight: weight});
+        stacks.push({annotation: annotation, addresses: addresses, weight: weight});
     }
 
     // parse symbols
@@ -158,19 +158,19 @@ function parseMzfg(input) {
     let names = {};
     
     while (i < lines.length) {
-	const line = lines[i];
-	++i;
+        const line = lines[i];
+        ++i;
 
-	const parsedLine = symbolRegex.exec(line);
-	if (!parsedLine) {
-	    throw "Invalid symbol line: " + line;
-	}
+        const parsedLine = symbolRegex.exec(line);
+        if (!parsedLine) {
+            throw "Invalid symbol line: " + line;
+        }
 
-	let path = parsedLine.groups['names'].split(';');
-	// ignore the trailing comma
-	path.pop();
-	const addr = parsedLine.groups['address'];
-	names[addr] = path;
+        let path = parsedLine.groups['names'].split(';');
+        // ignore the trailing comma
+        path.pop();
+        const addr = parsedLine.groups['address'];
+        names[addr] = path;
     }
 
     return {names: names, stacks: stacks, anyAnnotation: anyAnnotation, header: header};
@@ -180,21 +180,21 @@ function renderExtra(extra) {
     let div = document.getElementById("extras");
     div.textContent = '';
     for (const extraKey in extra) {
-	let domLine = document.createElement("p");
-	const text = document.createTextNode(extraKey + ": " + extra[extraKey]);
-	domLine.appendChild(text);
-	div.appendChild(domLine);
+        let domLine = document.createElement("p");
+        const text = document.createTextNode(extraKey + ": " + extra[extraKey]);
+        domLine.appendChild(text);
+        div.appendChild(domLine);
     }
 }
 
 function renderPageFromMzfg(mzfg) {
     try {
-	let parsedMzfg = parseMzfg(mzfg);
-	let data = collateStacks(parsedMzfg.stacks, parsedMzfg.names, parsedMzfg.anyAnnotation);
-	renderFlamegraph(data, parsedMzfg.header['display_bytes']);
-	renderExtra(parsedMzfg.header);
+        let parsedMzfg = parseMzfg(mzfg);
+        let data = collateStacks(parsedMzfg.stacks, parsedMzfg.names, parsedMzfg.anyAnnotation);
+        renderFlamegraph(data, parsedMzfg.header['display_bytes']);
+        renderExtra(parsedMzfg.header);
     } catch(error) {
-	alert("Error: " + error);
+        alert("Error: " + error);
     }
 }
 
@@ -241,7 +241,7 @@ function renderFlamegraph(data, displayBytes) {
 function loadFile(ev) {
     const file = ev.target.files[0];
     file.text().then((mzfg) => {
-	renderPageFromMzfg(mzfg);
+        renderPageFromMzfg(mzfg);
     });
 }
 

--- a/src/prof/src/http/static/js/flamegraph.js
+++ b/src/prof/src/http/static/js/flamegraph.js
@@ -17,6 +17,187 @@ function toHumanBytes(n) {
     return n.toFixed(2) + " " + tokens[iTok];
 }
 
+/// Given some stack traces along with their weights,
+/// collate them into a tree structure by function name.
+///
+/// For example: given the following stacks and weights:
+/// ([0x1234, 0xabcd], 100)
+/// ([0x123a, 0xabff, 0x1234], 200)
+/// ([0x1234, 0xffcc], 50)
+/// and assuming that 0x1234 and 0x123a come from the function `f`,
+/// 0xabcd and 0xabff come from `g`, and 0xffcc from `h`, this will produce:
+///
+/// "f" (350) -> "g" 200
+///  |
+///  v
+/// "h" (50)
+///
+/// Stacks may carry an "annotation", which determines which top-level bin they fall into --
+/// as of this writing, that only applies to separate threads, for CPU profiles.
+function collateStacks(profile, symbols, anyAnnotation) {
+    function trieStep(node, name) {
+	for (const child of node.children) {
+	    if (child.name == name) {
+		return child;
+	    }
+	}
+	node.children.push({name: name, value: 0, children: []});
+	return node.children[node.children.length - 1];
+    }
+    let root = {name: "", value: 0, children: []};
+    for (let stack of profile) {
+	let curNode = root;
+	curNode.value += stack.weight;
+	if (anyAnnotation) {
+	    const anno = stack.annotation || "unknown";
+	    curNode = trieStep(curNode, anno);
+	    curNode.value += stack.weight;
+	}
+	for (let addr of stack.addresses) {
+	    const path = symbols[addr] || [addr];
+	    for (const name of path) {
+		curNode = trieStep(curNode, name);
+		curNode.value += stack.weight;
+	    }
+	}
+    }
+    return root;
+}
+
+
+// .mzfg format, in ABNF:
+//
+// hex-digit  = DIGIT / "a" / "b" / "c" / "d" / "e" / "f"
+//     / "A" / "B" / "C" / "D" / "E" / "F"
+// address    = "0x" 1*16hex-digit
+// non-lf     = %x00-09 / %x0B-FF ; anything but a newline
+// non-lf-sc  = %x00-09 / %x0B-3A / %x3C-FF
+//     ; anything but a newline or a semicolon
+// non-lf-c   = %x00-09 / %x0B-39 / %x3B-FF
+//     ; anything but a newline or a colon
+//
+// file        = header LF stacks [LF symbols]
+// header      = *(header-line LF)
+// header-line = *non-lf-c ": " *non-lf
+//
+// stacks = *(stack LF)
+// stack  = *(address ";") SP 1*DIGIT ["." *DIGIT] [SP *non-lf]
+//     ; The addresses of this stack, followed by
+//     ; its weight, optionally followed by an annotation
+//
+// symbols     = (*symbol LF)
+// symbol-name = *non-lf-sc
+// symbol      = address SP 1*(symbol-name ";")
+//     ; An address followed by its names.
+//     ; An address can have more than one name, due to inlining.
+//     ; For example, if 0x1234 is in function `f`, which is inlined in `g`,
+//     ; the corresponding line will be 0x1234 g;f; .
+function parseMzfg(input) {
+    let lines = input.split('\n');
+    if (lines.length != 0 && lines[lines.length - 1] == "") {
+	// ignore trailing newline
+	lines.pop();
+    }
+    let i = 0;
+    
+    // parse header
+    let header = {};
+    while (i < lines.length) {
+	const line = lines[i];
+	++i;
+	if (line.length == 0) {
+	    break;
+	}
+	
+	const separatorIdx = line.indexOf(': ');
+	if (separatorIdx == -1) {
+	    throw "Invalid header line: " + line;
+	}
+	const fieldName = line.slice(0, separatorIdx);
+	const fieldValue = line.slice(separatorIdx + 2);
+	header[fieldName] = fieldValue;
+    }
+
+    // validate header
+    const version = header["mz_fg_version"];
+    if (version != 1) {
+	throw "Unrecognized version: " + version;
+    }
+
+    // parse stacks
+    let stacks = [];
+    let anyAnnotation = false;
+    const stackRegex = /^(?<addresses>(0x[\da-fA-F]{1,16};)*) (?<weight>\d+(\.\d*)?)( (?<annotation>.*))?$/;
+    while (i < lines.length) {
+	const line = lines[i];
+	++i;
+	if (line.length == 0) {
+	    break;
+	}
+
+	const parsedLine = stackRegex.exec(line);
+	if (!parsedLine) {
+	    throw "Invalid stack trace line: " + line;
+	}
+	
+	let addresses = parsedLine.groups['addresses'].split(';');
+	// ignore the trailing semicolon
+	addresses.pop();
+	const weight = parseFloat(parsedLine.groups['weight']);
+	let annotation = null;
+	if (parsedLine.groups['annotation']) {
+	    annotation = parsedLine.groups['annotation'];
+	    anyAnnotation = true;
+	}
+
+	stacks.push({annotation: annotation, addresses: addresses, weight: weight});
+    }
+
+    // parse symbols
+    const symbolRegex = /^(?<address>0x[\da-fA-F]{1,16}) (?<names>.+)$/;
+    let names = {};
+    
+    while (i < lines.length) {
+	const line = lines[i];
+	++i;
+
+	const parsedLine = symbolRegex.exec(line);
+	if (!parsedLine) {
+	    throw "Invalid symbol line: " + line;
+	}
+
+	let path = parsedLine.groups['names'].split(';');
+	// ignore the trailing comma
+	path.pop();
+	const addr = parsedLine.groups['address'];
+	names[addr] = path;
+    }
+
+    return {names: names, stacks: stacks, anyAnnotation: anyAnnotation, header: header};
+}
+
+function renderExtra(extra) {
+    let div = document.getElementById("extras");
+    div.textContent = '';
+    for (const extraKey in extra) {
+	let domLine = document.createElement("p");
+	const text = document.createTextNode(extraKey + ": " + extra[extraKey]);
+	domLine.appendChild(text);
+	div.appendChild(domLine);
+    }
+}
+
+function renderPageFromMzfg(mzfg) {
+    try {
+	let parsedMzfg = parseMzfg(mzfg);
+	let data = collateStacks(parsedMzfg.stacks, parsedMzfg.names, parsedMzfg.anyAnnotation);
+	renderFlamegraph(data, parsedMzfg.header['display_bytes']);
+	renderExtra(parsedMzfg.header);
+    } catch(error) {
+	alert("Error: " + error);
+    }
+}
+
 function renderFlamegraph(data, displayBytes) {
     let chart = flamegraph()
         .width(960)
@@ -55,4 +236,24 @@ function renderFlamegraph(data, displayBytes) {
     d3.select("#search-input").on("keyup", function () {
         chart.search(this.value);
     });
+}
+
+function loadFile(ev) {
+    const file = ev.target.files[0];
+    file.text().then((mzfg) => {
+	renderPageFromMzfg(mzfg);
+    });
+}
+
+function download(filename, data) {
+    let element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(data));
+    element.setAttribute('download', filename);
+
+    element.style.display = 'none';
+    document.body.appendChild(element);
+
+    element.click();
+
+    document.body.removeChild(element);
 }

--- a/src/prof/src/http/static/js/flamegraph.js
+++ b/src/prof/src/http/static/js/flamegraph.js
@@ -99,7 +99,7 @@ function parseMzfg(input) {
         lines.pop();
     }
     let i = 0;
-    
+
     // parse header
     let header = {};
     while (i < lines.length) {
@@ -108,7 +108,7 @@ function parseMzfg(input) {
         if (line.length == 0) {
             break;
         }
-        
+
         const separatorIdx = line.indexOf(': ');
         if (separatorIdx == -1) {
             throw "Invalid header line: " + line;
@@ -139,7 +139,7 @@ function parseMzfg(input) {
         if (!parsedLine) {
             throw "Invalid stack trace line: " + line;
         }
-        
+
         let addresses = parsedLine.groups['addresses'].split(';');
         // ignore the trailing semicolon
         addresses.pop();
@@ -156,7 +156,7 @@ function parseMzfg(input) {
     // parse symbols
     const symbolRegex = /^(?<address>0x[\da-fA-F]{1,16}) (?<names>.+)$/;
     let names = {};
-    
+
     while (i < lines.length) {
         const line = lines[i];
         ++i;

--- a/src/prof/src/http/templates/flamegraph.html
+++ b/src/prof/src/http/templates/flamegraph.html
@@ -20,8 +20,8 @@
             <div class="separator"></div>
             <input id="search-input" type="text" placeholder="Filter...">
             <button id="clear-button" type="button">Clear</button>
-	    <input id="load-file" type="file" />
-	    <button id="save-file" type="submit">Save current trace</button>
+            <input id="load-file" type="file" />
+            <button id="save-file" type="submit">Save current trace</button>
         </form>
     </div>
     <div id="chart"></div>

--- a/src/prof/src/http/templates/flamegraph.html
+++ b/src/prof/src/http/templates/flamegraph.html
@@ -15,23 +15,27 @@
 <div id="wrapper">
     <div id="header">
       <h1>{{ title }}</h1>
-      <form id="search-form">
+      <form id="search-form" onsubmit="download('trace.mzfg', mzfg)">
             <button id="reset-zoom-button" type="button">Reset zoom</button>
             <div class="separator"></div>
             <input id="search-input" type="text" placeholder="Filter...">
             <button id="clear-button" type="button">Clear</button>
+	    <input id="load-file" type="file" />
+	    <button id="save-file" type="submit">Save current trace</button>
         </form>
     </div>
     <div id="chart"></div>
     <div id="extras">
-      {% for extra_line in extras %}
-      <p>{{ extra_line }}</p>
-      {% endfor %}
     </div>
     <div id="details"></div>
 </div>
 
 <script>
-renderFlamegraph({{ data_json|safe }}, {{ display_bytes|json }});
+  let mzfg = {{mzfg|json|safe}};
+  renderPageFromMzfg(mzfg);
+  
+  document.getElementById('load-file').addEventListener('change', ev => {
+      loadFile(ev);
+  });
 </script>
 {% endblock %}

--- a/src/prof/src/http/templates/flamegraph.html
+++ b/src/prof/src/http/templates/flamegraph.html
@@ -33,7 +33,7 @@
 <script>
   let mzfg = {{mzfg|json|safe}};
   renderPageFromMzfg(mzfg);
-  
+
   document.getElementById('load-file').addEventListener('change', ev => {
       loadFile(ev);
   });

--- a/src/prof/src/http/templates/prof.html
+++ b/src/prof/src/http/templates/prof.html
@@ -16,8 +16,8 @@
     {% endmatch %}
     <form method="post">
       <button name="action" value="deactivate">Deactivate</button>
-      <button name="action" value="dump_file">Download heap profile</button>
-      <button name="action" value="dump_symbolicated_file">Download symbolicated heap profile</button>
+      <button name="action" value="dump_jeheap">Download allocation profile (jemalloc heap format)</button>
+      <button name="action" value="dump_sym_mzfg">Download allocation profile (symbolicated MZ format)</button>
       <button name="action" value="mem_fg">Visualize heap profile (flamegraph)</button>
     </form>
   {% when None %}

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::Serialize;
-use std::{collections::HashMap, ffi::c_void, time::Instant};
+use mz_ore::soft_assert_or_log;
+use std::{collections::BTreeMap, ffi::c_void, time::Instant};
 
 pub mod http;
 #[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
@@ -34,6 +34,53 @@ pub struct StackProfile {
     annotations: Vec<String>,
     // The second element is the index in `annotations`, if one exists.
     stacks: Vec<(WeightedStack, Option<usize>)>,
+}
+
+impl StackProfile {
+    /// Writes out the `.mzfg` format, which is fully described in flamegraph.js.
+    pub fn to_mzfg(&self, symbolicate: bool, header_extra: &[(&str, &str)]) -> String {
+        // All the unwraps in this function are justified by the fact that
+        // String's fmt::Write impl is infallible.
+        use std::fmt::Write;
+        let mut builder = "mz_fg_version: 1\n".to_owned();
+        for (k, v) in header_extra {
+            assert!(!(k.contains(':') || k.contains('\n') || v.contains('\n')));
+            writeln!(&mut builder, "{k}: {v}").unwrap();
+        }
+        writeln!(&mut builder, "").unwrap() ;
+
+        for (WeightedStack { addrs, weight }, anno) in &self.stacks {
+            let anno = anno.map(|i| &self.annotations[i]);
+            for &addr in addrs {
+                write!(&mut builder, "{addr:#x};").unwrap();
+            }
+            write!(&mut builder, " {weight}").unwrap();
+            if let Some(anno) = anno {
+                write!(&mut builder, "{anno}").unwrap()
+            }
+            writeln!(&mut builder, "").unwrap();
+        }
+
+        if symbolicate {
+            let symbols = crate::symbolicate(self);
+            writeln!(&mut builder, "").unwrap();
+
+            for (addr, names) in symbols {
+                if !names.is_empty() {
+                    write!(&mut builder, "{addr:#x} ").unwrap();
+                    for name in names {
+                        // The client splits on semicolons, which shouldn't
+                        // be present in symbol names.
+                        soft_assert_or_log!(!name.contains(';'), "Invalid symbol name: {name}");
+                        write!(&mut builder, "{name};").unwrap();
+                    }
+                    writeln!(&mut builder, "").unwrap();
+                }
+            }
+        }
+
+        builder
+    }
 }
 
 pub struct StackProfileIter<'a> {
@@ -76,80 +123,13 @@ impl StackProfile {
         }
     }
 }
-#[derive(Serialize)]
-pub struct SymbolTrieNode {
-    pub name: String,
-    pub weight: f64,
-    links: Vec<usize>,
-}
-
-#[derive(Serialize)]
-pub struct WeightedSymbolTrie {
-    arena: Vec<SymbolTrieNode>,
-}
-
-impl WeightedSymbolTrie {
-    fn new() -> Self {
-        let root = SymbolTrieNode {
-            name: "".to_string(),
-            weight: 0.0,
-            links: vec![],
-        };
-        let arena = vec![root];
-        Self { arena }
-    }
-    pub fn dfs<F: FnMut(&SymbolTrieNode), G: FnMut(&SymbolTrieNode, bool)>(
-        &self,
-        mut pre: F,
-        mut post: G,
-    ) {
-        self.dfs_inner(0, &mut pre, &mut post, true);
-    }
-
-    fn dfs_inner<F: FnMut(&SymbolTrieNode), G: FnMut(&SymbolTrieNode, bool)>(
-        &self,
-        cur: usize,
-        pre: &mut F,
-        post: &mut G,
-        is_last: bool,
-    ) {
-        let node = &self.arena[cur];
-        pre(node);
-        for &link_idx in node.links.iter() {
-            let is_last = link_idx == *node.links.last().unwrap();
-            self.dfs_inner(link_idx, pre, post, is_last);
-        }
-        post(node, is_last);
-    }
-
-    fn step(&mut self, node: usize, next_name: &str) -> usize {
-        for &link_idx in self.arena[node].links.iter() {
-            if next_name == self.arena[link_idx].name {
-                return link_idx;
-            }
-        }
-        let next = SymbolTrieNode {
-            name: next_name.to_string(),
-            weight: 0.0,
-            links: vec![],
-        };
-        let idx = self.arena.len();
-        self.arena.push(next);
-        self.arena[node].links.push(idx);
-        idx
-    }
-
-    fn node_mut(&mut self, idx: usize) -> &mut SymbolTrieNode {
-        &mut self.arena[idx]
-    }
-}
 
 /// Given some stack traces, generate a map of addresses to their
 /// corresponding symbols.
 ///
 /// Each address could correspond to more than one symbol, because
 /// of inlining. (E.g. if 0x1234 comes from "g", which is inlined in "f", the corresponding vec of symbols will be ["f", "g"].)
-pub fn symbolicate(profile: &StackProfile) -> HashMap<usize, Vec<String>> {
+pub fn symbolicate(profile: &StackProfile) -> BTreeMap<usize, Vec<String>> {
     let mut all_addrs = vec![];
     for (stack, _annotation) in profile.stacks.iter() {
         all_addrs.extend(stack.addrs.iter().cloned());
@@ -174,48 +154,4 @@ pub fn symbolicate(profile: &StackProfile) -> HashMap<usize, Vec<String>> {
             (addr, syms)
         })
         .collect()
-}
-/// Given some stack traces along with their weights,
-/// collate them into a tree structure by function name.
-///
-/// For example: given the following stacks and weights:
-/// ([0x1234, 0xabcd], 100)
-/// ([0x123a, 0xabff, 0x1234], 200)
-/// ([0x1234, 0xffcc], 50)
-/// and assuming that 0x1234 and 0x123a come from the function `f`,
-/// 0xabcd and 0xabff come from `g`, and 0xffcc from `h`, this will produce:
-///
-/// "f" (350) -> "g" 200
-///  |
-///  v
-/// "h" (50)
-pub fn collate_stacks(profile: StackProfile) -> WeightedSymbolTrie {
-    let addr_to_symbols = symbolicate(&profile);
-    let mut trie = WeightedSymbolTrie::new();
-    let StackProfile {
-        annotations,
-        stacks,
-    } = profile;
-    let any_annotation = !annotations.is_empty();
-    for (stack, annotation) in stacks {
-        let mut cur = if any_annotation {
-            let annotation = annotation
-                .map(|idx| annotations[idx].as_str())
-                .unwrap_or("unknown");
-            trie.node_mut(0).weight += stack.weight;
-            trie.step(0, annotation)
-        } else {
-            0
-        };
-        for name in stack
-            .addrs
-            .into_iter()
-            .flat_map(|addr| addr_to_symbols.get(&addr).unwrap().iter())
-        {
-            trie.node_mut(cur).weight += stack.weight;
-            cur = trie.step(cur, name);
-        }
-        trie.node_mut(cur).weight += stack.weight;
-    }
-    trie
 }

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -47,7 +47,7 @@ impl StackProfile {
             assert!(!(k.contains(':') || k.contains('\n') || v.contains('\n')));
             writeln!(&mut builder, "{k}: {v}").unwrap();
         }
-        writeln!(&mut builder, "").unwrap() ;
+        writeln!(&mut builder, "").unwrap();
 
         for (WeightedStack { addrs, weight }, anno) in &self.stacks {
             let anno = anno.map(|i| &self.annotations[i]);


### PR DESCRIPTION
Add a feature to save and restore flamegraph traces.

At the same time, move all the parsing/collation logic to the client side. The motivation for this is that the previous fully-baked format had lost a lot of information, so if we ever want to enable richer features (think of the kind of stuff that Instruments.app provides: being able to filter out system stacks, being able to merge various things together, etc.), it doesn't provide what we need.

Thus, we invent a new format, `.mzfg`, which contains all relevant information, and interpret it on the client side.
