### PR TITLE
Limit heartbeat activation of persist sinks

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -624,7 +624,7 @@ where
                 // NOTE: We schedule ourselves to make sure that we keep
                 // heartbeating even in cases where there are no changes in our
                 // inputs (updates or frontier changes).
-                if last_heartbeat_activation <= Instant::now() + Duration::from_secs(60) {
+                if last_heartbeat_activation + Duration::from_secs(60) <= Instant::now() {
                     last_heartbeat_activation = Instant::now();
                     activator.activate_after(Duration::from_secs(60));
                 }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -13,13 +13,11 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{Collection, Hashable};
-use mz_persist_client::batch::Batch;
-use mz_persist_client::write::WriterEnrichedHollowBatch;
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{
@@ -28,17 +26,19 @@ use timely::dataflow::operators::{
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
-use timely::scheduling::Activator;
 use timely::PartialOrder;
 use tokio::sync::Mutex;
 use tracing::trace;
 
 use mz_compute_client::sinks::{ComputeSinkDesc, PersistSinkConnection};
+use mz_persist_client::batch::Batch;
 use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::write::WriterEnrichedHollowBatch;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage::controller::CollectionMetadata;
 use mz_storage::types::errors::DataflowError;
 use mz_storage::types::sources::SourceData;
+use mz_timely_util::activator::LimitingActivator;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::compute_state::ComputeState;
@@ -510,32 +510,6 @@ where
     (output_stream, token)
 }
 
-/// An activator that ignores new activation if one is already pending.
-///
-/// We use this for heartbeating the `write_batches` operator, rather than a timely `Activator`
-/// directly, to avoid accumulating more and more activations other time.
-struct LimitingActivator {
-    inner: Activator,
-    next_activation: Instant,
-}
-
-impl LimitingActivator {
-    fn new(inner: Activator) -> Self {
-        Self {
-            inner,
-            next_activation: Instant::now(),
-        }
-    }
-
-    fn activate_after(&mut self, duration: Duration) {
-        let now = Instant::now();
-        if self.next_activation < now {
-            self.next_activation = now + duration;
-            self.inner.activate_after(duration);
-        }
-    }
-}
-
 /// Writes `desired_stream - persist_stream` to persist, but only for updates
 /// that fall into batch a description that we get via `batch_descriptions`.
 /// This forwards a `HollowBatch` for any batch of updates that was written.
@@ -877,6 +851,7 @@ where
     let mut append_op = OperatorBuilder::new(operator_name, scope.clone());
 
     let activator = scope.activator_for(&append_op.operator_info().address[..]);
+    let mut activator = LimitingActivator::new(activator);
 
     // We never output anything, but we update our capabilities based on the
     // persist frontier we know about. So someone can listen on our output

--- a/src/timely-util/src/activator.rs
+++ b/src/timely-util/src/activator.rs
@@ -12,6 +12,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use timely::dataflow::Scope;
 use timely::scheduling::{Activator, SyncActivator};
 
@@ -222,5 +223,32 @@ impl ArcActivatorInner {
 
     fn ack(&mut self) {
         self.activated = 0;
+    }
+}
+
+/// An activator that ignores new activations if one is already pending.
+pub struct LimitingActivator {
+    inner: Activator,
+    next_activation: Instant,
+}
+
+impl LimitingActivator {
+    pub fn new(inner: Activator) -> Self {
+        Self {
+            inner,
+            next_activation: Instant::now(),
+        }
+    }
+
+    pub fn activate(&mut self) {
+        self.activate_after(Duration::ZERO);
+    }
+
+    pub fn activate_after(&mut self, duration: Duration) {
+        let now = Instant::now();
+        if self.next_activation < now {
+            self.next_activation = now + duration;
+            self.inner.activate_after(duration);
+        }
     }
 }

--- a/src/timely-util/src/activator.rs
+++ b/src/timely-util/src/activator.rs
@@ -246,7 +246,7 @@ impl LimitingActivator {
 
     pub fn activate_after(&mut self, duration: Duration) {
         let now = Instant::now();
-        if self.next_activation < now {
+        if self.next_activation <= now {
             self.next_activation = now + duration;
             self.inner.activate_after(duration);
         }


### PR DESCRIPTION
Currently, the persist sink schedules a heartbeat activation each time it goes around its main loop. This can cause a buildup of heartbeat activations that keep compute busy without doing actual work.

This change limits the scheduling of heartbeat activations to once every minute, which seems to limit the CPU utilization in the test reported previously.