### PR TITLE
coord: Speed up storage collection usage

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -94,7 +94,7 @@ use mz_compute_client::command::ReplicaId;
 use mz_compute_client::controller::{ComputeInstanceEvent, ComputeInstanceId};
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::NowFn;
+use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
@@ -907,7 +907,14 @@ impl<S: Append + 'static> Coordinator<S> {
         // Watcher that listens for and reports compute service status changes.
         let mut compute_events = self.controller.compute.watch_services();
 
-        self.schedule_storage_usage_collection().await;
+        self.schedule_storage_usage_collection(
+            self.catalog
+                .most_recent_storage_usage_collection()
+                .await
+                .unwrap()
+                .unwrap_or(EpochMillis::MIN),
+        )
+        .await;
 
         loop {
             // Before adding a branch to this select loop, please ensure that the branch is


### PR DESCRIPTION
Previously, the Coordinator would look up the previous storage collection timestamp from the stash every time. This commit updates this logic so the previous timestamp is always read from memory, except on startup.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
