### PR TITLE
persist: add missing "tracing" feature to mz_ore dep

### DIFF
--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -38,7 +38,7 @@ futures = "0.3.24"
 futures-util = "0.3"
 humantime = "2.1.0"
 mz-build-info = { path = "../build-info" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["tracing"] }
 mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }


### PR DESCRIPTION
Fixes a build error if certain subsets of mz targets are built.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
