### PR TITLE
storage: only source operators should carry tokens

### DIFF
--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -365,7 +365,7 @@ pub fn render_decode_delimited<G>(
     metadata_items: Vec<IncludedColumnSource>,
     metrics: DecodeMetrics,
     connection_context: &ConnectionContext,
-) -> (Stream<G, DecodeResult>, Option<Box<dyn Any + Send + Sync>>)
+) -> Stream<G, DecodeResult>
 where
     G: Scope,
 {
@@ -461,7 +461,7 @@ where
             }
         }
     });
-    (results, None)
+    results
 }
 
 /// Decode arbitrary chunks of bytes into rows.
@@ -486,7 +486,7 @@ pub fn render_decode<G>(
     metadata_items: Vec<IncludedColumnSource>,
     metrics: DecodeMetrics,
     connection_context: &ConnectionContext,
-) -> (Stream<G, DecodeResult>, Option<Box<dyn Any + Send + Sync>>)
+) -> Stream<G, DecodeResult>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -666,7 +666,7 @@ where
             }
         }
     });
-    (results, None)
+    results
 }
 
 fn to_metadata_row(

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -99,8 +99,6 @@
 //! roughly "as correct as possible" even when errors are present in the errs
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
-use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
 
 use mz_persist_client::ShardId;
 use timely::communication::Allocate;
@@ -161,7 +159,6 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     export.storage_metadata,
                     source_data,
                     storage_state,
-                    Rc::clone(&token),
                 );
             }
 
@@ -191,16 +188,7 @@ pub fn build_export_dataflow<A: Allocate>(
                 timely::dataflow::scopes::Child<TimelyWorker<A>, _>,
                 mz_repr::Timestamp,
             > = region;
-            let mut tokens = BTreeMap::new();
-            let import_ids = BTreeSet::new();
-            crate::render::sinks::render_sink(
-                region,
-                storage_state,
-                &mut tokens,
-                import_ids,
-                id,
-                &description,
-            );
+            crate::render::sinks::render_sink(region, storage_state, id, &description);
         })
     });
 }

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -36,7 +35,6 @@ pub fn render<G>(
     metadata: CollectionMetadata,
     source_data: Collection<G, Result<Row, DataflowError>, Diff>,
     storage_state: &mut StorageState,
-    token: Rc<dyn Any>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -64,8 +62,6 @@ pub fn render<G>(
         // calculation by advancing to the empty frontier.
         current_upper.borrow_mut().clear();
     }
-
-    let weak_token = Rc::downgrade(&token);
 
     let persist_clients = Arc::clone(&storage_state.persist_clients);
     persist_op.build_async(
@@ -98,10 +94,6 @@ pub fn render<G>(
 
             while scheduler.notified().await {
                 let input_upper = frontiers.borrow()[0].clone();
-
-                if weak_token.upgrade().is_none() || current_upper.borrow().is_empty() {
-                    return;
-                }
 
                 if !active_write_worker {
                     // We cannot simply return because that would block the

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -290,7 +290,7 @@ where
             // Depending on the type of _raw_ source produced for the given source
             // connection, render the _decode_ part of the pipeline, that turns a raw data
             // stream into a `DecodeResult`.
-            let (results, extra_token) = match ok_source {
+            let results = match ok_source {
                 SourceType::Delimited(source) => render_decode_delimited(
                     &source,
                     key_encoding,
@@ -308,21 +308,15 @@ where
                     storage_state.decode_metrics.clone(),
                     &storage_state.connection_context,
                 ),
-                SourceType::Row(source) => (
-                    source.map(|r| DecodeResult {
-                        key: None,
-                        value: Some(Ok((r.value, r.diff))),
-                        position: r.position,
-                        upstream_time_millis: r.upstream_time_millis,
-                        partition: r.partition,
-                        metadata: Row::default(),
-                    }),
-                    None,
-                ),
+                SourceType::Row(source) => source.map(|r| DecodeResult {
+                    key: None,
+                    value: Some(Ok((r.value, r.diff))),
+                    position: r.position,
+                    upstream_time_millis: r.upstream_time_millis,
+                    partition: r.partition,
+                    metadata: Row::default(),
+                }),
             };
-            if let Some(tok) = extra_token {
-                needed_tokens.push(Rc::new(tok));
-            }
 
             // render envelopes
             match &envelope {


### PR DESCRIPTION
### Motivation

The token mechanism is there to notify a timely operator that is producing data as a source (i.e does not have an input frontier to react to) that its output is no longer needed and therefore it should terminate by immediately advancing its output frontier to the empty antichain.

Out of confusion (at least speaking about me) we were also installing and constructing tokens and were using them for all sorts of operators when it was not necessary, and it was in fact problematic.

Every dataflow must ideally terminate gracefully which in timely terms means that all operators drop their capabilities, everything reaches the empty antichain and timely cleans up the resources.

Therefore, we only need to have a token for operators that produce data on their own and everything else must rely on the frontiers of its inputs to make decisions. This is true for all operators including our persist sink or external sinks.

Enforcing that dataflow terminate gracefully and always reach the empty antichain means that the storaged process will *always* send a FrontierUppers response back to the storage controller that is at the empty antichain. This is the moment for anyone listening to the feedback stream to cleanup any associated resources since this is the moment that no more updates will arrive after.

We were previously eagerly cleaning up the state of various things when the since frontier advanced to the empty antichain (by observing AllowCompaction commands), but then the components were confused when a stray FrontierUppers made it their way and panicked. This is fixed by waiting for the final terminating frontier to arrive before cleaning up.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
