### PR TITLE
Dbt v1.3.0

### DIFF
--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -39,8 +39,8 @@ setup(
             "include/materialize/macros/**/*.sql",
         ]
     },
-    install_requires=["dbt-postgres~=1.2.0"],
+    install_requires=["dbt-postgres~=1.3.0"],
     extras_require={
-        "dev": ["dbt-tests-adapter~=1.2.0"],
+        "dev": ["dbt-tests-adapter~=1.3.0"],
     },
 )

--- a/misc/dbt-materialize/tests/adapter/test_basic.py
+++ b/misc/dbt-materialize/tests/adapter/test_basic.py
@@ -19,7 +19,10 @@ from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
-from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.adapter.basic.test_incremental import (
+    BaseIncremental,
+    BaseIncrementalNotSchemaChange,
+)
 from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
 from dbt.tests.adapter.basic.test_singular_tests_ephemeral import (
     BaseSingularTestsEphemeral,
@@ -142,4 +145,9 @@ class TestBaseAdapterMethodMaterialize(BaseAdapterMethod):
 {% endif %}
 select * from {{ upstream }}
 """
+    pass
+
+
+@pytest.mark.skip(reason="dbt-materialize does not support incremental models")
+class TestBaseIncrementalNotSchemaChangeMaterialize(BaseIncrementalNotSchemaChange):
     pass

--- a/misc/dbt-materialize/tests/adapter/test_concurrency.py
+++ b/misc/dbt-materialize/tests/adapter/test_concurrency.py
@@ -1,3 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dbt.tests.adapter.concurrency.test_concurrency import TestConcurenncy
 
 

--- a/misc/dbt-materialize/tests/adapter/test_concurrency.py
+++ b/misc/dbt-materialize/tests/adapter/test_concurrency.py
@@ -1,0 +1,5 @@
+from dbt.tests.adapter.concurrency.test_concurrency import TestConcurenncy
+
+
+class TestConcurrencyMaterialize(TestConcurenncy):
+    pass

--- a/misc/dbt-materialize/tests/adapter/test_data_types.py
+++ b/misc/dbt-materialize/tests/adapter/test_data_types.py
@@ -1,0 +1,51 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.adapter.utils.data_types.test_type_bigint import BaseTypeBigInt
+from dbt.tests.adapter.utils.data_types.test_type_boolean import BaseTypeBoolean
+from dbt.tests.adapter.utils.data_types.test_type_float import BaseTypeFloat
+from dbt.tests.adapter.utils.data_types.test_type_int import BaseTypeInt
+from dbt.tests.adapter.utils.data_types.test_type_numeric import BaseTypeNumeric
+from dbt.tests.adapter.utils.data_types.test_type_string import BaseTypeString
+from dbt.tests.adapter.utils.data_types.test_type_timestamp import BaseTypeTimestamp
+
+
+class TestTypeBigInt(BaseTypeBigInt):
+    pass
+
+
+class TestTypeFloat(BaseTypeFloat):
+    pass
+
+
+class TestTypeInt(BaseTypeInt):
+    pass
+
+
+class TestTypeNumeric(BaseTypeNumeric):
+    pass
+
+
+class TestTypeString(BaseTypeString):
+    pass
+
+
+class TestTypeTimestamp(BaseTypeTimestamp):
+    pass
+
+
+class TestTypeBoolean(BaseTypeBoolean):
+    pass

--- a/misc/dbt-materialize/tests/adapter/test_ephemeral.py
+++ b/misc/dbt-materialize/tests/adapter/test_ephemeral.py
@@ -1,0 +1,14 @@
+import pytest
+from dbt.tests.adapter.ephemeral.test_ephemeral import BaseEphemeralMulti
+from dbt.tests.util import check_relations_equal, run_dbt
+
+
+class TestEphemeralMultiMaterialize(BaseEphemeralMulti):
+    def test_ephemeral_multi_materialize(self, project):
+        run_dbt(["seed"])
+        results = run_dbt(["run"])
+        assert len(results) == 3
+        check_relations_equal(
+            project.adapter,
+            ["seed", "dependent", "double_dependent", "super_dependent"],
+        )


### PR DESCRIPTION
Upgrade dbt-materialize to use dbt v1.3.0.

The only task pertinent to us was to port over the[ dbt utility functions](https://github.com/dbt-labs/dbt-core/discussions/6011) that moved to core in v.1.3.0. 

Closes https://github.com/MaterializeInc/materialize/issues/15321

### Tips for reviewer

1. The v1.2 PRs https://github.com/MaterializeInc/materialize/pull/15840 and https://github.com/MaterializeInc/materialize/pull/15775 will need to be merged before merging this. Once merged, I'll add the last tests, to `test_utils.py`. These have already been tested:

```
from dbt.tests.adapter.utils.test_array_append import BaseArrayAppend
from dbt.tests.adapter.utils.test_array_concat import BaseArrayConcat
from dbt.tests.adapter.utils.test_array_construct import BaseArrayConstruct
from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampAware

@pytest.mark.skip(reason="Materialize does not yet support array_append().")
class TestArrayAppend(BaseArrayAppend):
    pass


@pytest.mark.skip(reason="Materialize does not yet support array_concat().")
class TestArrayConcat(BaseArrayConcat):
    pass


@pytest.mark.skip(reason="Materialize does not yet support array_concat().")
class TestArrayConcat(BaseArrayConstruct):
    pass


class TestCurrentTimestamp(BaseCurrentTimestampAware):
    pass
```

2. Dbt upgrades will continue to add additional tests to our test suite. For this reason, we should consider removing test support for binary versions of Materialize. I'd rather not slow down CI more than we have to. Alternatively, we could move dbt-materialize into its own repo. Happy for other suggestions cc @benesch @morsapaes. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
