### PR TITLE
doc/user: list_agg does not take a delimiter

### DIFF
--- a/doc/user/content/sql/functions/list_agg.md
+++ b/doc/user/content/sql/functions/list_agg.md
@@ -6,7 +6,7 @@ menu:
     parent: 'sql-functions'
 ---
 
-The `list_agg(value, delimiter)` aggregate function concatenates
+The `list_agg(value)` aggregate function concatenates
 input values (including nulls) into a [`list`](/sql/types/list).
 The input values to the aggregate can be [filtered](../filters).
 


### PR DESCRIPTION
Update parameter list in `list_agg()`

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
