### PR TITLE
persist: log when heartbeat tasks take longer than expected to fire

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -361,36 +361,35 @@ where
         let mut machine = self;
         spawn(|| "persist::heartbeat_read", async move {
             let sleep_duration = machine.cfg.reader_lease_duration / 2;
-            let mut last_wakeup = Instant::now();
             loop {
+                let before_sleep = Instant::now();
                 tokio::time::sleep(sleep_duration).await;
-                let wakeup = Instant::now();
 
-                let elapsed_since_last_wakeup = wakeup - last_wakeup;
-                if elapsed_since_last_wakeup > machine.cfg.reader_lease_duration {
+                let elapsed_since_before_sleeping = before_sleep.elapsed();
+                if elapsed_since_before_sleeping > sleep_duration + Duration::from_secs(60) {
                     warn!(
                         "reader ({}) of shard ({}) went {}s between heartbeats",
                         reader_id,
                         machine.shard_id(),
-                        elapsed_since_last_wakeup.as_secs_f64()
+                        elapsed_since_before_sleeping.as_secs_f64()
                     );
                 }
 
+                let before_heartbeat = Instant::now();
                 let (_seqno, existed, _maintenance) = machine
                     .heartbeat_reader(&reader_id, (machine.cfg.now)())
                     .await;
 
-                let elapsed_since_this_wakeup = Instant::now() - wakeup;
-                if elapsed_since_this_wakeup > Duration::from_secs(60) {
+                let elapsed_since_heartbeat = before_heartbeat.elapsed();
+                if elapsed_since_heartbeat > Duration::from_secs(60) {
                     warn!(
                         "reader ({}) of shard ({}) heartbeat call took {}s",
                         reader_id,
                         machine.shard_id(),
-                        elapsed_since_this_wakeup.as_secs_f64(),
+                        elapsed_since_heartbeat.as_secs_f64(),
                     );
                 }
 
-                last_wakeup = wakeup;
                 if !existed {
                     return;
                 }
@@ -416,36 +415,35 @@ where
         let mut machine = self;
         spawn(|| "persist::heartbeat_write", async move {
             let sleep_duration = machine.cfg.writer_lease_duration / 4;
-            let mut last_wakeup = Instant::now();
             loop {
+                let before_sleep = Instant::now();
                 tokio::time::sleep(sleep_duration).await;
-                let wakeup = Instant::now();
 
-                let elapsed_since_last_wakeup = wakeup - last_wakeup;
-                if elapsed_since_last_wakeup > machine.cfg.writer_lease_duration {
+                let elapsed_since_before_sleeping = before_sleep.elapsed();
+                if elapsed_since_before_sleeping > sleep_duration + Duration::from_secs(60) {
                     warn!(
                         "writer ({}) of shard ({}) went {}s between heartbeats",
                         writer_id,
                         machine.shard_id(),
-                        elapsed_since_last_wakeup.as_secs_f64()
+                        elapsed_since_before_sleeping.as_secs_f64()
                     );
                 }
 
+                let before_heartbeat = Instant::now();
                 let (_seqno, existed, _maintenance) = machine
                     .heartbeat_writer(&writer_id, (machine.cfg.now)())
                     .await;
 
-                let elapsed_since_this_wakeup = Instant::now() - wakeup;
-                if elapsed_since_this_wakeup > Duration::from_secs(60) {
+                let elapsed_since_heartbeat = before_heartbeat.elapsed();
+                if elapsed_since_heartbeat > Duration::from_secs(60) {
                     warn!(
                         "writer ({}) of shard ({}) heartbeat call took {}s",
                         writer_id,
                         machine.shard_id(),
-                        elapsed_since_this_wakeup.as_secs_f64(),
+                        elapsed_since_heartbeat.as_secs_f64(),
                     );
                 }
 
-                last_wakeup = wakeup;
                 if !existed {
                     return;
                 }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -700,6 +700,15 @@ where
         let elapsed_since_last_heartbeat =
             Duration::from_millis(heartbeat_ts.saturating_sub(self.last_heartbeat));
         if elapsed_since_last_heartbeat >= min_elapsed {
+            if elapsed_since_last_heartbeat > self.machine.cfg.reader_lease_duration {
+                warn!(
+                    "reader ({}) of shard ({}) went {}s between heartbeats",
+                    self.reader_id,
+                    self.machine.shard_id(),
+                    elapsed_since_last_heartbeat.as_secs_f64()
+                );
+            }
+
             let (_, existed, maintenance) = self
                 .machine
                 .heartbeat_reader(&self.reader_id, heartbeat_ts)

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -646,6 +646,15 @@ where
         let elapsed_since_last_heartbeat =
             Duration::from_millis(heartbeat_ts.saturating_sub(self.last_heartbeat));
         if elapsed_since_last_heartbeat >= min_elapsed {
+            if elapsed_since_last_heartbeat > self.machine.cfg.writer_lease_duration {
+                warn!(
+                    "writer ({}) of shard ({}) went {}s between heartbeats",
+                    self.writer_id,
+                    self.machine.shard_id(),
+                    elapsed_since_last_heartbeat.as_secs_f64()
+                );
+            }
+
             let (_, existed, maintenance) = self
                 .machine
                 .heartbeat_writer(&self.writer_id, heartbeat_ts)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
