### PR TITLE
doc/user: polish v0.30.0 release notes

### DIFF
--- a/doc/user/content/releases/v0.30.md
+++ b/doc/user/content/releases/v0.30.md
@@ -1,13 +1,47 @@
 ---
 title: "Materialize v0.30"
 date: 2022-11-02
-released: false
+released: true
+patch: 1
 ---
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
 
 ## Changes
 
-* No documented changes yet.
+* Fix a bug that could cause updates in [sinks](/sql/create-sink) to appear as
+  two separate records, instead of consolidated into a single update record {{%
+  gh 15748 %}}. Previously, updates for multiple keys that occurred at the same
+  timestamp would either emit a deletion tombstone followed by a record with the
+  new value (`ENVELOPE UPSERT`), or a `{"before": "OLDVALUE", "after": null}`
+  record followed by a `{"before": null, "after": "NEWVALUE"}` record (`ENVELOPE
+  DEBEZIUM`).
+
+* Improve error message for unsupported types in the
+  [PostgreSQL source](/sql/create-source/postgres/), specifying the table and
+  column containing an unsupported type:
+
+  ```sql
+  CREATE SOURCE pg_source
+	FROM POSTGRES CONNECTION pg_connection (PUBLICATION 'mz_source')
+	FOR ALL TABLES
+	WITH (SIZE = '3xsmall');
+
+	ERROR:  column "person.current_mood" uses unrecognized type
+	DETAIL:  type with OID 211538 is unknown
+	HINT:  You may be using an unsupported type in Materialize, such as an enum. Try excluding the table from the publication.
+  ```
+
+  Fine-grained control for casting unsupported types into valid
+  [Materialize types](/sql/types/) is a work in progress {{% gh 15716 %}}.
+
+* When using both signed and unsigned integers as inputs to a function, cast the
+  inputs to a larger lossless type rather than [`double`](/sql/types/float). For
+  example, when determining equality between [`integer`](/sql/types/integer)
+  (32-bit signed integer) and [`uint4`](/sql/types/uint) (32-bit unsigned
+  integer), both values are now cast to [`bigint`](/sql/types/integer)
+  (64-bit signed integer). Previously both values would be cast to
+  [`double`](/sql/types/double) (64-bit floating point number).
+
+* Improve the performance of DDL statements, especially when many DDL statements
+  are run within the same 24 hour period.
+
+* Add an `xlarge` size for sources and sinks.

--- a/doc/user/content/releases/v0.31.md
+++ b/doc/user/content/releases/v0.31.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.31"
+date: 2022-11-09
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## Changes
+
+* No documented changes yet.

--- a/doc/user/content/sql/alter-sink.md
+++ b/doc/user/content/sql/alter-sink.md
@@ -15,7 +15,7 @@ menu:
 Field   | Use
 --------|-----
 _name_  | The identifier of the sink you want to alter.
-_value_ | The new value for the sink size. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+_value_ | The new value for the sink size. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ## See also
 

--- a/doc/user/content/sql/alter-source.md
+++ b/doc/user/content/sql/alter-source.md
@@ -15,7 +15,7 @@ menu:
 Field   | Use
 --------|-----
 _name_  | The identifier of the source you want to alter.
-_value_ | The new value for the source size. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+_value_ | The new value for the source size. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ## See also
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -65,7 +65,7 @@ Field                | Value  | Description
 Field                | Value  | Description
 ---------------------|--------|------------
 `SNAPSHOT`           | `bool` | Default: `true`. Whether to emit the consolidated results of the query before the sink was created at the start of the sink. To see only results after the sink is created, specify `WITH (SNAPSHOT = false)`.
-`SIZE`               | `text`    | **Required.** The [size](#sizing-a-sink) for the sink. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`               | `text`    | **Required.** The [size](#sizing-a-sink) for the sink. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ## Detail
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -63,7 +63,7 @@ Field                                | Value     | Description
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ## Supported formats
 

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -39,7 +39,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ## Description
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -35,7 +35,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`.
+`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
 
 ## Features
 


### PR DESCRIPTION
Release notes for v0.30.0. 🚀 

Deliberately left out #15825, which reads like generic stabilization work more than a user-facing change that grants a release note.