### PR TITLE
Remove a stale TODO

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -383,7 +383,6 @@ impl<S: Append + 'static> Coordinator<S> {
         }
 
         // Drop compute sinks.
-        // TODO(chae): Drop storage sinks when they're moved over
         let mut compute = self.controller.active_compute();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.


### PR DESCRIPTION
### Motivation

   * This PR removes a stale comment TODO.

[Context in Slack](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1667809793126529)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
