### PR TITLE
Group sink output by key

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -72,10 +72,9 @@ where
 
                         // Because `sort_by_key` is stable, it will not reorder equal elements. Therefore, elements with the same
                         // key will stay grouped together.
-                        buf.sort_by_key(|(t, _k, diff, _row)| (*t, *diff));
-                        for ((t, k), group) in &buf
-                            .into_iter()
-                            .group_by(|(t, k, _diff, _row)| (*t, k.clone()))
+                        buf.sort_by_key(|&(t, k, diff, _row)| (t, k, diff));
+                        for ((t, k), group) in
+                            &buf.into_iter().group_by(|&(t, k, _diff, _row)| (t, k))
                         {
                             let mut out = vec![];
                             let elts: Vec<(G::Timestamp, Option<&Row>, Diff, &Row)> =


### PR DESCRIPTION
I don't actually know what I'm doing, but this seems more likely to group sink output by key. For discussion only!

cc: @bkirwi 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
