### PR TITLE
Print status in SHOW CLUSTER REPLICAS

### DIFF
--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -22,10 +22,10 @@ SHOW CLUSTER REPLICAS;
 ```
 
 ```nofmt
-    cluster    | replica |  size  |
----------------+---------|--------|
- auction_house | bigger  | xlarge |
- default       | r1      | xsmall |
+    cluster    | replica |  size  | ready |
+---------------+---------|--------|-------|
+ auction_house | bigger  | xlarge | t     |
+ default       | r1      | xsmall | t     |
 ```
 
 ```sql
@@ -33,9 +33,9 @@ SHOW CLUSTER REPLICAS WHERE cluster='default';
 ```
 
 ```nofmt
-    cluster    | replica |  size  |
----------------+---------|--------|
- default       | r1      | xsmall |
+    cluster    | replica |  size  | ready|
+---------------+---------|--------|-------
+ default       | r1      | xsmall | t    |
 ```
 
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2351,13 +2351,15 @@ pub const MZ_SHOW_CLUSTER_REPLICAS: BuiltinView = BuiltinView {
             mz_catalog.mz_clusters.name AS cluster,
             mz_catalog.mz_cluster_replicas.name AS replica,
             mz_catalog.mz_cluster_replicas.size AS size,
-            statuses.ready
+            coalesce(statuses.ready, false) AS ready
         FROM
             mz_catalog.mz_cluster_replicas
                 JOIN
                     mz_catalog.mz_clusters
                     ON mz_catalog.mz_cluster_replicas.cluster_id = mz_catalog.mz_clusters.id
-                JOIN
+                -- TODO[btv] This has to be a left join, because `mz_cluster_replica_statuses`
+                -- is not filled in immediately on replica creation.
+                LEFT JOIN
                     (
                             SELECT
                                 replica_id,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2351,7 +2351,7 @@ pub const MZ_SHOW_CLUSTER_REPLICAS: BuiltinView = BuiltinView {
             mz_catalog.mz_clusters.name AS cluster,
             mz_catalog.mz_cluster_replicas.name AS replica,
             mz_catalog.mz_cluster_replicas.size AS size,
-            statuses.is_ready
+            statuses.ready
         FROM
             mz_catalog.mz_cluster_replicas
                 JOIN
@@ -2365,7 +2365,7 @@ pub const MZ_SHOW_CLUSTER_REPLICAS: BuiltinView = BuiltinView {
                                         mz_internal.mz_cluster_replica_statuses.status
                                         = 'ready'
                                     )
-                                    AS is_ready
+                                    AS ready
                             FROM mz_internal.mz_cluster_replica_statuses
                             GROUP BY replica_id
                         )
@@ -2483,7 +2483,7 @@ pub const MZ_SHOW_CLUSTER_REPLICAS_IND: BuiltinIndex = BuiltinIndex {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_show_cluster_replicas_ind
 IN CLUSTER mz_introspection
-ON mz_internal.mz_show_cluster_replicas (cluster, replica, size)",
+ON mz_internal.mz_show_cluster_replicas (cluster, replica, size, ready)",
 };
 
 pub const MZ_SHOW_SECRETS_IND: BuiltinIndex = BuiltinIndex {

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -551,8 +551,8 @@ pub fn show_cluster_replicas<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let query =
-        "SELECT cluster, replica, size, is_ready FROM mz_internal.mz_show_cluster_replicas".to_string();
+    let query = "SELECT cluster, replica, size, ready FROM mz_internal.mz_show_cluster_replicas"
+        .to_string();
 
     ShowSelect::new(scx, query, filter, None, None)
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -552,7 +552,7 @@ pub fn show_cluster_replicas<'a>(
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query =
-        "SELECT cluster, replica, size FROM mz_internal.mz_show_cluster_replicas".to_string();
+        "SELECT cluster, replica, size, is_ready FROM mz_internal.mz_show_cluster_replicas".to_string();
 
     ShowSelect::new(scx, query, filter, None, None)
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -611,6 +611,7 @@ impl<'a> ShowSelect<'a> {
             filter,
             order.unwrap_or("q.*")
         );
+        println!("[btv] query: {query}");
         let stmts = parse::parse(&query).expect("ShowSelect::new called with invalid SQL");
         let stmt = match stmts.into_element() {
             Statement::Select(select) => select,

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -378,7 +378,7 @@ CREATE CLUSTER REPLICA default.size_1 SIZE;
 statement ok
 CREATE CLUSTER REPLICA default.size_1 SIZE '1';
 
-query TTT
+query TTTT
 SHOW CLUSTER REPLICAS
 ----
 default r1 1 false
@@ -389,7 +389,7 @@ mz_system r1 1 false
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 
-query TTT
+query TTTT
 SHOW CLUSTER REPLICAS
 ----
 default r1 1 false
@@ -417,7 +417,7 @@ DROP CLUSTER REPLICA default.size_1
 statement ok
 DROP CLUSTER REPLICA foo.size_1, foo.size_2
 
-query TTT
+query TTTT
 SHOW CLUSTER REPLICAS
 ----
 default r1 1 false

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -381,10 +381,10 @@ CREATE CLUSTER REPLICA default.size_1 SIZE '1';
 query TTT
 SHOW CLUSTER REPLICAS
 ----
-default r1 1
-default size_1 1
-mz_introspection r1 1
-mz_system r1 1
+default r1 1 false
+default size_1 1 false
+mz_introspection r1 1 false
+mz_system r1 1 false
 
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
@@ -392,12 +392,12 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 query TTT
 SHOW CLUSTER REPLICAS
 ----
-default r1 1
-default size_1 1
-foo size_1 1
-foo size_2 2
-mz_introspection r1 1
-mz_system r1 1
+default r1 1 false
+default size_1 1 false
+foo size_1 1 false
+foo size_2 2 false
+mz_introspection r1 1 false
+mz_system r1 1 false
 
 statement ok
 DROP CLUSTER REPLICA IF EXISTS default.bar
@@ -420,9 +420,9 @@ DROP CLUSTER REPLICA foo.size_1, foo.size_2
 query TTT
 SHOW CLUSTER REPLICAS
 ----
-default r1 1
-mz_introspection r1 1
-mz_system r1 1
+default r1 1 false
+mz_introspection r1 1 false
+mz_system r1 1 false
 
 statement ok
 CREATE CLUSTER REPLICA default.foo_bar SIZE '1'

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -290,7 +290,7 @@ mz_raw_worker_compute_delays_s2_primary_idx                 mz_raw_worker_comput
 mz_scheduling_elapsed_internal_s2_primary_idx               mz_scheduling_elapsed_internal              mz_introspection    {id,worker_id}
 mz_scheduling_parks_internal_s2_primary_idx                 mz_scheduling_parks_internal                mz_introspection    {worker_id,slept_for,requested}
 mz_show_all_objects_ind                                     mz_objects                                  mz_introspection    {schema_id}
-mz_show_cluster_replicas_ind                                mz_show_cluster_replicas                    mz_introspection    {cluster,replica,size}
+mz_show_cluster_replicas_ind                                mz_show_cluster_replicas                    mz_introspection    {cluster,replica,size,ready}
 mz_show_clusters_ind                                        mz_clusters                                 mz_introspection    {name}
 mz_show_columns_ind                                         mz_columns                                  mz_introspection    {id}
 mz_show_connections_ind                                     mz_connections                              mz_introspection    {schema_id}

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -67,7 +67,7 @@ INSERT INTO temp SELECT * FROM temp
 2
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 1
+mz_system r1 1 false
 
 $ postgres-execute connection=mz_system
 DROP CLUSTER REPLICA mz_system.r1
@@ -78,4 +78,4 @@ $ postgres-execute connection=mz_system
 CREATE CLUSTER REPLICA mz_system.r1 SIZE '${arg.default-replica-size}';
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'mz_system'
-mz_system r1 ${arg.default-replica-size}
+mz_system r1 ${arg.default-replica-size} false


### PR DESCRIPTION
This is a useful thing to expose to users. Proposed by @ggnall in his observability notion doc.

### Motivation

  * This PR adds a feature that has not yet been specified.

The user should be able to easily see whether a replica is online

### Tips for reviewer

The formatting of the SQL query is from mz.sqlfum.pt

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `SHOW CLUSTER REPLICAS` now prints the replica status
