### PR TITLE
expr: correctly return NULL on jsonb path array

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1346,7 +1346,10 @@ fn jsonb_get_path<'a>(
                         // index backwards from the end
                         (list.iter().count() as i64) + i
                     };
-                    list.iter().nth(i as usize).unwrap_or(Datum::Null)
+                    match list.iter().nth(i as usize) {
+                        Some(e) => e,
+                        None => return Datum::Null,
+                    }
                 }
                 Err(_) => return Datum::Null,
             },

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -649,6 +649,11 @@ SELECT '{"a":[null]}'::JSONB#>>'{a,0}'::STRING[]
 ----
 NULL
 
+query T
+SELECT '{"a": [1]}'::jsonb #>> '{a,1}';
+----
+NULL
+
 query BB
 SELECT '{"a":1}'::JSONB ? 'a','{"a":1}'::JSONB ? 'b'
 ----


### PR DESCRIPTION
Fixes #15964

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fix a crash in the `#>>` operator when specifying an array index that does not exist.