### PR TITLE
[WIP] persist: more efficient merge request `since`

### DIFF
--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -247,7 +247,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
         fn covers<T: PartialOrder>(b0: &FueledMergeReq<T>, b1: &FueledMergeReq<T>) -> bool {
             PartialOrder::less_equal(b0.desc.lower(), b1.desc.lower())
                 && PartialOrder::less_equal(b1.desc.upper(), b0.desc.upper())
-                && b0.desc.since() == b1.desc.since()
+                && PartialOrder::less_equal(b1.desc.since(), b0.desc.since())
         }
 
         let mut ret = Vec::<FueledMergeReq<T>>::with_capacity(merge_reqs.len());

--- a/src/persist-client/tests/trace/compaction_apply_res_since
+++ b/src/persist-client/tests/trace/compaction_apply_res_since
@@ -35,7 +35,6 @@ take-merge-reqs
 ----
 [0][2][0] k0 k1
 [0][4][4] k0 k1 k2 k3
-[2][4][0] k2 k3
 
 # We cannot use a compaction response with a since in advance of the spine batch
 apply-merge-res


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

WIP idea that I'm going to table for a bit. Just wanted to sketch it out before I forget

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
