### PR TITLE
parser: fix NULLIF printing

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -362,7 +362,7 @@ impl<T: AstInfo> AstDisplay for Expr<T> {
                 f.write_str(")");
             }
             Expr::NullIf { l_expr, r_expr } => {
-                f.write_str("COALESCE(");
+                f.write_str("NULLIF(");
                 f.write_node(&display::comma_separated(&[l_expr, r_expr]));
                 f.write_str(")");
             }

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1285,3 +1285,10 @@ SELECT * FROM (SHOW TABLES)
 SELECT * FROM (SHOW TABLES)
 =>
 Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: None })), order_by: [], limit: None, offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT NULLIF(x, '')
+----
+SELECT NULLIF(x, '')
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: NullIf { l_expr: Identifier([Ident("x")]), r_expr: Value(String("")) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })


### PR DESCRIPTION
This wasn't tested, otherwise the roundtrip test would have caught it.

Fixes https://github.com/MaterializeInc/materialize/issues/15942

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - **Breaking change.** Fix a bug causing `NULLIF` to be incorrectly converted to `COALESCE`. Any view that intended to have `NULLIF` must be manually dropped and recreated.