### PR TITLE
Regression testing for invalid retractions from `mz_worker_compute_frontiers` upon reconciliation

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -315,8 +315,6 @@ def workflow_test_github_15930(c: Composition) -> None:
 
     c.down(destroy_volumes=True)
     with c.override(
-        # Start postgres for the pg source
-        Postgres(),
         Testdrive(no_reset=True),
     ):
         c.up("testdrive", persistent=True)


### PR DESCRIPTION
In #15930, we observed that invalid retractions for the introspection source `mz_worker_compute_frontiers` could be triggered by reconciliation. This undesirable behavior was amended in PR #15967; however, the latter PR did not include any regression testing for the issue.

This PR provides the missing regression test for issue #15930 in the form of a `mzcompose` workflow in `test/cluster/mzcompose.py`. The test workflow exercises `environmentd` crashes with and without the existence of user-defined objects in the schema. These two scenarios were the ones identified as reproductions in the comments https://github.com/MaterializeInc/materialize/issues/15930#issuecomment-1307072696 and https://github.com/MaterializeInc/materialize/issues/15930#issuecomment-1307128529.

Fixes #15930. This PR jointly fixes the issue by complementing PR #15967 with regression testing.  

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/15930

### Tips for reviewer

It would be great to get some feedback on whether my use of the testing framework was adequate or has opportunities for improvements. What I tried to achieve was to encode the two scenarios in the comments  https://github.com/MaterializeInc/materialize/issues/15930#issuecomment-1307072696 and https://github.com/MaterializeInc/materialize/issues/15930#issuecomment-1307128529 as a `mzcompose.py` workflow.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
