### PR TITLE
dbt-materialize: release v1.2.1

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 - 2022-11-01
 
-* Return the correct connection keys to the user on `dbt debug`.
+* Add `cluster` to the connection parameters returned on `dbt debug`.
 
 
 * Disallow the `cluster` option for `view` materializations. In the new

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased - 2022-10-28
+## 1.2.1 - 2022-11-01
 
 * Return the correct connection keys to the user on `dbt debug`.
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.2.0"
+version = "1.2.1"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.2.0",
+    version="1.2.1",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release `dbt-materialize`.

The changes in using kebab case for the materialize view type [here](https://github.com/MaterializeInc/materialize/commit/347b8f1f8f7fa165212ba239f5fe96f32ccf37b0) make a release important. dbt uses `list_relations_without_caching` to grab a list of relations - if the relation trying to be created is found, it gets dropped before being recreated. dbt runs which create materialized views would likely fail against the latest version Materialize.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
