### PR TITLE
Prevent leak in progress tracking state

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -439,6 +439,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
                     //Hold onto capbility until we receive a disconnected error
                     let mut cap_opt = Some(capability);
+                    // Drop capability if we are not the leader, as our queue will
+                    // be empty and we will never use nor importantly downgrade it.
+                    if idx != 0 {
+                        cap_opt = None;
+                    }
 
                     move |output| {
                         let mut disconnected = false;


### PR DESCRIPTION
Progress tracking has been observed on the top of a lot of stacks where `computed` CPU grows without bound. This ends up being traced back to operators that perform timestamped work that they do not need to tell others about. Timely will batch up that work until such a moment that it is worth telling folks, but .. that could be never and you'll just keep batching up the work. At the same time, it is weird to do work that you never need to tell anyone about.

In the `computed` command distributor dataflow, operators that do not produce commands hold capabilities forever, which means that no downstream operators need to communicate their receipt of timestamped messages. However, they continually receive messages with new timestamps from the operator that does produce commands, so their progress state grows without bound.

The fix is to have the operators that do not produce commands drop their capabilities rather than holding on to them indefinitely.

Fixes #15663

### Motivation

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
