### PR TITLE
sqllogictest: teach simple about users

### DIFF
--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -103,6 +103,13 @@ named connection. It will be created on first use. This can be used to
 test transaction isolation or otherwise do things that require multiple
 connections.
 
+If `conn` is specified, an additional `,user=<name>` can be added to specify the
+connecting user. If the user is `mz_system`, the internal SQL port will be used
+on which system commands like `ALTER SYSTEM` can be used.
+
+> simple conn=mz_system,user=mz_system
+> <SQL>
+
 The output is one line per row, one "COMPLETE X" (where X is the
 number of affected rows) per statement, or an error message.
 

--- a/src/sqllogictest/src/ast.rs
+++ b/src/sqllogictest/src/ast.rs
@@ -128,6 +128,7 @@ pub enum Record<'a> {
     Simple {
         location: Location,
         conn: Option<&'a str>,
+        user: Option<&'a str>,
         sql: &'a str,
         output: Output,
         output_str: &'a str,

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -194,3 +194,9 @@ SHOW extra_float_digits
 ----
 -3
 COMPLETE 1
+
+# Test the user= syntax for sqllogictest itself.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET max_tables = 100
+----
+COMPLETE 0


### PR DESCRIPTION
Allow testing things needing `ALTER SYSTEM` in sqllogictest.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a