### PR TITLE
devcontainer: require 64g of disk

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,9 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.238.0/containers/rust-postgres
 {
   "name": "Materialize",
+  "hostRequirements": {
+    "storage": "64gb"
+  },
   "dockerComposeFile": "docker-compose.yml",
   "service": "mz",
   "workspaceFolder": "/workspace",


### PR DESCRIPTION
32 is not enough to hold the target and .cargo directories.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a