### PR TITLE
storage: punctuation response for strict id checks

### DIFF
--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -70,7 +70,11 @@ message ProtoStorageCommand {
 }
 
 message ProtoStorageResponse {
+    message ProtoDroppedIds {
+        repeated mz_repr.global_id.ProtoGlobalId ids = 1;
+    }
     oneof kind {
         ProtoFrontierUppersKind frontier_uppers = 1;
+        ProtoDroppedIds dropped_ids = 2;
     }
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1366,6 +1366,11 @@ where
                 self.update_write_frontiers(&updates).await?;
                 Ok(())
             }
+            Some(StorageResponse::DroppedIds(_ids)) => {
+                // TODO(petrosagg): It looks like the storage controller never cleans up GlobalIds
+                // from its state. It should probably be done as a reaction to this response.
+                Ok(())
+            }
         }
     }
 }

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -111,6 +111,7 @@ pub fn serve(
                 sink_tokens: HashMap::new(),
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
+                dropped_ids: Vec::new(),
             },
         }
         .run()

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -163,6 +163,7 @@ where
                 sink_tokens: HashMap::new(),
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
+                dropped_ids: Vec::new(),
             };
 
             let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);


### PR DESCRIPTION
### Motivation

This PR adds a new type of storage response that serves as punctuation to let consumers of the response stream know that there will be no further updates for a particular id.

This is the moment where clients in the client stack can clean up their state and forget about the existence of an id.

Since dropping an id is now an explicit response clients can be strict about how the protocol behaves and panic if we ever deviate which would indicate a bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
