### PR TITLE
sql: don't add quotes when converting idents to values

### DIFF
--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -371,7 +371,7 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
     fn try_from_value(v: WithOptionValue<T>) -> Result<Self, PlanError> {
         match v {
             WithOptionValue::Value(v) => V::try_from_value(v),
-            WithOptionValue::Ident(i) => V::try_from_value(Value::String(i.to_string())),
+            WithOptionValue::Ident(i) => V::try_from_value(Value::String(i.into_string())),
             WithOptionValue::Sequence(_)
             | WithOptionValue::Object(_)
             | WithOptionValue::Secret(_)

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -333,8 +333,15 @@ CREATE CLUSTER foo2 REPLICAS (a (SIZE '32'))
 statement ok
 CREATE CLUSTER foo3 REPLICAS (a (SIZE '2-2'))
 
+# Ensure that identifiers are correctly handled in value position, even when
+# they can't be printed bare. We previously had a bug where `"1"` was
+# incorrectly parsed as size `"1"` (quotes included), but `"small"` was parsed
+# as size `small` (quotes excluded).
 statement ok
-DROP CLUSTER foo, foo2, foo3 CASCADE
+CREATE CLUSTER foo4 REPLICAS (a (SIZE "1"))
+
+statement ok
+DROP CLUSTER foo, foo2, foo3, foo4 CASCADE
 
 # Test that introspection source indexes are created and dropped correctly
 


### PR DESCRIPTION
We permit using identifiers as option values, e.g. `"xsmall"` instead of `'xsmall'`. But we were accidentally including the quotes during planning when the identifier could not be printed bare, by using `to_string` instead of `into_string`.

The API here is just *asking* for this kind of confusion (`to_string` vs `into_string` are mightly similar...), but fixing that is a larger refactor than I want to tackle right now.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Correctly handle using identifiers as option values when those identifiers cannot be printed without quotes. E.g., `SIZE "2xsmall"` now works consistently with `SIZE "xsmall"`. 

@morsapaes I'm not actually sure this one's worth mentioning.
