### PR TITLE
mzcompose: Fortify mzcompose against #15725

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -53,14 +53,6 @@ class StartMz(MzcomposeAction):
         )
 
         with c.override(mz):
-            # Work around https://github.com/MaterializeInc/materialize/issues/15725
-            # by cleaning up Process Orchestrator metadata on restart
-            c.run(
-                "materialized",
-                "-c",
-                "rm -rf /mzdata/*.pid /mzdata/*.ports",
-                entrypoint="bash",
-            )
             c.up("materialized")
 
         c.wait_for_materialized()

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -569,6 +569,16 @@ class Composition:
                 service["command"] = []
             self._write_compose()
 
+        if "materialized" in services:
+            # Work around https://github.com/MaterializeInc/materialize/issues/15725
+            # by cleaning up Process Orchestrator metadata on restart
+            self.run(
+                "materialized",
+                "-c",
+                "rm -rf /mzdata/*.pid /mzdata/*.ports",
+                entrypoint="bash",
+            )
+
         self.invoke("up", *(["--detach"] if detach else []), *services)
 
         if persistent:

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -19,15 +19,6 @@ class MzStart(Action):
     """Starts a Mz instance (all components are running in the same container)."""
 
     def run(self, c: Composition) -> None:
-        # Work around https://github.com/MaterializeInc/materialize/issues/15725
-        # by cleaning up Process Orchestrator metadata on restart
-        c.run(
-            "materialized",
-            "-c",
-            "rm -rf /mzdata/*.pid /mzdata/*.ports",
-            entrypoint="bash",
-        )
-
         c.up("materialized")
         # Loaded Mz environments take a while to start up
         c.wait_for_materialized(timeout_secs=300)


### PR DESCRIPTION
Due to #15725, environmentd may fail to spawn all the required computeds unless the process orchestrator metadata is wiped in advance.

We consolidate the wiping procedure in `up()` so that all testing frameworks that happen to restart Mz can benefit.

### Motivation

  * This PR fixes a previously unreported bug.
After the move to SIZE 4-4, more testing frameworks that restart Mz began exhibiting #15725 