### PR TITLE
Reduce MirScalarExprs when planning CREATE INDEX 

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -961,7 +961,9 @@ pub fn plan_index_exprs<'a>(
     for mut expr in exprs {
         transform_ast::transform_expr(scx, &mut expr)?;
         let expr = plan_expr_or_col_index(ecx, &expr)?;
-        out.push(expr.lower_uncorrelated()?);
+        let mut expr = expr.lower_uncorrelated()?;
+        expr.reduce(&on_desc.typ().column_types);
+        out.push(expr);
     }
     Ok(out)
 }

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -978,3 +978,24 @@ Used Indexes:
   - materialize.public.idx_t2_a_b_c
 
 EOF
+
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/15696
+
+statement ok
+CREATE TABLE bar(a BOOL, b BOOL);
+
+statement ok
+CREATE INDEX ON bar(b AND a);
+
+query T multiline
+EXPLAIN SELECT * FROM bar WHERE (b AND a) = TRUE;
+----
+Explained Query (fast path):
+  Project (#1, #2)
+    ReadExistingIndex materialize.public.bar_expr_idx lookup value (true)
+
+Used Indexes:
+  - materialize.public.bar_expr_idx
+
+EOF


### PR DESCRIPTION
Per #15696:
> CREATE INDEX is not calling MirScalarExpr::reduce on the index expressions. This can make some indexes unusable […]

Without this, at least `transform::CanonicalizeMfp::detect_literal_constraints` won't recognize that an index is usable, and possibly other parts of `transform::Optimizer`.

Clearly this makes the given test pass; I think the main question I have here is what other normalization might have been missed.  Is reduce on these exprs the only normalization of this kind we need?

### Motivation

This PR fixes #15696.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing behavior changes.
