### PR TITLE
make mzfg formut robust to semicolons in symbol names

### DIFF
--- a/src/prof/src/http/static/js/flamegraph.js
+++ b/src/prof/src/http/static/js/flamegraph.js
@@ -183,7 +183,7 @@ function parseMzfg(input) {
             }
         }
 
-        // There should be a trailing comma, but let's
+        // There should be a trailing semicolon, but let's
         // be robust in case there isn't
         if (name_buf) {
             path.push(name_buf);

--- a/src/prof/src/http/static/js/flamegraph.js
+++ b/src/prof/src/http/static/js/flamegraph.js
@@ -165,10 +165,29 @@ function parseMzfg(input) {
         if (!parsedLine) {
             throw "Invalid symbol line: " + line;
         }
+        // unescape the semicolons and backslashes in the line
+        let escaping = false;
+        let path = [];
+        let name_buf = "";
+        for (const ch of parsedLine.groups['names']) {
+            if (escaping) {
+                name_buf += ch;
+                escaping = false;
+            } else if (ch == '\\') {
+                escaping = true;
+            } else if (ch == ';') {
+                path.push(name_buf);
+                name_buf = "";
+            } else {
+                name_buf += ch;
+            }
+        }
 
-        let path = parsedLine.groups['names'].split(';');
-        // ignore the trailing comma
-        path.pop();
+        // There should be a trailing comma, but let's
+        // be robust in case there isn't
+        if (name_buf) {
+            path.push(name_buf);
+        }
         const addr = parsedLine.groups['address'];
         names[addr] = path;
     }

--- a/src/prof/src/http/static/js/flamegraph.js
+++ b/src/prof/src/http/static/js/flamegraph.js
@@ -176,6 +176,8 @@ function parseMzfg(input) {
             } else if (ch == '\\') {
                 escaping = true;
             } else if (ch == ';') {
+                // we split on un-escaped `;`, so we add the piece here
+                // and reset the buffer
                 path.push(name_buf);
                 name_buf = "";
             } else {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_ore::soft_assert_or_log;
 use std::{collections::BTreeMap, ffi::c_void, time::Instant};
 
 pub mod http;
@@ -68,10 +67,11 @@ impl StackProfile {
             for (addr, names) in symbols {
                 if !names.is_empty() {
                     write!(&mut builder, "{addr:#x} ").unwrap();
-                    for name in names {
-                        // The client splits on semicolons, which shouldn't
-                        // be present in symbol names.
-                        soft_assert_or_log!(!name.contains(';'), "Invalid symbol name: {name}");
+                    for mut name in names {
+                        // The client splits on semicolons, so
+                        // we have to escape them.
+                        name = name.replace('\\', "\\\\");
+                        name = name.replace(';', "\\;");
                         write!(&mut builder, "{name};").unwrap();
                     }
                     writeln!(&mut builder, "").unwrap();


### PR DESCRIPTION
despite what I previously thought, these _can_ exist in Rust symbols, since there are types called things like `[T; N]` 