### PR TITLE
Reconcile dataflows differently

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -709,7 +709,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         for dataflow in dataflows.iter() {
                             let export_ids = dataflow.export_ids().collect::<BTreeSet<_>>();
                             if let Some(old_dataflow) = old_dataflows.get(&export_ids) {
-                                let compatible = dataflow.compatible_with(old_dataflow);
+                                let compatible = old_dataflow.compatible_with(dataflow);
                                 let uncompacted = !export_ids
                                     .iter()
                                     .flat_map(|id| old_frontiers.get(id))


### PR DESCRIPTION
This very small change (courtesy @brennanvincent) changes ("corrects", I think) how we choose to reconcile dataflows. 

Specifically, we used to test whether `new_asof` is less or equal to `old_asof`, and mark it compatible if so. That seems to be the wrong way around, as the interval of times between the two would not be valid for `new_asof`, and we would not uphold the requested frontier. This direction also seems likely to have hamstrung reconciliation, in that we expect in the case of an `environmentd` reboot for it to recover with .. plausibly an `asof` that has advanced, rather than regressed, which would disable reconciliation and force re-evaluation.

This is all exploratory at the moment, but started up in the course of thinking about the missing rows aspect of https://github.com/MaterializeInc/materialize/issues/15185

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
