### PR TITLE
stash: only error log a pg error if it's happened a few times

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -433,7 +433,11 @@ impl Postgres {
                             }
                         }
                         attempt += 1;
-                        error!("tokio-postgres stash error, retry attempt {attempt}: {pgerr}");
+                        if attempt > 2 {
+                            error!("tokio-postgres stash error, retry attempt {attempt}: {pgerr}");
+                        } else {
+                            warn!("tokio-postgres stash error, retry attempt {attempt}: {pgerr}");
+                        }
                         self.client = None;
                         retry.next().await;
                     }


### PR DESCRIPTION
This should cut down on sentry spam. We regularly see a few of these per hour, but none of them I spot checked failed on attempt > 2, so the retry loop is clearly working.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
