### PR TITLE
sql: Fix statement timeout error code

### DIFF
--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -372,7 +372,7 @@ impl ErrorResponse {
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,
             AdapterError::ReadWriteUnavailable => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::StatementTimeout => SqlState::IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
+            AdapterError::StatementTimeout => SqlState::QUERY_CANCELED,
             AdapterError::RecursionLimit(_) => SqlState::INTERNAL_ERROR,
             AdapterError::RelationOutsideTimeDomain { .. } => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::ResourceExhaustion { .. } => SqlState::INSUFFICIENT_RESOURCES,


### PR DESCRIPTION
Previously, when a statement timed out, we were setting the error code to IDLE_IN_TRANSACTION_SESSION_TIMEOUT. PostgreSQL however uses the error code QUERY_CANCELED for statement timeouts:
https://github.com/postgres/postgres/blob/6e10631d1e6e350ba3f82b0bd3a29678f9f5badd/src/backend/tcop/postgres.c#L3298-L3304

This commit updates the error code we use for statement timeouts to QUERY_CANCELED to match PostgreSQL.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
