### PR TITLE
dbt-materialize: release v1.3.0

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * Upgrade to `dbt-postgres` v1.3.0.
 
-* Enable support for `any_value`, `bool_or`, `cast_bool_to_text`, `concat`, 
-  `date_add`, `date_diff`, `date_trunc`, `escape_single_quotes`, `except`, 
-  `hash`, `intercept`, `last_day`, `length`, `position`, `replace`, `right`, 
+* Enable support for `any_value`, `bool_or`, `cast_bool_to_text`, `concat`,
+  `date_add`, `date_diff`, `date_trunc`, `escape_single_quotes`, `except`,
+  `hash`, `intercept`, `last_day`, `length`, `position`, `replace`, `right`,
   `safe_cast`, `split_part`, `string_literal`, `current_timestamp` macros.
 
 ## 1.2.1 - 2022-11-01

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -4,10 +4,7 @@
 
 * Upgrade to `dbt-postgres` v1.3.0.
 
-* Enable support for `any_value`, `bool_or`, `cast_bool_to_text`, `concat`,
-  `date_add`, `date_diff`, `date_trunc`, `escape_single_quotes`, `except`,
-  `hash`, `intercept`, `last_day`, `length`, `position`, `replace`, `right`,
-  `safe_cast`, `split_part`, `string_literal`, `current_timestamp` macros.
+* Migrate cross-database macros from [`materialize-dbt-utils`](https://github.com/MaterializeInc/materialize-dbt-utils) into the adapter, as a result of [dbt-core #5298](https://github.com/dbt-labs/dbt-core/pull/5298). The `utils` macros will be deprecated in the upcoming release of the package, and removed in a subsequent release.
 
 ## 1.2.1 - 2022-11-01
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,14 @@
 # dbt-materialize Changelog
 
+## 1.3.0 - 2022-11-09
+
+* Upgrade to `dbt-postgres` v1.3.0.
+
+* Enable support for `any_value`, `bool_or`, `cast_bool_to_text`, `concat`, 
+  `date_add`, `date_diff`, `date_trunc`, `escape_single_quotes`, `except`, 
+  `hash`, `intercept`, `last_day`, `length`, `position`, `replace`, `right`, 
+  `safe_cast`, `split_part`, `string_literal`, `current_timestamp` macros.
+
 ## 1.2.1 - 2022-11-01
 
 * Add `cluster` to the connection parameters returned on `dbt debug`.

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.2.1"
+version = "1.3.0"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.2.1",
+    version="1.3.0",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Release dbt-materialize v.1.3.0. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
