### PR TITLE
Clean-up of leaking `CollectionState` metadata in compute controller

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -750,7 +750,14 @@ where
             let last_upper = collection.replica_write_frontiers.remove(&replica_id);
 
             if let Some(frontier) = last_upper {
-                dropped_collection_ids.push(id.clone());
+                // if there are other replicas, let them decide the fate of the collection metadata;
+                // if this replica was the last one, though, then get rid of the collection metadata
+                // only if we reached the empty frontier
+                if collection.replica_write_frontiers.len() > 0
+                    || collection.read_frontier().to_owned() == Antichain::new()
+                {
+                    dropped_collection_ids.push(id.clone());
+                }
 
                 // Update read holds on storage dependencies.
                 for storage_id in &collection.storage_dependencies {

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -248,7 +248,6 @@ where
         // Initialize frontier tracking for the new replica
         // and clean up any dropped collections that we can
         let mut updates = Vec::new();
-        let mut dropped_collection_ids = Vec::new();
         for (compute_id, collection) in &mut self.compute.collections {
             // Skip log collections not maintained by this replica.
             if collection.log_collection && !maintained_logs.contains(compute_id) {
@@ -256,13 +255,9 @@ where
             }
 
             let read_frontier = collection.read_frontier();
-            if read_frontier.is_empty() {
-                dropped_collection_ids.push(compute_id.clone());
-            }
             updates.push((*compute_id, read_frontier.to_owned()));
         }
         self.update_write_frontiers(id, &updates).await?;
-        self.update_dropped_collections(dropped_collection_ids)?;
 
         let replica = Replica::spawn(
             id,

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -245,7 +245,7 @@ where
             BTreeSet::new()
         };
 
-        // Initialize frontier tracking the new replica
+        // Initialize frontier tracking for the new replica
         // and clean up any dropped collections that we can
         let mut updates = Vec::new();
         let mut dropped_collection_ids = Vec::new();

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -816,6 +816,11 @@ where
                         .entry(key)
                         .or_insert_with(ChangeBatch::new)
                         .extend(update.drain())
+                } else {
+                    tracing::error!(
+                        "found neither compute nor storage collection with id {}",
+                        key
+                    );
                 }
             }
         }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -799,10 +799,12 @@ where
                 compute_net.push((key, update));
             } else {
                 // Storage presumably, but verify.
-                storage_todo
-                    .entry(key)
-                    .or_insert_with(ChangeBatch::new)
-                    .extend(update.drain())
+                if self.storage_controller.collection(key).is_ok() {
+                    storage_todo
+                        .entry(key)
+                        .or_insert_with(ChangeBatch::new)
+                        .extend(update.drain())
+                }
             }
         }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -904,7 +904,7 @@ where
     ) -> Result<(), ComputeError> {
         for id in dropped_collection_ids {
             // clean up the given collection if all replica frontiers are empty
-            let collection = self.compute.collection_mut(id)?;
+            let collection = self.compute.collection(id)?;
             let empty = Antichain::new();
             if collection
                 .replica_write_frontiers

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -439,11 +439,6 @@ where
                         compute_dependencies.clone(),
                     ),
                 );
-                println!(
-                    "Inserted collection id {} -- count(collections) = {}",
-                    export_id,
-                    self.compute.collections.len()
-                );
                 updates.push((export_id, as_of.clone()));
             }
             // Initialize tracking of replica frontiers.
@@ -582,11 +577,6 @@ where
             otel_ctx,
         }));
 
-        println!(
-            "Peeked collection id {} --- count(collections) = {}",
-            id,
-            self.compute.collections.len()
-        );
         Ok(())
     }
 
@@ -928,11 +918,6 @@ where
                     .all(|frontier| frontier.is_empty())
             {
                 self.compute.collections.remove(&id);
-                println!(
-                    "Removed collection id {} --- count(collections): {}",
-                    id,
-                    self.compute.collections.len()
-                );
             }
         }
         Ok(())

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -721,9 +721,6 @@ where
             self.update_read_capabilities(&mut compute_read_capability_changes)
                 .await?;
         }
-        if !dropped_collection_ids.is_empty() {
-            self.update_dropped_collections(dropped_collection_ids);
-        }
         if !storage_read_capability_changes.is_empty() {
             self.storage_controller
                 .update_read_capabilities(&mut storage_read_capability_changes)
@@ -747,6 +744,9 @@ where
             .update_write_frontiers(&storage_updates)
             .await?;
 
+        if !dropped_collection_ids.is_empty() {
+            self.update_dropped_collections(dropped_collection_ids);
+        }
         Ok(())
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -895,11 +895,7 @@ where
     ) -> Result<(), ComputeError> {
         for id in dropped_collection_ids {
             // clean up the given collection if all replica frontiers are empty
-            let collection = self
-                .compute
-                .collections
-                .get(&id)
-                .ok_or(ComputeError::IdentifierMissing(id))?;
+            let collection = self.compute.collection_mut(id)?;
             let empty = Antichain::new();
             if collection
                 .replica_write_frontiers


### PR DESCRIPTION
In the compute controller, we keep `CollectionState` metadata related to existing compute collections in each `Instance`. Presently, this metadata is never cleaned up, causing a memory leak. This leak is particularly problematic since temporary collections created in response to slow-path peeks get left behind indefinitely.

This PR ensures that this collection metadata gets cleaned up when all replicas in the current replica set of the `Instance` eventually report an empty frontier for the collection _and_ the read frontier for the collection also becomes empty. The replica reporting is done by a `FrontierUppers` response, which is triggered by an `AllowCompaction` command to the empty frontier. In a replay of the compute command history, an `AllowCompaction` with the empty frontier renders the dataflow no longer live, so its collection metadata can be garbage collected as long as we know that all replicas processed the latter command. However, even if there are no replicas in a cluster, a collection may need to be still kept around, e.g., if it was created in response to DDL such as `CREATE INDEX`. So we can only garbage collect a collection when other components in the system manifest that it is safe to drop it by advancement of the read frontier to empty. 

The definition of current replica set here takes some care, as we may, e.g., explicitly change the replica set managed by the `Instance` by dropping or adding replicas. So the clean-up must leave the collection metadata of the `Instance` in a well-known state even as we interleave peeks, replica rehydration, replica addition / removal, and explicit collection addition / removal (e.g., by creating / dropping indexes). The PR focuses on necessary changes to the `Instance` implementation under the assumption that adapter-led recovery in the case of a crash of the compute controller correctly recreates only necessary collection metadata.

Advances #15704; however, the PR does not include the addition of automated tests to avoid the reintroduction of the bug in the future. This addition for a final fix will be pursued in a separate PR in connection with exposing a proper metric to externalize the size of the collection metadata.

### Motivation

  * This PR fixes a recognized bug. #15704 

### Tips for reviewer

The following discussions may be helpful background to evaluate the changes in this PR:

- https://materializeinc.slack.com/archives/C02PPB50ZHS/p1666790066832059
- https://materializeinc.slack.com/archives/C02PPB50ZHS/p1666943411293669
- https://materializeinc.slack.com/archives/C041KPFCR98/p1667468315996489

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  The changes have been tested locally with scenarios where we offer the system different sequences of commands including peeks, replica addition / removal, as well as index addition / removal. In addition, we observed the state of the system after an `environmentd` fenced crash and restart.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
