### PR TITLE
adapter: only do a single read over storage usage

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -92,7 +92,7 @@ use mz_compute_client::command::ReplicaId;
 use mz_compute_client::controller::{ComputeInstanceEvent, ComputeInstanceId};
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -906,14 +906,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // Watcher that listens for and reports compute service status changes.
         let mut compute_events = self.controller.compute.watch_services();
 
-        self.schedule_storage_usage_collection(
-            self.catalog
-                .most_recent_storage_usage_collection()
-                .await
-                .unwrap()
-                .unwrap_or(EpochMillis::MIN),
-        )
-        .await;
+        self.schedule_storage_usage_collection();
 
         loop {
             // Before adding a branch to this select loop, please ensure that the branch is


### PR DESCRIPTION
During bootstrap we read storage usage to populate the builtin table. This can be a very large dataset (1 entry per shard per hour running). At high shard counts (100k+), the storage_usage() method can return millions of rows and take a while to run.

Decrease the total number of times we execute this to once per envd startup by merging the builtin table updates and timestamp calculation.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a