### PR TITLE
[DONOTMERGE] reintroduce persist bug for antithesis testing

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -468,44 +468,21 @@ where
         //   these batches, all data physically in the batch but outside of the
         //   truncated bounds must be ignored. Not every user batch is
         //   truncated.
-        // - Batches written by compaction. These always have an inline desc
-        //   that exactly matches the one they are registered with. The since
-        //   can be anything.
+        // - Batches written by compaction. These always have an inline desc that
+        //   is a subset of the description they are registered with. The since can
+        //   be anything.
         let inline_desc = &part.desc;
-        let needs_truncation = inline_desc.lower() != registered_desc.lower()
-            || inline_desc.upper() != registered_desc.upper();
-        if needs_truncation {
+        // Technically we could truncate any batch where the since is less_than the
+        // output_desc's lower, but we're strict here so we don't get any surprises.
+        let needs_truncation = inline_desc.since() == &Antichain::from_elem(T::minimum());
+        if !needs_truncation {
             assert!(
-                PartialOrder::less_equal(inline_desc.lower(), registered_desc.lower()),
+                PartialOrder::less_equal(registered_desc.lower(), inline_desc.lower())
+                    && PartialOrder::less_equal(inline_desc.upper(), registered_desc.upper()),
                 "key={} inline={:?} registered={:?}",
                 key,
                 inline_desc,
                 registered_desc
-            );
-            assert!(
-                PartialOrder::less_equal(registered_desc.upper(), inline_desc.upper()),
-                "key={} inline={:?} registered={:?}",
-                key,
-                inline_desc,
-                registered_desc
-            );
-            // As mentioned above, batches that needs truncation will always have a
-            // since of the minimum timestamp. Technically we could truncate any
-            // batch where the since is less_than the output_desc's lower, but we're
-            // strict here so we don't get any surprises.
-            assert_eq!(
-                inline_desc.since(),
-                &Antichain::from_elem(T::minimum()),
-                "key={} inline={:?} registered={:?}",
-                key,
-                inline_desc,
-                registered_desc
-            );
-        } else {
-            assert_eq!(
-                inline_desc, &registered_desc,
-                "key={} inline={:?} registered={:?}",
-                key, inline_desc, registered_desc
             );
         }
 

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -29,7 +29,7 @@ use mz_persist::indexed::columnar::{
 };
 use mz_persist::location::Blob;
 use mz_persist_types::{Codec, Codec64};
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot, TryAcquireError};
@@ -334,6 +334,39 @@ where
         writer_id: WriterId,
     ) -> Result<CompactRes<T>, anyhow::Error> {
         let () = Self::validate_req(&req)?;
+
+        // special case: if our inputs only contain a single batch with >0 updates in a single run,
+        // we can return the same batch with an updated description to avoid pulling it down and
+        // rewriting it.
+        let mut single_nonempty_batch = None;
+        for batch in &req.inputs {
+            if batch.len > 0 {
+                match single_nonempty_batch {
+                    None => single_nonempty_batch = Some(batch),
+                    Some(_previous_nonempty_batch) => {
+                        single_nonempty_batch = None;
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(single_nonempty_batch) = single_nonempty_batch {
+            // if we have a single nonempty batch, we still want to compact if:
+            //   - it has >1 run, so its runs can be merged together
+            //   - it it has a since of the minimum antichain. this implies the batch was
+            //     produced by a writer's append (i.e. not from compaction), and it could
+            //     require truncation. rewriting the batch via compaction will trim out any
+            //     of the unneeded data.
+            if single_nonempty_batch.runs.len() == 0
+                && single_nonempty_batch.desc.since() != &Antichain::from_elem(T::minimum())
+            {
+                let mut output = single_nonempty_batch.clone();
+                output.desc = req.desc;
+                metrics.compaction.single_batch_fast_path.inc();
+                return Ok(CompactRes { output });
+            }
+        }
+
         // compaction needs memory enough for at least 2 runs and 2 in-progress parts
         assert!(cfg.compaction_memory_bound_bytes >= 4 * cfg.blob_target_size);
         // reserve space for the in-progress part to be held in-mem representation and columnar

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -983,6 +983,11 @@ pub mod datadriven {
         let upper = args.expect_antichain("upper");
         let target_size = args.optional("target_size");
         let parts_size_override = args.optional("parts_size_override");
+        let runs = args.optional_str("runs").map(|x| {
+            x.split(',')
+                .map(|s| s.parse::<usize>().expect("invalid run"))
+                .collect()
+        });
         let updates = args.input.split('\n').flat_map(DirectiveArgs::parse_update);
 
         let mut cfg = datadriven.client.cfg.clone();
@@ -1002,11 +1007,15 @@ pub mod datadriven {
         for ((k, ()), t, d) in updates {
             builder.add(&k, &(), &t, &d).await.expect("invalid batch");
         }
-        let batch = builder
+        let mut batch = builder
             .finish(upper)
             .await
             .expect("invalid batch")
             .into_hollow_batch();
+
+        if let Some(runs) = runs {
+            batch.runs = runs;
+        }
 
         if let Some(size) = parts_size_override {
             let mut batch = batch.clone();
@@ -1084,13 +1093,18 @@ pub mod datadriven {
         let output = args.expect_str("output");
         let lower = args.expect_antichain("lower");
         let upper = args.expect_antichain("upper");
+        let since = args.optional_antichain("since");
 
         let mut batch = datadriven
             .batches
             .get(input)
             .expect("unknown batch")
             .clone();
-        let truncated_desc = Description::new(lower, upper, batch.desc.since().clone());
+        let truncated_desc = Description::new(
+            lower,
+            upper,
+            since.unwrap_or_else(|| batch.desc.since().clone()),
+        );
         let () = validate_truncate_batch(&batch.desc, &truncated_desc)?;
         batch.desc = truncated_desc;
         datadriven.batches.insert(output.to_owned(), batch.clone());

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -602,6 +602,7 @@ pub struct CompactionMetrics {
     pub(crate) noop: IntCounter,
     pub(crate) seconds: Counter,
     pub(crate) concurrency_waits: IntCounter,
+    pub(crate) single_batch_fast_path: IntCounter,
     pub(crate) memory_violations: IntCounter,
     pub(crate) runs_compacted: IntCounter,
     pub(crate) chunks_compacted: IntCounter,
@@ -667,6 +668,10 @@ impl CompactionMetrics {
             concurrency_waits: registry.register(metric!(
                 name: "mz_persist_compaction_concurrency_waits",
                 help: "count of compaction requests that ever blocked due to concurrency limit",
+            )),
+            single_batch_fast_path: registry.register(metric!(
+                name: "mz_persist_compaction_single_batch_fast_path",
+                help: "count of single nonempty batch fast path compactions",
             )),
             memory_violations: registry.register(metric!(
                 name: "mz_persist_compaction_memory_violations",

--- a/src/persist-client/tests/machine/compaction_single
+++ b/src/persist-client/tests/machine/compaction_single
@@ -1,0 +1,147 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+## Compaction with a single nonempty input is special cased to
+## return the nonempty batch directly with a new description
+
+# always compact if our only nonempty batch has a since of [0], in order to trim truncatable data
+write-batch output=b lower=1 upper=2
+zero 1 1
+----
+parts=1 len=1
+
+compact output=b_compacted inputs=(b) lower=1 upper=2 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b_compacted
+----
+<part 0>
+zero 99 1
+<run 0>
+part 0
+
+# attempting to compact our just-compacted batch should hit our special case,
+# as it is the single nonempty batch with since in advance of [0]
+compact output=b_compacted_again inputs=(b_compacted) lower=1 upper=2 since=999
+----
+parts=1 len=1
+
+# (the timestamp has not advanced, confirming we're reading the same contents referred by b_compacted)
+fetch-batch input=b_compacted_again
+----
+<part 0>
+zero 99 1
+<run 0>
+part 0
+
+# always compact if our only nonempty batch has >1 run, in order to consolidate across runs
+write-batch output=b lower=1 upper=2 target_size=0 runs=1
+zero 1 1
+one 1 1
+----
+parts=2 len=2
+
+# (same lower/upper, but rewrite the since to be in advance of [0])
+truncate-batch-desc input=b output=b lower=1 upper=2 since=1
+----
+parts=2 len=2
+
+fetch-batch input=b
+----
+<part 0>
+zero 1 1
+<part 1>
+one 1 1
+<run 0>
+part 0
+<run 1>
+part 1
+
+compact output=b_compacted inputs=(b) lower=1 upper=2 since=99
+----
+parts=1 len=2
+
+fetch-batch input=b_compacted
+----
+<part 0>
+one 99 1
+zero 99 1
+<run 0>
+part 0
+
+
+# now let's cover cases where we skip compaction and send back the same batch with a new description
+write-batch output=b0 lower=0 upper=1
+----
+parts=0 len=0
+
+write-batch output=b1 lower=1 upper=2
+zero 1 1
+----
+parts=1 len=1
+
+truncate-batch-desc input=b1 output=b1 lower=1 upper=2 since=1
+----
+parts=1 len=1
+
+write-batch output=b2 lower=2 upper=3
+----
+parts=0 len=0
+
+write-batch output=b3 lower=3 upper=4
+----
+parts=0 len=0
+
+# compacting b1 with empty batches will return a batch pointing to the same keys as b1, but with an updated desc
+compact output=b1_unchanged inputs=(b0,b1,b2,b3) lower=0 upper=4 since=99
+----
+parts=1 len=1
+
+# (the timestamp has not advanced, confirming we're reading the same contents referred by b1)
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
+<run 0>
+part 0
+
+# and test edge cases of our non-empty batch being the lower / upper / only batch
+compact output=b1_unchanged inputs=(b1,b2) lower=1 upper=3 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
+<run 0>
+part 0
+
+compact output=b1_unchanged inputs=(b0,b1) lower=0 upper=2 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
+<run 0>
+part 0
+
+compact output=b1_unchanged inputs=(b1) lower=1 upper=2 since=99
+----
+parts=1 len=1
+
+fetch-batch input=b1_unchanged
+----
+<part 0>
+zero 1 1
+<run 0>
+part 0


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Reintroduces the bug in https://github.com/MaterializeInc/materialize/issues/15590, where we could delete a blob during compaction (if it doesn't apply cleanly) that's still referenced in state. Hoping to repro in Antithesis, and if we're able to find it, should give us more confidence that our future _fix_ for the bug actually works

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
