### PR TITLE
stash-debug: add upgrade check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,6 +4280,7 @@ dependencies = [
  "mz-build-info",
  "mz-ore",
  "mz-postgres-util",
+ "mz-secrets",
  "mz-stash",
  "mz-storage",
  "once_cell",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1021,7 +1021,7 @@ pub async fn serve<S: Append + 'static>(
     availability_zones.shuffle(&mut rand::thread_rng());
 
     info!("coordinator init: opening catalog");
-    let (mut catalog, builtin_migration_metadata, builtin_table_updates) =
+    let (mut catalog, builtin_migration_metadata, builtin_table_updates, _last_catalog_version) =
         Catalog::open(catalog::Config {
             storage,
             unsafe_mode,

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -13,6 +13,7 @@ mz-adapter = { path = "../adapter" }
 mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore" }
 mz-postgres-util = { path = "../postgres-util" }
+mz-secrets = { path = "../secrets" }
 mz-stash = { path = "../stash" }
 mz-storage = { path = "../storage" }
 once_cell = "1.15.0"


### PR DESCRIPTION
Teach the stash how to create and operate in a mode that allows temporary writes that will never be committed to disk. This works by using a single long transaction that uses SAVEPOINTs internally to nest smaller transactions. The single outer transaction is never COMMIT'd, thus when it disconnects all of the write intents will be removed. The savepoint stash uses a low priority transaction to prevent a running read-write stash from being blocked.

Add a subcommand to stash-debug that opens a catalog with migrations using the savepoint stash.

Fixes #14681

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a