### PR TITLE
*: introduce halting as a softer way to panic

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -35,7 +35,7 @@ use crate::coord::peek::PendingPeek;
 use crate::coord::{ConnMeta, Coordinator, CreateSourceStatementReady, Message, PendingTxn};
 use crate::error::AdapterError;
 use crate::session::{PreparedStatement, Session, TransactionStatus};
-use crate::util::ClientTransmitter;
+use crate::util::{ClientTransmitter, ResultExt};
 
 impl<S: Append + 'static> Coordinator<S> {
     pub(crate) async fn handle_command(&mut self, cmd: Command) {
@@ -537,7 +537,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.drop_temp_items(session).await;
         self.catalog
             .drop_temporary_schema(session.conn_id())
-            .expect("unable to drop temporary schema");
+            .unwrap_or_terminate("unable to drop temporary schema");
         self.metrics.active_sessions.dec();
         self.active_conns.remove(&session.conn_id());
         self.cancel_pending_peeks(session.conn_id());

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -27,6 +27,7 @@ use mz_stash::Append;
 
 use crate::command::{Command, ExecuteResponse};
 use crate::coord::appends::{BuiltinTableUpdateSource, Deferred};
+use crate::util::ResultExt;
 use crate::{catalog, AdapterNotice};
 
 use crate::coord::{
@@ -460,7 +461,7 @@ impl<S: Append + 'static> Coordinator<S> {
             |_| Ok(()),
         )
         .await
-        .expect("updating compute instance status cannot fail");
+        .unwrap_or_terminate("updating compute instance status cannot fail");
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -468,7 +469,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.catalog
             .confirm_leadership()
             .await
-            .expect("unable to confirm leadership");
+            .unwrap_or_terminate("unable to confirm leadership");
         for PendingTxn {
             client_transmitter,
             response,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -31,6 +31,7 @@ use crate::client::ConnectionId;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::read_policy::ReadHolds;
 use crate::coord::Coordinator;
+use crate::util::ResultExt;
 use crate::AdapterError;
 
 /// Timestamps used by writes in an Append command.
@@ -249,7 +250,7 @@ impl<T: TimestampManipulation> DurableTimestampOracle<T> {
             self.durable_timestamp = ts.step_forward_by(&self.persist_interval);
             persist_fn(self.durable_timestamp.clone())
                 .await
-                .expect("can't persist timestamp");
+                .unwrap_or_terminate("can't persist timestamp");
         }
     }
 }

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -55,6 +55,7 @@ pub mod option;
 pub mod panic;
 pub mod path;
 pub mod permutations;
+pub mod process;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "process")))]
 pub mod result;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "network")))]
@@ -79,3 +80,9 @@ pub mod thread;
 #[cfg(feature = "tracing")]
 pub mod tracing;
 pub mod vec;
+
+#[doc(hidden)]
+pub mod __private {
+    #[cfg(feature = "tracing")]
+    pub use tracing;
+}

--- a/src/ore/src/process.rs
+++ b/src/ore/src/process.rs
@@ -1,0 +1,63 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Process utilities.
+
+use std::sync::atomic::AtomicBool;
+
+/// Halts the process.
+///
+/// `halt` forwards the provided arguments to the [`tracing::warn`] macro, then
+/// terminates the process with exit code 2.
+///
+/// Halting a process is a middle ground between a graceful shutdown and a
+/// panic. Use halts for errors that are severe enough to require shutting down
+/// the process, but not severe enough to be considered a crash. Halts are not
+/// intended to be reported to error tracking tools (e.g., Sentry).
+///
+/// There are two common classes of errors that trigger a halt:
+///
+///   * An error that indicates a new process has taken over (e.g., an error
+///     indicating that the process's leader epoch has expired).
+///
+///   * A retriable error where granular retry logic would be tricky enough to
+///     write that it has not yet been worth it. Since restarting from a fresh
+///     process must *always* be correct, forcing a restart is an easy way to
+///     tap into the existing whole-process retry logic. Use halt judiciously in
+///     these cases, as restarting a process can be inefficient (e.g., mandatory
+///     restart backoff, rehydrating expensive state).
+///
+/// If you need to write a Rust libtest test that asserts that a call to halt
+/// has occcurred, see [`PANIC_ON_HALT`].
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing")))]
+#[cfg(feature = "tracing")]
+#[macro_export]
+macro_rules! halt {
+    ($($arg:expr),* $(,)?) => {{
+        $crate::__private::tracing::warn!("halting process: {}", format!($($arg),*));
+        if $crate::process::PANIC_ON_HALT.load(std::sync::atomic::Ordering::SeqCst) {
+            panic!("promoting halt to panic because PANIC_ON_HALT is set");
+        } else {
+            ::std::process::exit(2);
+        }
+    }}
+}
+
+/// Override the behavior of [`halt`] to panic rather than exiting the process.
+///
+/// Intended for use in Rust libtest tests which want to assert that a halt has
+/// occurred via [`std::panic::catch_unwind`]. The default behavior exits the
+/// test binary itself, which is not testable from within the same process.
+pub static PANIC_ON_HALT: AtomicBool = AtomicBool::new(false);

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -464,8 +464,14 @@ pub struct StashError {
 }
 
 impl StashError {
-    // Returns whether the error is unrecoverable (retrying will never succeed).
+    /// Reports whether the error is unrecoverable (retrying will never
+    /// succeed).
     pub fn is_unrecoverable(&self) -> bool {
+        matches!(self.inner, InternalStashError::Fence(_))
+    }
+
+    /// Reports whether the error is a fence error.
+    pub fn is_fence(&self) -> bool {
         matches!(self.inner, InternalStashError::Fence(_))
     }
 }

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -18,6 +18,7 @@ use timely::progress::Antichain;
 use tokio::sync::Mutex;
 use tracing::trace;
 
+use mz_ore::halt;
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriteHandle;
@@ -81,8 +82,8 @@ impl Healthchecker {
         })
     }
 
-    /// Report a SinkStatus::Stalled and then panic with the same message
-    pub async fn report_stall_and_panic<S>(hc: Option<&mut Self>, msg: S) -> !
+    /// Report a SinkStatus::Stalled and then halt with the same message.
+    pub async fn report_stall_and_halt<S>(hc: Option<&mut Self>, msg: S) -> !
     where
         S: ToString + std::fmt::Debug,
     {
@@ -92,7 +93,7 @@ impl Healthchecker {
                 .await;
         }
 
-        panic!("{msg:?}")
+        halt!("{msg:?}")
     }
 
     /// Process a [`SinkStatus`] emitted by a sink


### PR DESCRIPTION
Introduce the concept of "halting", which a middle ground between gracefully exiting a process and panicking. A halt indicates an error has occurred that is severe enough to require shutting down the process, but not severe enough to be considered a crash. Halts are not intended to be reported to error tracking tools (e.g., Sentry).

There are two common classes of errors that trigger a halt:

  * An error that indicates a new process has taken over (e.g., an error indicating that the process's leader epoch has expired).

  * A retriable error where the retry logic is too difficult to write correctly. Sometimes the easiest way to retry an error is to tear down the process and allow a new process to start from scratch.

Halts are initiated via a new `halt!` macro in the `ore` crate.  Several expected panics in the `persist`, `compute`, `storage`, and `adapter` crates are downgraded to `halt`s, so that they don't unnecessarily accumulate in Sentry.

Fix #15771.
Fix #15772.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

  Part of the stability sprint, to make it easier to find unexpected panics in Sentry.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
