### PR TITLE
[sinks] Hold an extra handle for input data in the sink

### DIFF
--- a/src/storage/src/protocol/server.rs
+++ b/src/storage/src/protocol/server.rs
@@ -110,6 +110,7 @@ pub fn serve(
                 persist_clients,
                 sink_tokens: HashMap::new(),
                 sink_write_frontiers: HashMap::new(),
+                sink_handles: HashMap::new(),
             },
         }
         .run()

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -13,24 +13,27 @@ use std::sync::Arc;
 
 use crossbeam_channel::TryRecvError;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::ShardId;
+use mz_persist_client::{PersistLocation, ShardId};
 use timely::communication::Allocate;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp as _;
 use timely::worker::Worker as TimelyWorker;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinHandle;
 
 use mz_ore::halt;
 use mz_ore::now::NowFn;
-use mz_repr::{GlobalId, Timestamp};
+use mz_persist_client::read::ReadHandle;
+use mz_repr::{Diff, GlobalId, Timestamp};
 
 use crate::controller::CollectionMetadata;
 use crate::protocol::client::{StorageCommand, StorageResponse};
 use crate::sink::SinkBaseMetrics;
 use crate::types::connections::ConnectionContext;
 use crate::types::sinks::StorageSinkDesc;
-use crate::types::sources::IngestionDescription;
+use crate::types::sources::{IngestionDescription, SourceData};
 
 use crate::decode::metrics::DecodeMetrics;
 use crate::source::metrics::SourceBaseMetrics;
@@ -93,6 +96,66 @@ pub struct StorageState {
     /// Frontier of sink writes (all subsequent writes will be at times at or
     /// equal to this frontier)
     pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
+    /// See: [SinkHandle]
+    pub sink_handles: HashMap<GlobalId, SinkHandle>,
+}
+
+/// This maintains an additional read hold on the source data for a sink, alongside
+/// the controller's hold and the handle used to read the shard internally.
+/// This is useful because environmentd's hold might expire, and the handle we use
+/// to read advances ahead of what we've successfully committed.
+/// In theory this could be stored alongside the other sink data, but this isn't
+/// intended to be a long term solution; either this should become a "critical" handle
+/// or environmentd will learn to hold its handles across restarts and this won't be
+/// needed.
+pub struct SinkHandle {
+    downgrade_tx: UnboundedSender<Antichain<Timestamp>>,
+    _handle: JoinHandle<()>,
+}
+
+impl SinkHandle {
+    /// A new handle.
+    pub fn new(
+        persist_location: PersistLocation,
+        shard_id: ShardId,
+        persist_clients: Arc<Mutex<PersistClientCache>>,
+    ) -> SinkHandle {
+        let (downgrade_tx, mut rx) = mpsc::unbounded_channel();
+
+        let _handle = mz_ore::task::spawn(|| "Sink handle advancement", async move {
+            let client = persist_clients
+                .lock()
+                .await
+                .open(persist_location)
+                .await
+                .expect("opening persist client");
+
+            let mut read_handle: ReadHandle<SourceData, (), Timestamp, Diff> = client
+                .open_reader(shard_id)
+                .await
+                .expect("opening reader for shard");
+
+            while let Some(mut new_since) = rx.recv().await {
+                while let Ok(newer_since) = rx.try_recv() {
+                    new_since = newer_since;
+                }
+                read_handle.maybe_downgrade_since(&new_since).await;
+            }
+        });
+
+        SinkHandle {
+            downgrade_tx,
+            _handle,
+        }
+    }
+
+    /// Request a downgrade of the since. This should be called regularly;
+    /// the internal task will debounce.
+    pub fn downgrade_since(&self, to: Antichain<Timestamp>) {
+        self.downgrade_tx
+            .send(to)
+            .expect("sending to downgrade task")
+    }
 }
 
 /// A token that keeps a sink alive.
@@ -206,6 +269,19 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         Rc::new(RefCell::new(Antichain::from_elem(
                             mz_repr::Timestamp::minimum(),
                         ))),
+                    );
+
+                    self.storage_state.sink_handles.insert(
+                        export.id,
+                        SinkHandle::new(
+                            export
+                                .description
+                                .from_storage_metadata
+                                .persist_location
+                                .clone(),
+                            export.description.from_storage_metadata.data_shard,
+                            Arc::clone(&self.storage_state.persist_clients),
+                        ),
                     );
 
                     crate::render::build_export_dataflow(

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -141,6 +141,8 @@ impl SinkHandle {
                 }
                 read_handle.maybe_downgrade_since(&new_since).await;
             }
+
+            read_handle.expire().await;
         });
 
         SinkHandle {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -203,6 +203,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
             }
 
             self.report_frontier_progress(&response_tx);
+            for (id, frontier) in &self.storage_state.sink_write_frontiers {
+                let handle = &self.storage_state.sink_handles[id];
+                let frontier = frontier.borrow();
+                handle.downgrade_since(frontier.clone());
+            }
 
             // Handle any received commands.
             let mut cmds = vec![];

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crossbeam_channel::TryRecvError;
+use differential_dataflow::lattice::Lattice;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistLocation, ShardId};
 use timely::communication::Allocate;
@@ -148,7 +149,8 @@ impl SinkHandle {
                                 break 'downgrading;
                             }
                             Ok(()) => {
-                                downgrade_to = rx.borrow_and_update().clone();
+                                // Join to avoid attempting to rewind the handle
+                                downgrade_to.join_assign(&rx.borrow_and_update());
                             }
                         }
                     }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -154,7 +154,7 @@ impl SinkHandle {
                             }
                         }
                     }
-                    _ = sleep(Duration::from_secs(1)) => {}
+                    _ = sleep(Duration::from_secs(60)) => {}
                 };
                 read_handle.maybe_downgrade_since(&downgrade_to).await
             }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -324,6 +324,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         self.storage_state.reported_frontiers.remove(&id);
                         self.storage_state.source_tokens.remove(&id);
                         self.storage_state.sink_tokens.remove(&id);
+                        self.storage_state.sink_handles.remove(&id);
                     }
                 }
             }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -162,6 +162,7 @@ where
                 persist_clients,
                 sink_tokens: HashMap::new(),
                 sink_write_frontiers: HashMap::new(),
+                sink_handles: HashMap::new(),
             };
 
             let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);


### PR DESCRIPTION
### Motivation

This PR fixes an issue with holding back the since for a sink, believed to be responsible for some recent breakage in cloud.

Briefly, there are at least two read holds in play for any sink collection:
- The main one in `environmentd`, which is intended to hold back the since to the minimum that all downstreams may need, including sinks.
- The automatically-created read hold in the `persist_source` implementation that feeds data into the sink, which progresses automatically as data is read in.

If `environmentd` times out its hold for whatever reason, the only read hold will be the second one. However, that hold generally doesn't hold the since back aggressively enough... any delay committing or in the timely pipeline will cause it to advance ahead of the rest of the pipeline, potentially allowing data to be compacted away too early.

### Tips for reviewer

I haven't yet been able to reproduce the failure locally, which bothers me a bit. However, it seems like everyone agrees that this is a real risk that should be managed, at least until #15822 is in place.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
