### PR TITLE
Update to 1.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 
 [profile.dev]
 # TODO(gusywnn|benesch): remove this when incremental ice's are improved


### PR DESCRIPTION
- "MIR inlining is now enabled for optimized compilations. This provides a 3-10% improvement in compiletimes for real world crates."
- stable backtrace
- GATs
- let-else

my understanding is that the ci builder uses this value as well, so we should be good!
