### PR TITLE
Coord: Separate capability of storage and compute

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -389,7 +389,7 @@ pub struct Coordinator<S> {
     /// to the controller for it to have an effect.
     ///
     /// Access to this field should be restricted to methods in the [`read_policy`] API.
-    storage_read_capability: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
+    storage_read_capabilities: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
     /// For each identifier in COMPUTE, its read policy and any read holds on time.
     ///
     /// Transactions should introduce and remove constraints through the methods
@@ -398,7 +398,7 @@ pub struct Coordinator<S> {
     /// to the controller for it to have an effect.
     ///
     /// Access to this field should be restricted to methods in the [`read_policy`] API.
-    compute_read_capability: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
+    compute_read_capabilities: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
 
     /// For each transaction, the pinned storage and compute identifiers and time at
     /// which they are pinned.
@@ -1096,8 +1096,8 @@ pub async fn serve<S: Append + 'static>(
                 global_timelines: timestamp_oracles,
                 transient_id_counter: 1,
                 active_conns: HashMap::new(),
-                storage_read_capability: Default::default(),
-                compute_read_capability: Default::default(),
+                storage_read_capabilities: Default::default(),
+                compute_read_capabilities: Default::default(),
                 txn_reads: Default::default(),
                 pending_peeks: HashMap::new(),
                 client_pending_peeks: HashMap::new(),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -381,7 +381,7 @@ pub struct Coordinator<S> {
     /// active connections.
     active_conns: HashMap<ConnectionId, ConnMeta>,
 
-    /// For each identifier, its read policy and any transaction holds on time.
+    /// For each identifier in STORAGE, its read policy and any read holds on time.
     ///
     /// Transactions should introduce and remove constraints through the methods
     /// `acquire_read_holds` and `release_read_holds`, respectively. The base
@@ -389,7 +389,17 @@ pub struct Coordinator<S> {
     /// to the controller for it to have an effect.
     ///
     /// Access to this field should be restricted to methods in the [`read_policy`] API.
-    read_capability: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
+    storage_read_capability: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
+    /// For each identifier in COMPUTE, its read policy and any read holds on time.
+    ///
+    /// Transactions should introduce and remove constraints through the methods
+    /// `acquire_read_holds` and `release_read_holds`, respectively. The base
+    /// policy can also be updated, though one should be sure to communicate this
+    /// to the controller for it to have an effect.
+    ///
+    /// Access to this field should be restricted to methods in the [`read_policy`] API.
+    compute_read_capability: HashMap<GlobalId, ReadCapability<mz_repr::Timestamp>>,
+
     /// For each transaction, the pinned storage and compute identifiers and time at
     /// which they are pinned.
     ///
@@ -1086,7 +1096,8 @@ pub async fn serve<S: Append + 'static>(
                 global_timelines: timestamp_oracles,
                 transient_id_counter: 1,
                 active_conns: HashMap::new(),
-                read_capability: Default::default(),
+                storage_read_capability: Default::default(),
+                compute_read_capability: Default::default(),
                 txn_reads: Default::default(),
                 pending_peeks: HashMap::new(),
                 client_pending_peeks: HashMap::new(),

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -396,6 +396,9 @@ impl<S: Append + 'static> Coordinator<S> {
         }
 
         // Drop storage sources.
+        for id in &source_ids {
+            self.drop_storage_read_policy(id);
+        }
         self.controller
             .storage
             .drop_sources(source_ids)

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -312,7 +312,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
     async fn drop_sources(&mut self, sources: Vec<GlobalId>) {
         for id in &sources {
-            self.drop_read_policy(id);
+            self.drop_storage_read_policy(id);
         }
         self.controller.storage.drop_sources(sources).await.unwrap();
     }
@@ -341,7 +341,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
     pub(crate) async fn drop_storage_sinks(&mut self, sinks: Vec<GlobalId>) {
         for id in &sinks {
-            self.drop_read_policy(id);
+            self.drop_storage_read_policy(id);
         }
         self.controller.storage.drop_sinks(sinks).await.unwrap();
     }
@@ -349,7 +349,7 @@ impl<S: Append + 'static> Coordinator<S> {
     pub(crate) async fn drop_indexes(&mut self, indexes: Vec<(ComputeInstanceId, GlobalId)>) {
         let mut by_compute_instance = HashMap::new();
         for (compute_instance, id) in indexes {
-            if self.drop_read_policy(&id) {
+            if self.drop_compute_read_policy(&id) {
                 by_compute_instance
                     .entry(compute_instance)
                     .or_insert(vec![])
@@ -371,7 +371,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut by_compute_instance = HashMap::new();
         let mut source_ids = Vec::new();
         for (compute_instance, id) in mviews {
-            if self.drop_read_policy(&id) {
+            if self.drop_compute_read_policy(&id) {
                 by_compute_instance
                     .entry(compute_instance)
                     .or_insert(vec![])

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -265,11 +265,11 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                             .holds
                             .update_iter(time.iter().map(|t| (*t, 1)));
                     }
-                    self.read_capability.insert(id, read_capability);
+                    self.compute_read_capability.insert(id, read_capability);
                     compute_policy_updates
                         .entry(compute_instance)
                         .or_default()
-                        .push((id, self.read_capability[&id].policy()));
+                        .push((id, self.compute_read_capability[&id].policy()));
                 }
             }
 
@@ -280,8 +280,8 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                         .holds
                         .update_iter(time.iter().map(|t| (*t, 1)));
                 }
-                self.read_capability.insert(id, read_capability);
-                storage_policy_updates.push((id, self.read_capability[&id].policy()));
+                self.storage_read_capability.insert(id, read_capability);
+                storage_policy_updates.push((id, self.storage_read_capability[&id].policy()));
             }
         }
 
@@ -317,7 +317,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         base_policy: ReadPolicy<mz_repr::Timestamp>,
     ) {
         let capability = self
-            .read_capability
+            .compute_read_capability
             .get_mut(&id)
             .expect("coord out of sync");
         capability.base_policy = base_policy;
@@ -328,11 +328,18 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             .unwrap();
     }
 
-    /// Drop read policy for `id`.
+    /// Drop read policy in STORAGE for `id`.
     ///
-    /// Returns true if `id` had a read policy and false otherwise
-    pub(crate) fn drop_read_policy(&mut self, id: &GlobalId) -> bool {
-        self.read_capability.remove(id).is_some()
+    /// Returns true if `id` had a read policy and false otherwise.
+    pub(crate) fn drop_storage_read_policy(&mut self, id: &GlobalId) -> bool {
+        self.storage_read_capability.remove(id).is_some()
+    }
+
+    /// Drop read policy in COMPUTE for `id`.
+    ///
+    /// Returns true if `id` had a read policy and false otherwise.
+    pub(crate) fn drop_compute_read_policy(&mut self, id: &GlobalId) -> bool {
+        self.compute_read_capability.remove(id).is_some()
     }
 
     /// Creates a `ReadHolds` struct that creates a read hold for each id in
@@ -393,7 +400,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         // Update STORAGE read policies.
         let mut policy_changes = Vec::new();
         for (time, id) in read_holds.storage_ids() {
-            let read_needs = self.read_capability.get_mut(id).unwrap();
+            let read_needs = self.storage_read_capability.get_mut(id).unwrap();
             read_needs.holds.update_iter(time.iter().map(|t| (*t, 1)));
             policy_changes.push((*id, read_needs.policy()));
         }
@@ -407,7 +414,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             let mut policy_changes = Vec::new();
             let mut compute = self.controller.active_compute();
             for (time, id) in compute_ids {
-                let read_needs = self.read_capability.get_mut(id).unwrap();
+                let read_needs = self.compute_read_capability.get_mut(id).unwrap();
                 read_needs.holds.update_iter(time.iter().map(|t| (*t, 1)));
                 policy_changes.push((*id, read_needs.policy()));
             }
@@ -456,7 +463,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                             new_time,
                             old_time,
                     );
-                    let read_needs = self.read_capability.get_mut(&id).unwrap();
+                    let read_needs = self.storage_read_capability.get_mut(&id).unwrap();
                     read_needs
                         .holds
                         .update_iter(new_time.iter().map(|t| (*t, 1)));
@@ -478,7 +485,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                                 new_time,
                                 old_time,
                         );
-                        let read_needs = self.read_capability.get_mut(&id).unwrap();
+                        let read_needs = self.compute_read_capability.get_mut(&id).unwrap();
                         read_needs
                             .holds
                             .update_iter(new_time.iter().map(|t| (*t, 1)));
@@ -529,7 +536,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         let mut policy_changes = Vec::new();
         for (time, id) in read_holds.storage_ids() {
             // It's possible that a concurrent DDL statement has already dropped this GlobalId
-            if let Some(read_needs) = self.read_capability.get_mut(id) {
+            if let Some(read_needs) = self.storage_read_capability.get_mut(id) {
                 read_needs.holds.update_iter(time.iter().map(|t| (*t, -1)));
                 policy_changes.push((*id, read_needs.policy()));
             }
@@ -545,7 +552,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             let mut policy_changes = Vec::new();
             for (time, id) in compute_ids {
                 // It's possible that a concurrent DDL statement has already dropped this GlobalId
-                if let Some(read_needs) = self.read_capability.get_mut(id) {
+                if let Some(read_needs) = self.compute_read_capability.get_mut(id) {
                     read_needs.holds.update_iter(time.iter().map(|t| (*t, -1)));
                     policy_changes.push((*id, read_needs.policy()));
                 }


### PR DESCRIPTION
Previously the Coordinator stored the read capability of all objects in
a map whose key was Global ID. For most objects this works fine since
most Global IDs refer to a single object. However for some objects,
such as materialized views and certain introspection sources, a COMPUTE
object and a STORAGE object share the same Global ID. This caused the
two objects to use the same value in the read capability map which led
to various inconsistencies.

This commit updates the Coordinator's state to store COMPUTE and
STORAGE read capabilities separately.

Fixes #15887

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A