### PR TITLE
persist: use a new Opaque trait instead of Default for CaDS

### DIFF
--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::now::EpochMillis;
-use mz_persist_types::{Codec, Codec64};
+use mz_persist_types::{Codec, Codec64, Opaque};
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use tracing::instrument;
@@ -101,7 +101,7 @@ where
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
-    O: Codec64 + Default,
+    O: Opaque + Codec64,
 {
     pub(crate) machine: Machine<K, V, T, D>,
     pub(crate) gc: GarbageCollector<K, V, T, D>,
@@ -118,7 +118,7 @@ where
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
-    O: Clone + Codec64 + Default,
+    O: Opaque + Codec64,
 {
     pub(crate) fn new(
         machine: Machine<K, V, T, D>,

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -27,7 +27,7 @@ use crate::critical::CriticalReaderId;
 use crate::error::CodecMismatch;
 use crate::internal::paths::{PartialBatchKey, PartialRollupKey};
 use crate::internal::state::{
-    CriticalReaderState, HollowBatch, HollowBatchPart, LeasedReaderState, Opaque,
+    CriticalReaderState, HollowBatch, HollowBatchPart, LeasedReaderState, OpaqueState,
     ProtoCriticalReaderState, ProtoHollowBatch, ProtoHollowBatchPart, ProtoLeasedReaderState,
     ProtoStateDiff, ProtoStateField, ProtoStateFieldDiffType, ProtoStateFieldDiffs,
     ProtoStateRollup, ProtoTrace, ProtoU64Antichain, ProtoU64Description, ProtoWriterState, State,
@@ -688,7 +688,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoCriticalReaderState> for CriticalRead
             since: proto
                 .since
                 .into_rust_if_some("ProtoCriticalReaderState::since")?,
-            opaque: Opaque(i64::to_le_bytes(proto.opaque)),
+            opaque: OpaqueState(i64::to_le_bytes(proto.opaque)),
             opaque_codec: proto.opaque_codec,
         })
     }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, warn};
 use mz_ore::fmt::FormatBuffer;
 use mz_persist::location::{ExternalError, Indeterminate, SeqNo};
 use mz_persist::retry::Retry;
-use mz_persist_types::{Codec, Codec64};
+use mz_persist_types::{Codec, Codec64, Opaque};
 
 use crate::critical::CriticalReaderId;
 use crate::error::{CodecMismatch, InvalidUsage};
@@ -186,7 +186,7 @@ where
         (shard_upper, read_cap)
     }
 
-    pub async fn register_critical_reader<O: Codec64 + Default>(
+    pub async fn register_critical_reader<O: Opaque + Codec64>(
         &mut self,
         reader_id: &CriticalReaderId,
     ) -> CriticalReaderState<T> {

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -363,7 +363,7 @@ where
         .await
     }
 
-    pub async fn compare_and_downgrade_since<O: Codec64>(
+    pub async fn compare_and_downgrade_since<O: Opaque + Codec64>(
         &mut self,
         reader_id: &CriticalReaderId,
         expected_opaque: &O,

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -370,7 +370,7 @@ where
         Continue(Since(reader_current_since))
     }
 
-    pub fn compare_and_downgrade_since<O: Codec64>(
+    pub fn compare_and_downgrade_since<O: Opaque + Codec64>(
         &mut self,
         reader_id: &CriticalReaderId,
         expected_opaque: &O,
@@ -379,7 +379,7 @@ where
         let reader_state = self.critical_reader(reader_id);
         assert_eq!(reader_state.opaque_codec, O::codec_name());
 
-        if reader_state.opaque.0 != Codec64::encode(expected_opaque) {
+        if &O::decode(reader_state.opaque.0) != expected_opaque {
             // No-op, but still commit the state change so that this gets
             // linearized.
             return Continue(Err((

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -27,7 +27,7 @@ use mz_build_info::BuildInfo;
 use mz_ore::now::NowFn;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{Blob, Consensus, ExternalError};
-use mz_persist_types::{Codec, Codec64};
+use mz_persist_types::{Codec, Codec64, Opaque};
 use proptest_derive::Arbitrary;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -507,7 +507,7 @@ impl PersistClient {
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64 + Send + Sync,
-        O: Clone + Codec64 + Default,
+        O: Opaque + Codec64,
     {
         let state_versions = StateVersions::new(
             self.cfg.clone(),

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -11,7 +11,7 @@
 
 use bytes::BufMut;
 
-use crate::{Codec, Codec64};
+use crate::{Codec, Codec64, Opaque};
 
 impl Codec for () {
     fn codec_name() -> String {
@@ -92,5 +92,11 @@ impl Codec64 for u64 {
 
     fn decode(buf: [u8; 8]) -> Self {
         u64::from_le_bytes(buf)
+    }
+}
+
+impl Opaque for u64 {
+    fn initial() -> Self {
+        u64::MIN
     }
 }

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -100,3 +100,11 @@ impl Opaque for u64 {
         u64::MIN
     }
 }
+
+// TODO: Remove this once we wrap coord epochs in an `Epoch` struct and impl
+// Opaque on `Epoch` instead.
+impl Opaque for i64 {
+    fn initial() -> Self {
+        i64::MIN
+    }
+}

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -76,3 +76,10 @@ pub trait Codec64: Sized + 'static {
     /// handle bytes output by all previous versions of encode.
     fn decode(buf: [u8; 8]) -> Self;
 }
+
+/// An opaque fencing token used in compare_and_downgrade_since.
+pub trait Opaque: Clone + Sized + 'static {
+    /// The value of the opaque token when no compare_and_downgrade_since calls
+    /// have yet been successful.
+    fn initial() -> Self;
+}

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -78,7 +78,7 @@ pub trait Codec64: Sized + 'static {
 }
 
 /// An opaque fencing token used in compare_and_downgrade_since.
-pub trait Opaque: Clone + Sized + 'static {
+pub trait Opaque: PartialEq + Clone + Sized + 'static {
     /// The value of the opaque token when no compare_and_downgrade_since calls
     /// have yet been successful.
     fn initial() -> Self;


### PR DESCRIPTION
This came out of a discussion with Matt. Using Default here was a bit too prescriptive, so allow the user to specify the initial value.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
