### PR TITLE
Clean up of frontier introspection events during reconciliation

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -161,11 +161,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     Antichain::from_elem(timely::progress::Timestamp::minimum()),
                 ) {
                     error!(
-                        "existing frontier {} for newly created dataflow id {}",
-                        frontier
-                            .get(0)
-                            .expect("empty frontier found for newly created dataflow"),
-                        object_id
+                        "existing frontier {frontier:?} for newly created dataflow id {object_id}"
                     );
                 }
 
@@ -542,11 +538,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 Antichain::from_elem(timely::progress::Timestamp::minimum()),
             ) {
                 error!(
-                    "existing frontier {} for newly initialized logging export id {}",
-                    frontier
-                        .get(0)
-                        .expect("empty frontier found for newly initialized logging export"),
-                    id
+                    "existing frontier {frontier:?} for newly initialized logging export id {id}"
                 );
             }
             logger.log(ComputeEvent::Frontier(

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -41,7 +41,7 @@ use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::activator::RcActivator;
 use mz_timely_util::operator::CollectionExt;
-use tracing::{span, Level};
+use tracing::{error, span, Level};
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
@@ -156,10 +156,18 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
             // Initialize frontiers for each object, and optionally log their construction.
             for (object_id, collection_id) in exported_ids {
-                self.compute_state.reported_frontiers.insert(
+                if let Some(frontier) = self.compute_state.reported_frontiers.insert(
                     object_id,
                     Antichain::from_elem(timely::progress::Timestamp::minimum()),
-                );
+                ) {
+                    error!(
+                        "existing frontier {} for newly created dataflow id {}",
+                        frontier
+                            .get(0)
+                            .expect("empty frontier found for newly created dataflow"),
+                        object_id
+                    );
+                }
 
                 // Log dataflow construction, frontier construction, and any dependencies.
                 if let Some(logger) = self.compute_state.compute_logger.as_mut() {
@@ -204,7 +212,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     .expect("Dropped compute collection with no frontier");
                 if let Some(logger) = self.compute_state.compute_logger.as_mut() {
                     logger.log(ComputeEvent::Dataflow(id, false));
-                    for time in prev_frontier.elements().iter() {
+                    if let Some(time) = prev_frontier.get(0) {
                         logger.log(ComputeEvent::Frontier(id, *time, -1));
                     }
                 }
@@ -529,10 +537,18 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let index_ids = logging.index_logs.values().copied();
         let sink_ids = logging.sink_logs.values().map(|(id, _)| *id);
         for id in index_ids.chain(sink_ids) {
-            self.compute_state.reported_frontiers.insert(
+            if let Some(frontier) = self.compute_state.reported_frontiers.insert(
                 id,
                 Antichain::from_elem(timely::progress::Timestamp::minimum()),
-            );
+            ) {
+                error!(
+                    "existing frontier {} for newly initialized logging export id {}",
+                    frontier
+                        .get(0)
+                        .expect("empty frontier found for newly initialized logging export"),
+                    id
+                );
+            }
             logger.log(ComputeEvent::Frontier(
                 id,
                 timely::progress::Timestamp::minimum(),

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -838,13 +838,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     if let Some(time) = frontier.get(0) {
                         use crate::logging::compute::ComputeEvent;
                         logger.log(ComputeEvent::Frontier(*id, *time, -1));
-                        logger.log(ComputeEvent::Frontier(
-                            *id,
-                            *(minimum
-                                .get(0)
-                                .expect("minimum antichain should not be empty")),
-                            1,
-                        ));
+                        logger.log(ComputeEvent::Frontier(*id, Timestamp::minimum(), 1));
                     }
                 }
                 *frontier = minimum;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -833,7 +833,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // We compact away removed frontiers, and so only need to reset ids we continue to use.
             // We must remember, though, to compensate what already was sent to logging sources.
             for (id, frontier) in compute_state.reported_frontiers.iter_mut() {
-                let minimum = timely::progress::Antichain::from_elem(<_>::minimum());
                 if let Some(logger) = &compute_state.compute_logger {
                     if let Some(time) = frontier.get(0) {
                         use crate::logging::compute::ComputeEvent;
@@ -841,7 +840,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         logger.log(ComputeEvent::Frontier(*id, Timestamp::minimum(), 1));
                     }
                 }
-                *frontier = minimum;
+                *frontier = timely::progress::Antichain::from_elem(<_>::minimum());
             }
             // Sink tokens should be retained for retained dataflows, and dropped for dropped dataflows.
             compute_state


### PR DESCRIPTION
In issue #15930, it was observed that executing reconciliation after the crash of `environmentd` with existing `computed`s, the introspection source `mz_worker_compute_frontiers` was left in an inconsistent state where excessive retractions had been issued with a logical timestamp of zero.

This PR resolves this problem by fixes to the replica-side reconciliation code. In particular, the reconciliation code was resetting replica-side metadata in `ComputeState` regarding `reported_frontiers`, but did not consider that this reset had to be aligned with reporting to the corresponding logging source. 

Advances #15930. The PR addresses the issue, but lacks regression testing. A future PR introducing regression testing is necessary to eventually fix the issue.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/15930

### Tips for reviewer

The PR includes the fixes to the reconciliation code, but also some hardening of related code performing logging of `ComputeEvent::Frontier` events. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  The PR was tested locally by repeating the reproduction steps documented in #15930.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
