### PR TITLE
Always install introspection indexes

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -218,8 +218,8 @@ pub type ProcessId = i64;
 #[derive(Arbitrary, Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// Configuration sent to new compute instances.
 pub struct InstanceConfig {
-    /// Optionally, request the installation of logging sources.
-    pub logging: Option<LoggingConfig>,
+    /// Configuration of logging sources.
+    pub logging: LoggingConfig,
     /// Max size in bytes of any result.
     pub max_result_size: u32,
 }
@@ -238,14 +238,16 @@ pub struct CommunicationConfig {
 impl RustType<ProtoInstanceConfig> for InstanceConfig {
     fn into_proto(&self) -> ProtoInstanceConfig {
         ProtoInstanceConfig {
-            logging: self.logging.into_proto(),
+            logging: Some(self.logging.into_proto()),
             max_result_size: self.max_result_size,
         }
     }
 
     fn from_proto(proto: ProtoInstanceConfig) -> Result<Self, TryFromProtoError> {
         Ok(Self {
-            logging: proto.logging.into_rust()?,
+            logging: proto
+                .logging
+                .into_rust_if_some("ProtoInstanceConfig::logging")?,
             max_result_size: proto.max_result_size,
         })
     }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -46,7 +46,7 @@ pub(super) struct Replica<T> {
     /// Location of the replica
     pub location: ComputeReplicaLocation,
     /// The logging config specific to this replica.
-    pub logging_config: Option<LoggingConfig>,
+    pub logging_config: LoggingConfig,
 }
 
 impl<T> Replica<T>
@@ -59,7 +59,7 @@ where
         instance_id: ComputeInstanceId,
         build_info: &'static BuildInfo,
         location: ComputeReplicaLocation,
-        logging_config: Option<LoggingConfig>,
+        logging_config: LoggingConfig,
         orchestrator: ComputeOrchestrator,
     ) -> Self {
         // Launch a task to handle communication with the replica
@@ -115,7 +115,7 @@ struct ReplicaTask<T> {
     /// Location
     location: ComputeReplicaLocation,
     /// Logging
-    logging_config: Option<LoggingConfig>,
+    logging_config: LoggingConfig,
     /// The build information for this process.
     build_info: &'static BuildInfo,
     /// A channel upon which commands intended for the replica are delivered.
@@ -255,7 +255,7 @@ where
 }
 
 struct CommandSpecialization {
-    logging_config: Option<LoggingConfig>,
+    logging_config: LoggingConfig,
     comm_config: CommunicationConfig,
 }
 

--- a/src/compute-client/src/logging.proto
+++ b/src/compute-client/src/logging.proto
@@ -16,7 +16,7 @@ import "proto/src/proto.proto";
 
 package mz_compute_client.logging;
 
-message ProtoActiveLog {
+message ProtoIndexLog {
     ProtoLogVariant key = 1;
     mz_repr.global_id.ProtoGlobalId value = 2;
 }
@@ -70,7 +70,8 @@ message ProtoLogVariant {
 
 message ProtoLoggingConfig {
     mz_proto.ProtoU128 interval_ns = 1;
-    repeated ProtoActiveLog active_logs = 2;
+    bool enable_logging = 2;
     bool log_logging = 3;
-    repeated ProtoSinkLog sink_logs = 4;
+    repeated ProtoIndexLog index_logs = 4;
+    repeated ProtoSinkLog sink_logs = 5;
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -134,9 +134,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     }
 
     fn handle_create_instance(&mut self, config: InstanceConfig) {
-        if config.logging.enable_logging {
-            self.initialize_logging(&config.logging);
-        }
+        self.initialize_logging(&config.logging);
     }
 
     fn handle_create_dataflows(

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -134,8 +134,8 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     }
 
     fn handle_create_instance(&mut self, config: InstanceConfig) {
-        if let Some(logging) = config.logging {
-            self.initialize_logging(&logging);
+        if config.logging.enable_logging {
+            self.initialize_logging(&config.logging);
         }
     }
 
@@ -503,32 +503,32 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
         // Install traces as maintained indexes
         for (log, (trace, token)) in t_traces {
-            let id = logging.active_logs[&log];
+            let id = logging.index_logs[&log];
             self.compute_state
                 .traces
                 .set(id, TraceBundle::new(trace, errs.clone()).with_drop(token));
         }
         for (log, (trace, token)) in r_traces {
-            let id = logging.active_logs[&log];
+            let id = logging.index_logs[&log];
             self.compute_state
                 .traces
                 .set(id, TraceBundle::new(trace, errs.clone()).with_drop(token));
         }
         for (log, (trace, token)) in d_traces {
-            let id = logging.active_logs[&log];
+            let id = logging.index_logs[&log];
             self.compute_state
                 .traces
                 .set(id, TraceBundle::new(trace, errs.clone()).with_drop(token));
         }
         for (log, (trace, token)) in c_traces {
-            let id = logging.active_logs[&log];
+            let id = logging.index_logs[&log];
             self.compute_state
                 .traces
                 .set(id, TraceBundle::new(trace, errs.clone()).with_drop(token));
         }
 
         // Initialize frontier reporting for all logging indexes and sinks.
-        let index_ids = logging.active_logs.values().copied();
+        let index_ids = logging.index_logs.values().copied();
         let sink_ids = logging.sink_logs.values().map(|(id, _)| *id);
         for id in index_ids.chain(sink_ids) {
             self.compute_state.reported_frontiers.insert(

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -405,7 +405,7 @@ pub fn construct<A: Allocate>(
 
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
-            if config.active_logs.contains_key(&variant) {
+            if config.index_logs.contains_key(&variant) {
                 let key = variant.index_by();
                 let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
                     &key.iter()

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -175,7 +175,7 @@ pub fn construct<A: Allocate>(
 
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
-            if config.active_logs.contains_key(&variant) {
+            if config.index_logs.contains_key(&variant) {
                 let key = variant.index_by();
                 let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
                     &key.iter()

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -87,7 +87,7 @@ pub fn construct<A: Allocate>(
         // Do we need to construct the common reachability common dataflow?
         let common_needed = logs_active
             .iter()
-            .any(|variant| config.active_logs.contains_key(variant))
+            .any(|variant| config.index_logs.contains_key(variant))
             || sink_common;
 
         let mut result = std::collections::HashMap::new();
@@ -171,7 +171,7 @@ pub fn construct<A: Allocate>(
             }
 
             for variant in logs_active {
-                if config.active_logs.contains_key(&variant) {
+                if config.index_logs.contains_key(&variant) {
                     let key = variant.index_by();
                     let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
                         &key.iter()

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -20,6 +20,7 @@ use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use timely::communication::Allocate;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::capture::EventLink;
+use timely::dataflow::operators::Filter;
 use timely::logging::WorkerIdentifier;
 
 use mz_compute_client::logging::LoggingConfig;
@@ -67,12 +68,19 @@ pub fn construct<A: Allocate>(
 
     // A dataflow for multiple log-derived arrangements.
     let traces = worker.dataflow_named("Dataflow: timely reachability logging", move |scope| {
-        let (logs, token) = Some(linked).mz_replay(
+        let (mut logs, token) = Some(linked).mz_replay(
             scope,
             "reachability logs",
             Duration::from_nanos(config.interval_ns as u64),
             activator,
         );
+
+        // If logging is disabled, we still need to install the indexes, but we can leave them
+        // empty. We do so by immediately filtering all logs events.
+        // TODO(teskje): Remove this once we remove the arranged introspection sources.
+        if !config.enable_logging {
+            logs = logs.filter(|_| false);
+        }
 
         use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -458,7 +458,7 @@ pub fn construct<A: Allocate>(
 
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
-            if config.active_logs.contains_key(&variant) {
+            if config.index_logs.contains_key(&variant) {
                 let key = variant.index_by();
                 let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
                     &key.iter()

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -20,6 +20,7 @@ use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use timely::communication::Allocate;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::capture::EventLink;
+use timely::dataflow::operators::Filter;
 use timely::logging::{ParkEvent, TimelyEvent, WorkerIdentifier};
 
 use mz_compute_client::logging::LoggingConfig;
@@ -55,12 +56,19 @@ pub fn construct<A: Allocate>(
 
     // A dataflow for multiple log-derived arrangements.
     let traces = worker.dataflow_named("Dataflow: timely logging", move |scope| {
-        let (logs, token) = Some(linked).mz_replay(
+        let (mut logs, token) = Some(linked).mz_replay(
             scope,
             "timely logs",
             Duration::from_nanos(config.interval_ns as u64),
             activator,
         );
+
+        // If logging is disabled, we still need to install the indexes, but we can leave them
+        // empty. We do so by immediately filtering all logs events.
+        // TODO(teskje): Remove this once we remove the arranged introspection sources.
+        if !config.enable_logging {
+            logs = logs.filter(|_| false);
+        }
 
         use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -767,10 +767,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         }
 
                         // Ensure we retain the logging sink dataflows.
-                        if let Some(logging) = &new_config.logging {
-                            for (id, _) in logging.sink_logs.values() {
-                                retain_ids.insert(*id);
-                            }
+                        for (id, _) in new_config.logging.sink_logs.values() {
+                            retain_ids.insert(*id);
                         }
                     }
                     // All other commands we apply as requested.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -57,6 +57,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-cluster",
         "test-github-12251",
         "test-github-15535",
+        "test-github-15799",
         "test-remote-storaged",
         "test-drop-default-cluster",
         "test-upsert",
@@ -259,6 +260,48 @@ def workflow_test_github_15535(c: Composition) -> None:
     assert mv_upper, "mv has empty upper frontier"
     assert t_since, "t has empty since frontier"
     assert t_upper, "t has empty upper frontier"
+
+
+def workflow_test_github_15799(c: Composition) -> None:
+    """
+    Test that querying arranged introspection sources on a replica does not
+    crash other replicas in the same cluster that have introspection disabled.
+
+    Regression test for https://github.com/MaterializeInc/materialize/issues/15799.
+    """
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+    c.up("computed_1")
+    c.up("computed_2")
+    c.wait_for_materialized()
+
+    c.sql(
+        """
+        CREATE CLUSTER cluster1 REPLICAS (
+            logging_on (
+                REMOTE ['computed_1:2100'],
+                COMPUTE ['computed_1:2102'],
+                WORKERS 2
+            ),
+            logging_off (
+                REMOTE ['computed_2:2100'],
+                COMPUTE ['computed_2:2102'],
+                WORKERS 2,
+                INTROSPECTION INTERVAL 0
+            )
+        );
+        SET cluster = cluster1;
+
+        -- query the arranged introspection sources on the replica with logging enabled
+        SET cluster_replica = logging_on;
+        SELECT * FROM mz_internal.mz_active_peeks, mz_internal.mz_compute_exports;
+
+        -- verify that the other replica has not crashed and still responds
+        SET cluster_replica = logging_off;
+        SELECT * FROM mz_tables, mz_sources;
+        """
+    )
 
 
 def workflow_test_upsert(c: Composition) -> None:


### PR DESCRIPTION
This PR changes how we configure logging in compute. Previously, when introspection was disabled we would refrain from creating the introspection dataflows. For arranged introspection sources, this approach causes an issue because other replicas in the same cluster might have introspection enabled. A peek targeted at another replica could cause an ad-hoc dataflow reading from introspection indexes to be installed on replicas with introspection disabled as well (remember that replica-targeting only filters peek responses, not the creation of dataflows). The dataflow installation would fail because the input introspection indexes would be absent, and the replica would crash.

With this PR, logging dataflows and indexes are instead always installed. If introspection is disabled, we filter all log events inside the dataflows, to ensure no unnecessary resources are consumed by the operators and the exported arrangements.

This change makes it necessary to adjust the compute protocol to always transmit a `LoggingConfig` (previously this was only done if logging was enabled). I took the opportunity to refactor the `LoggingConfig` struct at the same time, to rename the confusing  `active_logs` field to something more obvious.

### Motivation

  * This PR fixes a recognized bug.

Fixes #15799. 

### Tips for reviewer

Look at the commits and associated commit messages separately!

We introduce a backwards-breaking change to the compute protocols protobuf structures here. This is fine because [the compute protocol is not yet part of our stable interface.](https://www.notion.so/materialize/Backwards-compatibility-policy-434ecf894656435795ef3f61b3a54976#c839062780354d8b952fe22509168395)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
