### PR TITLE
Bump hyper from 0.14.20 to 0.14.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -2335,9 +2335,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -6314,9 +6314,9 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.86"
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]
-hyper = { version = "0.14.20", features = ["server"] }
+hyper = { version = "0.14.23", features = ["server"] }
 once_cell = "1.15.0"
 mz-ore = { path = "../ore", features = ["task"] }
 serde_json = "1.0.86"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.24"
 headers = "0.3.7"
 http = "0.2.8"
 humantime = "2.1.0"
-hyper = { version = "0.14.20", features = ["http1", "server"] }
+hyper = { version = "0.14.23", features = ["http1", "server"] }
 hyper-openssl = "0.9.2"
 include_dir = "0.7.3"
 itertools = "0.10.5"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -52,7 +52,7 @@ tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing.git",
 tonic = { version = "0.8.2", features = ["transport"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2.11", features = ["alpn"], optional = true }
-hyper = { version = "0.14.20", features = ["http1", "server"], optional = true }
+hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"], optional = true }
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }


### PR DESCRIPTION
This PR updates hyper, specifically to include the fix for this issue: https://github.com/hyperium/hyper/issues/2649. My hope is that this solves #16003. 

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
