### PR TITLE
compute: assert that imported indexes are not compacted

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::Instant;
 
+use differential_dataflow::lattice::antichain_join;
 use differential_dataflow::trace::TraceReader;
 use prometheus::core::{AtomicF64, AtomicU64};
 use timely::progress::frontier::{Antichain, AntichainRef};
@@ -232,5 +233,13 @@ impl TraceBundle {
     /// Returns a reference to the `to_drop` tokens.
     pub fn to_drop(&self) -> &Option<Rc<dyn Any>> {
         &self.to_drop
+    }
+
+    /// Returns the frontier up to which the traces have been allowed to compact.
+    pub fn compaction_frontier(&mut self) -> Antichain<Timestamp> {
+        antichain_join(
+            &self.oks.get_logical_compaction(),
+            &self.errs.get_logical_compaction(),
+        )
     }
 }


### PR DESCRIPTION
This change makes Philip's repro for #15185... still fail, but with a panic instead of silently missed rows.

```
thread 'timely:work-0' panicked at 'Index u2 has been allowed to compact beyond the dataflow as_of', src/compute/src/render/mod.rs:324:13
```

### Motivation

  * This PR adds a feature that has not yet been specified.

    Crashing early in this case should help us find bugs. It is certainly preferable to spending days debugging join operators!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
