### PR TITLE
computed,storaged,timely-util: halt, not panic, on TCP errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,9 +4504,11 @@ version = "0.0.0"
 dependencies = [
  "differential-dataflow",
  "futures-util",
+ "mz-ore",
  "proptest",
  "serde",
  "timely",
+ "timely_communication",
  "tokio",
 ]
 
@@ -6651,7 +6653,7 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#9548bf9c53418284a811ffc0d397d3d9c26c78ff"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#157b80dead4f943a2ee6548eb2245787fbe9c5bd"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -6669,12 +6671,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#9548bf9c53418284a811ffc0d397d3d9c26c78ff"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#157b80dead4f943a2ee6548eb2245787fbe9c5bd"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#9548bf9c53418284a811ffc0d397d3d9c26c78ff"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#157b80dead4f943a2ee6548eb2245787fbe9c5bd"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -6690,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#9548bf9c53418284a811ffc0d397d3d9c26c78ff"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#157b80dead4f943a2ee6548eb2245787fbe9c5bd"
 dependencies = [
  "columnation",
  "serde",
@@ -6699,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#9548bf9c53418284a811ffc0d397d3d9c26c78ff"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#157b80dead4f943a2ee6548eb2245787fbe9c5bd"
 
 [[package]]
 name = "tinytemplate"

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -96,6 +96,7 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
+    mz_timely_util::panic::halt_on_timely_communication_panic();
     let (tracing_target_callbacks, _sentry_guard) = mz_ore::tracing::configure(
         "computed",
         &args.tracing,

--- a/src/storage/src/bin/storaged.rs
+++ b/src/storage/src/bin/storaged.rs
@@ -127,6 +127,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
+    mz_timely_util::panic::halt_on_timely_communication_panic();
     let (tracing_target_callbacks, _sentry_guard) = mz_ore::tracing::configure(
         "storaged",
         &args.tracing,

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -11,7 +11,9 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 futures-util = "0.3.25"
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.147", features = ["derive"] }
+mz-ore = { path = "../ore", features = ["tracing"] }
 
 [dev-dependencies]
 tokio = { version = "1.20.2", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -21,5 +21,6 @@ pub mod event;
 pub mod operator;
 pub mod operators_async_ext;
 pub mod order;
+pub mod panic;
 pub mod progress;
 pub mod replay;

--- a/src/timely-util/src/panic.rs
+++ b/src/timely-util/src/panic.rs
@@ -1,0 +1,41 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic;
+
+use mz_ore::halt;
+
+/// Intercepts expected [`timely_communication`] panics and downgrades them to
+/// [`halt`]s.
+///
+/// Because processes in a timely cluster are shared fate, once one process in
+/// the cluster crashes, the other processes in the cluster are expected to
+/// panic with communication errors. This function sniffs out these
+/// communication errors and downgrades them to halts, to keep the attention on
+/// the process that crashed first.
+pub fn halt_on_timely_communication_panic() {
+    let old_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |panic_info| {
+        // We have to sniff out expected panics based on their message because
+        // Rust does not have good support for panicking with structured
+        // payloads.
+        match panic_info.payload().downcast_ref::<String>() {
+            Some(e) if e.starts_with("timely communication error:") => {
+                halt!("{}", e);
+            }
+            _ => old_hook(panic_info),
+        }
+    }))
+}


### PR DESCRIPTION
This commit is an extension to c0be2f86f, which introduced "halting" as a softer way of panicking, to TCP errors in timely. TCP errors are expected when a peer process in the timely cluster crashes. By downgrading TCP errors from panics to halts, we'll focus attention on the process that initially crashed, rather than distracting folks with backtraces in the processes whose fate was shared.

Depends on https://github.com/TimelyDataflow/timely-dataflow/pull/486.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
