### PR TITLE
enable frame pointers

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,4 +5,6 @@
 #
 # See: https://github.com/rust-lang/rust/issues/56068
 # See: https://reviews.llvm.org/D74169#1990180
+#
+# We enable frame pointers to (hopefully) improve the speed of backtrace collection
 rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-C", "force-frame-pointers=true"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -5,4 +5,4 @@
 #
 # See: https://github.com/rust-lang/rust/issues/56068
 # See: https://reviews.llvm.org/D74169#1990180
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]
+rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-C", "force-frame-pointers=true"]


### PR DESCRIPTION
Polar Signals have advised us that frame pointers are the preferred way to collect backtraces. Let's try it out.

The extra code bloat is probably not going to move the needle for us on perf, but good to keep it in mind if we run out of low-hanging fruit a few years down the road.

### Motivation

  * This PR adds a feature that has not yet been specified.

Build Materialize with frame pointers to enable faster backtracing

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None