### PR TITLE
stash: expose epoch counter

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -392,6 +392,10 @@ pub trait Stash: std::fmt::Debug + Send {
     /// point from the invocation of this method to the return of this
     /// method. Otherwise, returns `Err`.
     async fn confirm_leadership(&mut self) -> Result<(), StashError>;
+
+    /// Returns the stash's epoch number. If `Some`, it is a number that
+    /// increases with each start of a stash.
+    fn epoch(&self) -> Option<i64>;
 }
 
 /// `StashCollection` is like a differential dataflow [`Collection`], but the

--- a/src/stash/src/memory.rs
+++ b/src/stash/src/memory.rs
@@ -311,6 +311,10 @@ impl<S: Stash> Stash for Memory<S> {
     async fn confirm_leadership(&mut self) -> Result<(), StashError> {
         self.stash.confirm_leadership().await
     }
+
+    fn epoch(&self) -> Option<i64> {
+        self.stash.epoch()
+    }
 }
 
 #[async_trait]

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1054,6 +1054,10 @@ impl Stash for Postgres {
     async fn confirm_leadership(&mut self) -> Result<(), StashError> {
         self.transact(|_, _| Box::pin(async { Ok(()) })).await
     }
+
+    fn epoch(&self) -> Option<i64> {
+        self.epoch
+    }
 }
 
 impl From<tokio_postgres::Error> for StashError {

--- a/src/stash/src/sqlite.rs
+++ b/src/stash/src/sqlite.rs
@@ -507,6 +507,10 @@ impl Stash for Sqlite {
         // SQLite doesn't have a concept of leadership
         Ok(())
     }
+
+    fn epoch(&self) -> Option<i64> {
+        None
+    }
 }
 
 impl From<rusqlite::Error> for StashError {


### PR DESCRIPTION
Needed for an upcoming compute controller feature.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a