### PR TITLE
storage: model type relationships through traits

### DIFF
--- a/src/storage/src/source/delimited_value_reader.rs
+++ b/src/storage/src/source/delimited_value_reader.rs
@@ -16,52 +16,70 @@ use mz_expr::PartitionId;
 use mz_repr::GlobalId;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
-use mz_storage_client::types::sources::MzOffset;
+use mz_storage_client::types::sources::{MzOffset, SourceConnection};
 
-use crate::source::types::SourceMessageType;
-use crate::source::types::SourceReaderError;
-use crate::source::types::{NextMessage, SourceMessage, SourceReader};
+use crate::source::types::{
+    NextMessage, SourceConnectionBuilder, SourceMessage, SourceMessageType, SourceReader,
+    SourceReaderError,
+};
+
+/// A wrapper that converts a delimited source connection that only provides
+/// values into a key/value reader whose key is always None
+#[derive(Clone)]
+pub struct DelimitedValueSourceConnection<C>(pub(crate) C);
 
 /// A wrapper that converts a delimited source reader that only provides
 /// values into a key/value reader whose key is always None
-pub struct DelimitedValueSource<S>(S);
+pub struct DelimitedValueSourceReader<S>(S);
 
-impl<S, D: timely::Data> SourceReader for DelimitedValueSource<S>
+impl<C: SourceConnection> SourceConnection for DelimitedValueSourceConnection<C> {
+    fn name(&self) -> &'static str {
+        self.0.name()
+    }
+}
+
+impl<C: SourceConnectionBuilder> SourceConnectionBuilder for DelimitedValueSourceConnection<C>
+where
+    C::Reader: SourceReader<Key = (), Value = Option<Vec<u8>>>,
+{
+    type Reader = DelimitedValueSourceReader<C::Reader>;
+    type OffsetCommitter = C::OffsetCommitter;
+
+    fn into_reader(
+        self,
+        source_name: String,
+        source_id: GlobalId,
+        worker_id: usize,
+        worker_count: usize,
+        consumer_activator: SyncActivator,
+        restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
+        encoding: SourceDataEncoding,
+        metrics: crate::source::metrics::SourceBaseMetrics,
+        connection_context: ConnectionContext,
+    ) -> Result<(Self::Reader, Self::OffsetCommitter), anyhow::Error> {
+        self.0
+            .into_reader(
+                source_name,
+                source_id,
+                worker_id,
+                worker_count,
+                consumer_activator,
+                restored_offsets,
+                encoding,
+                metrics,
+                connection_context,
+            )
+            .map(|(s, sc)| (DelimitedValueSourceReader(s), sc))
+    }
+}
+
+impl<S, D: timely::Data> SourceReader for DelimitedValueSourceReader<S>
 where
     S: SourceReader<Key = (), Value = Option<Vec<u8>>, Diff = D>,
 {
     type Key = Option<Vec<u8>>;
     type Value = Option<Vec<u8>>;
     type Diff = D;
-    type OffsetCommitter = S::OffsetCommitter;
-    type Connection = S::Connection;
-
-    fn new(
-        source_name: String,
-        source_id: GlobalId,
-        worker_id: usize,
-        worker_count: usize,
-        consumer_activator: SyncActivator,
-        connection: Self::Connection,
-        restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
-        encoding: SourceDataEncoding,
-        metrics: crate::source::metrics::SourceBaseMetrics,
-        connection_context: ConnectionContext,
-    ) -> Result<(Self, Self::OffsetCommitter), anyhow::Error> {
-        S::new(
-            source_name,
-            source_id,
-            worker_id,
-            worker_count,
-            consumer_activator,
-            connection,
-            restored_offsets,
-            encoding,
-            metrics,
-            connection_context,
-        )
-        .map(|(s, sc)| (Self(s), sc))
-    }
 
     fn get_next_message(
         &mut self,

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -53,7 +53,7 @@ mod source_reader_pipeline;
 pub mod testscript;
 pub mod types;
 
-pub use delimited_value_reader::DelimitedValueSource;
+pub use delimited_value_reader::DelimitedValueSourceConnection;
 pub use generator::LoadGeneratorSourceReader;
 pub use kafka::KafkaSourceReader;
 pub use kinesis::KinesisSourceReader;


### PR DESCRIPTION

### Motivation

Add a trait that encodes the 1-1 relationship between a `SourceConnection` and its corresponding `SourceReader` implementation.

Defining it this way instead of the other way around as it used to be requires less manual type annotations as there is only one reader that can be instantiated for a particular source connection.

This PR also fixes some generic parameters that were under-constrained so that type inference can figure them out instead.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
