### PR TITLE
[sink] Investigate a sink timestamp bug

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -784,10 +784,6 @@ impl KafkaSinkState {
     /// This will emit a progress record to the progress topic if the frontier
     /// advanced and advance the maintained write frontier, which will in turn
     /// unblock compaction of timestamp bindings in sources.
-    ///
-    /// *NOTE*: Progress records will only be emitted when
-    /// `KafkaSinkConnection.consistency` points to a progress topic. The
-    /// write frontier will be advanced regardless.
     async fn maybe_emit_progress(
         &mut self,
         mut input_frontier: Antichain<Timestamp>,

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -761,7 +761,7 @@ impl KafkaSinkState {
 
     /// Asserts that the write frontier has not yet advanced beyond `t`.
     fn assert_progress(&self, ts: &Timestamp) {
-        assert!(self.write_frontier.borrow().less_equal(ts));
+        assert!(self.write_frontier.borrow().less_than(ts));
     }
 
     /// Updates the latest progress update timestamp to `latest_update_ts` if it

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -789,7 +789,6 @@ impl KafkaSinkState {
         mut input_frontier: Antichain<Timestamp>,
         as_of: &SinkAsOf<Timestamp>,
     ) -> bool {
-        input_frontier.extend(self.pending_rows.keys().min().cloned());
         let min_frontier = input_frontier;
 
         // If we emit a progress record before the as_of, we open ourselves to the possibility that


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
