### PR TITLE
zippy,platform-checks: Clean up Process Orchestrator metadata on restart

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -46,6 +46,14 @@ class StartMz(MzcomposeAction):
         mz = Materialized(image=image, options=StartMz.DEFAULT_MZ_OPTIONS)
 
         with c.override(mz):
+            # Work around https://github.com/MaterializeInc/materialize/issues/15725
+            # by cleaning up Process Orchestrator metadata on restart
+            c.run(
+                "materialized",
+                "-c",
+                "rm -rf /mzdata/*.pid /mzdata/*.ports",
+                entrypoint="bash",
+            )
             c.up("materialized")
 
         c.wait_for_materialized()

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -467,6 +467,7 @@ class Composition:
         env_extra: Dict[str, str] = {},
         capture: bool = False,
         stdin: Optional[str] = None,
+        entrypoint: Optional[str] = None,
     ) -> subprocess.CompletedProcess:
         """Run a one-off command in a service.
 
@@ -490,6 +491,7 @@ class Composition:
         self.invoke("up", "--detach", "--scale", f"{service}=0", service)
         return self.invoke(
             "run",
+            *(["--entrypoint", entrypoint] if entrypoint else []),
             *(f"-e{k}={v}" for k, v in env_extra.items()),
             *(["--detach"] if detach else []),
             *(["--rm"] if rm else []),

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -19,6 +19,15 @@ class MzStart(Action):
     """Starts a Mz instance (all components are running in the same container)."""
 
     def run(self, c: Composition) -> None:
+        # Work around https://github.com/MaterializeInc/materialize/issues/15725
+        # by cleaning up Process Orchestrator metadata on restart
+        c.run(
+            "materialized",
+            "-c",
+            "rm -rf /mzdata/*.pid /mzdata/*.ports",
+            entrypoint="bash",
+        )
+
         c.up("materialized")
         # Loaded Mz environments take a while to start up
         c.wait_for_materialized(timeout_secs=300)


### PR DESCRIPTION
In order to work around #15725, clean up the Progress Orchestrator information on PIDs and TCP ports on restart. As the tests are running in containers, the processes that may have held those PIDs and ports are now gone anyway when environmentd restarts, as they lived in the same container.

### Motivation

  * This PR fixes a recognized bug.
 #15725 causes sporadic failures in CI jobs that restart the entire Mz instance.

### Tips for reviewer

@benesch the original idea was to simply put the Process Orchestrator metadata storage on a ephimeral volume. However,
the secrets are also stored in the same directory so this did not work out of the box. I then tried to separate the storage
location of the metadata and the secrets, however this required introducing a new environmentd command-line option and
made the entire thing incompatible with previous-version Mz , which in turn prevented upgrade tests from running.

So I had to fix this on the test framework side by adding an explicit cleanup step.