### PR TITLE
Add quick and dirty script for launching the flamegraph visualizer

### DIFF
--- a/bin/fgviz
+++ b/bin/fgviz
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# fgviz — generate and launch flamegraph visualizer
+
+cargo run --bin fgviz > $( dirname "$0" )/../src/prof/src/http/flamegraph.html
+
+if ! command -v open &> /dev/null
+then
+    echo "Open 'src/prof/src/http/static/flamegraph.html' in your favorite browser."
+else
+    open $( dirname "$0" )/../src/prof/src/http/flamegraph.html
+fi
+

--- a/src/prof/src/bin/fgviz.rs
+++ b/src/prof/src/bin/fgviz.rs
@@ -1,0 +1,16 @@
+use askama::Template;
+
+use mz_build_info::build_info;
+use mz_prof::http::FlamegraphTemplate;
+
+fn main() {
+    let bi = build_info!();
+    let rendered = FlamegraphTemplate {
+        version: &bi.human_version(),
+        title: "Flamegraph Visualizer",
+        mzfg: "",
+    }
+    .render()
+    .expect("template rendering cannot fail");
+    print!("{}", rendered);
+}

--- a/src/prof/src/http/mod.rs
+++ b/src/prof/src/http/mod.rs
@@ -77,10 +77,10 @@ struct ProfTemplate<'a> {
 
 #[derive(Template)]
 #[template(path = "http/templates/flamegraph.html")]
-struct FlamegraphTemplate<'a> {
-    version: &'a str,
-    title: &'a str,
-    mzfg: &'a str,
+pub struct FlamegraphTemplate<'a> {
+    pub version: &'a str,
+    pub title: &'a str,
+    pub mzfg: &'a str,
 }
 
 #[allow(clippy::drop_copy)]

--- a/src/prof/src/http/templates/flamegraph.html
+++ b/src/prof/src/http/templates/flamegraph.html
@@ -20,6 +20,7 @@
             <div class="separator"></div>
             <input id="search-input" type="text" placeholder="Filter...">
             <button id="clear-button" type="button">Clear</button>
+            <label for="load-file">Upload MZFG:</label>
             <input id="load-file" type="file" />
             <button id="save-file" type="submit">Save current trace</button>
         </form>
@@ -32,7 +33,9 @@
 
 <script>
   let mzfg = {{mzfg|json|safe}};
-  renderPageFromMzfg(mzfg);
+  if (mzfg) {
+      renderPageFromMzfg(mzfg);
+  }
 
   document.getElementById('load-file').addEventListener('change', ev => {
       loadFile(ev);


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

    Users should be able to run the flamegraph visualizer without having Materialize up and running


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None