### PR TITLE
leadership loss

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2197,7 +2197,11 @@ mod persist_write_handles {
                                                         // results in the meantime.
                                                         result = Ok(Ok(Ok(())))
                                                     } else {
-                                                        panic!("Table write failed: `write.upper` set to value that signals we have lost leadership");
+                                                        panic!(
+                                                            "Table write failed: `write.upper` set to value that signals we have lost leadership.  \
+                                                            Actual {:?}; Expected new upper: {:?}; Expected persist upper: {:?}; for {:?}; with updates {:?}",
+                                                            write.upper(), new_upper, persist_upper, id, updates
+                                                        );
                                                     }
                                                 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1961,7 +1961,7 @@ mod persist_write_handles {
     use mz_persist_client::write::WriteHandle;
     use mz_persist_types::Codec64;
     use mz_repr::{Diff, GlobalId, TimestampManipulation};
-    use tracing::Instrument;
+    use tracing::{error, Instrument};
 
     use crate::client::StorageResponse;
     use crate::client::{TimestamplessUpdate, Update};
@@ -2197,11 +2197,12 @@ mod persist_write_handles {
                                                         // results in the meantime.
                                                         result = Ok(Ok(Ok(())))
                                                     } else {
-                                                        panic!(
+                                                        error!(
                                                             "Table write failed: `write.upper` set to value that signals we have lost leadership.  \
                                                             Actual {:?}; Expected new upper: {:?}; Expected persist upper: {:?}; for {:?}; with updates {:?}",
                                                             write.upper(), new_upper, persist_upper, id, updates
                                                         );
+                                                        return Err(*id);
                                                     }
                                                 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
