### PR TITLE
compute-client: fix handling of subscribe reponses

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -967,30 +967,34 @@ where
                 // If this batch advances the subscribe's frontier, we emit all updates at times
                 // greater or equal to the last frontier (to avoid emitting duplicate updates).
                 // let old_upper_bound = entry.bounds.upper.clone();
-                let lower = self
+                let prev_frontier = self
                     .compute
                     .subscribes
                     .remove(&subscribe_id)
                     .unwrap_or_else(Antichain::new);
 
-                if PartialOrder::less_than(&lower, &upper) {
+                if PartialOrder::less_than(&prev_frontier, &upper) {
                     if !upper.is_empty() {
                         // This subscribe can produce more data. Keep tracking it.
                         self.compute.subscribes.insert(subscribe_id, upper.clone());
                     }
 
                     if let Ok(updates) = updates.as_mut() {
-                        updates.retain(|(time, _data, _diff)| lower.less_equal(time));
+                        updates.retain(|(time, _data, _diff)| prev_frontier.less_equal(time));
                     }
                     Some(ComputeControllerResponse::SubscribeResponse(
                         subscribe_id,
                         SubscribeResponse::Batch(SubscribeBatch {
-                            lower,
+                            lower: prev_frontier,
                             upper,
                             updates,
                         }),
                     ))
                 } else {
+                    if !prev_frontier.is_empty() {
+                        // This subscribe can produce more data. Keep tracking it.
+                        self.compute.subscribes.insert(subscribe_id, prev_frontier);
+                    }
                     None
                 }
             }


### PR DESCRIPTION
Subscribe tracking had a bug where the compute controller would remove the tracked subscribe frontier to avoid cloning, but then would fail to put it back into the tracking state if there was not progress to emit.

### Motivation

  * This PR fixes a recognized bug.

Fixes #15798.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
