### PR TITLE
persist: run background heartbeat tasks on CpuHeavyRuntime

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -439,11 +439,11 @@ impl PersistClient {
             machine,
             gc,
             Arc::clone(&self.blob),
+            Arc::clone(&self.cpu_heavy_runtime),
             reader_id,
             read_cap.since,
             heartbeat_ts,
-        )
-        .await;
+        );
 
         Ok(reader)
     }
@@ -501,8 +501,7 @@ impl PersistClient {
             writer_id,
             shard_upper.0,
             heartbeat_ts,
-        )
-        .await;
+        );
         Ok(writer)
     }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -149,7 +149,7 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         cfg: PersistConfig,
         metrics: Arc<Metrics>,
         machine: Machine<K, V, T, D>,
@@ -161,19 +161,22 @@ where
         upper: Antichain<T>,
         last_heartbeat: EpochMillis,
     ) -> Self {
+        let heartbeat_task = machine
+            .clone()
+            .start_writer_heartbeat_task(writer_id.clone(), &cpu_heavy_runtime);
         WriteHandle {
             cfg,
             metrics,
-            machine: machine.clone(),
+            machine,
             gc,
             compact,
             blob,
             cpu_heavy_runtime,
-            writer_id: writer_id.clone(),
+            writer_id,
             upper,
             last_heartbeat,
             explicitly_expired: false,
-            heartbeat_task: Some(machine.start_writer_heartbeat_task(writer_id).await),
+            heartbeat_task: Some(heartbeat_task),
         }
     }
 


### PR DESCRIPTION
(They're not actually cpu heavy.) It's critical that these heartbeats run on time. Given that any instances of blocking work accidentally running on the common Runtime could prevent that from happening, run them on the one that happens to be entirely under persist's control. (We should definitely fix any instances of blocking work on the common runtime, this is just persist being defensive.)

Touches #15209

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
