### PR TITLE
Fix broken memory profiler due to #15878

### DIFF
--- a/src/prof/src/http/mod.rs
+++ b/src/prof/src/http/mod.rs
@@ -202,13 +202,13 @@ mod disabled {
             "time_fg" => {
                 let time_secs = time_secs.ok_or_else(|| {
                     (
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                        StatusCode::BAD_REQUEST,
                         "Expected value for `time_secs`".to_owned(),
                     )
                 })?;
                 let hz = hz.ok_or_else(|| {
                     (
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                        StatusCode::BAD_REQUEST,
                         "Expected value for `hz`".to_owned(),
                     )
                 })?;
@@ -387,13 +387,13 @@ mod enabled {
             "time_fg" => {
                 let time_secs = time_secs.ok_or_else(|| {
                     (
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                        StatusCode::BAD_REQUEST,
                         "Expected value for `time_secs`".to_owned(),
                     )
                 })?;
                 let hz = hz.ok_or_else(|| {
                     (
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                        StatusCode::BAD_REQUEST,
                         "Expected value for `hz`".to_owned(),
                     )
                 })?;


### PR DESCRIPTION
#15878 introduced some new form fields which are only filled in by the CPU profiling section of the page, so `ProfForm` couldn't be deserialized when using the memory profiling section. This fixes that bug.

### Motivation

  * This PR fixes a previously unreported bug.
  
The allocation profiler is completely broken 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
