### PR TITLE
add TimeZone and interval_style to notify set

### DIFF
--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -389,6 +389,8 @@ impl SessionVars {
             &self.integer_datetimes,
             &self.server_version,
             &self.standard_conforming_strings,
+            &self.timezone,
+            &self.interval_style,
         ]
         .into_iter()
     }


### PR DESCRIPTION
psycopg3 async code (at least) like to randomly segfault when `TimeZone` isn't known to `PQparameterStatus`.

I went ahead and added `interval_style` too, to match Postgres.