### PR TITLE
persist: increase write lease duration from 15m to 1h

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -390,7 +390,7 @@ where
     pub async fn start_writer_heartbeat_task(self, writer_id: WriterId) -> JoinHandle<()> {
         let mut machine = self;
         spawn(|| "persist::heartbeat_write", async move {
-            let sleep_duration = machine.cfg.writer_lease_duration / 2;
+            let sleep_duration = machine.cfg.writer_lease_duration / 4;
             loop {
                 tokio::time::sleep(sleep_duration).await;
                 let (_seqno, existed, _maintenance) = machine

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -302,7 +302,7 @@ impl PersistConfig {
             compaction_queue_size: 20,
             compaction_minimum_timeout: Duration::from_secs(90),
             consensus_connection_pool_max_size: 50,
-            writer_lease_duration: Duration::from_secs(60 * 15),
+            writer_lease_duration: 60 * Duration::from_secs(60),
             reader_lease_duration: Self::DEFAULT_READ_LEASE_DURATION,
         }
     }


### PR DESCRIPTION
Unlike read leases, which hold back since and seqno, there isn't a real downside to longer write leases. It will only delay reclamation of leaked blobs (by the leaked blob task we still haven't had a chance to get to yet).

On the other hand, a longer write lease should help with periods of transient network unavailability or high CPU usage (sufficiently high that the heartbeat task doesn't get a chance to run).

It's become clear that we need more graceful handling of writer lease timeouts, but in the meantime this should be a straightforward, quick win to reduce the number of "WriterId ... was expired due to inactivity" panics we see in prod.

Also halve the duration between heartbeats in the background task, because we're making the lease duration so much longer.

Touches #15209

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
