### PR TITLE
Add note about rebooting after changing rds.logical_replication

### DIFF
--- a/doc/user/content/integrations/aws-rds.md
+++ b/doc/user/content/integrations/aws-rds.md
@@ -14,6 +14,9 @@ As an account with the `rds_superuser` role, make these changes to the upstream 
 1. Create a custom RDS parameter group with your instance and associate it with your instance. You will not be able to set custom parameters on the default RDS parameter groups.
 
 1. In the custom RDS parameter group, set the `rds.logical_replication` static parameter to `1`.
+{{< note >}}
+If you change this setting for an existing RDS database, you will need to reboot the instance for it to take effect.
+{{</ note >}}
 
 1. The Materialize instance will need access to connect to the upstream database. This is usually controlled by IP address. If you are hosting your own installation of Materialize, add the instance's IP address in the security group for the RDS instance.
 


### PR DESCRIPTION
Adds a note about rebooting after changing `rds.logical_replication` to our docs for integration with AWS RDS.

### Motivation

  * This PR fixes a previously unreported bug.
Unclear steps when setting up logical replication for RDS.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing behavior changes, just a documentation note.
