### PR TITLE
doc/user: polish v0.31.0 release notes

### DIFF
--- a/doc/user/content/releases/v0.30.md
+++ b/doc/user/content/releases/v0.30.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.30"
 date: 2022-11-02
 released: true
-patch: 1
+patch: 2
 ---
 
 ## Changes

--- a/doc/user/content/releases/v0.31.md
+++ b/doc/user/content/releases/v0.31.md
@@ -1,13 +1,28 @@
 ---
 title: "Materialize v0.31"
 date: 2022-11-09
-released: false
+released: true
 ---
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
 
 ## Changes
 
-* No documented changes yet.
+* **Breaking change.** Fix a bug that caused `NULLIF` to be incorrectly
+    converted to `COALESCE` {{% gh 15943 %}}. Existing views and materialized
+    views using `NULLIF` must be manually dropped and recreated.
+
+* Include the replica status in the output of [`SHOW CLUSTER REPLICAS`](/sql/show-cluster-replicas/)
+  as a new column named `ready`, which indicates if a cluster replica is
+  online (`t`) or not (`f`).
+
+* Improve the output of [`EXPLAIN`](/sql/explain/) to make the printing of index
+  lookups consistent regardless of whether the explained query uses the fast
+  path or not. For both cases, the output will look similar to:
+
+  ```nofmt
+  ReadExistingIndex materialize.public.t1 lookup values [("l2"); ("l3")]
+  ```
+
+* Fix a bug where subsources were counted towards resource limits for existing
+  sources {{% gh 15958 %}}. This resulted in an error for users of the Postgres
+  source if the number of replicated tables exceeded the default value for
+  `max_sources` (25).

--- a/doc/user/content/releases/v0.32.md
+++ b/doc/user/content/releases/v0.32.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.32"
+date: 2022-11-16
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## Changes
+
+* No documented changes yet.


### PR DESCRIPTION
Release notes for v0.31.0. ☁️ 

## Tips for reviewer

- Although #15516 wasn't included in the release notes for v0.29.0 and I was inclined to not include #15958, some users ran into the error caused by this bug.
- Deliberately left out:
  - #15766, which doesn't fix the user-facing asks in #14034;
  - #15867, which is a fix for behavior that was undesired in the first place.
- I assumed that the spine deletion fix that went into v0.30.2 didn't call for a release note, but if you can think of a nice way to phrase it, go for it @benesch!