### PR TITLE
coord: Don't count subsources for resource limits

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1408,6 +1408,14 @@ impl Source {
             DataSourceDesc::Introspection(_) | DataSourceDesc::Source => None,
         }
     }
+
+    /// Returns whether this source ingests data from an external source.
+    pub fn is_external(&self) -> bool {
+        match self.data_source {
+            DataSourceDesc::Ingestion(_) => true,
+            DataSourceDesc::Source | DataSourceDesc::Introspection(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -272,8 +272,11 @@ ALTER SYSTEM RESET ALL
 
 # Test sub-sources are excluded from source counts
 
+> DROP TABLE t3;
+> DROP TABLE t4;
+
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_sources = 1
+ALTER SYSTEM SET max_sources = 2
 
 # Insert Postgres data
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -287,9 +290,12 @@ CREATE TABLE t1 (a INT);
 ALTER TABLE t1 REPLICA IDENTITY FULL;
 CREATE TABLE t2 (b INT);
 ALTER TABLE t2 REPLICA IDENTITY FULL;
+CREATE TABLE t3 (c INT);
+ALTER TABLE t3 REPLICA IDENTITY FULL;
 
 INSERT INTO t1 VALUES (1);
-INSERT INTO t2 VALUES (2)
+INSERT INTO t2 VALUES (2);
+INSERT INTO t3 VALUES (3);
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
@@ -309,6 +315,24 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > SELECT * FROM t2
 2
+
+> SELECT * FROM t3
+3
+
+# Insert more Postgres data
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP PUBLICATION IF EXISTS mz_source2;
+CREATE TABLE t4 (d INT);
+ALTER TABLE t4 REPLICA IDENTITY FULL;
+INSERT INTO t4 VALUES (4);
+CREATE PUBLICATION mz_source2 FOR TABLE t4;
+
+> CREATE SOURCE mz_source2
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source2')
+  FOR ALL TABLES;
+
+> SELECT * FROM t4
+4
 
 > SHOW max_aws_privatelink_connections
 0


### PR DESCRIPTION
f650ffb56e726b63e6778ff59ca71490f146bd1d excluded counting subsources when counting new sources to create. However, it still included subsources when counting how many sources already exist. This commit fixes that issue so that subsources are excluded from the count of existing sources.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fixes bug in counting max sources.
