### PR TITLE
Test that even non-enforced keys get grouped properly

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -17,18 +17,23 @@ use differential_dataflow::{
     trace::{implementations::ord::OrdValBatch, Cursor},
 };
 use differential_dataflow::{AsCollection, Collection};
-use itertools::Itertools;
+use itertools::{EitherOrBoth, Itertools};
 use maplit::hashmap;
-use mz_ore::collections::CollectionExt;
-use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, Row, RowPacker, ScalarType};
 use once_cell::sync::Lazy;
 use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
 
+use mz_ore::cast::CastFrom;
+use mz_ore::collections::CollectionExt;
+use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, Row, RowPacker, ScalarType};
+
 use crate::avro::DiffPair;
 
-/// Given a stream of batches, produce a stream of (vectors of) DiffPairs, in timestamp order.
-// This is useful for some sink envelopes (e.g., Debezium and Upsert), which need
-// to do specific logic based on the _entire_ set of before/after diffs at a given timestamp.
+/// Given a stream of batches, produce a stream of groups of DiffPairs, grouped
+/// by key, at each timestamp.
+///
+// This is useful for some sink envelopes (e.g., Debezium and Upsert), which
+// need to do specific logic based on the _entire_ set of before/after diffs for
+// a given key at each timestamp.
 pub fn combine_at_timestamp<G: Scope>(
     batches: Stream<G, Rc<OrdValBatch<Option<Row>, Row, G::Timestamp, Diff>>>,
 ) -> Collection<G, (Option<Row>, Vec<DiffPair<Row>>), Diff>
@@ -43,68 +48,66 @@ where
                     let mut session = output.session(&cap);
                     batches.swap(&mut rows_buf);
                     for batch in rows_buf.drain(..) {
-                        let mut cursor = batch.cursor();
-                        let mut buf: Vec<(G::Timestamp, Option<&Row>, Diff, &Row)> = vec![];
+                        let mut befores = vec![];
+                        let mut afters = vec![];
 
-                        // This batch is valid for a range of timestamps, but it might not present things in timestamp order.
-                        // Slurp it into a vector, so we can sort that by timestamps.
+                        let mut cursor = batch.cursor();
                         while cursor.key_valid(&batch) {
                             let k = cursor.key(&batch);
+
+                            // Partition updates into retractions (befores)
+                            // and insertions (afters).
                             while cursor.val_valid(&batch) {
-                                let val = cursor.val(&batch);
+                                let v = cursor.val(&batch);
                                 cursor.map_times(&batch, |&t, &diff| {
-                                    buf.push((t, k.as_ref(), diff, val));
+                                    let update = (t, v, usize::cast_from(diff.unsigned_abs()));
+                                    if diff < 0 {
+                                        befores.push(update);
+                                    } else {
+                                        afters.push(update);
+                                    }
                                 });
                                 cursor.step_val(&batch);
                             }
-                            cursor.step_key(&batch);
-                        }
-                        // For each (timestamp, key) we've seen,
-                        // we need to generate a series of (before, after) pairs.
-                        //
-                        // Steps to do this:
-                        // (1) sort by ts, key, diff (so that for each (ts, key), diffs appear in ascending order).
-                        // (2) in each (ts, key), find the point where negative and positive diffs meet, using binary search.
-                        // (3) The (ts, entry, diff) elements before that point will go into "before" fields in DiffPairs;
-                        //     the ones after that point will go in "after".
 
-                        // Step (1) above
-                        buf.sort_by_key(|&(t, k, diff, _row)| (t, k, diff));
-                        for ((t, k), group) in
-                            &buf.into_iter().group_by(|&(t, k, _diff, _row)| (t, k))
-                        {
-                            let mut out = vec![];
-                            let elts: Vec<(G::Timestamp, Option<&Row>, Diff, &Row)> =
-                                group.collect();
-                            // Step (2) above
-                            let pos_idx = elts
-                                .binary_search_by(|(_t, _k, diff, _row)| diff.cmp(&0))
-                                .expect_err("there should be no zero-multiplicity entries");
+                            // Sort by timestamp.
+                            befores.sort_by_key(|(t, _v, _diff)| *t);
+                            afters.sort_by_key(|(t, _v, _diff)| *t);
 
-                            // Step (3) above
-                            let befores = elts[0..pos_idx].iter().flat_map(|elt| {
-                                iter::repeat(elt).take(elt.2.unsigned_abs() as usize)
-                            });
-                            let afters = elts[pos_idx..]
-                                .iter()
-                                .flat_map(|elt| iter::repeat(elt).take(elt.2 as usize));
-                            debug_assert!(befores.clone().all(|(_, _, diff, _)| *diff < 0));
-                            debug_assert!(afters.clone().all(|(_, _, diff, _)| *diff > 0));
-                            for pair in befores.zip_longest(afters) {
-                                let (before, after) = match pair {
-                                    itertools::EitherOrBoth::Both(before, after) => {
-                                        (Some(before.3.clone()), Some(after.3.clone()))
-                                    }
-                                    itertools::EitherOrBoth::Left(before) => {
-                                        (Some(before.3.clone()), None)
-                                    }
-                                    itertools::EitherOrBoth::Right(after) => {
-                                        (None, Some(after.3.clone()))
-                                    }
-                                };
-                                out.push(DiffPair { before, after });
+                            // Convert diff into unary representation.
+                            let befores = befores
+                                .drain(..)
+                                .flat_map(|(t, v, cnt)| iter::repeat((t, v)).take(cnt));
+                            let afters = afters
+                                .drain(..)
+                                .flat_map(|(t, v, cnt)| iter::repeat((t, v)).take(cnt));
+
+                            // At each timestamp, zip together the insertions
+                            // and retractions into diff pairs.
+                            let groups = itertools::merge_join_by(
+                                befores,
+                                afters,
+                                |(t1, _v1), (t2, _v2)| t1.cmp(t2),
+                            )
+                            .map(|pair| match pair {
+                                EitherOrBoth::Both((t, before), (_t, after)) => {
+                                    (t, Some(before.clone()), Some(after.clone()))
+                                }
+                                EitherOrBoth::Left((t, before)) => (t, Some(before.clone()), None),
+                                EitherOrBoth::Right((t, after)) => (t, None, Some(after.clone())),
+                            })
+                            .group_by(|(t, _before, _after)| *t);
+
+                            // For each timestamp, emit the group of
+                            // `DiffPair`s.
+                            for (t, group) in &groups {
+                                let group = group
+                                    .map(|(_t, before, after)| DiffPair { before, after })
+                                    .collect();
+                                session.give(((k.clone(), group), t, 1));
                             }
-                            session.give(((k.cloned(), out), t, 1));
+
+                            cursor.step_key(&batch);
                         }
                     }
                 }

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -63,19 +63,15 @@ where
                         // we need to generate a series of (before, after) pairs.
                         //
                         // Steps to do this:
-                        // (1) sort by ts, diff (so that for each ts, diffs appear in ascending order).
+                        // (1) sort by ts, key, diff (so that for each (ts, key), diffs appear in ascending order).
                         // (2) in each (ts, key), find the point where negative and positive diffs meet, using binary search.
                         // (3) The (ts, entry, diff) elements before that point will go into "before" fields in DiffPairs;
                         //     the ones after that point will go in "after".
 
-                        // Step (1) above)
-
-                        // Because `sort_by_key` is stable, it will not reorder equal elements. Therefore, elements with the same
-                        // key will stay grouped together.
-                        buf.sort_by_key(|(t, _k, diff, _row)| (*t, *diff));
-                        for ((t, k), group) in &buf
-                            .into_iter()
-                            .group_by(|(t, k, _diff, _row)| (*t, k.clone()))
+                        // Step (1) above
+                        buf.sort_by_key(|&(t, k, diff, _row)| (t, k, diff));
+                        for ((t, k), group) in
+                            &buf.into_iter().group_by(|&(t, k, _diff, _row)| (t, k))
                         {
                             let mut out = vec![];
                             let elts: Vec<(G::Timestamp, Option<&Row>, Diff, &Row)> =

--- a/test/testdrive/github-15748.td
+++ b/test/testdrive/github-15748.td
@@ -1,0 +1,160 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# This test creates a single timestamp with multiple events in it
+#
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+$ set schema=[
+  {
+    "type": "array",
+    "items": {
+      "type": "record",
+      "name": "update",
+      "namespace": "com.materialize.cdc",
+      "fields": [
+        {
+          "name": "data",
+          "type": {
+            "type": "record",
+            "name": "data",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          }
+        },
+        {
+          "name": "time",
+          "type": "long"
+        },
+        {
+          "name": "diff",
+          "type": "long"
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "name": "progress",
+    "namespace": "com.materialize.cdc",
+    "fields": [
+      {
+        "name": "lower",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "upper",
+        "type": {
+          "type": "array",
+          "items": "long"
+        }
+      },
+      {
+        "name": "counts",
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "counts",
+            "fields": [
+              {
+                "name": "time",
+                "type": "long"
+              },
+              {
+                "name": "count",
+                "type": "long"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+  ]
+
+
+#
+# Insert some rows and then delete, upsert and insert even more in the same timestamp
+#
+
+$ kafka-create-topic topic=topic1
+> CREATE SOURCE source1
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
+> CREATE SINK sink1 FROM source1
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink1-${testdrive.seed}') KEY (a) NOT ENFORCED
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
+
+# We start with 10 records
+
+$ kafka-ingest format=avro topic=topic1 schema=${schema}
+{"array":[{"data":{"a":10,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":9,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":8,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":7,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":6,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":5,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":4,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":3,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+
+# All of the below happens in a single timestamp "time":2
+
+# Delete 2 records
+$ kafka-ingest format=avro topic=topic1 schema=${schema}
+{"array":[{"data":{"a":7,"b":1},"time":2,"diff":-1}]}
+{"array":[{"data":{"a":3,"b":1},"time":2,"diff":-1}]}
+
+# Upsert 2 records
+$ kafka-ingest format=avro topic=topic1 schema=${schema}
+{"array":[{"data":{"a":8,"b":1},"time":2,"diff":-1}]}
+{"array":[{"data":{"a":2,"b":1},"time":2,"diff":-1}]}
+{"array":[{"data":{"a":8,"b":8},"time":2,"diff":1}]}
+{"array":[{"data":{"a":2,"b":2},"time":2,"diff":1}]}
+
+# Insert 2 records
+$ kafka-ingest format=avro topic=topic1 schema=${schema}
+{"array":[{"data":{"a":0,"b":0},"time":2,"diff":1}]}
+{"array":[{"data":{"a":15,"b":15},"time":2,"diff":1}]}
+
+# Emit the progress
+$ kafka-ingest format=avro topic=topic1 schema=${schema}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[10],"counts":[{"time":1,"count":10}, {"time":2,"count":8}]}}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=testdrive-sink1-${testdrive.seed}
+1	{"a": 1} {"a": 1, "b": 1}
+1	{"a": 2} {"a": 2, "b": 1}
+1	{"a": 3} {"a": 3, "b": 1}
+1	{"a": 4} {"a": 4, "b": 1}
+1	{"a": 5} {"a": 5, "b": 1}
+1	{"a": 6} {"a": 6, "b": 1}
+1	{"a": 7} {"a": 7, "b": 1}
+1	{"a": 8} {"a": 8, "b": 1}
+1	{"a": 9} {"a": 9, "b": 1}
+1	{"a": 10} {"a": 10, "b": 1}
+2	{"a": 0} {"a": 0, "b": 0}
+2	{"a": 2} {"a": 2, "b": 2}
+2	{"a": 3}
+2	{"a": 7}
+2	{"a": 8} {"a": 8, "b": 8}
+2	{"a": 15} {"a": 15, "b": 15}

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -279,6 +279,22 @@ $ kafka-create-topic topic=non-keyed-input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'not-enforced-sink-${testdrive.seed}') KEY (a) NOT ENFORCED
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
+# Send a create, an update, and a delete.
+$ kafka-ingest format=avro topic=non-keyed-input schema=${schema}
+{"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":1,"b":1},"time":2,"diff":-1}]}
+{"array":[{"data":{"a":1,"b":2},"time":2,"diff":1}]}
+{"array":[{"data":{"a":1,"b":2},"time":3,"diff":-1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[10],"counts":[{"time":1,"count":1}, {"time":2,"count":2}, {"time":3,"count":1}]}}
+
+# Verify that the update appears as an upsert instead of a create + delete, even when keys are not enforced.
+# NB: these messages appear out of order because of the way sort-messages shuffles them; see the timestamps
+# for the "true" order.
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed} sort-messages=true
+3	{"a": 1}
+1	{"a": 1} {"a": 1, "b": 1}
+2	{"a": 1} {"a": 1, "b": 2}
+
 # Bad upsert keys
 
 ! CREATE SINK invalid_key FROM input

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -279,21 +279,26 @@ $ kafka-create-topic topic=non-keyed-input
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'not-enforced-sink-${testdrive.seed}') KEY (a) NOT ENFORCED
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
-# Send a create, an update, and a delete.
+# Send a create, an update, and a delete for two separate keys.
 $ kafka-ingest format=avro topic=non-keyed-input schema=${schema}
 {"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
+{"array":[{"data":{"a":2,"b":1},"time":1,"diff":1}]}
 {"array":[{"data":{"a":1,"b":1},"time":2,"diff":-1}]}
+{"array":[{"data":{"a":2,"b":1},"time":2,"diff":-1}]}
 {"array":[{"data":{"a":1,"b":2},"time":2,"diff":1}]}
+{"array":[{"data":{"a":2,"b":2},"time":2,"diff":1}]}
 {"array":[{"data":{"a":1,"b":2},"time":3,"diff":-1}]}
-{"com.materialize.cdc.progress":{"lower":[0],"upper":[10],"counts":[{"time":1,"count":1}, {"time":2,"count":2}, {"time":3,"count":1}]}}
+{"array":[{"data":{"a":2,"b":2},"time":3,"diff":-1}]}
+{"com.materialize.cdc.progress":{"lower":[0],"upper":[10],"counts":[{"time":1,"count":2}, {"time":2,"count":4}, {"time":3,"count":2}]}}
 
 # Verify that the update appears as an upsert instead of a create + delete, even when keys are not enforced.
-# NB: these messages appear out of order because of the way sort-messages shuffles them; see the timestamps
-# for the "true" order.
-$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed} sort-messages=true
-3	{"a": 1}
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed}
 1	{"a": 1} {"a": 1, "b": 1}
+1	{"a": 2} {"a": 2, "b": 1}
 2	{"a": 1} {"a": 1, "b": 2}
+2	{"a": 2} {"a": 2, "b": 2}
+3	{"a": 1}
+3	{"a": 2}
 
 # Bad upsert keys
 


### PR DESCRIPTION
### Motivation

  * This PR fixes a bug reported by a prospect on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

Sorry, @morsapaes, but this one will require some wordsmithing. Here's a quick braindump for the note though.

> Fix a bug in sinks that could cause updates to appear as two separate records instead of consolidated into a single update record. For `ENVELOPE UPSERT`, as a deletion tombstone followed by a record with the new value, and for `ENVELOPE DEBEZIUM`, as a `{"before": "OLDVALUE", "after": null}` record followed by a `{"before": null, "after": "NEWVALUE"}` record. The bug occurred when updates for multiple keys occurred at the same timestamp.