### PR TITLE
adapter: remove replica not ready notice

### DIFF
--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -11,6 +11,7 @@ import threading
 import time
 from io import StringIO
 
+import pytest
 from pg8000 import Connection
 
 from materialize.cloudtest.application import MaterializeApplication
@@ -47,6 +48,7 @@ def assert_notice(conn: Connection, contains: bytes) -> None:
 
 # Test that a crashed (and restarted) computed replica generates expected notice
 # events.
+@pytest.mark.skip(reason="https://github.com/MaterializeInc/materialize/issues/16002")
 def test_crash_computed(mz: MaterializeApplication) -> None:
     mz.environmentd.sql("DROP TABLE IF EXISTS t1 CASCADE")
     mz.environmentd.sql("CREATE TABLE t1 (f1 TEXT)")


### PR DESCRIPTION
While well intentioned, it's actual perception among users is more confusing than useful. Remove for now.

Fixes #15760
Fixes #15692

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a