### PR TITLE
persist: remove dep on tokio-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,7 +3865,6 @@ dependencies = [
  "tempfile",
  "timely",
  "tokio",
- "tokio-test",
  "tracing",
  "uuid",
 ]
@@ -6854,19 +6853,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -38,7 +38,7 @@ futures = "0.3.24"
 futures-util = "0.3"
 humantime = "2.1.0"
 mz-build-info = { path = "../build-info" }
-mz-ore = { path = "../ore", features = ["tracing"] }
+mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
@@ -71,7 +71,6 @@ num_cpus = "1.13.1"
 num_enum = "0.5.7"
 serde_json = "1.0.86"
 tempfile = "3.2.0"
-tokio-test = "0.4.2"
 
 [build-dependencies]
 prost-build = "0.11.1"

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -174,11 +174,10 @@ where
     ///
     /// ```rust,no_run
     /// use timely::progress::Antichain;
-    /// use tokio_test;
     /// use mz_persist_client::critical::SinceHandle;
     /// use mz_persist_types::Codec64;
     ///
-    /// # tokio_test::block_on(async {
+    /// # async fn example() {
     /// let fencing_token: u64 = unimplemented!();
     /// let mut since: SinceHandle<String, String, u64, i64, u64> = unimplemented!();
     ///
@@ -201,7 +200,7 @@ where
     ///         // no problem, we'll try again later
     ///     }
     /// }
-    /// # });
+    /// # }
     /// ```
     ///
     /// If fencing is not required and it's acceptable to have concurrent [SinceHandle] for
@@ -209,11 +208,10 @@ where
     ///
     /// ```rust,no_run
     /// use timely::progress::Antichain;
-    /// use tokio_test;
     /// use mz_persist_client::critical::SinceHandle;
     /// use mz_persist_types::Codec64;
     ///
-    /// # tokio_test::block_on(async {
+    /// # async fn example() {
     /// let mut since: SinceHandle<String, String, u64, i64, u64> = unimplemented!();
     /// let new_since: Antichain<u64> = unimplemented!();
     /// let res = since
@@ -234,7 +232,7 @@ where
     ///         // no problem, we'll try again later
     ///     }
     /// };
-    /// # })
+    /// # }
     /// ```
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn maybe_compare_and_downgrade_since(


### PR DESCRIPTION
It was showing up for philip as an unused dep.

(While I'm in here, correct the "tracing" -> "tracing_" feature on our mz_ore dep.)


### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
