### PR TITLE
persist: replace LeasedBatchPart's panic on drop with a metric

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -772,6 +772,7 @@ impl GcMetrics {
 #[derive(Debug)]
 pub struct LeaseMetrics {
     pub(crate) timeout_read: IntCounter,
+    pub(crate) dropped_part: IntCounter,
 }
 
 impl LeaseMetrics {
@@ -780,6 +781,10 @@ impl LeaseMetrics {
             timeout_read: registry.register(metric!(
                 name: "mz_persist_lease_timeout_read",
                 help: "count of readers whose lease timed out",
+            )),
+            dropped_part: registry.register(metric!(
+                name: "mz_persist_lease_dropped_part",
+                help: "count of LeasedBatchParts that were dropped without being politely returned",
             )),
         }
     }


### PR DESCRIPTION
Work to add better cancellation to persist_source (#15860) resulted in a panic because LeasedBatchParts were held within the Subscription. These panics have already required one somewhat unsatisfying fix for a very similar (the same?) issue: #15234. At this point, I think the panics were a well-intentioned idea, but in practice haven't turned out to be worth the maintenance.


### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
