### PR TITLE
optbench: add `--db-pass` and `--db-require-ssl` CLI options

### DIFF
--- a/misc/python/materialize/cli/optbench.py
+++ b/misc/python/materialize/cli/optbench.py
@@ -91,6 +91,12 @@ class Opt:
 
     db_pass = dict(default=None, help="DB connection password.", envvar="PGPASSWORD")
 
+    db_require_ssl = dict(
+        is_flag=True,
+        help="DB connection requires SSL.",
+        envvar="PGREQUIRESSL",
+    )
+
 
 @app.command()
 @click.argument("scenario", **Arg.scenario)
@@ -99,6 +105,7 @@ class Opt:
 @click.option("--db-host", **Opt.db_host)
 @click.option("--db-user", **Opt.db_user)
 @click.option("--db-pass", **Opt.db_pass)
+@click.option("--db-require-ssl", **Opt.db_require_ssl)
 def init(
     scenario: Scenario,
     no_indexes: bool,
@@ -106,13 +113,20 @@ def init(
     db_host: str,
     db_user: str,
     db_pass: Optional[str],
+    db_require_ssl: bool,
 ) -> None:
     """Initialize the DB under test for the given scenario."""
 
     info(f'Initializing "{scenario}" as the DB under test')
 
     try:
-        db = sql.Database(port=db_port, host=db_host, user=db_user, password=db_pass)
+        db = sql.Database(
+            port=db_port,
+            host=db_host,
+            user=db_user,
+            password=db_pass,
+            require_ssl=db_require_ssl,
+        )
 
         db.drop_database(scenario)
         db.create_database(scenario)
@@ -150,13 +164,20 @@ def run(
     db_host: str,
     db_user: str,
     db_pass: Optional[str],
+    db_require_ssl: bool,
 ) -> None:
     """Run benchmark in the DB under test for a given scenario."""
 
     info(f'Running "{scenario}" scenario')
 
     try:
-        db = sql.Database(port=db_port, host=db_host, user=db_user, password=db_pass)
+        db = sql.Database(
+            port=db_port,
+            host=db_host,
+            user=db_user,
+            password=db_pass,
+            require_ssl=db_require_ssl,
+        )
         db.set_database(scenario)
 
         df = pd.DataFrame.from_records(

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -66,13 +66,10 @@ class Database:
     """An API to the database under test."""
 
     def __init__(
-        self,
-        port: int,
-        host: str,
-        user: str,
+        self, port: int, host: str, user: str, password: Optional[str] = None
     ) -> None:
         logging.debug(f"Initialize Database with host={host} port={port}, user={user}")
-        self.conn = pg8000.connect(host=host, port=port, user=user)
+        self.conn = pg8000.connect(host=host, port=port, user=user, password=password)
         self.conn.autocommit = True
 
     def mz_version(self) -> str:

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -9,6 +9,7 @@
 
 import logging
 import re
+import ssl
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -66,10 +67,24 @@ class Database:
     """An API to the database under test."""
 
     def __init__(
-        self, port: int, host: str, user: str, password: Optional[str] = None
+        self,
+        port: int,
+        host: str,
+        user: str,
+        password: Optional[str],
+        require_ssl: bool,
     ) -> None:
         logging.debug(f"Initialize Database with host={host} port={port}, user={user}")
-        self.conn = pg8000.connect(host=host, port=port, user=user, password=password)
+
+        if require_ssl:
+            # verify_mode=ssl.CERT_REQUIRED is the default
+            ssl_context = ssl.create_default_context()
+        else:
+            ssl_context = None
+
+        self.conn = pg8000.connect(
+            host=host, port=port, user=user, password=password, ssl_context=ssl_context
+        )
         self.conn.autocommit = True
 
     def mz_version(self) -> str:

--- a/misc/python/stubs/pg8000/__init__.pyi
+++ b/misc/python/stubs/pg8000/__init__.pyi
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from ssl import SSLContext
 from types import TracebackType
 from typing import IO, Any, AnyStr, ContextManager, Deque, Optional, Sequence
 
@@ -36,4 +37,5 @@ def connect(
     database: Optional[str] = ...,
     password: Optional[str] = ...,
     timeout: Optional[int] = ...,
+    ssl_context: Optional[SSLContext] = ...,
 ) -> Connection: ...


### PR DESCRIPTION
This allows to connect to password-protected databases, including those in cloud prod or staging.

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR adds a feature that has not yet been specified.

This allows one to type `bin/optbench init tpch` with a suitable set of `--db-*` CLI options in order to initialize a tpch schema on a materialize instance running on https://cloud.materialize.com/.

### Tips for reviewer

* Nothing scary here.
* I talked to @bobbyiliev about potentially including the `ssl_context` config to [our Python examples](https://github.com/MaterializeInc/connection-examples/blob/main/python/connection.py) code (the current state only covers `psycopg2`).

I tested manually as follows:

```bash
PGPASSWORD="mzp_..." ./bin/optbench init tpch \
    --db-require-ssl \
    --db-user $my_email \
    --db-host my_host_id.us-east-1.aws.materialize.cloud \
    --db-port 6875
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
