### PR TITLE
stash: add set method to TableTransaction

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -9,6 +9,7 @@
 
 //! Durable metadata storage.
 
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
 use std::fmt::{self, Debug};
@@ -920,7 +921,7 @@ where
     /// Iterates over the items viewable in the current transaction in arbitrary
     /// order.
     pub fn for_values<F: FnMut(&K, &V)>(&self, mut f: F) {
-        let mut seen = HashSet::new();
+        let mut seen = HashSet::with_capacity(self.pending.len());
         for (k, v) in self.pending.iter() {
             seen.insert(k);
             // Deleted items don't exist so shouldn't be visited, but still suppress
@@ -934,6 +935,17 @@ where
             if !seen.contains(k) {
                 f(k, v);
             }
+        }
+    }
+
+    /// Returns the current value of `k`.
+    pub fn get(&self, k: &K) -> Option<&V> {
+        if let Some(v) = self.pending.get(k) {
+            v.as_ref()
+        } else if let Some(v) = self.initial.get(k) {
+            Some(v)
+        } else {
+            None
         }
     }
 
@@ -997,6 +1009,45 @@ where
             Err(err)
         } else {
             Ok(changed)
+        }
+    }
+
+    /// Set the value for a key. Returns the previous entry if the key existed,
+    /// otherwise None.
+    ///
+    /// Returns an error if the uniqueness check failed.
+    pub fn set(&mut self, k: K, v: Option<V>) -> Result<Option<V>, StashError> {
+        // Save the pending value for the key so we can restore it in case of
+        // uniqueness violation.
+        let restore = self.pending.get(&k).cloned();
+
+        let prev = match self.pending.entry(k.clone()) {
+            // key hasn't been set in this txn yet. Set it and return the
+            // initial txn's value of k.
+            Entry::Vacant(e) => {
+                e.insert(v);
+                self.initial.get(&k).cloned()
+            }
+            // key has been set in this txn. Set it and return the previous
+            // pending value.
+            Entry::Occupied(mut e) => e.insert(v),
+        };
+
+        // Check for uniqueness violation.
+        if let Err(err) = self.verify() {
+            // Revert self.pending to the state it was in before calling this
+            // function.
+            match restore {
+                Some(v) => {
+                    self.pending.insert(k, v);
+                }
+                None => {
+                    self.pending.remove(&k);
+                }
+            }
+            Err(err)
+        } else {
+            Ok(prev)
         }
     }
 


### PR DESCRIPTION
Previously all mutations iterated through the entire initial and pending set of a TableTransaction. Add a set method that operates on a single key and can set its value or remove it.

Change some catalog calls to use this.

See: #13772

mz-adapter catalog benchmark:

```
transact                time:   [78.752 ms 83.451 ms 88.210 ms]
                        change: [-13.319% -6.7646% -1.0079%] (p = 0.02 < 0.05)
                        Performance has improved.
```

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
