### PR TITLE
Handle replica-targeting in the compute controller

### DIFF
--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -51,8 +51,7 @@ message ProtoComputeCommand {
 
 message ProtoInstanceConfig {
     mz_compute_client.logging.ProtoLoggingConfig logging = 1;
-    uint64 replica_id = 2;
-    uint32 max_result_size = 3;
+    uint32 max_result_size = 2;
 }
 
 message ProtoCommunicationConfig {
@@ -124,8 +123,7 @@ message ProtoPeek {
     uint64 timestamp = 4;
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
-    optional uint64 target_replica = 7;
-    map<string, string> otel_ctx = 8;
+    map<string, string> otel_ctx = 7;
 }
 
 message ProtoUpdateMaxResultSize {

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -218,8 +218,6 @@ pub type ProcessId = i64;
 #[derive(Arbitrary, Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// Configuration sent to new compute instances.
 pub struct InstanceConfig {
-    /// The instance's replica ID.
-    pub replica_id: ReplicaId,
     /// Optionally, request the installation of logging sources.
     pub logging: Option<LoggingConfig>,
     /// Max size in bytes of any result.
@@ -240,7 +238,6 @@ pub struct CommunicationConfig {
 impl RustType<ProtoInstanceConfig> for InstanceConfig {
     fn into_proto(&self) -> ProtoInstanceConfig {
         ProtoInstanceConfig {
-            replica_id: self.replica_id,
             logging: self.logging.into_proto(),
             max_result_size: self.max_result_size,
         }
@@ -248,7 +245,6 @@ impl RustType<ProtoInstanceConfig> for InstanceConfig {
 
     fn from_proto(proto: ProtoInstanceConfig) -> Result<Self, TryFromProtoError> {
         Ok(Self {
-            replica_id: proto.replica_id,
             logging: proto.logging.into_rust()?,
             max_result_size: proto.max_result_size,
         })
@@ -888,11 +884,6 @@ pub struct Peek<T = mz_repr::Timestamp> {
     pub finishing: RowSetFinishing,
     /// Linear operation to apply in-line on each result.
     pub map_filter_project: mz_expr::SafeMfpPlan,
-    /// Target replica of this peek.
-    ///
-    /// If `Some`, the peek is only handled by the given replica.
-    /// If `None`, the peek is handled by all replicas.
-    pub target_replica: Option<ReplicaId>,
     /// An `OpenTelemetryContext` to forward trace information along
     /// to the compute worker to allow associating traces between
     /// the compute controller and the compute worker.
@@ -917,7 +908,6 @@ impl RustType<ProtoPeek> for Peek {
             timestamp: self.timestamp.into(),
             finishing: Some(self.finishing.into_proto()),
             map_filter_project: Some(self.map_filter_project.into_proto()),
-            target_replica: self.target_replica,
             otel_ctx: self.otel_ctx.clone().into(),
         }
     }
@@ -939,7 +929,6 @@ impl RustType<ProtoPeek> for Peek {
             map_filter_project: x
                 .map_filter_project
                 .into_rust_if_some("ProtoPeek::map_filter_project")?,
-            target_replica: x.target_replica,
             otel_ctx: x.otel_ctx.into(),
         })
     }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -138,7 +138,6 @@ where
 
         instance.send(ComputeCommand::CreateTimely(Default::default()));
         instance.send(ComputeCommand::CreateInstance(InstanceConfig {
-            replica_id: Default::default(),
             logging: None,
             max_result_size,
         }));
@@ -546,10 +545,7 @@ where
         updates.insert(id, ChangeBatch::new_from(timestamp.clone(), 1));
         self.update_read_capabilities(&mut updates).await?;
 
-        let unfinished = match &target_replica {
-            Some(target) => [*target].into(),
-            None => self.compute.replicas.keys().copied().collect(),
-        };
+        let unfinished = self.compute.replicas.keys().copied().collect();
         let otel_ctx = OpenTelemetryContext::obtain();
         self.compute.peeks.insert(
             uuid,
@@ -557,6 +553,7 @@ where
                 target: id,
                 time: timestamp.clone(),
                 unfinished,
+                target_replica,
                 // TODO(guswynn): can we just hold the `tracing::Span` here instead?
                 otel_ctx: Some(otel_ctx.clone()),
             },
@@ -569,7 +566,6 @@ where
             timestamp,
             finishing,
             map_filter_project,
-            target_replica,
             // Obtain an `OpenTelemetryContext` from the thread-local tracing
             // tree to forward it on to the compute worker.
             otel_ctx,
@@ -921,7 +917,9 @@ where
             }
         };
 
-        // If this is the first response, forward it; otherwise do not.
+        // Forward the peek response, if we didn't already forward a response
+        // to this peek previously. If the peek is targeting a replica, only
+        // forward the response from that replica.
         // TODO: we could collect the other responses to assert equivalence?
         // Trades resources (memory) for reassurances; idk which is best.
         //
@@ -933,10 +931,14 @@ where
         //
         // Additionally, we just use the `otel_ctx` from the first worker to
         // respond.
-        let controller_response = peek
-            .otel_ctx
-            .take()
-            .map(|_| ComputeControllerResponse::PeekResponse(uuid, response, otel_ctx));
+        let replica_targeted = peek.target_replica.unwrap_or(replica_id) == replica_id;
+        let controller_response = if replica_targeted {
+            peek.otel_ctx
+                .take()
+                .map(|_| ComputeControllerResponse::PeekResponse(uuid, response, otel_ctx))
+        } else {
+            None
+        };
 
         // Update the per-replica tracking and draw appropriate consequences.
         peek.unfinished.remove(&replica_id);
@@ -1022,6 +1024,10 @@ struct PendingPeek<T> {
     time: T,
     /// Replicas that have yet to respond to this peek.
     unfinished: BTreeSet<ReplicaId>,
+    /// For replica-targeted peeks, this specifies the replica whose response we should pass on.
+    ///
+    /// If this value is `None`, we pass on the first response.
+    target_replica: Option<ReplicaId>,
     /// The OpenTelemetry context for this peek.
     ///
     /// This value is `Some` as long as we have not yet passed a response up the chain, and `None`

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -162,7 +162,6 @@ where
             .await?;
 
         let cmd_spec = CommandSpecialization {
-            replica_id,
             logging_config,
             comm_config,
         };
@@ -256,7 +255,6 @@ where
 }
 
 struct CommandSpecialization {
-    replica_id: ReplicaId,
     logging_config: Option<LoggingConfig>,
     comm_config: CommunicationConfig,
 }
@@ -269,7 +267,6 @@ impl CommandSpecialization {
     fn specialize_command<T>(&self, command: &mut ComputeCommand<T>) {
         // Set new replica ID and obtain set the sinked logs specific to this replica
         if let ComputeCommand::CreateInstance(config) = command {
-            config.replica_id = self.replica_id;
             config.logging = self.logging_config.clone();
         }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -27,7 +27,7 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, Mutex};
 
 use mz_compute_client::command::{
-    ComputeCommand, ComputeCommandHistory, DataflowDescription, InstanceConfig, Peek, ReplicaId,
+    ComputeCommand, ComputeCommandHistory, DataflowDescription, InstanceConfig, Peek,
 };
 use mz_compute_client::logging::LoggingConfig;
 use mz_compute_client::plan::Plan;
@@ -51,8 +51,6 @@ use crate::logging::compute::ComputeEvent;
 /// This state is restricted to the COMPUTE state, the deterministic, idempotent work
 /// done between data ingress and egress.
 pub struct ComputeState {
-    /// The ID of the replica this worker belongs to.
-    pub replica_id: ReplicaId,
     /// The traces available for sharing across dataflows.
     pub traces: TraceManager,
     /// Tokens that should be dropped when a dataflow is dropped to clean up
@@ -230,13 +228,6 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     fn handle_peek(&mut self, peek: Peek) {
-        // Only handle peeks that are not targeted at a different replica.
-        if let Some(target) = peek.target_replica {
-            if target != self.compute_state.replica_id {
-                return;
-            }
-        }
-
         // Acquire a copy of the trace suitable for fulfilling the peek.
         let mut trace_bundle = self.compute_state.traces.get(&peek.id).unwrap().clone();
         let timestamp_frontier = Antichain::from_elem(peek.timestamp);

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -555,7 +555,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
         match &cmd {
             ComputeCommand::CreateInstance(config) => {
                 self.compute_state = Some(ComputeState {
-                    replica_id: config.replica_id,
                     traces: TraceManager::new(
                         self.trace_metrics.clone(),
                         self.timely_worker.index(),


### PR DESCRIPTION
We can handle replica-targeting in the compute controller, there is no need to bother the replicas with this detail and add another edge-case to the compute protocol in the process.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

This PR makes breaking changes to the protobuf types of the compute command protocol  (`ProtoInstanceConfig` and `ProtoPeek`. This is fine because we are not currently storing these types anywhere durably and our update process restarts environmentd and its compute instances together. See also our [backwards compatibility policy](https://www.notion.so/materialize/Backwards-compatibility-policy-434ecf894656435795ef3f61b3a54976#c839062780354d8b952fe22509168395).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
