### PR TITLE
instrument pgwire with some metrics

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -314,12 +314,14 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         .send(adapter_client.clone())
         .expect("internal HTTP server should not drop first");
 
+    let metrics = mz_pgwire::MetricsConfig::register_into(&config.metrics_registry);
     // Launch SQL server.
     task::spawn(|| "sql_server", {
         let sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
             tls: pgwire_tls,
             adapter_client: adapter_client.clone(),
             frontegg: config.frontegg.clone(),
+            metrics: metrics.clone(),
             internal: false,
         });
         server::serve(sql_conns, sql_server)
@@ -331,6 +333,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             tls: None,
             adapter_client: adapter_client.clone(),
             frontegg: None,
+            metrics,
             internal: true,
         });
         server::serve(internal_sql_conns, internal_sql_server)

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -24,9 +24,11 @@
 
 mod codec;
 mod message;
+mod metrics;
 mod protocol;
 mod server;
 
 pub use message::Severity;
+pub use metrics::MetricsConfig;
 pub use protocol::match_handshake;
 pub use server::{Config, Server, TlsConfig, TlsMode};

--- a/src/pgwire/src/metrics.rs
+++ b/src/pgwire/src/metrics.rs
@@ -1,0 +1,62 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use mz_ore::metric;
+use mz_ore::metrics::raw::IntCounterVec;
+use mz_ore::metrics::{IntCounter, MetricsRegistry};
+
+#[derive(Clone, Debug)]
+pub struct MetricsConfig {
+    connection_status: IntCounterVec,
+}
+
+impl MetricsConfig {
+    pub fn register_into(registry: &MetricsRegistry) -> Self {
+        Self {
+            connection_status: registry.register(metric! {
+                name: "mz_connection_status",
+                help: "Count of completed network connections, by status",
+                var_labels: ["source", "status"],
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Metrics {
+    inner: MetricsConfig,
+    internal: bool,
+}
+
+impl Metrics {
+    pub fn new(inner: MetricsConfig, internal: bool) -> Self {
+        let self_ = Self { inner, internal };
+
+        // pre-initialize labels we are planning to use to ensure they are all
+        // always emitted as time series
+        self_.connection_status("success");
+        self_.connection_status("error");
+
+        self_
+    }
+
+    pub fn connection_status(&self, status: &str) -> IntCounter {
+        self.inner
+            .connection_status
+            .with_label_values(&[self.source_label(), status])
+    }
+
+    fn source_label(&self) -> &'static str {
+        if self.internal {
+            "internal_pgwire"
+        } else {
+            "external_pgwire"
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

fixes https://github.com/MaterializeInc/cloud/issues/4146

adds some basic status metrics for slo definitions. this adds a metric for `mz_connection_status` to track network connection failures, and adds failure tracking to the existing `mz_query_total` metric.

### Tips for reviewer

this is a partial revert of #12869

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
