### PR TITLE
Hardening of SQL in regression test of invalid introspection source retractions upon reconciliation

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -339,8 +339,8 @@ def workflow_test_github_15930(c: Composition) -> None:
             input=dedent(
                 """
             > SET cluster = cluster1;
-            > SELECT 1 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;
-            1
+            > SELECT worker_id < 2 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;
+            true
                 """
             )
         )
@@ -355,8 +355,8 @@ def workflow_test_github_15930(c: Composition) -> None:
             input=dedent(
                 """
             > SET cluster = cluster1;
-            > SELECT 1 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;
-            1
+            > SELECT worker_id < 2 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;
+            true
                 """
             )
         )
@@ -381,8 +381,8 @@ def workflow_test_github_15930(c: Composition) -> None:
             input=dedent(
                 """
             > SET cluster = cluster1;
-            > SELECT 1 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;
-            1
+            > SELECT worker_id < 2 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;
+            true
             > SELECT * FROM t;
             42
                 """


### PR DESCRIPTION
A regression test was introduced in PR #15986 as part of a fix to issue #15930 on invalid introspection source retractions upon reconciliation. As part of the test, the SQL query `SELECT 1 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;` was used. However, use of this query implies that a future constant-folding optimization could break the test. 

This PR proposes to change the query to `SELECT worker_id < 2 FROM mz_internal.mz_worker_compute_frontiers LIMIT 1;`, as this takes advantage of our knowledge of the cluster size in the test, which should not be used by the query optimizer as an information source. We are always vulnerable to future optimizations making errors disappear from queries, but this looks a bit safer (especially in the absence of ordered indexes and quite specific query rewrites).  

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A