### PR TITLE
environmentd: decrease severity of conn errors

### DIFF
--- a/src/environmentd/src/server.rs
+++ b/src/environmentd/src/server.rs
@@ -19,7 +19,7 @@ use futures::stream::{Stream, StreamExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
-use tracing::error;
+use tracing::{debug, error};
 
 use mz_ore::task;
 
@@ -104,7 +104,7 @@ where
         let fut = server.handle_connection(conn);
         task::spawn(|| &task_name, async {
             if let Err(e) = fut.await {
-                error!("error handling connection in {}: {:#}", S::NAME, e);
+                debug!("error handling connection in {}: {:#}", S::NAME, e);
             }
         });
     }


### PR DESCRIPTION
This is a very old message and is not generally useful.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a