### PR TITLE
Update mz CLI CLOUD_PROVIDERS path

### DIFF
--- a/src/mz/src/main.rs
+++ b/src/mz/src/main.rs
@@ -157,7 +157,7 @@ struct CloudProviderAndRegion {
 }
 
 /// Constants
-const CLOUD_PROVIDERS_URL: &str = "https://cloud.materialize.com/api/cloud-providers";
+const CLOUD_PROVIDERS_URL: &str = "https://cloud.materialize.com/_metadata/cloud-regions.json";
 const API_TOKEN_AUTH_URL: &str =
     "https://admin.cloud.materialize.com/identity/resources/users/api-tokens/v1";
 const API_FRONTEGG_TOKEN_AUTH_URL: &str =


### PR DESCRIPTION


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
  * This PR fixes a previously unreported bug.
`cloud-providers` was an internal-only endpoint used by the web UI. We recently removed it, which unexpectedly broke the `mz` CLI tool. To support this use-case we have introduced an officially-supported endpoint under the `_metadata/` path segment.


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes.
