### PR TITLE
Join EXPLAIN improvements and other stuff

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5454,6 +5454,14 @@ impl ExprHumanizer for ConnCatalog<'_> {
             .map(|name| self.resolve_full_name(name).to_string())
     }
 
+    fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String> {
+        self.state
+            .entry_by_id
+            .get(&id)
+            .map(|entry| entry.name())
+            .map(|name| name.item.clone())
+    }
+
     fn humanize_scalar_type(&self, typ: &ScalarType) -> String {
         use ScalarType::*;
 

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -78,10 +78,14 @@ impl<'a> Displayable<'a, HirRelationExpr> {
         use HirRelationExpr::*;
         match &self.0 {
             Constant { rows, .. } => {
-                writeln!(f, "{}Constant", ctx.indent)?;
-                ctx.indented(|ctx| {
-                    fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.indent)
-                })?;
+                if !rows.is_empty() {
+                    writeln!(f, "{}Constant", ctx.indent)?;
+                    ctx.indented(|ctx| {
+                        fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.indent)
+                    })?;
+                } else {
+                    writeln!(f, "{}Constant <empty>", ctx.indent)?;
+                }
             }
             Let {
                 name: _,

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -52,14 +52,18 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, Plan> {
         match &self.0 {
             Constant { rows } => match rows {
                 Ok(rows) => {
-                    writeln!(f, "{}Constant", ctx.indent)?;
-                    ctx.indented(|ctx| {
-                        fmt_text_constant_rows(
-                            f,
-                            rows.iter().map(|(data, _, diff)| (data, diff)),
-                            &mut ctx.indent,
-                        )
-                    })?;
+                    if !rows.is_empty() {
+                        writeln!(f, "{}Constant", ctx.indent)?;
+                        ctx.indented(|ctx| {
+                            fmt_text_constant_rows(
+                                f,
+                                rows.iter().map(|(data, _, diff)| (data, diff)),
+                                &mut ctx.indent,
+                            )
+                        })?;
+                    } else {
+                        writeln!(f, "{}Constant <empty>", ctx.indent)?;
+                    }
                 }
                 Err(err) => {
                     writeln!(f, "{}Error {}", ctx.indent, err.to_string().quoted())?;

--- a/src/compute-client/src/plan/join/linear_join.rs
+++ b/src/compute-client/src/plan/join/linear_join.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use crate::plan::join::JoinBuildState;
 use crate::plan::join::JoinClosure;
 use crate::plan::AvailableCollections;
-use mz_expr::MapFilterProject;
+use mz_expr::{JoinInputCharacteristics, MapFilterProject};
 
 use mz_expr::join_permutations;
 use mz_expr::permutation_for_arrangement;
@@ -168,7 +168,7 @@ impl LinearJoinPlan {
         source_relation: usize,
         source_arrangement: Option<&(Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>)>,
         equivalences: &[Vec<MirScalarExpr>],
-        join_order: &[(usize, Vec<MirScalarExpr>)],
+        join_order: &[(usize, Vec<MirScalarExpr>, Option<JoinInputCharacteristics>)],
         input_mapper: mz_expr::JoinInputMapper,
         mfp_above: &mut MapFilterProject,
         available: &[AvailableCollections],
@@ -216,7 +216,7 @@ impl LinearJoinPlan {
 
         // Iterate through the join order instructions, assembling keys and
         // closures to use.
-        for (lookup_relation, lookup_key) in join_order.iter() {
+        for (lookup_relation, lookup_key, _characteristics) in join_order.iter() {
             let available = &available[*lookup_relation];
 
             let (lookup_permutation, lookup_thinning) = available

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1114,7 +1114,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                         // Start with the constant input. This is important at least until #14059
                         // is fixed.
                         let start: usize = 1;
-                        let order = vec![(0usize, key.clone())];
+                        let order = vec![(0usize, key.clone(), None)];
                         let source_arrangement = input_keys[start].arbitrary_arrangement();
                         let (ljp, missing) = LinearJoinPlan::create_from(
                             start,
@@ -1143,7 +1143,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                     DeltaQuery(orders) => {
                         let (djp, missing) = DeltaJoinPlan::create_from(
                             equivalences,
-                            &orders[..],
+                            orders,
                             input_mapper,
                             &mut mfp,
                             &input_keys,

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -193,6 +193,10 @@ impl ExprHumanizer for TestCatalog {
         self.names.get(&id).map(|s| s.to_string())
     }
 
+    fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String> {
+        self.names.get(&id).map(|s| s.to_string())
+    }
+
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
         DummyHumanizer.humanize_scalar_type(ty)
     }

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -87,8 +87,8 @@ build
 (join
     [(get y) (get y)]
     [[#0 #3]]
-    (delta_query [[[0 [#0]] [1 [#0]]]
-                  [[1 [#0]] [0 [#0]]]]))
+    (delta_query [[[0 [#0] (false 1 true (false false false 0 false) 0)] [1 [#0] (false 1 true (false false false 0 false) 0)]]
+                  [[1 [#0] (false 1 true (false false false 0 false) 0)] [0 [#0] (false 1 true (false false false 0 false) 0)]]]))
 ----
 ----
 %0 =

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -381,7 +381,7 @@ impl<'a> ViewExplanation<'a> {
                 },
                 separated(
                     " ",
-                    inputs.iter().map(|(pos, input)| {
+                    inputs.iter().map(|(pos, input, _characteristics)| {
                         format!(
                             "%{}.({})",
                             self.expr_chain(&join_inputs[*pos]),
@@ -399,7 +399,7 @@ impl<'a> ViewExplanation<'a> {
                         self.expr_chain(&join_inputs[pos]),
                         separated(
                             " ",
-                            inputs.iter().map(|(pos, input)| {
+                            inputs.iter().map(|(pos, input, _characteristics)| {
                                 format!(
                                     "%{}.({})",
                                     self.expr_chain(&join_inputs[*pos]),

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -45,7 +45,10 @@ pub use relation::{
     MirRelationExpr, ProtoAggregateExpr, RowSetFinishing, WindowFrame, WindowFrameBound,
     WindowFrameUnits, RECURSION_LIMIT,
 };
-pub use relation::{ProtoAggregateFunc, ProtoColumnOrder, ProtoRowSetFinishing, ProtoTableFunc};
+pub use relation::{
+    JoinInputCharacteristics, ProtoAggregateFunc, ProtoColumnOrder, ProtoRowSetFinishing,
+    ProtoTableFunc,
+};
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, FilterCharacteristics, MirScalarExpr};
 pub use scalar::{ProtoDomainLimit, ProtoEvalError, ProtoMirScalarExpr};

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2031,6 +2031,26 @@ impl FilterCharacteristics {
         }
     }
 
+    pub fn explain(&self) -> String {
+        let mut e = "".to_owned();
+        if self.literal_equality {
+            e.push_str("e");
+        }
+        if self.like {
+            e.push_str("l");
+        }
+        if self.is_null {
+            e.push_str("n");
+        }
+        for _ in 0..self.literal_inequality {
+            e.push_str("i");
+        }
+        if self.any_filter {
+            e.push_str("f");
+        }
+        e
+    }
+
     pub fn filter_characteristics(
         filters: &Vec<MirScalarExpr>,
     ) -> Result<FilterCharacteristics, RecursionLimitError> {

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -834,7 +834,9 @@ fn find_next_type_in_tuple(type_name: &str, prev_elem_end: usize) -> Option<(usi
     let mut it = type_name.chars().skip(current_elem_begin).peekable();
     let mut paren_level = 0;
     let mut bracket_level = 0;
-    while i < type_name.len() && !(paren_level == 0 && bracket_level == 0 && *it.peek().unwrap() == ',') {
+    while i < type_name.len()
+        && !(paren_level == 0 && bracket_level == 0 && *it.peek().unwrap() == ',')
+    {
         if *it.peek().unwrap() == '(' {
             paren_level += 1;
         } else if *it.peek().unwrap() == ')' {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -729,6 +729,10 @@ impl ExprHumanizer for DummyCatalog {
         DummyHumanizer.humanize_id(id)
     }
 
+    fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String> {
+        DummyHumanizer.humanize_id_unqualified(id)
+    }
+
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
         DummyHumanizer.humanize_scalar_type(ty)
     }

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -311,6 +311,10 @@ impl ExprHumanizer for TestCatalog {
         DummyHumanizer.humanize_id(id)
     }
 
+    fn humanize_id_unqualified(&self, id: GlobalId) -> Option<String> {
+        DummyHumanizer.humanize_id_unqualified(id)
+    }
+
     fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
         DummyHumanizer.humanize_scalar_type(ty)
     }

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -138,23 +138,23 @@ Applied Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGu
 No change: Fixpoint { transforms: [ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }], limit: 100 }, CanonicalizeMfp
 ====
 Applied Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }:
-(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
 
 ====
 No change: CanonicalizeMfp
 ====
 Applied RelationCSE:
-(let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]])) (get l3)))))
+(let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (Join [(get l1) (get l2)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0] (false 1 true (false false false 0 false) 0)]])) (get l3)))))
 
 ====
 Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
-(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
 
 ====
 No change: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, ThresholdElision
 ====
 Final:
-(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0]]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 null] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
 
 ====
 ====

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -197,8 +197,8 @@ Explained Query:
     Filter ((#4 = 24) OR ((#3 = 6) AND (#4 <= 4) AND (#4 >= 3))) // { arity: 25 }
       Join on=(#0 = #16) type=delta // { arity: 25 }
         implementation
-          %0 » %1[#0]
-          %1 » %0[#0]
+          %0:lineitem » %1:orders[#0]KA
+          %1:orders » %0:lineitem[#0]KAeif
         ArrangeBy keys=[[#0]] // { arity: 16 }
           Get materialize.public.lineitem // { arity: 16 }
         ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -243,9 +243,9 @@ Explained Query:
     Filter (#11 > #20) AND (#10 >= #20) AND (#30 >= #19) // { arity: 33 }
       Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
         implementation
-          %0 » %1[#0] » %2[#0]
-          %1 » %0[#0] » %2[#0]
-          %2 » %1[#1] » %0[#0]
+          %0:lineitem » %1:orders[#0]KA » %2:customer[#0]KA
+          %1:orders » %0:lineitem[#0]KA » %2:customer[#0]KA
+          %2:customer » %1:orders[#1]KA » %0:lineitem[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 16 }
           Get materialize.public.lineitem // { arity: 16 }
         ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -304,9 +304,9 @@ Explained Query:
         Filter (#10 <= 1995-11-14) AND (#30 <= 12907776) AND (#10 >= 1995-04-19) AND (#30 >= #5) // { arity: 33 }
           Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
             implementation
-              %0 » %1[#0] » %2[#0]
-              %1 » %0[#0] » %2[#0]
-              %2 » %1[#1] » %0[#0]
+              %0:lineitem » %1:orders[#0]KA » %2:customer[#0]KAif
+              %1:orders » %0:lineitem[#0]KAiif » %2:customer[#0]KAif
+              %2:customer » %1:orders[#1]KA » %0:lineitem[#0]KAiif
             ArrangeBy keys=[[#0]] // { arity: 16 }
               Get materialize.public.lineitem // { arity: 16 }
             ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -364,7 +364,7 @@ Explained Query:
       Filter (#19 < #8) AND (#19 <= #3) // { arity: 22 }
         Join on=(#4 = #9 AND #6 = #14) type=differential // { arity: 22 }
           implementation
-            materialize.public.orders » %0[#4] » %2[#0]
+            %1:orders » %0:lineitem[#4]KAf » %2:customer[#0]KAf
           ArrangeBy keys=[[#4]] // { arity: 5 }
             Project (#2..=#5, #12) // { arity: 5 }
               Filter (#3 != 1) AND (#3 != 2) AND (#3 != 6) // { arity: 16 }
@@ -412,7 +412,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0 » %1[#0]
+                    %0:l1 » %1[#0]UKAif
                   Project (#4, #11) // { arity: 2 }
                     Get l1 // { arity: 16 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -432,7 +432,7 @@ Explained Query:
       Project (#0..=#4) // { arity: 5 }
         Join on=(#2 = #5) type=differential // { arity: 6 }
           implementation
-            %1 » %0[#2]
+            %1:orders » %0:lineitem[#2]KA
           ArrangeBy keys=[[#2]] // { arity: 4 }
             Project (#0, #4, #11, #12) // { arity: 4 }
               Get materialize.public.lineitem // { arity: 16 }
@@ -476,7 +476,7 @@ Explained Query:
     Filter (#12 <= #5) AND ((#1 = 7) OR (#1 = 33) OR ((#1 = 17) AND (#13 <= "x") AND (#13 >= "s"))) // { arity: 14 }
       Join on=(#0 = #2) type=differential // { arity: 14 }
         implementation
-          %2 » %0[] » %1[#0]
+          %2:customer » %0:lineitem[×]Aef » %1:orders[#0]KAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Project (#0, #4) // { arity: 2 }
             Filter ((#4 = 7) OR (#4 = 17) OR (#4 = 33)) // { arity: 16 }
@@ -527,9 +527,9 @@ Explained Query:
       Filter (#4 <= 30) AND (#12 <= 1998-11-27) AND (#12 <= 1992-11-22) AND (#4 >= 1) AND (#12 >= 1992-06-21) AND (#12 >= 1992-07-13) // { arity: 33 }
         Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
           implementation
-            %0 » %1[#0] » %2[#0]
-            %1 » %0[#0] » %2[#0]
-            %2 » %1[#1] » %0[#0]
+            %0:lineitem » %1:orders[#0]KA » %2:customer[#0]KA
+            %1:orders » %0:lineitem[#0]KAiiiiiif » %2:customer[#0]KA
+            %2:customer » %1:orders[#1]KA » %0:lineitem[#0]KAiiiiiif
           ArrangeBy keys=[[#0]] // { arity: 16 }
             Get materialize.public.lineitem // { arity: 16 }
           ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -584,7 +584,7 @@ Explained Query:
         Filter (#1 < #6) AND (#16 > #5) AND (#16 >= #0) // { arity: 19 }
           Join on=(#3 = #11) type=differential // { arity: 19 }
             implementation
-              %2 » %1[#1] » %0[]
+              %2:customer » %1:orders[#1]KA » %0:lineitem[×]Af
             ArrangeBy keys=[[]] // { arity: 2 }
               Project (#5, #10) // { arity: 2 }
                 Filter (#3 != 4) // { arity: 16 }
@@ -635,9 +635,9 @@ Explained Query:
       Filter (#0 <= 280) AND (#0 <= 289) AND (#0 >= 62) AND (#0 >= 117) AND (#10 > #20) // { arity: 33 }
         Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
           implementation
-            %0 » %1[#0] » %2[#0]
-            %1 » %0[#0] » %2[#0]
-            %2 » %1[#1] » %0[#0]
+            %0:lineitem » %1:orders[#0]KAiiiiiiiif » %2:customer[#0]KA
+            %1:orders » %0:lineitem[#0]KAiiiiiiiif » %2:customer[#0]KA
+            %2:customer » %1:orders[#1]KAiiiiiiiif » %0:lineitem[#0]KAiiiiiiiif
           ArrangeBy keys=[[#0]] // { arity: 16 }
             Get materialize.public.lineitem // { arity: 16 }
           ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -687,7 +687,7 @@ Explained Query:
       Filter (#10 <= 1994-03-17) AND (#0 >= 53) AND (#5 < #19) AND (#26 < #19) // { arity: 27 }
         Join on=(#0 = #16) type=differential // { arity: 27 }
           implementation
-            %1 » %0[#0] » %2[]
+            %1:orders » %0:lineitem[#0]KAiiiiif » %2:customer[×]Aiiiiif
           ArrangeBy keys=[[#0]] // { arity: 16 }
             Get materialize.public.lineitem // { arity: 16 }
           ArrangeBy keys=[[#0]] // { arity: 9 }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -304,7 +304,7 @@ Explained Query:
       Project (#2, #3, #12, #0, #1, #4, #6, #7) // { arity: 8 }
         Join on=(eq(#0, #8, #15) AND #2 = #10 AND #5 = #11 AND #9 = #16 AND #13 = #14) type=differential // { arity: 17 }
           implementation
-            %2 » %5[#0, #1] » %0[#0] » %1[#0] » %3[#0] » l0[#0]
+            %2:stock » %5[#0, #1]UKKA » %0:item[#0]UKAlf » %1:supplier[#0]UKAlf » %3:nation[#0]UKAlf » %4:l0[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Project (#0, #2) // { arity: 2 }
               Filter "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -325,7 +325,7 @@ Explained Query:
                 Project (#0, #2) // { arity: 2 }
                   Join on=(#17 = #18 AND #19 = #20 AND #21 = #22) type=differential // { arity: 23 }
                     implementation
-                      %0 » %1[#0] » %2[#0] » l0[#0]
+                      %0:stock » %1:supplier[#0]UKA » %2:nation[#0]UKA » %3:l0[#0]UKAlf
                     ArrangeBy keys=[[#17]] // { arity: 18 }
                       Get materialize.public.stock // { arity: 18 }
                     ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -384,7 +384,7 @@ Explained Query:
         Project (#1..=#3, #10, #14) // { arity: 5 }
           Join on=(#0 = #9 AND eq(#1, #4, #7, #12) AND eq(#2, #5, #8, #13) AND eq(#3, #6, #11)) type=differential // { arity: 15 }
             implementation
-              %3 » %2[#0, #1, #2] » %0[#0, #1, #2] » %1[#0, #1, #2]
+              %3:orderline » %2:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAlif » %1:neworder[#0, #1, #2]UKKKAlif
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Filter "A%" ~~(padchar(#9)) // { arity: 22 }
@@ -430,7 +430,7 @@ Explained Query:
         Project (#4) // { arity: 1 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 9 }
             implementation
-              %0 » %1[#0, #1, #2, #3]
+              %0:l0 » %1[#0, #1, #2, #3]UKKKKAiif
             Project (#0..=#2, #4, #6) // { arity: 5 }
               Get l0 // { arity: 9 }
             ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 4 }
@@ -439,8 +439,8 @@ Explained Query:
                   Filter (#10 >= #3) // { arity: 14 }
                     Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=delta // { arity: 14 }
                       implementation
-                        %0 » %1[#2, #1, #0]
-                        %1 » %0[#0, #1, #2]
+                        %0:l0 » %1:orderline[#2, #1, #0]KKKA
+                        %1:orderline » %0:l0[#0, #1, #2]UKKKAiif
                       ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                         Project (#0..=#2, #4) // { arity: 4 }
                           Get l0 // { arity: 9 }
@@ -488,7 +488,7 @@ Explained Query:
       Project (#12, #19) // { arity: 2 }
         Join on=(#0 = #7 AND eq(#1, #5, #9) AND eq(#2, #6, #10, #14) AND eq(#3, #17, #18) AND #4 = #8 AND #11 = #13 AND #15 = #16 AND #20 = #21) type=differential // { arity: 22 }
           implementation
-            %2 » %1[#0, #1, #2] » %0[#0, #1, #2] » %3[#0, #1] » %4[#0, #1] » %5[#0] » %6[#0]
+            %2:orderline » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:stock[#0, #1]UKKAif » %4:supplier[#0, #1]UKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif
           ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
             Project (#0..=#2, #21) // { arity: 4 }
               Filter (#21) IS NOT NULL // { arity: 22 }
@@ -599,7 +599,7 @@ Explained Query:
           Filter (((#22 = "GERMANY") AND (#24 = "CAMBODIA")) OR ((#22 = "CAMBODIA") AND (#24 = "GERMANY"))) // { arity: 25 }
             Join on=(#0 = #4 AND #1 = #21 AND #2 = #8 AND #3 = #9 AND #5 = #11 AND eq(#6, #12, #17) AND eq(#7, #13, #18) AND #14 = #16 AND #20 = #23) type=differential // { arity: 25 }
               implementation
-                %2 » %3[#0, #1, #2] » %4[#0, #1, #2] » %1[#0, #1] » l0[#0] » %0[#0] » l0[#0]
+                %2:orderline » %3:order[#0, #1, #2]UKKKAiif » %4:customer[#0, #1, #2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
               ArrangeBy keys=[[#0]] // { arity: 2 }
                 Project (#0, #3) // { arity: 2 }
                   Get materialize.public.supplier // { arity: 7 }
@@ -673,7 +673,7 @@ Explained Query:
           Project (#11, #16, #24) // { arity: 3 }
             Join on=(eq(#0, #3, #9) AND #1 = #5 AND #2 = #23 AND #4 = #10 AND #6 = #12 AND eq(#7, #13, #18) AND eq(#8, #14, #19) AND #15 = #17 AND #20 = #21 AND #22 = #25) type=differential // { arity: 26 }
               implementation
-                %3 » %4[#0, #1, #2] » %5[#0, #1, #2] » %2[#0, #1] » %0[#0] » %1[#0] » %6[#0] » %8[#0] » %7[#0]
+                %3:orderline » %4:order[#0, #1, #2]UKKKAiiif » %5:customer[#0, #1, #2]UKKKAiiif » %2:stock[#0, #1]UKKAiiiif » %0:item[#0]UKAliiiiif » %1:supplier[#0]UKAliiiiif » %6:nation[#0]UKAliiiiif » %8:region[#0]UKAeliiiiif » %7:nation[#0]UKAeliiiiif
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (#0 < 1000) AND "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -752,7 +752,7 @@ Explained Query:
       Project (#11, #15, #17) // { arity: 3 }
         Join on=(eq(#0, #1, #9) AND #2 = #10 AND #3 = #4 AND #5 = #16 AND #6 = #12 AND #7 = #13 AND #8 = #14) type=differential // { arity: 18 }
           implementation
-            %3 » %4[#0, #1, #2] » %1[#0, #1] » %0[#0] » %2[#0] » %5[#0]
+            %3:orderline » %4:order[#0, #1, #2]UKKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter "%BB" ~~(padchar(#4)) // { arity: 5 }
@@ -813,7 +813,7 @@ Explained Query:
           Filter (#11 <= #15) // { arity: 19 }
             Join on=(#0 = #10 AND eq(#1, #8, #13) AND eq(#2, #9, #14) AND #6 = #17 AND #7 = #12) type=differential // { arity: 19 }
               implementation
-                %2 » %1[#0, #1, #2] » %0[#0, #1, #2] » %3[#0]
+                %2:orderline » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:nation[#0]UKAif
               ArrangeBy keys=[[#0, #1, #2]] // { arity: 7 }
                 Project (#0..=#2, #5, #8, #11, #21) // { arity: 7 }
                   Filter (#21) IS NOT NULL // { arity: 22 }
@@ -861,7 +861,7 @@ Explained Query:
         Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0 » %1[]
+              %0 » %1[×]UA
             Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
               Get l0 // { arity: 2 }
             ArrangeBy keys=[[]] // { arity: 1 }
@@ -873,7 +873,7 @@ Explained Query:
         Project (#0, #14) // { arity: 2 }
           Join on=(#17 = #18 AND #19 = #20) type=differential // { arity: 21 }
             implementation
-              %0 » %1[#0] » %2[#0]
+              %0:stock » %1:supplier[#0]UKA » %2:nation[#0]UKAef
             ArrangeBy keys=[[#17]] // { arity: 18 }
               Get materialize.public.stock // { arity: 18 }
             ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -915,8 +915,8 @@ Explained Query:
         Filter (date_to_timestamp(#12) < 2020-01-01 00:00:00) AND (#3 <= #12) // { arity: 16 }
           Join on=(#0 = #6 AND #1 = #7 AND #2 = #8) type=delta // { arity: 16 }
             implementation
-              %0 » %1[#2, #1, #0]
-              %1 » %0[#0, #1, #2]
+              %0:order » %1:orderline[#2, #1, #0]KKKAif
+              %1:orderline » %0:order[#0, #1, #2]UKKKA
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
               Project (#0..=#2, #4..=#6) // { arity: 6 }
                 Get materialize.public.order // { arity: 8 }
@@ -969,8 +969,8 @@ Explained Query:
           Filter (#27 > 8) // { arity: 30 }
             Join on=(#0 = #25 AND #1 = #23 AND #2 = #24) type=delta // { arity: 30 }
               implementation
-                %0 » %1[#2, #1, #3]
-                %1 » %0[#0, #1, #2]
+                %0:customer » %1:order[#2, #1, #3]KKKAif
+                %1:order » %0:customer[#0, #1, #2]UKKKA
               ArrangeBy keys=[[#0, #1, #2]] // { arity: 22 }
                 Get materialize.public.customer // { arity: 22 }
               ArrangeBy keys=[[#2, #1, #3]] // { arity: 8 }
@@ -1013,8 +1013,8 @@ Explained Query:
             Map (date_to_timestamp(#6)) // { arity: 13 }
               Join on=(#4 = #10) type=delta // { arity: 12 }
                 implementation
-                  %0 » %1[#0]
-                  %1 » %0[#4]
+                  %0:orderline » %1:item[#0]UKA
+                  %1:item » %0:orderline[#4]KAiif
                 ArrangeBy keys=[[#4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1068,7 +1068,7 @@ Explained Query:
       Project (#0..=#3, #5) // { arity: 5 }
         Join on=(#0 = #4 AND #5 = #6) type=differential // { arity: 7 }
           implementation
-            %0 » %1[#0] » %2[#0]
+            %0:supplier » %1:l0[#0]UKA » %2[#0]UKA
           Project (#0..=#2, #4) // { arity: 4 }
             Get materialize.public.supplier // { arity: 7 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1085,8 +1085,8 @@ Explained Query:
             Filter (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 13 }
               Join on=(#4 = #10 AND #5 = #11) type=delta // { arity: 13 }
                 implementation
-                  %0 » %1[#0, #1]
-                  %1 » %0[#5, #4]
+                  %0:orderline » %1:stock[#0, #1]UKKA
+                  %1:stock » %0:orderline[#5, #4]KKAif
                 ArrangeBy keys=[[#5, #4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0, #1]] // { arity: 3 }
@@ -1124,7 +1124,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %1 » %0[#0]
+              %1 » %0:l0[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Get l0 // { arity: 4 }
             Union // { arity: 1 }
@@ -1132,7 +1132,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %1 » %0[#0]
+                      %1:supplier » %0:l1[#0]UKAlf
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     Project (#0) // { arity: 1 }
@@ -1148,8 +1148,8 @@ Explained Query:
         Project (#17, #19..=#21) // { arity: 4 }
           Join on=(#0 = #18) type=delta // { arity: 22 }
             implementation
-              %0 » %1[#0]
-              %1 » %0[#0]
+              %0:stock » %1:item[#0]UKAf
+              %1:item » %0:stock[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 18 }
               Get materialize.public.stock // { arity: 18 }
             ArrangeBy keys=[[#0]] // { arity: 4 }
@@ -1204,16 +1204,16 @@ Explained Query:
           Filter (integer_to_double(#7) < (bigint_to_double(#11) / bigint_to_double(case when (#12 = 0) then null else #12 end))) // { arity: 13 }
             Join on=(#4 = #10) type=delta // { arity: 13 }
               implementation
-                l0 » %1[#0]
-                %1 » l0[#4]
+                %0:l0 » %1[#0]UKA
+                %1 » %0:l0[#4]KA
               Get l0 // { arity: 10 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Reduce group_by=[#0] aggregates=[sum(#1), count(#1)] // { arity: 3 }
                   Project (#0, #8) // { arity: 2 }
                     Join on=(#0 = #5) type=delta // { arity: 11 }
                       implementation
-                        %0 » l0[#4]
-                        l0 » %0[#0]
+                        %0:item » %1:l0[#4]KA
+                        %1:l0 » %0:item[#0]UKAlf
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Filter "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -1256,7 +1256,7 @@ Explained Query:
           Project (#0..=#4, #8, #9, #13) // { arity: 8 }
             Join on=(#0 = #7 AND eq(#1, #5, #11) AND eq(#2, #6, #12) AND #4 = #10) type=differential // { arity: 14 }
               implementation
-                %2 » %1[#0, #1, #2] » %0[#0, #1, #2]
+                %2:orderline » %1:order[#0, #1, #2]UKKKA » %0:customer[#0, #1, #2]UKKKA
               ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                 Project (#0..=#2, #5) // { arity: 4 }
                   Get materialize.public.customer // { arity: 22 }
@@ -1321,8 +1321,8 @@ Explained Query:
             Map ((#2 = 1), (#2 = 2), (#2 = 3), (#2 = 4), (#2 = 5), padchar(#11)) // { arity: 18 }
               Join on=(#4 = #10) type=delta // { arity: 12 }
                 implementation
-                  %0 » %1[#0]
-                  %1 » %0[#4]
+                  %0:orderline » %1:item[#0]UKAliif
+                  %1:item » %0:orderline[#4]KAeiif
                 ArrangeBy keys=[[#4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1366,7 +1366,7 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            l0 » %1[#0]
+            %0:l0 » %1[#0]UKA
           Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Distinct group_by=[#0] // { arity: 1 }
@@ -1377,7 +1377,7 @@ Explained Query:
                       Filter (date_to_timestamp(#25) > 2010-05-23 12:00:00) // { arity: 30 }
                         Join on=(eq(#1, #23, #29)) type=differential // { arity: 30 }
                           implementation
-                            %2 » %3[#0] » %1[#0] » %0[]
+                            %2:orderline » %3:item[#0]UKAlif » %1:stock[#0]KAlif » %0:l0[×]Alif
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l0 // { arity: 3 }
@@ -1394,8 +1394,8 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#3 = #7) type=delta // { arity: 8 }
             implementation
-              %0 » %1[#0]
-              %1 » %0[#3]
+              %0:supplier » %1:nation[#0]UKAef
+              %1:nation » %0:supplier[#3]KA
             ArrangeBy keys=[[#3]] // { arity: 7 }
               Get materialize.public.supplier // { arity: 7 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1450,7 +1450,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
             implementation
-              %1 » %0[#1, #2, #3, #4]
+              %1 » %0:l0[#1, #2, #3, #4]KKKKA
             ArrangeBy keys=[[#1, #2, #3, #4]] // { arity: 5 }
               Get l0 // { arity: 5 }
             Union // { arity: 4 }
@@ -1460,7 +1460,7 @@ Explained Query:
                     Filter (#10 > #3) // { arity: 14 }
                       Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
                         implementation
-                          l1 » %1[#2, #1, #0]
+                          %0:l1 » %1:orderline[#2, #1, #0]KKKA
                         Get l1 // { arity: 4 }
                         ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
                           Get materialize.public.orderline // { arity: 10 }
@@ -1475,7 +1475,7 @@ Explained Query:
           Filter (#7 > #11) // { arity: 16 }
             Join on=(#0 = #14 AND #2 = #15 AND #3 = #8 AND #4 = #9 AND eq(#5, #10, #13) AND #6 = #12) type=differential // { arity: 16 }
               implementation
-                %1 » %2[#0, #1, #2] » %3[#0, #1] » %0[#0] » %4[#0]
+                %1:orderline » %2:order[#0, #1, #2]UKKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Project (#0, #1, #3) // { arity: 3 }
                   Get materialize.public.supplier // { arity: 7 }
@@ -1532,7 +1532,7 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
-              %1 » %0[#0, #1, #2]
+              %1 » %0:l1[#0, #1, #2]UKKKA
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
               Get l1 // { arity: 5 }
             Union // { arity: 3 }
@@ -1540,7 +1540,7 @@ Explained Query:
                 Project (#0..=#2) // { arity: 3 }
                   Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                     implementation
-                      l2 » %1[#0, #1, #2]
+                      %0:l2 » %1[#0, #1, #2]UKKKA
                     Get l2 // { arity: 3 }
                     ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                       Distinct group_by=[#2, #0, #1] // { arity: 3 }
@@ -1557,7 +1557,7 @@ Explained Query:
           Filter (numeric_to_double(#4) > (numeric_to_double(#5) / bigint_to_double(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
             CrossJoin type=differential // { arity: 7 }
               implementation
-                %0 » %1[]
+                %0:l0 » %1[×]UAef
               Project (#0..=#2, #9, #16) // { arity: 5 }
                 Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                   Get l0 // { arity: 23 }

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -44,7 +44,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 , t2 WHERE t1.f1 = 123 AND t1.f
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1 » %0[]
+      %1:t2 » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -79,7 +79,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1 » %0[]
+          %1:t2 » %0:l0[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Get l0 // { arity: 2 }
         Filter (#0 = 123) // { arity: 2 }
@@ -117,7 +117,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 3 }
         implementation
-          %1 » %0[]
+          %1:t2 » %0:t1[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Filter (#0 = 123) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -138,7 +138,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 ON (TRUE) WHERE t1
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1 » %0[]
+      %1:t2 » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -160,7 +160,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, t2, t3 WHERE t1.f1 = 123 AND t
 Explained Query:
   CrossJoin type=differential // { arity: 6 }
     implementation
-      %2 » %0[] » %1[]
+      %2:t3 » %0:t1[×]UAef » %1:t2[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -188,7 +188,7 @@ Explained Query:
   Map (123) // { arity: 1 }
     CrossJoin type=differential // { arity: 0 }
       implementation
-        %1 » %0[]
+        %1:t2 » %0:t1[×]UAef
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
           Filter (#0 = 123) // { arity: 2 }
@@ -219,7 +219,7 @@ Explained Query:
   Return // { arity: 1 }
     CrossJoin type=differential // { arity: 1 }
       implementation
-        %1 » l1[]
+        %1 » %0:l1[×]UAef
       Get l1 // { arity: 0 }
       Union // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -233,7 +233,7 @@ Explained Query:
     cte l2 =
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » l1[]
+          %1:t1 » %0:l1[×]UAef
         Get l1 // { arity: 0 }
         Project (#0) // { arity: 1 }
           Filter (#0 = 123) // { arity: 2 }
@@ -267,7 +267,7 @@ Explained Query:
       Map ((#0 = 123)) // { arity: 2 }
         CrossJoin type=differential // { arity: 1 }
           implementation
-            %1 » %0[]
+            %1 » %0:t2[×]UAef
           ArrangeBy keys=[[]] // { arity: 0 }
             Project () // { arity: 0 }
               Filter (#0 = 123) // { arity: 2 }
@@ -310,7 +310,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (S
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1 » %0[]
+      %1:t2 » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -333,7 +333,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (S
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %2 » %0[] » %1[]
+      %2:t3 » %0:t1[×]UAef » %1:t2[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -364,7 +364,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, (SELECT t2.f1 FROM t2) AS dt1 
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1 » %0[]
+      %1:t2 » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -387,7 +387,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE 123 = (SELECT t2.f1 FROM 
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1 » %0[]
+      %1 » %0:t1[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Union // { arity: 0 }
@@ -412,7 +412,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = (
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1 » %0[]
+      %1 » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -491,7 +491,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 234;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -503,7 +503,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 FULL OUTER JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 234;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -515,7 +515,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, t2 WHERE t1.f1 = 123 AND t1.f1
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1 » %0[]
+      %1:t2 » %0:t1[×]UAeif
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -543,7 +543,7 @@ explain with(arity, join_impls) select * from int_table, double_table where int_
 Explained Query:
   Join on=(#1 = integer_to_double(#0)) type=differential // { arity: 2 }
     implementation
-      %1 » %0[integer_to_double(#0)]
+      %1:double_table » %0:int_table[integer_to_double(#0)]KA
     ArrangeBy keys=[[integer_to_double(#0)]] // { arity: 1 }
       Get materialize.public.int_table // { arity: 1 }
     Filter (#0) IS NOT NULL // { arity: 1 }

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -1486,7 +1486,20 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                             [
                                               [
                                                 0,
-                                                []
+                                                [],
+                                                {
+                                                  "unique_key": false,
+                                                  "key_length": 0,
+                                                  "arranged": true,
+                                                  "filters": {
+                                                    "literal_equality": false,
+                                                    "like": false,
+                                                    "is_null": false,
+                                                    "literal_inequality": 0,
+                                                    "any_filter": false
+                                                  },
+                                                  "input": 0
+                                                }
                                               ]
                                             ]
                                           ]
@@ -1552,7 +1565,20 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": true,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 1
+                          }
                         ]
                       ],
                       [
@@ -1562,7 +1588,20 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 0
+                          }
                         ]
                       ]
                     ]
@@ -1697,7 +1736,20 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                             [
                                               [
                                                 0,
-                                                []
+                                                [],
+                                                {
+                                                  "unique_key": false,
+                                                  "key_length": 0,
+                                                  "arranged": true,
+                                                  "filters": {
+                                                    "literal_equality": false,
+                                                    "like": false,
+                                                    "is_null": false,
+                                                    "literal_inequality": 0,
+                                                    "any_filter": false
+                                                  },
+                                                  "input": 0
+                                                }
                                               ]
                                             ]
                                           ]
@@ -1767,7 +1819,20 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": true,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 1
+                          }
                         ]
                       ]
                     ]
@@ -2006,7 +2071,20 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             {
                                               "Column": 0
                                             }
-                                          ]
+                                          ],
+                                          {
+                                            "unique_key": true,
+                                            "key_length": 1,
+                                            "arranged": true,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 0
+                                          }
                                         ]
                                       ]
                                     ]
@@ -2127,7 +2205,20 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                 {
                                                   "Column": 0
                                                 }
-                                              ]
+                                              ],
+                                              {
+                                                "unique_key": true,
+                                                "key_length": 1,
+                                                "arranged": true,
+                                                "filters": {
+                                                  "literal_equality": false,
+                                                  "like": false,
+                                                  "is_null": false,
+                                                  "literal_inequality": 0,
+                                                  "any_filter": false
+                                                },
+                                                "input": 0
+                                              }
                                             ]
                                           ]
                                         ]
@@ -2443,7 +2534,20 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             {
                                               "Column": 0
                                             }
-                                          ]
+                                          ],
+                                          {
+                                            "unique_key": true,
+                                            "key_length": 1,
+                                            "arranged": true,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 1
+                                          }
                                         ],
                                         [
                                           2,
@@ -2451,7 +2555,20 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                             {
                                               "Column": 0
                                             }
-                                          ]
+                                          ],
+                                          {
+                                            "unique_key": true,
+                                            "key_length": 1,
+                                            "arranged": true,
+                                            "filters": {
+                                              "literal_equality": false,
+                                              "like": false,
+                                              "is_null": false,
+                                              "literal_inequality": 0,
+                                              "any_filter": false
+                                            },
+                                            "input": 2
+                                          }
                                         ]
                                       ]
                                     ]
@@ -2710,7 +2827,20 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                     {
                                       "Column": 1
                                     }
-                                  ]
+                                  ],
+                                  {
+                                    "unique_key": false,
+                                    "key_length": 1,
+                                    "arranged": true,
+                                    "filters": {
+                                      "literal_equality": false,
+                                      "like": false,
+                                      "is_null": false,
+                                      "literal_inequality": 0,
+                                      "any_filter": false
+                                    },
+                                    "input": 0
+                                  }
                                 ],
                                 [
                                   1,
@@ -2718,7 +2848,20 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                     {
                                       "Column": 1
                                     }
-                                  ]
+                                  ],
+                                  {
+                                    "unique_key": false,
+                                    "key_length": 1,
+                                    "arranged": true,
+                                    "filters": {
+                                      "literal_equality": false,
+                                      "like": false,
+                                      "is_null": false,
+                                      "literal_inequality": 0,
+                                      "any_filter": false
+                                    },
+                                    "input": 1
+                                  }
                                 ]
                               ]
                             ]
@@ -2852,7 +2995,20 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                     {
                                                       "Column": 0
                                                     }
-                                                  ]
+                                                  ],
+                                                  {
+                                                    "unique_key": true,
+                                                    "key_length": 1,
+                                                    "arranged": true,
+                                                    "filters": {
+                                                      "literal_equality": false,
+                                                      "like": false,
+                                                      "is_null": false,
+                                                      "literal_inequality": 0,
+                                                      "any_filter": false
+                                                    },
+                                                    "input": 1
+                                                  }
                                                 ]
                                               ]
                                             ]
@@ -3148,7 +3304,20 @@ FROM
                                             [
                                               [
                                                 0,
-                                                []
+                                                [],
+                                                {
+                                                  "unique_key": false,
+                                                  "key_length": 0,
+                                                  "arranged": true,
+                                                  "filters": {
+                                                    "literal_equality": false,
+                                                    "like": false,
+                                                    "is_null": false,
+                                                    "literal_inequality": 0,
+                                                    "any_filter": false
+                                                  },
+                                                  "input": 0
+                                                }
                                               ]
                                             ]
                                           ]
@@ -3210,7 +3379,20 @@ FROM
                                     {
                                       "Column": 0
                                     }
-                                  ]
+                                  ],
+                                  {
+                                    "unique_key": true,
+                                    "key_length": 1,
+                                    "arranged": true,
+                                    "filters": {
+                                      "literal_equality": false,
+                                      "like": false,
+                                      "is_null": false,
+                                      "literal_inequality": 0,
+                                      "any_filter": true
+                                    },
+                                    "input": 1
+                                  }
                                 ]
                               ],
                               [
@@ -3220,7 +3402,20 @@ FROM
                                     {
                                       "Column": 0
                                     }
-                                  ]
+                                  ],
+                                  {
+                                    "unique_key": false,
+                                    "key_length": 1,
+                                    "arranged": true,
+                                    "filters": {
+                                      "literal_equality": false,
+                                      "like": false,
+                                      "is_null": false,
+                                      "literal_inequality": 0,
+                                      "any_filter": false
+                                    },
+                                    "input": 0
+                                  }
                                 ]
                               ]
                             ]
@@ -3364,7 +3559,20 @@ FROM
                                             [
                                               [
                                                 0,
-                                                []
+                                                [],
+                                                {
+                                                  "unique_key": false,
+                                                  "key_length": 0,
+                                                  "arranged": true,
+                                                  "filters": {
+                                                    "literal_equality": false,
+                                                    "like": false,
+                                                    "is_null": false,
+                                                    "literal_inequality": 0,
+                                                    "any_filter": false
+                                                  },
+                                                  "input": 0
+                                                }
                                               ]
                                             ]
                                           ]
@@ -3430,7 +3638,20 @@ FROM
                                     {
                                       "Column": 0
                                     }
-                                  ]
+                                  ],
+                                  {
+                                    "unique_key": true,
+                                    "key_length": 1,
+                                    "arranged": true,
+                                    "filters": {
+                                      "literal_equality": false,
+                                      "like": false,
+                                      "is_null": true,
+                                      "literal_inequality": 0,
+                                      "any_filter": false
+                                    },
+                                    "input": 1
+                                  }
                                 ]
                               ]
                             ]
@@ -3605,7 +3826,20 @@ SELECT t1.a, t2.a FROM t as t1, t as t2
                   [
                     [
                       0,
-                      []
+                      [],
+                      {
+                        "unique_key": false,
+                        "key_length": 0,
+                        "arranged": true,
+                        "filters": {
+                          "literal_equality": false,
+                          "like": false,
+                          "is_null": false,
+                          "literal_inequality": 0,
+                          "any_filter": false
+                        },
+                        "input": 0
+                      }
                     ]
                   ]
                 ]
@@ -3815,7 +4049,20 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                                 {
                                   "Column": 1
                                 }
-                              ]
+                              ],
+                              {
+                                "unique_key": false,
+                                "key_length": 1,
+                                "arranged": true,
+                                "filters": {
+                                  "literal_equality": false,
+                                  "like": false,
+                                  "is_null": false,
+                                  "literal_inequality": 0,
+                                  "any_filter": false
+                                },
+                                "input": 0
+                              }
                             ],
                             [
                               1,
@@ -3823,7 +4070,20 @@ WHERE t1.b = t2.b AND t2.b = t3.b
                                 {
                                   "Column": 1
                                 }
-                              ]
+                              ],
+                              {
+                                "unique_key": false,
+                                "key_length": 1,
+                                "arranged": true,
+                                "filters": {
+                                  "literal_equality": false,
+                                  "like": false,
+                                  "is_null": false,
+                                  "literal_inequality": 0,
+                                  "any_filter": false
+                                },
+                                "input": 1
+                              }
                             ]
                           ]
                         ]
@@ -4061,7 +4321,20 @@ WHERE a = c and d = e and b = f
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 0
+                          }
                         ],
                         [
                           2,
@@ -4072,7 +4345,20 @@ WHERE a = c and d = e and b = f
                             {
                               "Column": 1
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 2,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 2
+                          }
                         ]
                       ]
                     ]
@@ -4271,7 +4557,20 @@ WHERE b = c and d = e
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 1
+                          }
                         ],
                         [
                           2,
@@ -4279,7 +4578,20 @@ WHERE b = c and d = e
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 2
+                          }
                         ]
                       ],
                       [
@@ -4289,7 +4601,20 @@ WHERE b = c and d = e
                             {
                               "Column": 1
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 0
+                          }
                         ],
                         [
                           2,
@@ -4297,7 +4622,20 @@ WHERE b = c and d = e
                             {
                               "Column": 0
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 2
+                          }
                         ]
                       ],
                       [
@@ -4307,7 +4645,20 @@ WHERE b = c and d = e
                             {
                               "Column": 1
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 1
+                          }
                         ],
                         [
                           0,
@@ -4315,7 +4666,20 @@ WHERE b = c and d = e
                             {
                               "Column": 1
                             }
-                          ]
+                          ],
+                          {
+                            "unique_key": false,
+                            "key_length": 1,
+                            "arranged": true,
+                            "filters": {
+                              "literal_equality": false,
+                              "like": false,
+                              "is_null": false,
+                              "literal_inequality": 0,
+                              "any_filter": false
+                            },
+                            "input": 0
+                          }
                         ]
                       ]
                     ]

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -572,7 +572,7 @@ Explained Query:
     Filter (#0) IS NOT NULL
       Join on=(#0 = #2 AND #1 = #5 AND #3 = #4) type=differential
         implementation
-          %1 » %0[#0] » %2[#0, #1]
+          %1:u » %0:t[#0]KA » %2:v[#0, #1]KKA
         ArrangeBy keys=[[#0]]
           Get materialize.public.t
         ArrangeBy keys=[[#0]]
@@ -593,7 +593,7 @@ EOF
 statement ok
 CREATE INDEX t_b_idx ON T(b);
 
-# Test a delta join WITH(join_impls).
+# Test a delta join without WITH(join_impls).
 query T multiline
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR
 SELECT a, b, c, d, e, f
@@ -631,9 +631,9 @@ Explained Query:
     Filter (#1) IS NOT NULL AND (#3) IS NOT NULL
       Join on=(#1 = #2 AND #3 = #4) type=delta
         implementation
-          %0 » %1[#0] » %2[#0]
-          %1 » %0[#1] » %2[#0]
-          %2 » %1[#1] » %0[#1]
+          %0:t » %1:u[#0]KA » %2:v[#0]KA
+          %1:u » %0:t[#1]KA » %2:v[#0]KA
+          %2:v » %1:u[#1]KA » %0:t[#1]KA
         ArrangeBy keys=[[#1]]
           Get materialize.public.t
         ArrangeBy keys=[[#0], [#1]]

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -247,7 +247,7 @@ Explained Query:
     Map (date_truncts(#0, #1)) // { arity: 3 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.date_trunc_timestamps » %0[]
+          %1:date_trunc_timestamps » %0:date_trunc_fields[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.date_trunc_fields // { arity: 1 }
         Get materialize.public.date_trunc_timestamps // { arity: 1 }

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -34,7 +34,7 @@ Explained Query:
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
-        %1 » %0[]
+        %1 » %0:test1[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.test1 // { arity: 2 }
       Union // { arity: 1 }

--- a/test/sqllogictest/github-7585.slt
+++ b/test/sqllogictest/github-7585.slt
@@ -19,6 +19,6 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT FROM t1 LEFT JOIN t2 ON TRUE WHERE t1.f1 = t1.f2 + 4 AND t1.f1 IS NULL AND NOT t1.f2 = t1.f1
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF

--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -20,7 +20,7 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        materialize.public.t1 » %1[#0]
+        %0:t1 » %1[#0]UKA
       Get materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Distinct group_by=[#0] // { arity: 1 }

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -19,7 +19,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -27,7 +27,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -35,7 +35,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -43,7 +43,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -51,7 +51,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM table_f1 , LATERAL ( SELECT * FROM (  table_f4 AS a1 LEFT JOIN table_f4 AS a2 ON a1.f4 = a2.f4 ) WHERE a1.f4 <= f1  ) WHERE  f1 IS  NULL;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -69,7 +69,7 @@ Explained Query:
     Project (#0, #2, #3, #1) // { arity: 4 }
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1 » %0[]
+          %1 » %0:table_f1[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.table_f1 // { arity: 1 }
         Union // { arity: 3 }
@@ -77,7 +77,7 @@ Explained Query:
           Project (#0..=#2) // { arity: 3 }
             Join on=(#0 = #3) type=differential // { arity: 4 }
               implementation
-                %1 » %0[#0]
+                %1:l0 » %0[#0]KAf
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Union // { arity: 3 }
                   Negate // { arity: 3 }
@@ -92,7 +92,7 @@ Explained Query:
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#0]
+            %1:table_f5_f6 » %0:l0[#0]KAf
           ArrangeBy keys=[[#0]] // { arity: 3 }
             Get l0 // { arity: 3 }
           Project (#0) // { arity: 1 }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -115,7 +115,7 @@ Explained Query:
     Project (#0, #2, #4) // { arity: 3 }
       Join on=(#1 = (#0 + 1) AND #3 = (#0 + #1)) type=differential // { arity: 5 }
         implementation
-          l0 » %0[(#0 + 1)] » %2[#0]
+          %1:l0 » %0:l0[(#0 + 1)]KA » %2:l0[#0]KA
         ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 2 }
@@ -156,14 +156,14 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          materialize.public.l » %1[#0]
+          %0:l » %1[#0]UKA
         Get materialize.public.l // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Distinct group_by=[#0] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Join on=(eq(#1, #2, #3)) type=differential // { arity: 4 }
                 implementation
-                  %0 » %1[#0] » %2[#0]
+                  %0:l1 » %1[#0]UKAf » %2[#0]UKAf
                 Filter (#0 = (#1 + 1)) // { arity: 2 }
                   Get l1 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -180,7 +180,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          l0 » %0[]
+          %1:l0 » %0[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Distinct group_by=[#0] // { arity: 1 }
             Get l0 // { arity: 1 }
@@ -317,7 +317,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  materialize.public.l » %1[#0]
+                  %0:l » %1[#0]UKA
                 Get materialize.public.l // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
@@ -331,7 +331,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#0]
+            %1:r » %0:l[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -357,7 +357,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    materialize.public.r » %1[#0]
+                    %0:r » %1[#0]UKA
                   Get materialize.public.r // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
@@ -371,7 +371,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#0]
+            %1:r » %0:l[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -397,7 +397,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    materialize.public.r » l1[#0]
+                    %0:r » %1:l1[#0]UKA
                   Get materialize.public.r // { arity: 2 }
                   Get l1 // { arity: 1 }
             Get materialize.public.r // { arity: 2 }
@@ -407,7 +407,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  materialize.public.l » l1[#0]
+                  %0:l » %1:l1[#0]UKA
                 Get materialize.public.l // { arity: 2 }
                 Get l1 // { arity: 1 }
           Get materialize.public.l // { arity: 2 }
@@ -423,7 +423,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#0]
+            %1:r » %0:l[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -449,7 +449,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = m
 Explained Query:
   Join on=((#0 % 2) = (#2 % 2)) type=differential // { arity: 4 }
     implementation
-      %1 » %0[(#0 % 2)]
+      %1:r » %0:l[(#0 % 2)]KA
     ArrangeBy keys=[[(#0 % 2)]] // { arity: 2 }
       Filter (#0) IS NOT NULL // { arity: 2 }
         Get materialize.public.l // { arity: 2 }
@@ -506,7 +506,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %1 » %0[#0]
+          %1 » %0:t4362[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.t4362 // { arity: 2 }
         Union // { arity: 1 }
@@ -576,7 +576,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1 » %0[#0]
+        %1:r3 » %0:l3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.l3 // { arity: 2 }
@@ -603,7 +603,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        materialize.public.r3 » %0[#0]
+        %1:r3 » %0:l3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.l3 // { arity: 2 }
       Get materialize.public.r3 // { arity: 2 }
@@ -624,7 +624,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        materialize.public.r3 » %0[#0]
+        %1:r3 » %0:l3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.l3 // { arity: 2 }
       Get materialize.public.r3 // { arity: 2 }

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -548,7 +548,7 @@ EXPLAIN WITH(arity, join_impls) SELECT a FROM t1
 WHERE a = 3 AND a = 5
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -557,7 +557,7 @@ EXPLAIN WITH(arity, join_impls) SELECT a FROM t1
 WHERE a IN (1,2) AND a IN (3,4,5)
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -602,7 +602,7 @@ WHERE
 ((a = 2 AND a = 3) OR b = 'z')
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -623,8 +623,8 @@ Explained Query:
     Filter (#0) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #3) type=delta // { arity: 6 }
         implementation
-          %0 » %1[#0]
-          %1 » %0[#0]
+          %0:t1 » %1:t2[#0]KA
+          %1:t2 » %0:t1[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
           Join on=(#1 = #2) type=indexed_filter // { arity: 3 }
             ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -664,8 +664,8 @@ Explained Query:
     Filter (#0) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #3) type=delta // { arity: 6 }
         implementation
-          %0 » %1[#0]
-          %1 » %0[#0]
+          %0:t1 » %1:t2[#0]KA
+          %1:t2 » %0:t1[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
           Join on=(#1 = #2) type=indexed_filter // { arity: 3 }
             ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -704,7 +704,7 @@ WHERE
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1 » %0[]
+      %1:t2 » %0:t1[×]Ae
     ArrangeBy keys=[[]] // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2 AND #1 = #3) type=indexed_filter // { arity: 4 }
@@ -953,7 +953,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM foo
 WHERE a = 1000000;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -32,7 +32,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 AS a1 , t1 AS a2;
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      materialize.public.t1 » %0[]
+      %1:t1 » %0:t1[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Get materialize.public.t1 // { arity: 2 }
@@ -53,7 +53,7 @@ Explained Query:
   Return // { arity: 6 }
     CrossJoin type=differential // { arity: 6 }
       implementation
-        materialize.public.t1 » l0[] » l0[]
+        %2:t1 » %0:l0[×]A » %1:l0[×]A
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
@@ -74,7 +74,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        l0 » %0[]
+        %1:l0 » %0:l0[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
@@ -99,7 +99,7 @@ Explained Query:
   Return // { arity: 6 }
     CrossJoin type=differential // { arity: 6 }
       implementation
-        l0 » l1[] » l1[]
+        %2:l0 » %0:l1[×]Ae » %1:l1[×]Ae
       Get l1 // { arity: 2 }
       Get l1 // { arity: 2 }
       Get l0 // { arity: 2 }
@@ -131,7 +131,7 @@ Explained Query:
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
-        %1 » %0[]
+        %1:l0 » %0:l0[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Get l0 // { arity: 3 }
@@ -162,7 +162,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
         implementation
-          l0 » %0[#1] » %1[#0]
+          %2:l0 » %0:t1[#1]KA » %1:l0[#0]KA
         ArrangeBy keys=[[#1]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -195,7 +195,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
         implementation
-          l1 » %0[#1] » %1[#0]
+          %2:l1 » %0:t1[#1]KA » %1:l1[#0]KA
         ArrangeBy keys=[[#1]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -232,7 +232,7 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        %1 » %0[#0]
+        %1 » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
       Union // { arity: 1 }
@@ -260,7 +260,7 @@ Explained Query:
       Filter ((#0 = #2) OR (#1 = #3)) // { arity: 4 }
         CrossJoin type=differential // { arity: 4 }
           implementation
-            l1 » %0[] » %1[]
+            %2:l1 » %0:t1[×]A » %1:l1[×]A
           ArrangeBy keys=[[]] // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
           ArrangeBy keys=[[]] // { arity: 1 }
@@ -308,7 +308,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        l0 » %0[]
+        %1:l0 » %0:l0[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
@@ -337,7 +337,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        l0 » %0[]
+        %1:l0 » %0:l0[×]Aef
       ArrangeBy keys=[[]] // { arity: 2 }
         Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
@@ -368,7 +368,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1 » %0[]
+        %1:l0 » %0:l0[×]Aef
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Filter (#1 = 2) // { arity: 3 }
@@ -454,7 +454,7 @@ Explained Query:
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1 » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t1 // { arity: 2 }
@@ -510,7 +510,7 @@ Explained Query:
       Reduce aggregates=[min(#0), max(#1)] // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
           implementation
-            l2 » %0[] » %1[]
+            %2:l2 » %0:t1[×]A » %1:l2[×]A
           ArrangeBy keys=[[]] // { arity: 0 }
             Project () // { arity: 0 }
               Get materialize.public.t1 // { arity: 2 }
@@ -561,7 +561,7 @@ Explained Query:
   Return // { arity: 1 }
     CrossJoin type=differential // { arity: 1 }
       implementation
-        %2 » %1[] » %0[]
+        %2 » %1[×]UA » %0:t1[×]A
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
           Get materialize.public.t1 // { arity: 2 }
@@ -613,7 +613,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1 » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t1 // { arity: 2 }
@@ -676,7 +676,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 4 }
         implementation
-          materialize.public.t1 » %0[]
+          %1:t1 » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -705,7 +705,7 @@ Explained Query:
         Map (null) // { arity: 5 }
           Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
             implementation
-              materialize.public.t1 » %0[#0, #1]
+              %1:t1 » %0[#0, #1]KKA
             ArrangeBy keys=[[#0, #1]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
@@ -720,8 +720,8 @@ Explained Query:
         Filter (#0) IS NOT NULL // { arity: 4 }
           Join on=(#0 = #2) type=delta // { arity: 4 }
             implementation
-              l0 » l0[#0]
-              l0 » l0[#0]
+              %0:l0 » %1:l0[#0]KA
+              %1:l0 » %0:l0[#0]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
     cte l0 =
@@ -744,7 +744,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1:l1 » %0:l1[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l1 // { arity: 3 }
@@ -752,7 +752,7 @@ Explained Query:
           Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1:l2 » %0:l2[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l2 // { arity: 3 }
@@ -789,7 +789,7 @@ Explained Query:
   Return // { arity: 2 }
     CrossJoin type=differential // { arity: 2 }
       implementation
-        l2 » l1[] » %1[] » l1[]
+        %3:l2 » %0:l1[×]Ae » %1:l2[×]Ae » %2:l1[×]Ae
       Get l1 // { arity: 1 }
       ArrangeBy keys=[[]] // { arity: 0 }
         Get l2 // { arity: 0 }
@@ -826,7 +826,7 @@ Explained Query:
   Return // { arity: 2 }
     CrossJoin type=differential // { arity: 2 }
       implementation
-        %3 » %0[] » %1[] » %2[]
+        %3:l2 » %0:l1[×]Ae » %1:l1[×]Ae » %2:l2[×]Ae
       ArrangeBy keys=[[]] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l1 // { arity: 3 }
@@ -937,7 +937,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.t1 » %1[]
+          %0:t1 » %1[×]UA
         Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
           Distinct // { arity: 0 }
@@ -969,7 +969,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » l0[#0]
+            %1 » %0:l0[#0]KA
           Get l0 // { arity: 2 }
           Union // { arity: 1 }
             Project (#0) // { arity: 1 }
@@ -1193,7 +1193,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.t1 » %1[]
+          %0:t1 » %1[×]UA
         Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
           Distinct // { arity: 0 }
@@ -1230,7 +1230,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.t1 » %1[]
+          %0:t1 » %1[×]UA
         Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
           Distinct // { arity: 0 }
@@ -1257,12 +1257,12 @@ Explained Query:
     Union // { arity: 2 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.t1 » l0[]
+          %0:t1 » %1:l0[×]UA
         Get materialize.public.t1 // { arity: 2 }
         Get l0 // { arity: 0 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.t2 » l0[]
+          %0:t2 » %1:l0[×]UA
         Get materialize.public.t2 // { arity: 2 }
         Get l0 // { arity: 0 }
   With
@@ -1290,7 +1290,7 @@ Explained Query:
   Return // { arity: 2 }
     CrossJoin type=differential // { arity: 2 }
       implementation
-        %1 » %0[]
+        %1 » %0[×]A
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
           Project (#0) // { arity: 1 }
@@ -1353,7 +1353,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1 » %0[]
+        %1:t1 » %0:t1[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=indexed_filter // { arity: 3 }
@@ -1386,7 +1386,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1:l1 » %0:l1[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l1 // { arity: 3 }
@@ -1394,7 +1394,7 @@ Explained Query:
           Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1:l2 » %0:l2[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l2 // { arity: 3 }

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -53,7 +53,7 @@ Explained Query:
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1 » %0:t2[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t2 // { arity: 1 }
@@ -96,7 +96,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0[#0]
+          %1 » %0:t2[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         Union // { arity: 2 }
@@ -122,7 +122,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t1 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Filter (#0) IS NOT NULL // { arity: 1 }
@@ -156,7 +156,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0[#0]
+          %1 » %0:t2[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         Union // { arity: 2 }
@@ -182,13 +182,13 @@ Explained Query:
       Union // { arity: 2 }
         Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
           implementation
-            l2 » %0[(#0 + 1)]
+            %1:l2 » %0:l1[(#0 + 1)]KA
           ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Get l2 // { arity: 1 }
         Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
           implementation
-            l2 » %0[(#0 + 2)]
+            %1:l2 » %0:l1[(#0 + 2)]KA
           ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Get l2 // { arity: 1 }
@@ -219,7 +219,7 @@ Explained Query:
     Project (#2, #4) // { arity: 2 }
       Join on=(eq(#0, #1, #3)) type=differential // { arity: 5 }
         implementation
-          %2 » %0[#0] » %1[#0]
+          %2 » %0:t2[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -254,7 +254,7 @@ Explained Query:
     cte l5 =
       Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
         implementation
-          l2 » %0[(#0 + 2)]
+          %1:l2 » %0:l1[(#0 + 2)]KA
         ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
           Get l1 // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -270,7 +270,7 @@ Explained Query:
     cte l3 =
       Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
         implementation
-          l2 » %0[(#0 + 1)]
+          %1:l2 » %0:l1[(#0 + 1)]KA
         ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
           Get l1 // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -308,7 +308,7 @@ Explained Query:
     Project (#2, #4) // { arity: 2 }
       Join on=(eq(#0, #1, #3)) type=differential // { arity: 5 }
         implementation
-          %2 » %0[#0] » %1[#0]
+          %2 » %0:t2[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -351,7 +351,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t1 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Filter (#0) IS NOT NULL // { arity: 1 }
@@ -380,7 +380,7 @@ Explained Query:
     Project (#2, #4) // { arity: 2 }
       Join on=(eq(#0, #1, #3)) type=differential // { arity: 5 }
         implementation
-          materialize.public.t2 » %1[#0] » %2[#0]
+          %0:t2 » %1[#0]UKA » %2[#0]UKA
         Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Union // { arity: 2 }
@@ -429,7 +429,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t1 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Filter (#0) IS NOT NULL // { arity: 1 }
@@ -462,7 +462,7 @@ Explained Query:
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0[#0]
+          %1 » %0:t3[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t3 // { arity: 1 }
         Union // { arity: 2 }
@@ -488,7 +488,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1 » %0:l1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Union // { arity: 2 }
@@ -513,7 +513,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t1 » %0:l2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l2 // { arity: 1 }
           Filter (#0) IS NOT NULL // { arity: 1 }
@@ -525,7 +525,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Filter (#0) IS NOT NULL // { arity: 1 }
@@ -572,7 +572,7 @@ Explained Query:
         Project (#1, #3) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 4 }
             implementation
-              %1 » %0[#0]
+              %1 » %0:l4[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Get l4 // { arity: 2 }
             Union // { arity: 2 }
@@ -597,7 +597,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            l1 » %0[#0]
+            %1:l1 » %0:l5[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l5 // { arity: 1 }
           Get l1 // { arity: 1 }
@@ -609,7 +609,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1 » %0:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.t2 // { arity: 1 }
           Union // { arity: 2 }
@@ -634,7 +634,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            l1 » %0[#0]
+            %1:l1 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Get l1 // { arity: 1 }
@@ -671,7 +671,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0[#0]
+          %1 » %0:t3[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t3 // { arity: 1 }
         Union // { arity: 2 }
@@ -697,7 +697,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(eq(#0, #1, #2)) type=differential // { arity: 3 }
           implementation
-            %2 » %0[#0] » %1[#0]
+            %2:t2 » %0:l0[#0]UKA » %1:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -742,7 +742,7 @@ Explained Query:
     Project (#4, #4) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
         implementation
-          %1 » %0[#0, #1]
+          %1 » %0:l0[#0, #1]KKA
         ArrangeBy keys=[[#0, #1]] // { arity: 2 }
           Get l0 // { arity: 2 }
         Union // { arity: 3 }
@@ -768,7 +768,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t1 » %0:l1[#0]UKAf
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0 = #1) // { arity: 2 }
               Get l1 // { arity: 2 }
@@ -780,7 +780,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          materialize.public.t3 » %0[]
+          %1:t3 » %0:t2[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         Get materialize.public.t3 // { arity: 1 }

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -249,7 +249,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 Explained Query:
   CrossJoin type=differential // { arity: 1 }
     implementation
-      materialize.public.t1 » %1[]
+      %0:t1 » %1[×]UA
     Get materialize.public.t1 // { arity: 1 }
     ArrangeBy keys=[[]] // { arity: 0 }
       Distinct // { arity: 0 }
@@ -269,7 +269,7 @@ Explained Query:
   Project (#0, #0, #2) // { arity: 3 }
     Join on=(#0 = #1) type=differential // { arity: 3 }
       implementation
-        materialize.public.t3 » %2[] » %0[#0]
+        %1:t3 » %2[×]UA » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Get materialize.public.t1 // { arity: 1 }
       Get materialize.public.t3 // { arity: 2 }
@@ -291,7 +291,7 @@ Explained Query:
   Project (#0, #0, #2) // { arity: 3 }
     Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 4 }
       implementation
-        materialize.public.t3 » %2[#0] » %0[#0]
+        %1:t3 » %2[#0]UKA » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Get materialize.public.t1 // { arity: 1 }
       Get materialize.public.t3 // { arity: 2 }
@@ -322,7 +322,7 @@ Explained Query:
     Map ((ascii(substr(replace(#1, "o", "i"), 2, 1)) * 2)) // { arity: 5 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1 » %0[#0]
+          %1:age » %0:likes[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL // { arity: 2 }
             Get materialize.public.likes // { arity: 2 }
@@ -444,7 +444,7 @@ Explained Query:
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0[#0]
+          %1 » %0:y[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
         Union // { arity: 2 }
@@ -460,8 +460,8 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=delta // { arity: 2 }
           implementation
-            %0 » %1[#0]
-            %1 » %0[#0]
+            %0:l0 » %1[#0]UKA
+            %1 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -482,7 +482,7 @@ Explained Query:
       Map (NOT(#2)) // { arity: 4 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1 » %0:y[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.y // { arity: 1 }
           Union // { arity: 2 }
@@ -498,8 +498,8 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=delta // { arity: 2 }
           implementation
-            %0 » %1[#0]
-            %1 » %0[#0]
+            %0:l0 » %1[#0]UKA
+            %1 » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -521,7 +521,7 @@ Explained Query:
       Map (NOT(#2)) // { arity: 4 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1 » %0:y[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.y // { arity: 1 }
           Union // { arity: 2 }
@@ -539,7 +539,7 @@ Explained Query:
           Filter (#0 <= #1) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
-                materialize.public.x » %0[]
+                %1:x » %0:l0[×]A
               ArrangeBy keys=[[]] // { arity: 1 }
                 Get l0 // { arity: 1 }
               Get materialize.public.x // { arity: 1 }

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -206,7 +206,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM x, generate_series(1, 10)
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1 » %0[]
+      %1 » %0:x[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.x // { arity: 2 }
     Constant // { arity: 1 }
@@ -242,7 +242,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#1 = #3) type=differential // { arity: 4 }
             implementation
-              l0 » %0[#1]
+              %1:l0 » %0:l0[#1]KA
             ArrangeBy keys=[[#1]] // { arity: 2 }
               Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
@@ -266,7 +266,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#1 = #3) type=differential // { arity: 4 }
             implementation
-              l0 » %0[#1]
+              %1:l0 » %0:l0[#1]KA
             ArrangeBy keys=[[#1]] // { arity: 2 }
               Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
@@ -293,7 +293,7 @@ Explained Query:
           Project (#0..=#2) // { arity: 3 }
             Join on=(#1 = #3) type=differential // { arity: 4 }
               implementation
-                l0 » %0[#1]
+                %1:l0 » %0:l0[#1]KA
               ArrangeBy keys=[[#1]] // { arity: 2 }
                 Get l0 // { arity: 2 }
               Get l0 // { arity: 2 }

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -111,7 +111,7 @@ EXPLAIN WITH(arity, join_impls) SELECT state, COUNT(*) FROM (
     GROUP BY state
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -243,7 +243,7 @@ Explained Query:
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
         Join on=(#0 = #9 AND #7 = #10) type=differential // { arity: 11 }
           implementation
-            l4 » %1[#0, #1]
+            %0:l4 » %1[#0, #1]UKKA
           Get l4 // { arity: 9 }
           ArrangeBy keys=[[#0, #1]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
@@ -251,11 +251,11 @@ Explained Query:
                 Filter (#18 = "EUROPE") // { arity: 20 }
                   Join on=(#0 = #1 AND #2 = #6 AND #9 = #13 AND #15 = #17) type=delta // { arity: 20 }
                     implementation
-                      %0 » l1[#0] » l0[#0] » l2[#0] » l3[#0]
-                      l1 » %0[#0] » l0[#0] » l2[#0] » l3[#0]
-                      l0 » l1[#1] » %0[#0] » l2[#0] » l3[#0]
-                      l2 » l3[#0] » l0[#3] » l1[#1] » %0[#0]
-                      l3 » l2[#2] » l0[#3] » l1[#1] » %0[#0]
+                      %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                      %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                      %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
+                      %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
+                      %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
@@ -270,11 +270,11 @@ Explained Query:
           Filter (#5 = 15) AND (#26 = "EUROPE") AND "%BRASS" ~~(varchar_to_text(#4)) // { arity: 28 }
             Join on=(#0 = #16 AND #9 = #17 AND #12 = #21 AND #23 = #25) type=delta // { arity: 28 }
               implementation
-                %0 » l1[#0] » l0[#0] » l2[#0] » l3[#0]
-                l0 » l1[#1] » %0[#0] » l2[#0] » l3[#0]
-                l1 » %0[#0] » l0[#0] » l2[#0] » l3[#0]
-                l2 » l3[#0] » l0[#3] » l1[#1] » %0[#0]
-                l3 » l2[#2] » l0[#3] » l1[#1] » %0[#0]
+                %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
+                %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+                %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
               ArrangeBy keys=[[#0]] // { arity: 9 }
                 Get materialize.public.part // { arity: 9 }
               Get l0 // { arity: 7 }
@@ -340,9 +340,9 @@ Explained Query:
           Filter (#6 = "BUILDING") AND (#12 < 1995-03-15) AND (#27 > 1995-03-15) // { arity: 33 }
             Join on=(#0 = #9 AND #8 = #17) type=delta // { arity: 33 }
               implementation
-                %0 » %1[#1] » %2[#0]
-                %1 » %0[#0] » %2[#0]
-                %2 » %1[#0] » %0[#0]
+                %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
+                %1:orders » %0:customer[#0]KAef » %2:lineitem[#0]KAif
+                %2:lineitem » %1:orders[#0]KAif » %0:customer[#0]KAef
               ArrangeBy keys=[[#0]] // { arity: 8 }
                 Get materialize.public.customer // { arity: 8 }
               ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -390,9 +390,9 @@ Explained Query:
         Filter (#4 >= 1993-07-01) AND (date_to_timestamp(#4) < 1993-10-01 00:00:00) // { arity: 11 }
           Join on=(eq(#0, #9, #10)) type=delta // { arity: 11 }
             implementation
-              %0 » %1[#0] » %2[#0]
-              %1 » %2[#0] » %0[#0]
-              %2 » %1[#0] » %0[#0]
+              %0:orders » %1[#0]UKA » %2[#0]UKA
+              %1 » %2[#0]UKA » %0:orders[#0]KAiif
+              %2 » %1[#0]UKA » %0:orders[#0]KAiif
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.orders // { arity: 9 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -447,7 +447,7 @@ Explained Query:
         Filter (#40 = "ASIA") AND (#12 < 1995-01-01) AND (#12 >= 1994-01-01) // { arity: 42 }
           Join on=(#0 = #9 AND eq(#3, #34, #35) AND #8 = #17 AND #19 = #33 AND #37 = #39) type=differential // { arity: 42 }
             implementation
-              %5 » %4[#2] » %0[#3] » %1[#1] » %2[#0] » %3[#0, #1]
+              %5:region » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKAeiif
             ArrangeBy keys=[[#3]] // { arity: 8 }
               Get materialize.public.customer // { arity: 8 }
             ArrangeBy keys=[[#1]] // { arity: 9 }
@@ -561,12 +561,12 @@ Explained Query:
             Map ((#41 = "FRANCE"), (#41 = "GERMANY"), (#45 = "FRANCE"), (#45 = "GERMANY")) // { arity: 52 }
               Join on=(#0 = #9 AND #3 = #40 AND #7 = #23 AND #24 = #32 AND #35 = #44) type=delta // { arity: 48 }
                 implementation
-                  %0 » l0[#0] » %1[#2] » %2[#0] » %3[#0] » l0[#0]
-                  %1 » %0[#0] » l0[#0] » %2[#0] » %3[#0] » l0[#0]
-                  %2 » %1[#0] » %0[#0] » l0[#0] » %3[#0] » l0[#0]
-                  %3 » l0[#0] » %2[#1] » %1[#0] » %0[#0] » l0[#0]
-                  l0 » %0[#3] » %1[#2] » %2[#0] » %3[#0] » l0[#0]
-                  l0 » %3[#3] » %2[#1] » %1[#0] » %0[#0] » l0[#0]
+                  %0:supplier » %4:l0[#0]KAef » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
+                  %1:lineitem » %0:supplier[#0]KA » %4:l0[#0]KAef » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
+                  %2:orders » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef » %3:customer[#0]KA » %5:l0[#0]KAef
+                  %3:customer » %5:l0[#0]KAef » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
+                  %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
+                  %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
                 ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
                   Get materialize.public.supplier // { arity: 7 }
                 ArrangeBy keys=[[#0], [#2]] // { arity: 16 }
@@ -645,14 +645,14 @@ Explained Query:
             Filter (#58 = "AMERICA") AND (#36 <= 1996-12-31) AND (#36 >= 1995-01-01) AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4)) // { arity: 60 }
               Join on=(#0 = #17 AND #9 = #18 AND #12 = #53 AND #16 = #32 AND #33 = #41 AND #44 = #49 AND #51 = #57) type=delta // { arity: 60 }
                 implementation
-                  %0 » %2[#1] » %3[#0] » %1[#0] » %4[#0] » %5[#0] » %7[#0] » %6[#0]
-                  %1 » %2[#2] » %0[#0] » %3[#0] » %4[#0] » %5[#0] » %7[#0] » %6[#0]
-                  %2 » %0[#0] » %3[#0] » %1[#0] » %4[#0] » %5[#0] » %7[#0] » %6[#0]
-                  %3 » %2[#0] » %0[#0] » %1[#0] » %4[#0] » %5[#0] » %7[#0] » %6[#0]
-                  %4 » %3[#1] » %2[#0] » %0[#0] » %1[#0] » %5[#0] » %7[#0] » %6[#0]
-                  %5 » %7[#0] » %4[#3] » %3[#1] » %2[#0] » %0[#0] » %1[#0] » %6[#0]
-                  %6 » %1[#3] » %2[#2] » %0[#0] » %3[#0] » %4[#0] » %5[#0] » %7[#0]
-                  %7 » %5[#2] » %4[#3] » %3[#1] » %2[#0] » %0[#0] » %1[#0] » %6[#0]
+                  %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                  %1:supplier » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                  %2:lineitem » %0:part[#0]KAef » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                  %3:orders » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                  %4:customer » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                  %5:nation » %7:region[#0]KAef » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
+                  %6:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef
+                  %7:region » %5:nation[#2]KA » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
                 ArrangeBy keys=[[#0]] // { arity: 9 }
                   Get materialize.public.part // { arity: 9 }
                 ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
@@ -730,12 +730,12 @@ Explained Query:
         Filter "%green%" ~~(varchar_to_text(#1)) // { arity: 50 }
           Join on=(eq(#0, #17, #32) AND eq(#9, #18, #33) AND #12 = #46 AND #16 = #37) type=delta // { arity: 50 }
             implementation
-              %0 » %2[#1] » %3[#0, #1] » %1[#0] » %4[#0] » %5[#0]
-              %1 » %2[#2] » %3[#0, #1] » %0[#0] » %4[#0] » %5[#0]
-              %2 » %3[#0, #1] » %0[#0] » %1[#0] » %4[#0] » %5[#0]
-              %3 » %2[#1, #2] » %0[#0] » %1[#0] » %4[#0] » %5[#0]
-              %4 » %2[#0] » %3[#0, #1] » %0[#0] » %1[#0] » %5[#0]
-              %5 » %1[#3] » %2[#2] » %3[#0, #1] » %0[#0] » %4[#0]
+              %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
+              %1:supplier » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA » %5:nation[#0]KA
+              %2:lineitem » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
+              %3:partsupp » %2:lineitem[#1, #2]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
+              %4:orders » %2:lineitem[#0]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %5:nation[#0]KA
+              %5:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.part // { arity: 9 }
             ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
@@ -807,10 +807,10 @@ Explained Query:
           Filter (#25 = "R") AND (#12 < 1994-01-01) AND (#12 >= 1993-10-01) AND (date_to_timestamp(#12) < 1994-01-01 00:00:00) // { arity: 37 }
             Join on=(#0 = #9 AND #3 = #33 AND #8 = #17) type=delta // { arity: 37 }
               implementation
-                %0 » %1[#1] » %2[#0] » %3[#0]
-                %1 » %2[#0] » %0[#0] » %3[#0]
-                %2 » %1[#0] » %0[#0] » %3[#0]
-                %3 » %0[#3] » %1[#1] » %2[#0]
+                %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
+                %1:orders » %2:lineitem[#0]KAef » %0:customer[#0]KA » %3:nation[#0]KA
+                %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
+                %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
               ArrangeBy keys=[[#0], [#3]] // { arity: 8 }
                 Get materialize.public.customer // { arity: 8 }
               ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -868,7 +868,7 @@ Explained Query:
         Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0 » %1[]
+              %0 » %1[×]UA
             Reduce group_by=[#0] aggregates=[sum((#2 * integer_to_numeric(#1)))] // { arity: 2 }
               Get l0 // { arity: 3 }
             ArrangeBy keys=[[]] // { arity: 1 }
@@ -881,9 +881,9 @@ Explained Query:
           Filter (#13 = "GERMANY") // { arity: 16 }
             Join on=(#1 = #5 AND #8 = #12) type=delta // { arity: 16 }
               implementation
-                %0 » %1[#0] » %2[#0]
-                %1 » %2[#0] » %0[#1]
-                %2 » %1[#3] » %0[#1]
+                %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
+                %1:supplier » %2:nation[#0]KAef » %0:partsupp[#1]KA
+                %2:nation » %1:supplier[#3]KA » %0:partsupp[#1]KA
               ArrangeBy keys=[[#1]] // { arity: 5 }
                 Get materialize.public.partsupp // { arity: 5 }
               ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
@@ -938,8 +938,8 @@ Explained Query:
         Filter (#21 >= 1994-01-01) AND (#19 < #20) AND (#20 < #21) AND (date_to_timestamp(#21) < 1995-01-01 00:00:00) AND ((#23 = "MAIL") OR (#23 = "SHIP")) // { arity: 25 }
           Join on=(#0 = #9) type=delta // { arity: 25 }
             implementation
-              %0 » %1[#0]
-              %1 » %0[#0]
+              %0:orders » %1:lineitem[#0]KAeiif
+              %1:lineitem » %0:orders[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.orders // { arity: 9 }
             ArrangeBy keys=[[#0]] // { arity: 16 }
@@ -988,7 +988,7 @@ Explained Query:
                 Map (null) // { arity: 17 }
                   Join on=(#0 = #8 AND #1 = #9 AND #2 = #10 AND #3 = #11 AND #4 = #12 AND #5 = #13 AND #6 = #14 AND #7 = #15) type=differential // { arity: 16 }
                     implementation
-                      materialize.public.customer » %0[#0, #1, #2, #3, #4, #5, #6, #7]
+                      %1:customer » %0[#0, #1, #2, #3, #4, #5, #6, #7]KKKKKKKKA
                     ArrangeBy keys=[[#0, #1, #2, #3, #4, #5, #6, #7]] // { arity: 8 }
                       Union // { arity: 8 }
                         Negate // { arity: 8 }
@@ -1004,8 +1004,8 @@ Explained Query:
           Filter NOT("%special%requests%" ~~(varchar_to_text(#16))) // { arity: 17 }
             Join on=(#0 = #9) type=delta // { arity: 17 }
               implementation
-                %0 » %1[#1]
-                %1 » %0[#0]
+                %0:customer » %1:orders[#1]KAf
+                %1:orders » %0:customer[#0]KA
               ArrangeBy keys=[[#0]] // { arity: 8 }
                 Get materialize.public.customer // { arity: 8 }
               ArrangeBy keys=[[#1]] // { arity: 9 }
@@ -1054,8 +1054,8 @@ Explained Query:
           Filter (#10 >= 1995-09-01) AND (date_to_timestamp(#10) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1 = #16) type=delta // { arity: 25 }
               implementation
-                %0 » %1[#0]
-                %1 » %0[#1]
+                %0:lineitem » %1:part[#0]KA
+                %1:part » %0:lineitem[#1]KAiif
               ArrangeBy keys=[[#1]] // { arity: 16 }
                 Get materialize.public.lineitem // { arity: 16 }
               ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1109,7 +1109,7 @@ Explained Query:
       Project (#0..=#2, #4, #8) // { arity: 5 }
         Join on=(#0 = #7 AND #8 = #9) type=differential // { arity: 10 }
           implementation
-            %0 » %1[#0] » %2[#0]
+            %0:supplier » %1:l0[#0]UKA » %2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 7 }
             Get materialize.public.supplier // { arity: 7 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1175,7 +1175,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %1 » %0[#0]
+              %1 » %0:l0[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Get l0 // { arity: 4 }
             Union // { arity: 1 }
@@ -1185,7 +1185,7 @@ Explained Query:
                     Filter ((#1) IS NULL OR (#0 = #1)) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
                         implementation
-                          %1 » %0[]
+                          %1:supplier » %0:l1[×]Alf
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Get l1 // { arity: 1 }
                         Project (#0) // { arity: 1 }
@@ -1202,8 +1202,8 @@ Explained Query:
           Filter (#8 != "Brand#45") AND NOT("MEDIUM POLISHED%" ~~(varchar_to_text(#9))) AND ((#10 = 3) OR (#10 = 9) OR (#10 = 14) OR (#10 = 19) OR (#10 = 23) OR (#10 = 36) OR (#10 = 45) OR (#10 = 49)) // { arity: 14 }
             Join on=(#0 = #5) type=delta // { arity: 14 }
               implementation
-                %0 » %1[#0]
-                %1 » %0[#0]
+                %0:partsupp » %1:part[#0]KAef
+                %1:part » %0:partsupp[#0]KA
               ArrangeBy keys=[[#0]] // { arity: 5 }
                 Get materialize.public.partsupp // { arity: 5 }
               ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1257,15 +1257,15 @@ Explained Query:
           Filter (numeric_to_double(#1) < (0.2 * (numeric_to_double(#4) / bigint_to_double(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
             Join on=(#0 = #3) type=differential // { arity: 6 }
               implementation
-                l1 » %1[#0]
+                %0:l1 » %1[#0]UKA
               Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Reduce group_by=[#0] aggregates=[sum(#1), count(true)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #2) type=delta // { arity: 17 }
                       implementation
-                        %0 » l0[#1]
-                        l0 » %0[#0]
+                        %0 » %1:l0[#1]KA
+                        %1:l0 » %0[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#0) // { arity: 1 }
@@ -1276,8 +1276,8 @@ Explained Query:
         Filter (#19 = "Brand#23") AND (#22 = "MED BOX") // { arity: 25 }
           Join on=(#1 = #16) type=delta // { arity: 25 }
             implementation
-              l0 » %1[#0]
-              %1 » l0[#1]
+              %0:l0 » %1:part[#0]KAef
+              %1:part » %0:l0[#1]KA
             Get l0 // { arity: 16 }
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.part // { arity: 9 }
@@ -1335,15 +1335,15 @@ Explained Query:
           Filter (#7 > 300) // { arity: 8 }
             Join on=(#2 = #6) type=differential // { arity: 8 }
               implementation
-                l1 » %1[#0]
+                %0:l1 » %1[#0]UKAif
               Get l1 // { arity: 6 }
               ArrangeBy keys=[[#0]] // { arity: 2 }
                 Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #1) type=delta // { arity: 17 }
                       implementation
-                        %0 » l0[#0]
-                        l0 » %0[#0]
+                        %0 » %1:l0[#0]KA
+                        %1:l0 » %0[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#2) // { arity: 1 }
@@ -1354,9 +1354,9 @@ Explained Query:
         Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
           Join on=(#0 = #9 AND #8 = #17) type=delta // { arity: 33 }
             implementation
-              %0 » %1[#1] » l0[#0]
-              %1 » %0[#0] » l0[#0]
-              l0 » %1[#0] » %0[#0]
+              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 8 }
               Get materialize.public.customer // { arity: 8 }
             ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
@@ -1432,8 +1432,8 @@ Explained Query:
             Map ((#4 <= 20), (#4 >= 10), (#4 <= 30), (#4 >= 20), (#4 <= 11), (#4 >= 1), (#19 = "Brand#12"), (#21 <= 5), ((#22 = "SM BOX") OR (#22 = "SM PKG") OR (#22 = "SM CASE") OR (#22 = "SM PACK")), (#19 = "Brand#23"), (#21 <= 10), ((#22 = "MED BAG") OR (#22 = "MED BOX") OR (#22 = "MED PKG") OR (#22 = "MED PACK")), (#19 = "Brand#34"), (#21 <= 15), ((#22 = "LG BOX") OR (#22 = "LG PKG") OR (#22 = "LG CASE") OR (#22 = "LG PACK"))) // { arity: 40 }
               Join on=(#1 = #16) type=delta // { arity: 25 }
                 implementation
-                  %0 » %1[#0]
-                  %1 » %0[#1]
+                  %0:lineitem » %1:part[#0]KAeiiif
+                  %1:part » %0:lineitem[#1]KAeiif
                 ArrangeBy keys=[[#1]] // { arity: 16 }
                   Get materialize.public.lineitem // { arity: 16 }
                 ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1492,7 +1492,7 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            l0 » %1[#0]
+            %0:l0 » %1[#0]UKA
           Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Distinct group_by=[#0] // { arity: 1 }
@@ -1500,7 +1500,7 @@ Explained Query:
                 Filter (integer_to_numeric(#2) > (0.5 * #5)) // { arity: 6 }
                   Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
                     implementation
-                      %0 » %1[#0, #1]
+                      %0:l1 » %1[#0, #1]UKKAf
                     Project (#0, #1, #3) // { arity: 3 }
                       Filter (#0 = #2) // { arity: 4 }
                         Get l1 // { arity: 4 }
@@ -1510,8 +1510,8 @@ Explained Query:
                           Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
                             Join on=(#0 = #3 AND #1 = #4) type=delta // { arity: 18 }
                               implementation
-                                %0 » %1[#1, #2]
-                                %1 » %0[#0, #1]
+                                %0 » %1:lineitem[#1, #2]KKAiif
+                                %1:lineitem » %0[#0, #1]UKKA
                               ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                                 Distinct group_by=[#0, #1] // { arity: 2 }
                                   Project (#1, #2) // { arity: 2 }
@@ -1523,7 +1523,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#1 = #6) type=differential // { arity: 7 }
             implementation
-              %1 » %2[#0] » %0[]
+              %1:partsupp » %2[#0]UKA » %0[×]A
             ArrangeBy keys=[[]] // { arity: 1 }
               Distinct group_by=[#0] // { arity: 1 }
                 Project (#0) // { arity: 1 }
@@ -1540,8 +1540,8 @@ Explained Query:
           Filter (#8 = "CANADA") // { arity: 11 }
             Join on=(#3 = #7) type=delta // { arity: 11 }
               implementation
-                %0 » %1[#0]
-                %1 » %0[#3]
+                %0:supplier » %1:nation[#0]KAef
+                %1:nation » %0:supplier[#3]KA
               ArrangeBy keys=[[#3]] // { arity: 7 }
                 Get materialize.public.supplier // { arity: 7 }
               ArrangeBy keys=[[#0]] // { arity: 4 }
@@ -1606,7 +1606,7 @@ Explained Query:
         Project (#1) // { arity: 1 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
-              %1 » %0[#0, #2]
+              %1 » %0:l2[#0, #2]KKA
             ArrangeBy keys=[[#0, #2]] // { arity: 3 }
               Get l2 // { arity: 3 }
             Union // { arity: 2 }
@@ -1616,7 +1616,7 @@ Explained Query:
                     Filter (#1 != #4) AND (#14 > #13) // { arity: 18 }
                       Join on=(#0 = #2) type=differential // { arity: 18 }
                         implementation
-                          l3 » l1[#0]
+                          %0:l3 » %1:l1[#0]KAf
                         Get l3 // { arity: 2 }
                         Get l1 // { arity: 16 }
               Get l3 // { arity: 2 }
@@ -1629,7 +1629,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
-              l0 » %1[#0, #1]
+              %0:l0 » %1[#0, #1]UKKA
             Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0, #1]] // { arity: 2 }
               Distinct group_by=[#0, #1] // { arity: 2 }
@@ -1637,7 +1637,7 @@ Explained Query:
                   Filter (#1 != #4) // { arity: 18 }
                     Join on=(#0 = #2) type=differential // { arity: 18 }
                       implementation
-                        %0 » l1[#0]
+                        %0 » %1:l1[#0]KA
                       Distinct group_by=[#1, #0] // { arity: 2 }
                         Project (#0, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
@@ -1650,10 +1650,10 @@ Explained Query:
           Filter (#25 = "F") AND (#33 = "SAUDI ARABIA") AND (#19 > #18) // { arity: 36 }
             Join on=(#0 = #9 AND #3 = #32 AND #7 = #23) type=delta // { arity: 36 }
               implementation
-                %0 » %3[#0] » %1[#2] » %2[#0]
-                %1 » %2[#0] » %0[#0] » %3[#0]
-                %2 » %1[#0] » %0[#0] » %3[#0]
-                %3 » %0[#3] » %1[#2] » %2[#0]
+                %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+                %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
+                %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
+                %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
               ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
                 Get materialize.public.supplier // { arity: 7 }
               ArrangeBy keys=[[#0], [#2]] // { arity: 16 }
@@ -1731,7 +1731,7 @@ Explained Query:
         Project (#1, #2) // { arity: 2 }
           Join on=(#0 = #3) type=differential // { arity: 4 }
             implementation
-              %1 » %0[#0]
+              %1 » %0:l1[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 3 }
               Get l1 // { arity: 3 }
             Union // { arity: 1 }
@@ -1739,8 +1739,8 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=delta // { arity: 2 }
                     implementation
-                      %0 » %1[#0]
-                      %1 » %0[#0]
+                      %0:l2 » %1[#0]UKA
+                      %1 » %0:l2[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l2 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1758,7 +1758,7 @@ Explained Query:
           Filter (numeric_to_double(#2) > (numeric_to_double(#3) / bigint_to_double(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
-                %0 » %1[]
+                %0:l0 » %1[×]UAef
               Project (#0, #4, #5) // { arity: 3 }
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -33,7 +33,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      l1 » %1[#0]
+                      %0:l1 » %1[#0]UKA
                     Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
@@ -49,7 +49,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -84,7 +84,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -122,7 +122,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    materialize.public.t1 » %1[#0]
+                    %0:t1 » %1[#0]UKA
                   Get materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
@@ -136,7 +136,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -165,7 +165,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      materialize.public.t1 » %1[#0]
+                      %0:t1 » %1[#0]UKA
                     Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
@@ -179,7 +179,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -208,7 +208,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      materialize.public.t1 » %1[#0]
+                      %0:t1 » %1[#0]UKA
                     Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
@@ -222,7 +222,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -267,7 +267,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -297,7 +297,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -332,7 +332,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      l1 » %1[#0]
+                      %0:l1 » %1[#0]UKA
                     Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
@@ -349,7 +349,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -375,7 +375,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -402,7 +402,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -437,7 +437,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      l1 » %1[#0]
+                      %0:l1 » %1[#0]UKA
                     Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
@@ -453,7 +453,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -486,7 +486,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    l1 » %1[#0]
+                    %0:l1 » %1[#0]UKA
                   Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
@@ -502,7 +502,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -532,7 +532,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    l1 » %1[#0]
+                    %0:l1 » %1[#0]UKA
                   Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
@@ -548,7 +548,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -574,7 +574,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -601,7 +601,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -657,7 +657,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    materialize.public.t1 » %1[#0]
+                    %0:t1 » %1[#0]UKA
                   Get materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
@@ -670,7 +670,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#1]
+            %1:t2 » %0:t1[#1]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -696,7 +696,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#1 = #2) type=differential // { arity: 3 }
                     implementation
-                      materialize.public.t1 » %1[#0]
+                      %0:t1 » %1[#0]UKA
                     Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
@@ -709,7 +709,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#1]
+            %1:t2 » %0:t1[#1]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -731,7 +731,7 @@ Explained Query:
       Project (#0, #3) // { arity: 2 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1 » %0[#1]
+            %1:t2 » %0:t1[#1]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -827,7 +827,7 @@ Explained Query:
     Project (#1) // { arity: 1 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %0 » %1[#1]
+          %0:t1 » %1[#1]UKA
         Project (#1) // { arity: 1 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -840,7 +840,7 @@ Explained Query:
                   Map (null) // { arity: 5 }
                     Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
                       implementation
-                        materialize.public.t3 » %0[#0, #1]
+                        %1:t3 » %0[#0, #1]KKA
                       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                         Union // { arity: 2 }
                           Map (6) // { arity: 2 }
@@ -855,7 +855,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1 » %0[]
+          %1:t3 » %0:t2[×]Aef
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Get materialize.public.t2 // { arity: 2 }
@@ -911,7 +911,7 @@ Explained Query:
             Map (null) // { arity: 3 }
               Join on=(#0 = #1) type=differential // { arity: 2 }
                 implementation
-                  materialize.public.t2 » %0[#0]
+                  %1:t2 » %0[#0]KA
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
@@ -926,7 +926,7 @@ Explained Query:
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
           implementation
-            materialize.public.t1 » %0[]
+            %1:t1 » %0:t2[×]A
           ArrangeBy keys=[[]] // { arity: 1 }
             Get materialize.public.t2 // { arity: 1 }
           Get materialize.public.t1 // { arity: 1 }

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -75,7 +75,7 @@ explain with(arity, join_impls) select * from foo, bar where foo.a = abs(bar.a) 
 Explained Query:
   CrossJoin type=differential // { arity: 6 }
     implementation
-      %1 » %0[]
+      %1:bar » %0:foo[×]Aef
     ArrangeBy keys=[[]] // { arity: 3 }
       Filter (#0 = 3) // { arity: 3 }
         Get materialize.public.foo // { arity: 3 }

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -19,7 +19,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT FROM ( SELECT FROM t2 a1 RIGHT JOIN t2 ON a1.f1 IS NULL WHERE TRUE AND a1.f1 = a1.f2 )
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -31,7 +31,7 @@ Explained Query:
   Project () // { arity: 0 }
     Join on=(#0 = (#1 + #2)) type=differential // { arity: 3 }
       implementation
-        %1 » %0[]
+        %1:t2 » %0:t1[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -54,7 +54,7 @@ Explained Query:
     Project () // { arity: 0 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         implementation
-          l0 » %1[#0]
+          %0:l0 » %1[#0]UKA
         Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Distinct group_by=[#0] // { arity: 1 }
@@ -78,7 +78,7 @@ Explained Query:
           Filter (#2 > #0) // { arity: 3 }
             CrossJoin type=differential // { arity: 3 }
               implementation
-                l0 » %0[] » %1[] » %2[]
+                %3:l0 » %0:t2[×]A » %1:l1[×]A » %2:t1[×]A
               ArrangeBy keys=[[]] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Get materialize.public.t2 // { arity: 2 }

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -35,7 +35,7 @@ Explained Query:
     Filter (#0 <= #2) // { arity: 6 }
       Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
         implementation
-          %2 » %0[#0] » %1[#1]
+          %2:t3 » %0:t1[#0]KAiif » %1:t2[#1]KAiif
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0 > 0) AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -115,7 +115,7 @@ Explained Query:
     Filter (#5 != #11) AND (#14 >= #10) // { arity: 15 }
       Join on=(#0 = #8 AND date_to_timestamp(#11) = (#5 - 9 months)) type=differential // { arity: 15 }
         implementation
-          materialize.public.customer » %0[] » %1[#0, date_to_timestamp(#3)]
+          %2:customer » %0:lineitem[×]A » %1:orders[#0, date_to_timestamp(#3)]KKA
         ArrangeBy keys=[[]] // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }
         ArrangeBy keys=[[#0, date_to_timestamp(#3)]] // { arity: 4 }
@@ -156,7 +156,7 @@ Explained Query:
           Filter (#1 <= 195) AND (#1 >= 38) AND (1997-08-25 00:00:00 = date_to_timestamp(#4)) // { arity: 6 }
             Join on=(#0 = #3 AND #1 = #5) type=differential // { arity: 6 }
               implementation
-                %2 » %1[#0] » %0[#0]
+                %2 » %1:orders[#0]KAeiiiif » %0:lineitem[#0]KAeiiiif
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Project (#4) // { arity: 1 }
                   Filter (#6 = 1997-01-25) // { arity: 8 }
@@ -197,7 +197,7 @@ Explained Query:
   Project (#1, #0, #1) // { arity: 3 }
     Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
       implementation
-        %2 » %1[] » %0[#2, #3]
+        %2:customer » %1:orders[×]Aef » %0:lineitem[#2, #3]KKAef
       ArrangeBy keys=[[#2, #3]] // { arity: 4 }
         Project (#0, #1, #4, #6) // { arity: 4 }
           Filter (#4 = (#4 % 5)) // { arity: 8 }
@@ -236,7 +236,7 @@ Explained Query:
   Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
     Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 15 }
       implementation
-        %1 » %0[#4, #5] » %2[]
+        %1:orders » %0:lineitem[#4, #5]KKAef » %2:customer[×]Aef
       ArrangeBy keys=[[#4, #5]] // { arity: 8 }
         Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }
@@ -271,6 +271,6 @@ WHERE a2.f1 + a1.f2 = (SELECT 1)
 AND a2.f1 IS NULL;
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -32,7 +32,7 @@ EXPLAIN WITH(arity, join_impls) select * from foo inner join bar on foo.a = bar.
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1 » %0[]
+      %1:bar » %0:foo[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 1) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -61,7 +61,7 @@ EXPLAIN WITH(arity, join_impls) select * from foo inner join bar on foo.a = abs(
 Explained Query:
   Join on=(#0 = abs(#2)) type=differential // { arity: 4 }
     implementation
-      %1 » %0[#0]
+      %1:bar » %0:foo[#0]KAef
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Filter (1 = (#0 % 2)) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -95,7 +95,7 @@ EXPLAIN WITH(arity, join_impls) select * from (select * from foo where a = 1) fi
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1 » %0[]
+      %1:bar » %0:foo[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 1) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -141,7 +141,7 @@ Explained Query:
   Project (#0, #5) // { arity: 2 }
     Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
       implementation
-        %1 » %2[#0] » %0[#0]
+        %1:bar » %2:baz[#0]UKA » %0:foo[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
@@ -189,7 +189,7 @@ Explained Query:
     Filter (#0) IS NOT NULL AND (#3) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
         implementation
-          %1 » %0[#0] » %2[#0]
+          %1:bar » %0:foo[#0]KA » %2:baz[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -232,8 +232,8 @@ Explained Query:
     Filter (#2) IS NOT NULL AND (case when (#0 = 0) then null else #0 end) IS NOT NULL // { arity: 4 }
       Join on=(-(#2) = if (#0 = 0) then {null} else {#0}) type=delta // { arity: 4 }
         implementation
-          %0 » %1[-(#0)]
-          %1 » %0[case when (#0 = 0) then null else #0 end]
+          %0:foo » %1:bar[-(#0)]KA
+          %1:bar » %0:foo[case when (#0 = 0) then null else #0 end]KA
         ArrangeBy keys=[[case when (#0 = 0) then null else #0 end]] // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
         ArrangeBy keys=[[-(#0)]] // { arity: 2 }
@@ -276,7 +276,7 @@ Explained Query:
     Filter (#0) IS NOT NULL AND (#4) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #4 = (#0 + 4)) type=differential // { arity: 6 }
         implementation
-          %2 » %0[(#0 + 4)] » %1[#0]
+          %2:baz » %0:bar[(#0 + 4)]KA » %1:foo[#0]KA
         ArrangeBy keys=[[(#0 + 4)]] // { arity: 2 }
           Get materialize.public.bar // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -313,7 +313,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(1 = (#0 / #2)) type=differential // { arity: 4 }
       implementation
-        materialize.public.bar » %0[]
+        %1:bar » %0:foo[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       Get materialize.public.bar // { arity: 2 }
@@ -343,7 +343,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(eq(-1, (#3 - #1), (#0 / #2))) type=differential // { arity: 4 }
       implementation
-        materialize.public.bar » %0[]
+        %1:bar » %0:foo[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       Get materialize.public.bar // { arity: 2 }
@@ -380,7 +380,7 @@ Explained Query:
   Project (#1, #3, #5) // { arity: 3 }
     Join on=(#0 = #2 AND #4 = (#0 + 4)) type=differential // { arity: 6 }
       implementation
-        %2 » %0[(#0 + 4)] » %1[#0]
+        %2:baz » %0:foo[(#0 + 4)]KA » %1:bar[#0]KA
       ArrangeBy keys=[[(#0 + 4)]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
@@ -591,17 +591,17 @@ Explained Query:
     Filter (#109) IS NULL AND "a%" ~~(#125) AND (#137 = 71) AND (#95 <= 8) AND (#81 > 5) AND (#95 >= 3) AND NOT("b%" ~~(#69)) AND (#39 != #40) AND (#53 != #54) // { arity: 154 }
       Join on=(eq(#0, #15, #30, #45, #60, #75, #90, #105, #120, #135, #150)) type=delta // { arity: 154 }
         implementation
-          %0 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %1[#1] » %10[#10]
-          %1 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %10[#10]
-          %2 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %3[#3] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %3 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %4 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %0[#0] » %1[#1] » %10[#10]
-          %5 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %6 » %9[#9] » %8[#8] » %7[#7] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %7 » %9[#9] » %8[#8] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %8 » %9[#9] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %9 » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %1[#1] » %10[#10]
-          %10 » %9[#9] » %8[#8] » %7[#7] » %6[#6] » %5[#5] » %2[#2] » %3[#3] » %4[#4] » %0[#0] » %1[#1]
+          %0:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %1:big[#1]KA » %10:big[#10]KA
+          %1:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %10:big[#10]KA
+          %2:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %3:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %4:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %5:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %6:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %7:big » %9:big[#9]KAef » %8:big[#8]KAlf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %8:big » %9:big[#9]KAef » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %9:big » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA » %10:big[#10]KA
+          %10:big » %9:big[#9]KAef » %8:big[#8]KAlf » %7:big[#7]KAnf » %6:big[#6]KAiif » %5:big[#5]KAif » %2:big[#2]KAf » %3:big[#3]KAf » %4:big[#4]KAf » %0:big[#0]KA » %1:big[#1]KA
         ArrangeBy keys=[[#0]] // { arity: 14 }
           Get materialize.public.big // { arity: 14 }
         ArrangeBy keys=[[#1]] // { arity: 14 }
@@ -657,9 +657,9 @@ Explained Query:
     Filter "a%" ~~(#13) // { arity: 43 }
       Join on=(eq(#0, #15, #31)) type=delta // { arity: 43 }
         implementation
-          %0 » %1[#1] » %2[#2]
-          %1 » %0[#0] » %2[#2]
-          %2 » %1[#1] » %0[#0]
+          %0:big » %1:big[#1]KAe » %2:big[#2]KA
+          %1:big » %0:big[#0]KAlf » %2:big[#2]KA
+          %2:big » %1:big[#1]KAe » %0:big[#0]KAlf
         ArrangeBy keys=[[#0]] // { arity: 14 }
           Get materialize.public.big // { arity: 14 }
         ArrangeBy keys=[[#1]] // { arity: 15 }

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -113,7 +113,7 @@ Explained Query:
     Map (1) // { arity: 4 }
       CrossJoin type=differential // { arity: 3 }
         implementation
-          materialize.public.t » %0[]
+          %1:t » %0:t[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Map ((#0 + 1)) // { arity: 3 }
@@ -131,7 +131,7 @@ Explained Query:
     Map (2, 1) // { arity: 6 }
       CrossJoin type=differential // { arity: 4 }
         implementation
-          materialize.public.t » %0[]
+          %1:t » %0:t[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Project (#2, #3) // { arity: 2 }
             Map ((#1 + 1), (#0 + 1)) // { arity: 4 }
@@ -149,7 +149,7 @@ Explained Query:
     Map (3, 2, 1) // { arity: 8 }
       CrossJoin type=differential // { arity: 5 }
         implementation
-          materialize.public.t » %0[]
+          %1:t » %0:t[×]A
         ArrangeBy keys=[[]] // { arity: 3 }
           Project (#2..=#4) // { arity: 3 }
             Map ((#1 + 1), (#0 + 2), (#0 + 1)) // { arity: 5 }
@@ -198,7 +198,7 @@ Explained Query:
     Map ((1 + #0), 1) // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0[]
+          %1:t » %0[×]
         Constant // { arity: 0 }
           - (() x 7)
         Project (#0) // { arity: 1 }
@@ -750,7 +750,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %1 » %0[#0]
+              %1 » %0:t_pk[#0]UKAiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
@@ -799,7 +799,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %1 » %0[#0]
+              %1 » %0:t[#0]KAiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
@@ -866,7 +866,7 @@ explain with(arity, join_impls) select * from t1 as a1 join t1 as a2 on (a2.f2 =
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1 » %2[] » %0[]
+      %1:t1 » %2[×]UAef » %0:t1[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Filter (#1 = 9) // { arity: 2 }

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -172,7 +172,7 @@ Explained Query:
   Project (#0, #1, #0, #1) // { arity: 4 }
     Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
       implementation
-        %1 » %0[#0, #1]
+        %1:t2 » %0:t1[#0, #1]KKA
       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
         Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -194,7 +194,7 @@ select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and t2.f1 is null
 Explained Query:
   Join on=(#0 = (#2 + 1)) type=differential // { arity: 4 }
     implementation
-      materialize.public.t2 » %0[#0]
+      %1:t2 » %0:t1[#0]KA
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Get materialize.public.t2 // { arity: 2 }
@@ -208,7 +208,7 @@ select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 Explained Query:
   Join on=(#0 = (#2 + 1)) type=differential // { arity: 4 }
     implementation
-      materialize.public.t2 » %0[#0]
+      %1:t2 » %0:t1[#0]KA
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Get materialize.public.t2 // { arity: 2 }
@@ -222,7 +222,7 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 Explained Query:
   Join on=(#2 = (#0 + 1)) type=differential // { arity: 4 }
     implementation
-      materialize.public.t2 » %0[(#0 + 1)]
+      %1:t2 » %0:t1[(#0 + 1)]KA
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Get materialize.public.t2 // { arity: 2 }
@@ -236,7 +236,7 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and ((t2.f1 + 1) 
 Explained Query:
   Join on=(#2 = (#0 + 1)) type=differential // { arity: 4 }
     implementation
-      materialize.public.t2 » %0[(#0 + 1)]
+      %1:t2 » %0:t1[(#0 + 1)]KA
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     Get materialize.public.t2 // { arity: 2 }
@@ -254,7 +254,7 @@ Explained Query:
     Filter (((#1 = 3) AND (#3 = 4)) OR ((#1 = 5) AND (#3 = 6))) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1 » %0[#0]
+          %1:t2 » %0:t1[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND ((#1 = 3) OR (#1 = 5)) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -277,7 +277,7 @@ Explained Query:
     Filter ((#1 = 5) OR ((#1 = 3) AND (#3 = 4))) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1 » %0[#0]
+          %1:t2 » %0:t1[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND ((#1 = 3) OR (#1 = 5)) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -300,7 +300,7 @@ Explained Query:
   Filter ((#1 = 27) OR ((#0 = #2) AND (#1 <= 1995))) // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        materialize.public.t2 » %0[]
+        %1:t2 » %0:t1[×]Aeiif
       ArrangeBy keys=[[]] // { arity: 2 }
         Filter ((#1 = 27) OR (#1 <= 1995)) // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }

--- a/test/sqllogictest/transform/predicate_reduction.slt
+++ b/test/sqllogictest/transform/predicate_reduction.slt
@@ -98,7 +98,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE ((f1 is null)::int - 1)::string LIKE '1' and ((f1 is null) or not (((f1 is null)::int - 1)::string LIKE '1'))
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -82,7 +82,7 @@ query T multiline
 explain with(types) select * from (select * from with_primary_key limit 0);
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -142,7 +142,7 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              materialize.public.t3 » %1[#0]
+              %0:t3 » %1[#0]UKA
             Get materialize.public.t3 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Distinct group_by=[#0] // { arity: 1 }
@@ -155,7 +155,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » %0[#0]
+            %1:t2 » %0:t3[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t3 // { arity: 2 }

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -79,7 +79,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 EXCEPT ALL SELECT * FROM t1
 ----
 Explained Query (fast path):
-  Constant
+  Constant <empty>
 
 EOF
 
@@ -202,7 +202,7 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              materialize.public.t3 » %1[#0]
+              %0:t3 » %1[#0]UKA
             Get materialize.public.t3 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Distinct group_by=[#0] // { arity: 1 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -248,7 +248,7 @@ Explained Query:
     Project (#0) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         implementation
-          l0 » %1[#0]
+          %0:l0 » %1[#0]UKA
         Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Distinct group_by=[record_get[0](record_get[1](#0))] // { arity: 1 }
@@ -259,7 +259,7 @@ Explained Query:
                     Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
                       CrossJoin type=differential // { arity: 3 }
                         implementation
-                          materialize.public.t2 » %0[]
+                          %1:t2 » %0[×]A
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Distinct group_by=[#0] // { arity: 1 }
                             Get l0 // { arity: 1 }

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -31,7 +31,7 @@ count
 1
 
 > EXPLAIN WITH(join_impls) VIEW delta_join;
-"Explained Query:  Project (#0, #1, #0, #3)    Filter (#0) IS NOT NULL      Join on=(#0 = #2) type=delta        implementation          %0 » %1[#0]          %1 » %0[#0]        ArrangeBy keys=[[#0]]          Get t1        ArrangeBy keys=[[#0]]          Get t2Used Indexes:  - i1  - i2"
+"Explained Query:  Project (#0, #1, #0, #3)    Filter (#0) IS NOT NULL      Join on=(#0 = #2) type=delta        implementation          %0:t1 » %1:t2[#0]KA          %1:t2 » %0:t1[#0]KA        ArrangeBy keys=[[#0]]          Get t1        ArrangeBy keys=[[#0]]          Get t2Used Indexes:  - i1  - i2"
 
 > SELECT count(*) AS count FROM delta_join;
 count

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -79,7 +79,7 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # Use of a deterministic function
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null % 2 = 5 AND (col_not_null % 2 = 5 IS NULL);
-"Explained Query (fast path):  Constant"
+"Explained Query (fast path):  Constant <empty>"
 
 # This is not optimized
 > EXPLAIN SELECT * FROM t1 WHERE (col_not_null % 2) = 1 AND (((col_not_null % 2) = 1) = TRUE);
@@ -107,7 +107,7 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 "Explained Query (fast path):  Filter (#1 = 3)    ReadExistingIndex t1_primary_idxUsed Indexes:  - t1_primary_idx"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (4, 5);
-"Explained Query (fast path):  Constant"
+"Explained Query (fast path):  Constant <empty>"
 
 # Expression inside an IN list
 


### PR DESCRIPTION
- Improve the printing of `WITH(join_impls)`:
  - Add input characteristics.
    - This involves moving `Characteristics` from `join_implementation.rs` (`transform`) to `expr`, so that I can put the `Characteristics` into the `JoinImplementation` enum.
  - Try to dig out an `Id` when humanizing an input name. (from below MFPs, ArrangeBys, IndexedFilters)
  - Always print input number (e.g. `%1`) in addition to names. (This is necessary now, because the name might not unambiguously point to the join input anymore in some edge cases.)
  - Shorten names to not include the qualification (e.g., only `foo` instead of `materialize.public.foo`).
    - Even with this shortening, sometimes the EXPLAIN gets wide. But I believe that doing some horizontal scrolling sometimes is still easier than trying to look up the inputs by number all the time.
  - For an empty key (`[]`), explicitly indicate that it is a cross: `[×]`.
- Update EXPLAIN docs for join_impls
- When EXPLAINing `MirRelationExpr::Constant`
  - Explicitly indicate empty collections
  - Handle negative diffs
- Fixed some lowertest bugs
  - in `find_next_type_in_tuple`:
    - There was some confusion around whether certain indexes are from the beginning of `type_name`, or from the beginning of a certain slice of `type_name`.
    - If a tuple contained more than 2 nested tuples (e.g. `((u8,u8),(u8,u8),(u8,u8))`), then the `rfind` would find the closing paren of the last one when it should have been finding the 2nd one.
  - in `normalize_type_name`, we have to also remove `\n`.

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/14034
    * Well, this PR won't actually close that issue, because the issue also asks for a more digestable summary for users, but this PR doesn't do that.
  * Plus the `Constant` thingy.
  * And fixing the lowertest bugs.

### Tips for reviewer

The commits are best viewed individually. (But not all slts have been rewritten for every commit.)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - EXPLAIN improvements for `WITH(join_impls)`.
