### PR TITLE
k8s-orchestrator: logically name containers

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use chrono::Utc;
 use clap::ArgEnum;
@@ -344,6 +344,15 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             // cluster-autoscaler. Notably, eviction of pods for resource overuse is still enabled.
             "cluster-autoscaler.kubernetes.io/safe-to-evict".to_owned() => "false".to_string(),
         };
+
+        let container_name = image
+            .splitn(2, '/')
+            .skip(1)
+            .next()
+            .and_then(|name_version| name_version.splitn(2, ':').next())
+            .context("`image` is not ORG/NAME:VERSION")?
+            .to_string();
+
         let mut pod_template_spec = PodTemplateSpec {
             metadata: Some(ObjectMeta {
                 labels: Some(labels.clone()),
@@ -352,7 +361,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             }),
             spec: Some(PodSpec {
                 containers: vec![Container {
-                    name: "default".into(),
+                    name: container_name,
                     image: Some(image),
                     args: Some(args),
                     image_pull_policy: Some(self.config.image_pull_policy.to_string()),


### PR DESCRIPTION
People have pointed out that the container name being `default` makes what would be the cleanest filter for questions like "give me all the logs for storaged instances in this environment" annoying/hard to write in honeycomb, so naming the containers accurately (as we do for `environmentd` right now)


Some notes:
- `format!("{}d", self.namespace)` is a bit hacky, but something better would require a discussion around adding an extension to the namespace api
- this would cause restart churn, but it'll be during a release so its fine!

### Motivation

  * This PR adds a known-desirable feature.
part of https://github.com/MaterializeInc/materialize/issues/15904


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

