### PR TITLE
zippy,platform-checks: Add peek cancellation to frameworks

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -422,6 +422,7 @@ steps:
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/zippy]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -457,6 +458,7 @@ steps:
   - id: checks-drop-create-default-replica
     label: "Checks + DROP/CREATE replica"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -468,6 +470,7 @@ steps:
   - id: checks-restart-computed
     label: "Checks + restart computed"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -479,6 +482,7 @@ steps:
   - id: checks-restart-entire-mz
     label: "Checks + restart of the entire Mz"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -490,6 +494,7 @@ steps:
   - id: checks-restart-environmentd-storaged
     label: "Checks + restart of environmentd & storaged"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -501,6 +506,7 @@ steps:
   - id: checks-kill-storaged
     label: "Checks + kill storaged"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -512,6 +518,7 @@ steps:
   - id: checks-restart-postgres-backend
     label: "Checks + restart Postgres backend"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -523,6 +530,7 @@ steps:
   - id: checks-restart-source-postgres
     label: "Checks + restart source Postgres"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -536,7 +544,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_cloudtest_*.xml
-    inputs: [test/cloudtest]
+    inputs: [test/cloudtest, misc/python/materialize/cloudtest]
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
@@ -545,6 +553,7 @@ steps:
   - id: checks-restart-redpanda
     label: "Checks + restart Redpanda"
     depends_on: build-x86_64
+    inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -35,6 +35,7 @@ from materialize.checks.materialized_views import *  # noqa: F401 F403
 from materialize.checks.nested_types import *  # noqa: F401 F403
 from materialize.checks.null_value import *  # noqa: F401 F403
 from materialize.checks.numeric_types import *  # noqa: F401 F403
+from materialize.checks.peek_cancellation import *  # noqa: F401 F403
 from materialize.checks.pg_cdc import *  # noqa: F401 F403
 from materialize.checks.regex import *  # noqa: F401 F403
 from materialize.checks.rename_index import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/peek_cancellation.py
+++ b/misc/python/materialize/checks/peek_cancellation.py
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+
+class PeekCancellation(Check):
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > CREATE TABLE peek_cancellation (f1 INTEGER);
+                > CREATE DEFAULT INDEX ON peek_cancellation;
+                > INSERT INTO peek_cancellation SELECT * FROM generate_series(1, 10000);
+                """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > SET statement_timeout = '10ms';
+                ! INSERT INTO peek_cancellation SELECT * FROM peek_cancellation;
+                contains: timeout
+                """,
+                """
+                > SET statement_timeout = '10ms';
+                ! INSERT INTO peek_cancellation SELECT * FROM peek_cancellation;
+                contains: timeout
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SET statement_timeout = '10ms';
+                ! INSERT INTO peek_cancellation SELECT * FROM peek_cancellation;
+                contains: timeout
+                """
+            )
+        )

--- a/misc/python/materialize/zippy/peek_actions.py
+++ b/misc/python/materialize/zippy/peek_actions.py
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+from typing import Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+
+
+class PeekCancellation(Action):
+    """Perfoms a peek cancellation."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}
+
+    def run(self, c: Composition) -> None:
+        c.testdrive(
+            dedent(
+                f"""
+                    > DROP TABLE IF EXISTS peek_cancellation;
+                    > CREATE TABLE IF NOT EXISTS peek_cancellation (f1 INTEGER);
+                    > INSERT INTO peek_cancellation SELECT generate_series(1, 1000);
+
+                    > SET statement_timeout = '10ms';
+
+                    ! INSERT INTO peek_cancellation
+                      SELECT 1 FROM peek_cancellation AS a1, peek_cancellation AS a2, peek_cancellation AS a3;
+                    contains: timeout
+                    """
+            )
+        )

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -18,6 +18,7 @@ from materialize.zippy.kafka_actions import (
     KafkaStart,
 )
 from materialize.zippy.mz_actions import KillComputed, KillStoraged, MzStart, MzStop
+from materialize.zippy.peek_actions import PeekCancellation
 from materialize.zippy.pg_cdc_actions import CreatePostgresCdcTable
 from materialize.zippy.postgres_actions import (
     CreatePostgresTable,
@@ -55,6 +56,7 @@ class KafkaSources(Scenario):
             CreateSink: 5,
             ValidateView: 10,
             Ingest: 100,
+            PeekCancellation: 5,
         }
 
 
@@ -137,6 +139,7 @@ class ClusterReplicas(Scenario):
             ValidateView: 20,
             Ingest: 50,
             DML: 50,
+            PeekCancellation: 5,
         }
 
 


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

Cancelling peaks is not a no-op in Mz, so needs to be exercised.