### PR TITLE
ci/deploy: use new queue name in deploy step

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -12,7 +12,7 @@ steps:
     branches: lts-docs
     timeout_in_minutes: 30
     agents:
-      queue: builder
+      queue: builder-linux-x86_64
     concurrency: 1
     concurrency_group: deploy/website
     retry:


### PR DESCRIPTION
Since MaterializeInc/i2#441, the queue name "builder" has been removed. Use the new name ("builder-linux-x86_64") instead.
