### PR TITLE
Embed a UUID in the binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ version = "0.0.0"
 dependencies = [
  "compile-time-run",
  "semver",
+ "uuid",
 ]
 
 [[package]]

--- a/src/build-info/Cargo.toml
+++ b/src/build-info/Cargo.toml
@@ -9,6 +9,10 @@ publish = false
 [dependencies]
 compile-time-run = "0.2.12"
 semver = { version = "1.0.14", optional = true }
+uuid = "1.2.1"
+
+[build-dependencies]
+uuid = { version = "1.2.1", features = ["v4"] }
 
 [features]
 default = ["semver"]

--- a/src/build-info/build.rs
+++ b/src/build-info/build.rs
@@ -14,4 +14,8 @@ fn main() {
         "cargo:rustc-env=TARGET_TRIPLE={}",
         env::var("TARGET").unwrap()
     );
+    println!(
+        "cargo:rustc-env=MZ_BUILD_UUID={}",
+        uuid::Uuid::new_v4()
+    )
 }

--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -12,6 +12,8 @@
 //! These types are located in a dependency-free crate so they can be used
 //! from any layer of the stack.
 
+use uuid::Uuid;
+
 /// Build information.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuildInfo {
@@ -21,6 +23,8 @@ pub struct BuildInfo {
     pub sha: &'static str,
     /// The time of the build in UTC as an ISO 8601-compliant string.
     pub time: &'static str,
+    /// A UUID generated at build time
+    pub uuid: Uuid,
 }
 
 /// Dummy build information.
@@ -31,6 +35,13 @@ pub const DUMMY_BUILD_INFO: BuildInfo = BuildInfo {
     version: "0.0.0+dummy",
     sha: "0000000000000000000000000000000000000000",
     time: "",
+    uuid: Uuid::nil()
+};
+
+const UUID_STR: &str = env!("MZ_BUILD_UUID");
+pub const UUID: Uuid = match Uuid::try_parse(UUID_STR) {
+    Ok(uuid) => uuid,
+    Err(_e) => panic!("Bad MZ_BUILD_UUID"),
 };
 
 /// The target triple of the platform.
@@ -103,6 +114,7 @@ macro_rules! build_info {
                    fi"#
             ),
             time: $crate::private::run_command_str!("date", "-u", "+%Y-%m-%dT%H:%M:%SZ"),
+            uuid: $crate::UUID,
         }
     }
 }

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -24,6 +24,7 @@ use mz_ore::now::SYSTEM_TIME;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::RustType;
+use uuid::Uuid;
 
 use crate::internal::paths::{
     BlobKey, BlobKeyPrefix, PartialBatchKey, PartialBlobKey, PartialRollupKey,
@@ -35,6 +36,7 @@ const READ_ALL_BUILD_INFO: BuildInfo = BuildInfo {
     version: "10000000.0.0+test",
     sha: "0000000000000000000000000000000000000000",
     time: "",
+    uuid: Uuid::nil()
 };
 
 /// Fetches the current state of a given shard


### PR DESCRIPTION

### Motivation

This can be useful for debugging / interpreting unsymbolicated profiling traces

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None