### PR TITLE
testdrive: Fortify recent Kafka tests against message re-ordering

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -764,9 +764,34 @@ or Protobuf.
 
 #### `kafka-verify-data format=avro [sink=... | topic=...] [sort-messages=true] [partial-search=usize]`
 
-Obtains the data from the specified `sink` or `topic` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test.
+Obtains the data from the specified `sink` or `topic` and compares it to the expected data recorded in the test.
 
-If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The records do not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
+The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used
+along with manually pre-sorting the expected data in the test. The rows in the expected data section need to
+be ordered according to the following rules:
+ - earlier timestamps sort first
+ - deletes sort before inserts
+ - as all items are sorted as strings, "10" sorts before "2"
+
+It is possible to call `$ kafka-verify` multiple times on the same topic in case the test needs to check
+that the data arrives in some partial order. For example, to make sure that all of timestamp `1` arrived
+before all of timestamp `2`:
+
+```
+$ kafka-verify ... sort-messages=true
+1 {"a":"1"}
+1 {"b":"1"}
+
+$ kafka-verify ... sort-messages=true
+2 {"c":"1"}
+2 {"d":"1"}
+```
+
+If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and
+compared to the provided records. The records do not have to match starting at the beginning of the sink but
+once one record matches, the following must all match.  There are permitted to be records remaining in the
+topic after the matching is complete.  Note that if the topic is not required to have `partial-search`
+elements in it but there will be an attempt to read up to this number with a blocking read.
 
 #### `kafka-verify-commit consumer-group-id=... topic=... partition=...
 

--- a/src/testdrive/src/action/kafka/verify_data.rs
+++ b/src/testdrive/src/action/kafka/verify_data.rs
@@ -226,7 +226,7 @@ pub async fn run_verify_data(
             }
 
             if sort_messages {
-                actual_messages.sort_by_key(|r| format!("{:?}", r.value));
+                actual_messages.sort_by_key(|r| format!("{:?}", r));
             }
 
             if debug_print_only {

--- a/test/testdrive/github-15748.td
+++ b/test/testdrive/github-15748.td
@@ -141,8 +141,9 @@ $ kafka-ingest format=avro topic=topic1 schema=${schema}
 $ kafka-ingest format=avro topic=topic1 schema=${schema}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[10],"counts":[{"time":1,"count":10}, {"time":2,"count":8}]}}
 
-$ kafka-verify-data headers=materialize-timestamp format=avro topic=testdrive-sink1-${testdrive.seed}
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=testdrive-sink1-${testdrive.seed} sort-messages=true
 1	{"a": 1} {"a": 1, "b": 1}
+1	{"a": 10} {"a": 10, "b": 1}
 1	{"a": 2} {"a": 2, "b": 1}
 1	{"a": 3} {"a": 3, "b": 1}
 1	{"a": 4} {"a": 4, "b": 1}
@@ -151,10 +152,11 @@ $ kafka-verify-data headers=materialize-timestamp format=avro topic=testdrive-si
 1	{"a": 7} {"a": 7, "b": 1}
 1	{"a": 8} {"a": 8, "b": 1}
 1	{"a": 9} {"a": 9, "b": 1}
-1	{"a": 10} {"a": 10, "b": 1}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=testdrive-sink1-${testdrive.seed} sort-messages=true
 2	{"a": 0} {"a": 0, "b": 0}
+2	{"a": 15} {"a": 15, "b": 15}
 2	{"a": 2} {"a": 2, "b": 2}
 2	{"a": 3}
 2	{"a": 7}
 2	{"a": 8} {"a": 8, "b": 8}
-2	{"a": 15} {"a": 15, "b": 15}

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -292,11 +292,15 @@ $ kafka-ingest format=avro topic=non-keyed-input schema=${schema}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[10],"counts":[{"time":1,"count":2}, {"time":2,"count":4}, {"time":3,"count":2}]}}
 
 # Verify that the update appears as an upsert instead of a create + delete, even when keys are not enforced.
-$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed}
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed} sort-messages=true
 1	{"a": 1} {"a": 1, "b": 1}
 1	{"a": 2} {"a": 2, "b": 1}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed} sort-messages=true
 2	{"a": 1} {"a": 1, "b": 2}
 2	{"a": 2} {"a": 2, "b": 2}
+
+$ kafka-verify-data headers=materialize-timestamp format=avro topic=not-enforced-sink-${testdrive.seed} sort-messages=true
 3	{"a": 1}
 3	{"a": 2}
 


### PR DESCRIPTION
    testdrive: Fortify recent Kafka tests against message re-ordering
    
    * kafka-verify-data sort_messages=true was sorting the messages
      based on their value alone, ignoring the key and the timestamp.
      For deletions, there is no value, so if multiple deletions
      occured at the same timestamp, they were effectively not sorted
      in any way.
    
    * Within a given timestamp, we can emit messages to a sink in any
      order. So, all instances of kafka-verify-data that verify more than one
      timestamp must:
    
        - use sort-messages=true at all times
        - have separate calls to kafka-verify-data for every timestamp
        - have "10" placed before "2" because sort-messages=true sorts
          all things as strings
    
    * Those guidelines are also being added to doc/developer/testdrive.md


@benesch , if you could review the kafka-verify.rs change that would be much appreciated. 