### PR TITLE
sql-parser: correct type of AwsPrivateLinkConnectionOption

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -747,13 +747,16 @@ impl_display!(AwsPrivateLinkConnectionOptionName);
 /// An option in a `CREATE CONNECTION...AWS PRIVATELINK`.
 pub struct AwsPrivateLinkConnectionOption<T: AstInfo> {
     pub name: AwsPrivateLinkConnectionOptionName,
-    pub value: WithOptionValue<T>,
+    pub value: Option<WithOptionValue<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for AwsPrivateLinkConnectionOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.name);
-        f.write_node(&self.value);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
     }
 }
 impl_display_t!(AwsPrivateLinkConnectionOption);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2242,7 +2242,7 @@ impl<'a> Parser<'a> {
         };
         Ok(AwsPrivateLinkConnectionOption {
             name,
-            value: self.parse_option_value()?,
+            value: self.parse_optional_option_value()?,
         })
     }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -377,16 +377,16 @@ CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name:
 parse-statement
 CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4'))
 ----
-CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES('use1-az1', 'use1-az4'))
+CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4'))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("privatelinkconn")]), connection: AwsPrivateLink { with_options: [AwsPrivateLinkConnectionOption { name: ServiceName, value: Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc")) }, AwsPrivateLinkConnectionOption { name: AvailabilityZones, value: Sequence([Value(String("use1-az1")), Value(String("use1-az4"))]) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("privatelinkconn")]), connection: AwsPrivateLink { with_options: [AwsPrivateLinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivateLinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION privatelinkconn FOR AWS PRIVATELINK SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES ('use1-az1', 'use1-az4')
 ----
-CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES('use1-az1', 'use1-az4'))
+CREATE CONNECTION privatelinkconn TO AWS PRIVATELINK (SERVICE NAME = 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc', AVAILABILITY ZONES = ('use1-az1', 'use1-az4'))
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("privatelinkconn")]), connection: AwsPrivateLink { with_options: [AwsPrivateLinkConnectionOption { name: ServiceName, value: Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc")) }, AwsPrivateLinkConnectionOption { name: AvailabilityZones, value: Sequence([Value(String("use1-az1")), Value(String("use1-az4"))]) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("privatelinkconn")]), connection: AwsPrivateLink { with_options: [AwsPrivateLinkConnectionOption { name: ServiceName, value: Some(Value(String("com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc"))) }, AwsPrivateLinkConnectionOption { name: AvailabilityZones, value: Some(Sequence([Value(String("use1-az1")), Value(String("use1-az4"))])) }] }, if_not_exists: false })
 
 parse-statement
 CREATE CONNECTION pgconn FOR postgres HOST foo, PORT 1234, SSL CERTIFICATE AUTHORITY 'foo', SSH TUNNEL tun


### PR DESCRIPTION
All FOOConnectionOption structs need to have the same structure for the `generate_extracted_config!` macro to work correctly. Bring the AwsPrivateLinkConnectionOption struct in line with the rest.

This also corrects a minor roundtripping bug with the `CREATE CONNECTION ... TO AWS PRIVATELINK` statement, which was previously missing a space after option names.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported in a post-merge code review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
