### PR TITLE
[storage] Don't panic if someone else moves table upper

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2175,7 +2175,7 @@ mod persist_write_handles {
                                                 // if it is still appropriate, not retrying if it has advanced
                                                 // to `new_upper`, and panicking if it is anything else.
                                                 while let Err(indeterminate) = result {
-                                                    tracing::warn!("Retrying indeterminate table write: {:#}", indeterminate);
+                                                    tracing::warn!("Retrying indeterminate persist worker write: {:#}", indeterminate);
                                                     write.fetch_recent_upper().await;
                                                     if write.upper() == &persist_upper {
                                                         // If the upper frontier is the prior frontier, the commit
@@ -2204,7 +2204,7 @@ mod persist_write_handles {
                                                         result = Ok(Ok(Ok(())))
                                                     } else {
                                                         tracing::info!(
-                                                            "Table write failed: `write.upper` for {:?} advanced by
+                                                            "Persist writer failed: `write.upper` for {:?} advanced by
                                                             other writer. Actual upper {:?}; Expected new upper: {:?};
                                                             Persist upper: {:?}",
                                                             id, write.upper(), new_upper, persist_upper,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2203,7 +2203,13 @@ mod persist_write_handles {
                                                         // results in the meantime.
                                                         result = Ok(Ok(Ok(())))
                                                     } else {
-                                                        panic!("Table write failed: `write.upper` set to value that signals we have lost leadership");
+                                                        tracing::info!(
+                                                            "Table write failed: `write.upper` for {:?} advanced by
+                                                            other writer. Actual upper {:?}; Expected new upper: {:?};
+                                                            Persist upper: {:?}",
+                                                            id, write.upper(), new_upper, persist_upper,
+                                                        );
+                                                        return Err(*id);
                                                     }
                                                 }
 


### PR DESCRIPTION
The message in this panic is no longer true now that we persist sink status updates.  The panic was there (presumably?) because we thought we would no longer make progress because there was a new leader.  However, given that's not true, it should be sufficient to return an error.

It's also worth noting that, before this change, there are two different behaviors depending on whether we get an indeterminate error or not:
1) Read the upper from the writer, do a compare_and_append, get an `Upper` error because someone else advanced in the meantime, we return error from the function
2) Read the upper from the writer, do a compare_and_append, get an `Indeterminate` error, re-read the upper and notice that someone else has advanced in the meantime, we panic

### Motivation
Fixes #15949

### Tips for reviewer
I'd like a close look at this -- it seems like it could be a fix that's too simple to be correct.  I'm still working on getting a reliable repro with enough logs -- but it's possible the error would get filtered out below

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
