### PR TITLE
sql+storage: allow ingesting unsupported types as text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,6 +3958,7 @@ dependencies = [
  "anyhow",
  "mz-cloud-resources",
  "mz-ore",
+ "mz-pgrepr",
  "mz-proto",
  "mz-repr",
  "mz-ssh-util",

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -28,6 +28,7 @@ use once_cell::sync::Lazy;
 use serde::Serialize;
 
 use mz_compute_client::logging::{ComputeLog, DifferentialLog, LogVariant, TimelyLog};
+use mz_pgrepr::oid;
 use mz_repr::{RelationDesc, RelationType, ScalarType};
 use mz_sql::catalog::{
     CatalogItemType, CatalogType, CatalogTypeDetails, NameReference, TypeReference,
@@ -259,7 +260,7 @@ impl Fingerprint for RelationType {
 pub const TYPE_BOOL: BuiltinType<NameReference> = BuiltinType {
     name: "bool",
     schema: PG_CATALOG_SCHEMA,
-    oid: 16,
+    oid: oid::TYPE_BOOL_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Bool,
         array_id: None,
@@ -269,7 +270,7 @@ pub const TYPE_BOOL: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_BYTEA: BuiltinType<NameReference> = BuiltinType {
     name: "bytea",
     schema: PG_CATALOG_SCHEMA,
-    oid: 17,
+    oid: oid::TYPE_BYTEA_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Bytes,
         array_id: None,
@@ -279,7 +280,7 @@ pub const TYPE_BYTEA: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT8: BuiltinType<NameReference> = BuiltinType {
     name: "int8",
     schema: PG_CATALOG_SCHEMA,
-    oid: 20,
+    oid: oid::TYPE_INT8_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Int64,
         array_id: None,
@@ -289,7 +290,7 @@ pub const TYPE_INT8: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT4: BuiltinType<NameReference> = BuiltinType {
     name: "int4",
     schema: PG_CATALOG_SCHEMA,
-    oid: 23,
+    oid: oid::TYPE_INT4_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Int32,
         array_id: None,
@@ -299,7 +300,7 @@ pub const TYPE_INT4: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TEXT: BuiltinType<NameReference> = BuiltinType {
     name: "text",
     schema: PG_CATALOG_SCHEMA,
-    oid: 25,
+    oid: oid::TYPE_TEXT_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::String,
         array_id: None,
@@ -309,7 +310,7 @@ pub const TYPE_TEXT: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_OID: BuiltinType<NameReference> = BuiltinType {
     name: "oid",
     schema: PG_CATALOG_SCHEMA,
-    oid: 26,
+    oid: oid::TYPE_OID_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Oid,
         array_id: None,
@@ -319,7 +320,7 @@ pub const TYPE_OID: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_FLOAT4: BuiltinType<NameReference> = BuiltinType {
     name: "float4",
     schema: PG_CATALOG_SCHEMA,
-    oid: 700,
+    oid: oid::TYPE_FLOAT4_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Float32,
         array_id: None,
@@ -329,7 +330,7 @@ pub const TYPE_FLOAT4: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_FLOAT8: BuiltinType<NameReference> = BuiltinType {
     name: "float8",
     schema: PG_CATALOG_SCHEMA,
-    oid: 701,
+    oid: oid::TYPE_FLOAT8_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Float64,
         array_id: None,
@@ -339,7 +340,7 @@ pub const TYPE_FLOAT8: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_BOOL_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_bool",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1000,
+    oid: oid::TYPE_BOOL_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_BOOL.name,
@@ -351,7 +352,7 @@ pub const TYPE_BOOL_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_BYTEA_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_bytea",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1001,
+    oid: oid::TYPE_BYTEA_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_BYTEA.name,
@@ -363,7 +364,7 @@ pub const TYPE_BYTEA_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_int4",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1007,
+    oid: oid::TYPE_INT4_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_INT4.name,
@@ -375,7 +376,7 @@ pub const TYPE_INT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TEXT_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_text",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1009,
+    oid: oid::TYPE_TEXT_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_TEXT.name,
@@ -387,7 +388,7 @@ pub const TYPE_TEXT_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_int8",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1016,
+    oid: oid::TYPE_INT8_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_INT8.name,
@@ -399,7 +400,7 @@ pub const TYPE_INT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_FLOAT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_float4",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1021,
+    oid: oid::TYPE_FLOAT4_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_FLOAT4.name,
@@ -411,7 +412,7 @@ pub const TYPE_FLOAT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_FLOAT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_float8",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1022,
+    oid: oid::TYPE_FLOAT8_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_FLOAT8.name,
@@ -423,7 +424,7 @@ pub const TYPE_FLOAT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_OID_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_oid",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1028,
+    oid: oid::TYPE_OID_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_OID.name,
@@ -435,7 +436,7 @@ pub const TYPE_OID_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_DATE: BuiltinType<NameReference> = BuiltinType {
     name: "date",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1082,
+    oid: oid::TYPE_DATE_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Date,
         array_id: None,
@@ -445,7 +446,7 @@ pub const TYPE_DATE: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TIME: BuiltinType<NameReference> = BuiltinType {
     name: "time",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1083,
+    oid: oid::TYPE_TIME_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Time,
         array_id: None,
@@ -455,7 +456,7 @@ pub const TYPE_TIME: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TIMESTAMP: BuiltinType<NameReference> = BuiltinType {
     name: "timestamp",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1114,
+    oid: oid::TYPE_TIMESTAMP_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Timestamp,
         array_id: None,
@@ -465,7 +466,7 @@ pub const TYPE_TIMESTAMP: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_timestamp",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1115,
+    oid: oid::TYPE_TIMESTAMP_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_TIMESTAMP.name,
@@ -477,7 +478,7 @@ pub const TYPE_TIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_DATE_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_date",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1182,
+    oid: oid::TYPE_DATE_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_DATE.name,
@@ -489,7 +490,7 @@ pub const TYPE_DATE_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TIME_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_time",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1183,
+    oid: oid::TYPE_TIME_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_TIME.name,
@@ -501,7 +502,7 @@ pub const TYPE_TIME_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TIMESTAMPTZ: BuiltinType<NameReference> = BuiltinType {
     name: "timestamptz",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1184,
+    oid: oid::TYPE_TIMESTAMPTZ_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::TimestampTz,
         array_id: None,
@@ -511,7 +512,7 @@ pub const TYPE_TIMESTAMPTZ: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_TIMESTAMPTZ_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_timestamptz",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1185,
+    oid: oid::TYPE_TIMESTAMPTZ_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_TIMESTAMPTZ.name,
@@ -523,7 +524,7 @@ pub const TYPE_TIMESTAMPTZ_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INTERVAL: BuiltinType<NameReference> = BuiltinType {
     name: "interval",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1186,
+    oid: oid::TYPE_INTERVAL_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Interval,
         array_id: None,
@@ -533,7 +534,7 @@ pub const TYPE_INTERVAL: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INTERVAL_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_interval",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1187,
+    oid: oid::TYPE_INTERVAL_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_INTERVAL.name,
@@ -545,7 +546,7 @@ pub const TYPE_INTERVAL_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_NUMERIC: BuiltinType<NameReference> = BuiltinType {
     name: "numeric",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1700,
+    oid: oid::TYPE_NUMERIC_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Numeric,
         array_id: None,
@@ -555,7 +556,7 @@ pub const TYPE_NUMERIC: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_NUMERIC_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_numeric",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1231,
+    oid: oid::TYPE_NUMERIC_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_NUMERIC.name,
@@ -567,7 +568,7 @@ pub const TYPE_NUMERIC_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_RECORD: BuiltinType<NameReference> = BuiltinType {
     name: "record",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2249,
+    oid: oid::TYPE_RECORD_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -577,7 +578,7 @@ pub const TYPE_RECORD: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_RECORD_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_record",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2287,
+    oid: oid::TYPE_RECORD_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_RECORD.name,
@@ -589,7 +590,7 @@ pub const TYPE_RECORD_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_UUID: BuiltinType<NameReference> = BuiltinType {
     name: "uuid",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2950,
+    oid: oid::TYPE_UUID_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Uuid,
         array_id: None,
@@ -599,7 +600,7 @@ pub const TYPE_UUID: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_UUID_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_uuid",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2951,
+    oid: oid::TYPE_UUID_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_UUID.name,
@@ -611,7 +612,7 @@ pub const TYPE_UUID_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_JSONB: BuiltinType<NameReference> = BuiltinType {
     name: "jsonb",
     schema: PG_CATALOG_SCHEMA,
-    oid: 3802,
+    oid: oid::TYPE_JSONB_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Jsonb,
         array_id: None,
@@ -621,7 +622,7 @@ pub const TYPE_JSONB: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_JSONB_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_jsonb",
     schema: PG_CATALOG_SCHEMA,
-    oid: 3807,
+    oid: oid::TYPE_JSONB_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_JSONB.name,
@@ -633,7 +634,7 @@ pub const TYPE_JSONB_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANY: BuiltinType<NameReference> = BuiltinType {
     name: "any",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2276,
+    oid: oid::TYPE_ANY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -643,7 +644,7 @@ pub const TYPE_ANY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANYARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "anyarray",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2277,
+    oid: oid::TYPE_ANYARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -653,7 +654,7 @@ pub const TYPE_ANYARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANYELEMENT: BuiltinType<NameReference> = BuiltinType {
     name: "anyelement",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2283,
+    oid: oid::TYPE_ANYELEMENT_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -663,7 +664,7 @@ pub const TYPE_ANYELEMENT: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANYNONARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "anynonarray",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2776,
+    oid: oid::TYPE_ANYNONARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -673,7 +674,7 @@ pub const TYPE_ANYNONARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_CHAR: BuiltinType<NameReference> = BuiltinType {
     name: "char",
     schema: PG_CATALOG_SCHEMA,
-    oid: 18,
+    oid: oid::TYPE_CHAR_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::PgLegacyChar,
         array_id: None,
@@ -683,7 +684,7 @@ pub const TYPE_CHAR: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_VARCHAR: BuiltinType<NameReference> = BuiltinType {
     name: "varchar",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1043,
+    oid: oid::TYPE_VARCHAR_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::VarChar,
         array_id: None,
@@ -693,7 +694,7 @@ pub const TYPE_VARCHAR: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT2: BuiltinType<NameReference> = BuiltinType {
     name: "int2",
     schema: PG_CATALOG_SCHEMA,
-    oid: 21,
+    oid: oid::TYPE_INT2_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Int16,
         array_id: None,
@@ -703,7 +704,7 @@ pub const TYPE_INT2: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT2_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_int2",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1005,
+    oid: oid::TYPE_INT2_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_INT2.name,
@@ -715,7 +716,7 @@ pub const TYPE_INT2_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_BPCHAR: BuiltinType<NameReference> = BuiltinType {
     name: "bpchar",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1042,
+    oid: oid::TYPE_BPCHAR_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Char,
         array_id: None,
@@ -725,7 +726,7 @@ pub const TYPE_BPCHAR: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_CHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_char",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1002,
+    oid: oid::TYPE_CHAR_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_CHAR.name,
@@ -737,7 +738,7 @@ pub const TYPE_CHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_VARCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_varchar",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1015,
+    oid: oid::TYPE_VARCHAR_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_VARCHAR.name,
@@ -749,7 +750,7 @@ pub const TYPE_VARCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_BPCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_bpchar",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1014,
+    oid: oid::TYPE_BPCHAR_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_BPCHAR.name,
@@ -761,7 +762,7 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_REGPROC: BuiltinType<NameReference> = BuiltinType {
     name: "regproc",
     schema: PG_CATALOG_SCHEMA,
-    oid: 24,
+    oid: oid::TYPE_REGPROC_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::RegProc,
         array_id: None,
@@ -771,7 +772,7 @@ pub const TYPE_REGPROC: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_REGPROC_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_regproc",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1008,
+    oid: oid::TYPE_REGPROC_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_REGPROC.name,
@@ -783,7 +784,7 @@ pub const TYPE_REGPROC_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_REGTYPE: BuiltinType<NameReference> = BuiltinType {
     name: "regtype",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2206,
+    oid: oid::TYPE_REGTYPE_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::RegType,
         array_id: None,
@@ -793,7 +794,7 @@ pub const TYPE_REGTYPE: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_REGTYPE_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_regtype",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2211,
+    oid: oid::TYPE_REGTYPE_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_REGTYPE.name,
@@ -805,7 +806,7 @@ pub const TYPE_REGTYPE_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_REGCLASS: BuiltinType<NameReference> = BuiltinType {
     name: "regclass",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2205,
+    oid: oid::TYPE_REGCLASS_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::RegClass,
         array_id: None,
@@ -815,7 +816,7 @@ pub const TYPE_REGCLASS: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_REGCLASS_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_regclass",
     schema: PG_CATALOG_SCHEMA,
-    oid: 2210,
+    oid: oid::TYPE_REGCLASS_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_REGCLASS.name,
@@ -827,7 +828,7 @@ pub const TYPE_REGCLASS_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT2_VECTOR: BuiltinType<NameReference> = BuiltinType {
     name: "int2vector",
     schema: PG_CATALOG_SCHEMA,
-    oid: 22,
+    oid: oid::TYPE_INT2_VECTOR_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Int2Vector,
         array_id: None,
@@ -837,7 +838,7 @@ pub const TYPE_INT2_VECTOR: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_INT2_VECTOR_ARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "_int2vector",
     schema: PG_CATALOG_SCHEMA,
-    oid: 1006,
+    oid: oid::TYPE_INT2_VECTOR_ARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Array {
             element_reference: TYPE_INT2_VECTOR.name,
@@ -849,7 +850,7 @@ pub const TYPE_INT2_VECTOR_ARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANYCOMPATIBLE: BuiltinType<NameReference> = BuiltinType {
     name: "anycompatible",
     schema: PG_CATALOG_SCHEMA,
-    oid: 5077,
+    oid: oid::TYPE_ANYCOMPATIBLE_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -859,7 +860,7 @@ pub const TYPE_ANYCOMPATIBLE: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANYCOMPATIBLEARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "anycompatiblearray",
     schema: PG_CATALOG_SCHEMA,
-    oid: 5078,
+    oid: oid::TYPE_ANYCOMPATIBLEARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
@@ -869,7 +870,7 @@ pub const TYPE_ANYCOMPATIBLEARRAY: BuiltinType<NameReference> = BuiltinType {
 pub const TYPE_ANYCOMPATIBLENONARRAY: BuiltinType<NameReference> = BuiltinType {
     name: "anycompatiblenonarray",
     schema: PG_CATALOG_SCHEMA,
-    oid: 5079,
+    oid: oid::TYPE_ANYCOMPATIBLENONARRAY_OID,
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -96,7 +96,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             match &ingestion.desc.connection {
                                 GenericSourceConnection::Postgres(PostgresSourceConnection {
                                     connection,
-                                    details,
+                                    publication_details,
                                     ..
                                 }) => {
                                     let config = connection
@@ -105,7 +105,8 @@ impl<S: Append + 'static> Coordinator<S> {
                                         .unwrap_or_else(|e| {
                                             panic!("Postgres source {id} missing secrets: {e}")
                                         });
-                                    replication_slots_to_drop.push((config, details.slot.clone()));
+                                    replication_slots_to_drop
+                                        .push((config, publication_details.slot.clone()));
                                 }
                                 _ => {}
                             }

--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -11,6 +11,66 @@
 
 //! PostgreSQL OID constants.
 
+// PostgreSQL builtin type OIDs
+pub const TYPE_ANY_OID: u32 = 2276;
+pub const TYPE_ANYARRAY_OID: u32 = 2277;
+pub const TYPE_ANYCOMPATIBLE_OID: u32 = 5077;
+pub const TYPE_ANYCOMPATIBLEARRAY_OID: u32 = 5078;
+pub const TYPE_ANYCOMPATIBLENONARRAY_OID: u32 = 5079;
+pub const TYPE_ANYELEMENT_OID: u32 = 2283;
+pub const TYPE_ANYNONARRAY_OID: u32 = 2776;
+pub const TYPE_BOOL_ARRAY_OID: u32 = 1000;
+pub const TYPE_BOOL_OID: u32 = 16;
+pub const TYPE_BPCHAR_ARRAY_OID: u32 = 1014;
+pub const TYPE_BPCHAR_OID: u32 = 1042;
+pub const TYPE_BYTEA_ARRAY_OID: u32 = 1001;
+pub const TYPE_BYTEA_OID: u32 = 17;
+pub const TYPE_CHAR_ARRAY_OID: u32 = 1002;
+pub const TYPE_CHAR_OID: u32 = 18;
+pub const TYPE_DATE_ARRAY_OID: u32 = 1182;
+pub const TYPE_DATE_OID: u32 = 1082;
+pub const TYPE_FLOAT4_ARRAY_OID: u32 = 1021;
+pub const TYPE_FLOAT4_OID: u32 = 700;
+pub const TYPE_FLOAT8_ARRAY_OID: u32 = 1022;
+pub const TYPE_FLOAT8_OID: u32 = 701;
+pub const TYPE_INT2_ARRAY_OID: u32 = 1005;
+pub const TYPE_INT2_OID: u32 = 21;
+pub const TYPE_INT2_VECTOR_ARRAY_OID: u32 = 1006;
+pub const TYPE_INT2_VECTOR_OID: u32 = 22;
+pub const TYPE_INT4_ARRAY_OID: u32 = 1007;
+pub const TYPE_INT4_OID: u32 = 23;
+pub const TYPE_INT8_ARRAY_OID: u32 = 1016;
+pub const TYPE_INT8_OID: u32 = 20;
+pub const TYPE_INTERVAL_ARRAY_OID: u32 = 1187;
+pub const TYPE_INTERVAL_OID: u32 = 1186;
+pub const TYPE_JSONB_ARRAY_OID: u32 = 3807;
+pub const TYPE_JSONB_OID: u32 = 3802;
+pub const TYPE_LIST_OID_OID: u32 = 16_384;
+pub const TYPE_NUMERIC_ARRAY_OID: u32 = 1231;
+pub const TYPE_NUMERIC_OID: u32 = 1700;
+pub const TYPE_OID_ARRAY_OID: u32 = 1028;
+pub const TYPE_OID_OID: u32 = 26;
+pub const TYPE_RECORD_ARRAY_OID: u32 = 2287;
+pub const TYPE_RECORD_OID: u32 = 2249;
+pub const TYPE_REGCLASS_ARRAY_OID: u32 = 2210;
+pub const TYPE_REGCLASS_OID: u32 = 2205;
+pub const TYPE_REGPROC_ARRAY_OID: u32 = 1008;
+pub const TYPE_REGPROC_OID: u32 = 24;
+pub const TYPE_REGTYPE_ARRAY_OID: u32 = 2211;
+pub const TYPE_REGTYPE_OID: u32 = 2206;
+pub const TYPE_TEXT_ARRAY_OID: u32 = 1009;
+pub const TYPE_TEXT_OID: u32 = 25;
+pub const TYPE_TIME_ARRAY_OID: u32 = 1183;
+pub const TYPE_TIME_OID: u32 = 1083;
+pub const TYPE_TIMESTAMP_ARRAY_OID: u32 = 1115;
+pub const TYPE_TIMESTAMP_OID: u32 = 1114;
+pub const TYPE_TIMESTAMPTZ_ARRAY_OID: u32 = 1185;
+pub const TYPE_TIMESTAMPTZ_OID: u32 = 1184;
+pub const TYPE_UUID_ARRAY_OID: u32 = 2951;
+pub const TYPE_UUID_OID: u32 = 2950;
+pub const TYPE_VARCHAR_ARRAY_OID: u32 = 1015;
+pub const TYPE_VARCHAR_OID: u32 = 1043;
+
 /// The first OID in PostgreSQL's system catalog that is not pinned during
 /// bootstrapping.
 ///

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 anyhow = "1.0.65"
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-ore = { path = "../ore", features = ["task"] }
+mz-pgrepr = { path = "../pgrepr" }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -118,8 +118,9 @@ pub fn make_tls(config: &tokio_postgres::Config) -> Result<MakeTlsConnector, Pos
     Ok(tls_connector)
 }
 
-/// Fetches table schema information from an upstream Postgres source for all tables that are part
-/// of a publication, given a connection string and the publication name.
+/// Fetches table schema information from an upstream Postgres source for all
+/// tables that are part of a publication, given a connection string and the
+/// publication name.
 ///
 /// # Errors
 ///

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -958,6 +958,8 @@ pub enum PgConfigOptionName {
     Details,
     /// The name of the publication to sync
     Publication,
+    /// Columns whose types you want to unconditionally format as text
+    TextColumns,
 }
 
 impl AstDisplay for PgConfigOptionName {
@@ -965,6 +967,7 @@ impl AstDisplay for PgConfigOptionName {
         f.write_str(match self {
             PgConfigOptionName::Details => "DETAILS",
             PgConfigOptionName::Publication => "PUBLICATION",
+            PgConfigOptionName::TextColumns => "TEXT COLUMNS",
         })
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2207,6 +2207,7 @@ pub enum WithOptionValue<T: AstInfo> {
     DataType(T::DataType),
     Secret(T::ObjectName),
     Object(T::ObjectName),
+    UnresolvedObjectName(UnresolvedObjectName),
     Sequence(Vec<WithOptionValue<T>>),
     // Special cases.
     ClusterReplicas(Vec<ReplicaDefinition<T>>),
@@ -2229,6 +2230,7 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
                 f.write_node(name)
             }
             WithOptionValue::Object(obj) => f.write_node(obj),
+            WithOptionValue::UnresolvedObjectName(r) => f.write_node(r),
             WithOptionValue::ClusterReplicas(replicas) => {
                 f.write_str("(");
                 f.write_node(&display::comma_separated(replicas));

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -168,6 +168,13 @@ impl<T: AstDisplay> AstDisplay for Box<T> {
     }
 }
 
+// u32 used directly to represent, e.g., oids
+impl AstDisplay for u32 {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(self);
+    }
+}
+
 // u64 used directly to represent, e.g., type modifiers
 impl AstDisplay for u64 {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1544,6 +1544,13 @@ CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') 
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: Publication, value: Some(Value(String("mz_source"))) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], subsources: Some(All) })
 
 parse-statement
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (TEXT COLUMNS = [foo, foo.bar, foo.bar.qux, foo.bar.qux.qax, foo.bar.qux.qax.baz]) FOR ALL TABLES WITH (SIZE = 'small');
+----
+CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (TEXT COLUMNS = (foo, foo.bar, foo.bar.qux, foo.bar.qux.qax, foo.bar.qux.qax.baz)) FOR ALL TABLES WITH (SIZE = 'small')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("mz_source")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pg")])), options: [PgConfigOption { name: TextColumns, value: Some(Sequence([UnresolvedObjectName(UnresolvedObjectName([Ident("foo")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar"), Ident("qux")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax")])), UnresolvedObjectName(UnresolvedObjectName([Ident("foo"), Ident("bar"), Ident("qux"), Ident("qax"), Ident("baz")]))])) }] }, include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("small"))) }], subsources: Some(All) })
+
+parse-statement
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR TABLES (foo, bar as qux, baz into zop) WITH (SIZE = 'small');
 ----
 CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION = 'mz_source') FOR TABLES (foo, bar AS qux, baz AS zop) WITH (SIZE = 'small')

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1104,6 +1104,9 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 }
                 Object(object_name)
             }
+            UnresolvedObjectName(name) => {
+                UnresolvedObjectName(self.fold_unresolved_object_name(name))
+            }
             ClusterReplicas(replicas) => ClusterReplicas(
                 replicas
                     .into_iter()

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -38,7 +38,7 @@ use mz_sql_parser::ast::{
     AlterSinkAction, AlterSinkStatement, AlterSourceAction, AlterSourceStatement,
     AlterSystemResetAllStatement, AlterSystemResetStatement, AlterSystemSetStatement,
     CreateTypeListOption, CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName,
-    DeferredObjectName, SetVariableValue, SshConnectionOption,
+    DeferredObjectName, SetVariableValue, SshConnectionOption, UnresolvedObjectName,
 };
 use mz_storage_client::types::connections::aws::{
     AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri,
@@ -326,7 +326,12 @@ generate_extracted_config!(
     (TimestampInterval, Interval)
 );
 
-generate_extracted_config!(PgConfigOption, (Details, String), (Publication, String));
+generate_extracted_config!(
+    PgConfigOption,
+    (Details, String),
+    (Publication, String),
+    (TextColumns, Vec::<UnresolvedObjectName>, Default(vec![]))
+);
 
 pub fn plan_create_source(
     scx: &StatementContext,
@@ -596,6 +601,7 @@ pub fn plan_create_source(
             let PgConfigOptionExtracted {
                 details,
                 publication,
+                text_columns: _,
                 seen: _,
             } = options.clone().try_into()?;
 

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -18,7 +18,7 @@ use mz_repr::strconv;
 use mz_repr::GlobalId;
 use mz_storage_client::types::connections::StringOrSecret;
 
-use crate::ast::{AstInfo, IntervalValue, Value, WithOptionValue};
+use crate::ast::{AstInfo, IntervalValue, UnresolvedObjectName, Value, WithOptionValue};
 use crate::names::{ResolvedDataType, ResolvedObjectName};
 use crate::plan::{Aug, PlanError};
 
@@ -88,6 +88,24 @@ impl TryFromValue<WithOptionValue<Aug>> for Object {
 impl ImpliedValue for Object {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide an object")
+    }
+}
+
+impl TryFromValue<WithOptionValue<Aug>> for UnresolvedObjectName {
+    fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
+        Ok(match v {
+            WithOptionValue::UnresolvedObjectName(name) => name,
+            _ => sql_bail!("must provide an object name"),
+        })
+    }
+    fn name() -> String {
+        "object name".to_string()
+    }
+}
+
+impl ImpliedValue for UnresolvedObjectName {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide an object name")
     }
 }
 
@@ -319,12 +337,8 @@ impl ImpliedValue for u64 {
     }
 }
 
-impl<T, V> TryFromValue<WithOptionValue<T>> for Vec<V>
-where
-    T: AstInfo,
-    V: TryFromValue<WithOptionValue<T>>,
-{
-    fn try_from_value(v: WithOptionValue<T>) -> Result<Self, PlanError> {
+impl<V: TryFromValue<WithOptionValue<Aug>>> TryFromValue<WithOptionValue<Aug>> for Vec<V> {
+    fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, PlanError> {
         match v {
             WithOptionValue::Sequence(a) => {
                 let mut out = Vec::with_capacity(a.len());
@@ -344,7 +358,7 @@ where
     }
 }
 
-impl<V: TryFromValue<Value>> ImpliedValue for Vec<V> {
+impl<V: ImpliedValue> ImpliedValue for Vec<V> {
     fn implied_value() -> Result<Self, PlanError> {
         sql_bail!("must provide an array value")
     }
@@ -375,6 +389,7 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
             WithOptionValue::Ident(i) => V::try_from_value(Value::String(i.into_string())),
             WithOptionValue::Sequence(_)
             | WithOptionValue::Object(_)
+            | WithOptionValue::UnresolvedObjectName(_)
             | WithOptionValue::Secret(_)
             | WithOptionValue::DataType(_)
             | WithOptionValue::ClusterReplicas(_)
@@ -383,6 +398,7 @@ impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOpti
                 match v {
                     WithOptionValue::Sequence(_) => "sequences",
                     WithOptionValue::Object(_) => "object references",
+                    WithOptionValue::UnresolvedObjectName(_) => "object names",
                     WithOptionValue::Secret(_) => "secrets",
                     WithOptionValue::DataType(_) => "data types",
                     WithOptionValue::ClusterReplicas(_) => "cluster replicas",

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -285,8 +285,11 @@ pub async fn purify_create_source(
                     _ => sql_bail!("{} is not a postgres connection", item.name()),
                 }
             };
-            let crate::plan::statement::PgConfigOptionExtracted { publication, .. } =
-                options.clone().try_into()?;
+            let crate::plan::statement::PgConfigOptionExtracted {
+                publication,
+                text_columns: _,
+                ..
+            } = options.clone().try_into()?;
             let publication = publication
                 .ok_or_else(|| sql_err!("POSTGRES CONNECTION must specify PUBLICATION"))?;
 

--- a/src/storage-client/src/types/sources.proto
+++ b/src/storage-client/src/types/sources.proto
@@ -200,11 +200,14 @@ message ProtoPostgresSourceConnection {
     mz_repr.global_id.ProtoGlobalId connection_id = 6;
     mz_storage_client.types.connections.ProtoPostgresConnection connection = 1;
     string publication = 2;
-    ProtoPostgresSourceDetails details = 4;
+    ProtoPostgresSourcePublicationDetails details = 4;
     repeated ProtoPostgresTableCast table_casts = 5;
+    // Describes the position in the source's publication that the table cast
+    // correlates to; meant to be iterated over in tandem with table_casts
+    repeated uint64 table_cast_pos = 7;
 }
 
-message ProtoPostgresSourceDetails {
+message ProtoPostgresSourcePublicationDetails {
     repeated mz_postgres_util.desc.ProtoPostgresTableDesc tables = 1;
     string slot = 2;
 }

--- a/src/walkabout/src/ir.rs
+++ b/src/walkabout/src/ir.rs
@@ -307,7 +307,8 @@ fn analyze_type(ty: &syn::Type) -> Result<Type> {
                 };
 
                 match &*segment_name {
-                    "bool" | "usize" | "u64" | "i64" | "char" | "String" | "PathBuf" | "i32" => {
+                    "bool" | "usize" | "u8" | "u16" | "u32" | "u64" | "isize" | "i8" | "i16"
+                    | "i32" | "i64" | "f32" | "f64" | "char" | "String" | "PathBuf" => {
                         match segment.arguments {
                             syn::PathArguments::None => Ok(Type::Primitive),
                             _ => bail!(

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -93,9 +93,23 @@ INSERT INTO conflict_schema.conflict_table VALUES ('234');
 CREATE TABLE "space table" ("space column" INTEGER);
 
 CREATE TYPE an_enum AS ENUM ('var0', 'var1');
-
 CREATE TABLE enum_table (a an_enum);
+INSERT INTO enum_table VALUES ('var1'), ('var0');
 ALTER TABLE enum_table REPLICA IDENTITY FULL;
+
+CREATE TYPE another_enum AS ENUM ('var2', 'var3');
+CREATE TABLE another_enum_table ("колона" another_enum);
+INSERT INTO another_enum_table VALUES ('var2'), ('var3');
+ALTER TABLE another_enum_table REPLICA IDENTITY FULL;
+
+CREATE TABLE conflict_schema.another_enum_table ("колона" another_enum);
+ALTER TABLE conflict_schema.another_enum_table REPLICA IDENTITY FULL;
+INSERT INTO conflict_schema.another_enum_table VALUES ('var2'), ('var3');
+ALTER TABLE conflict_schema.another_enum_table REPLICA IDENTITY FULL;
+
+DROP PUBLICATION IF EXISTS mz_source_narrow;
+
+CREATE PUBLICATION mz_source_narrow FOR TABLE enum_table, public.another_enum_table, pk_table;
 
 #
 # Test that slots created for replication sources are deleted on DROP
@@ -183,7 +197,15 @@ exact:failed to fetch publication information from PostgreSQL database
   FOR TABLES (
     "enum_table"
   );
-contains: uses unrecognized type
+regex: the following columns contain unsupported types:\npostgres.public.enum_table.a \(OID \d+\)
+
+! CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+regex: the following columns contain unsupported types:\npostgres\.public\.another_enum_table\."колона" \(OID \d+\)\npostgres\.public\.enum_table\.a \(OID \d+\)
 
 #
 # Establish direct replication
@@ -476,8 +498,113 @@ DELETE FROM conflict_schema.conflict_table;
 > SELECT COUNT(*) FROM conflict_table;
 0
 
+#
+# Support enum values as strings
+#
+#
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [pk_table.col_dne]
+  )
+  FOR TABLES (
+    "enum_table"
+  );
+contains: invalid TEXT COLUMNS option value: column "pk_table.col_dne" does not exist
+
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [table_dne.col_dne]
+  )
+  FOR TABLES (
+    "enum_table"
+  );
+contains: invalid TEXT COLUMNS option value: table table_dne not found in source
+
+# Reference exists in two schemas, so is not unambiguous
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [another_enum_table."колона"]
+  )
+  FOR ALL TABLES;
+contains: invalid TEXT COLUMNS option value: table another_enum_table is ambiguous, consider specifying the schema
+
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [foo]
+  )
+  FOR ALL TABLES;
+contains: invalid TEXT COLUMNS option value: column name 'foo' must have at least a table qualification
+
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [foo.bar.qux.qax.foo]
+  )
+  FOR ALL TABLES;
+contains: invalid TEXT COLUMNS option value: qualified name did not have between 1 and 3 components: foo.bar.qux.qax
+
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [enum_table.a, enum_table.a]
+  )
+  FOR ALL TABLES;
+contains: invalid TEXT COLUMNS option value: unexpected multiple references to postgres.public.enum_table.a
+
+# utf8_table is not part of mz_source_narrow publication
+! CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source_narrow',
+    TEXT COLUMNS [enum_table.a, utf8_table.f1]
+  )
+  FOR ALL TABLES;
+contains: invalid TEXT COLUMNS option value: table utf8_table not found in source
+
+# n.b includes a reference to pk_table, which is not a table that's part of the
+# source, but is part of the publication.
+
+> CREATE SOURCE enum_source
+  FROM POSTGRES CONNECTION pg (
+    PUBLICATION 'mz_source',
+    TEXT COLUMNS [
+      enum_table.a,
+      public.another_enum_table."колона",
+      pk_table.pk
+    ]
+  )
+  FOR TABLES (
+    "enum_table",
+    public.another_enum_table
+  );
+
+$ set-regex match=\d+ replacement=<NUMBER>
+> SELECT * FROM (SHOW SOURCES) WHERE name LIKE '%enum%';
+another_enum_table      subsource <null>
+enum_source             postgres  <NUMBER>
+enum_table              subsource <null>
+
+$ unset-regex
+
+> SELECT * FROM enum_table
+var0
+var1
+
+> SELECT "колона" FROM another_enum_table
+var2
+var3
+
+#
+# Cleanup
+#
+#
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP PUBLICATION mz_source;
+DROP PUBLICATION mz_source_narrow;
 INSERT INTO pk_table VALUES (99999);
 
 # todo: we're purifying Postgres view names incorrectly, fix that and this error!

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -92,6 +92,11 @@ INSERT INTO conflict_schema.conflict_table VALUES ('234');
 
 CREATE TABLE "space table" ("space column" INTEGER);
 
+CREATE TYPE an_enum AS ENUM ('var0', 'var1');
+
+CREATE TABLE enum_table (a an_enum);
+ALTER TABLE enum_table REPLICA IDENTITY FULL;
+
 #
 # Test that slots created for replication sources are deleted on DROP
 #
@@ -173,10 +178,19 @@ exact:failed to fetch publication information from PostgreSQL database
 # TODO: assert on `detail` here.
 exact:failed to fetch publication information from PostgreSQL database
 
+! CREATE SOURCE "mz_source"
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR TABLES (
+    "enum_table"
+  );
+contains: uses unrecognized type
 
 #
 # Establish direct replication
 #
+#
+# Note: This implicitly tests that enum_table being part of the publication does not
+# prevent us from using other tables as subsources.
 #
 # TODO: This should produce an error because we included the `no_replica_identity` table
 > CREATE SOURCE "mz_source"

--- a/test/pg-cdc/types-enum.td
+++ b/test/pg-cdc/types-enum.td
@@ -8,10 +8,10 @@
 # by the Apache License, Version 2.0.
 
 #
-# Test the MONEY data type
+# ENUM supported only as TEXT
 #
 
-> CREATE SECRET pgpass AS 'password'
+> CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
@@ -28,29 +28,28 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
-CREATE TABLE t1 (f1 MONEY);
-ALTER TABLE t1 REPLICA IDENTITY FULL;
-
-INSERT INTO t1 VALUES (-92233720368547758.08), (+92233720368547758.07);
+CREATE TYPE enum1 AS ENUM ('val1', 'val2');
+CREATE TABLE enum_type ( f1 enum1);
+INSERT INTO enum_type VALUES ('val1'), ('val2');
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE SOURCE mz_source
-  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres' (PUBLICATION 'mz_source')
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source', TEXT COLUMNS (enum_type.f1))
   FOR ALL TABLES;
 
-> SELECT COUNT(*) > 0 FROM t1;
+> SELECT COUNT(*) > 0 FROM enum_type;
 true
 
 # Insert the same data post-snapshot
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO enum_type SELECT * FROM enum_type;
 
-> SELECT pg_typeof(f1) FROM t1 LIMIT 1;
-"double precision"
+> SELECT pg_typeof(f1) FROM enum_type LIMIT 1;
+text
 
-> SELECT * FROM t1;
--92233720368547758.08
-+92233720368547758.07
--92233720368547758.08
-+92233720368547758.07
+> SELECT * FROM enum_type;
+val1
+val1
+val2
+val2

--- a/test/pg-cdc/types-hstore.td
+++ b/test/pg-cdc/types-hstore.td
@@ -8,17 +8,16 @@
 # by the Apache License, Version 2.0.
 
 #
-# Test the HSTORE data type
+# HSTORE supported only as TEXT
 #
 
-> CREATE SECRET pgpass AS 'password'
+> CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
   )
-
 
 # Insert data pre-snapshot
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -36,7 +35,7 @@ INSERT INTO t1 VALUES (NULL), ('a=>1'::hstore);
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE SOURCE mz_source
-  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres' (PUBLICATION 'mz_source')
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source', TEXT COLUMNS (t1.f1))
   FOR ALL TABLES;
 
 > SELECT COUNT(*) > 0 FROM t1;
@@ -47,8 +46,10 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 INSERT INTO t1 SELECT * FROM t1;
 
 > SELECT pg_typeof(f1) FROM t1 LIMIT 1;
-"json"
+"text"
 
 > SELECT * FROM t1;
-"{\"a\":\"1\"}"
-"{\"a\":\"1\"}"
+<null>
+<null>
+"\"a\"=>\"1\""
+"\"a\"=>\"1\""

--- a/test/pg-cdc/types-money.td
+++ b/test/pg-cdc/types-money.td
@@ -8,17 +8,16 @@
 # by the Apache License, Version 2.0.
 
 #
-# Test the ENUM data type
+# MONEY data type supported only as TEXT
 #
 
-> CREATE SECRET pgpass AS 'password'
+> CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
     USER postgres,
     PASSWORD SECRET pgpass
   )
-
 
 # Insert data pre-snapshot
 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -28,28 +27,29 @@ DROP PUBLICATION IF EXISTS mz_source;
 
 CREATE SCHEMA public;
 
-CREATE TYPE enum1 AS ENUM ('val1', 'val2');
-CREATE TABLE enum_type ( f1 enum1);
-INSERT INTO enum_type VALUES ('val1'), ('val2');
+CREATE TABLE t1 (f1 MONEY);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+
+INSERT INTO t1 VALUES (-92233720368547758.08), (+92233720368547758.07);
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 > CREATE SOURCE mz_source
-  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres' (PUBLICATION 'mz_source')
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source', TEXT COLUMNS (t1.f1))
   FOR ALL TABLES;
 
-> SELECT COUNT(*) > 0 FROM enum_type;
+> SELECT COUNT(*) > 0 FROM t1;
 true
 
 # Insert the same data post-snapshot
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-INSERT INTO enum_type SELECT * FROM enum_type;
+INSERT INTO t1 SELECT * FROM t1;
 
-> SELECT pg_typeof(f1) FROM enum_type LIMIT 1;
-text
+> SELECT pg_typeof(f1) FROM t1 LIMIT 1;
+"text"
 
-> SELECT * FROM enum_type;
-val1
-val1
-val2
-val2
+> SELECT * FROM t1;
+"$92,233,720,368,547,758.07"
+"$92,233,720,368,547,758.07"
+"-$92,233,720,368,547,758.08"
+"-$92,233,720,368,547,758.08"

--- a/test/pg-cdc/types-numeric-arbitrary-precision.td
+++ b/test/pg-cdc/types-numeric-arbitrary-precision.td
@@ -8,10 +8,10 @@
 # by the Apache License, Version 2.0.
 
 #
-# Test arbitrary-precision NUMERIC
+# Arbitrary-precision NUMERIC supported only as TEXT
 #
 
-> CREATE SECRET pgpass AS 'password'
+> CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
     DATABASE postgres,
@@ -34,8 +34,9 @@ INSERT INTO t1 VALUES (NULL), ('0.000000000000000000000000000001'), ('-111111111
 
 CREATE PUBLICATION mz_source FOR ALL TABLES;
 
+
 > CREATE SOURCE mz_source
-  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres' (PUBLICATION 'mz_source')
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source', TEXT COLUMNS (t1.f1))
   FOR ALL TABLES;
 
 > SELECT COUNT(*) > 0 FROM t1;
@@ -46,9 +47,11 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 INSERT INTO t1 SELECT * FROM t1;
 
 > SELECT pg_typeof(f1) FROM t1 LIMIT 1;
-"numeric"
+"text"
 
 > SELECT * FROM t1;
+<null>
+<null>
 -1111111111111111111111111111111
 -1111111111111111111111111111111
 0.000000000000000000000000000001

--- a/test/pg-cdc/types-unsupported.td
+++ b/test/pg-cdc/types-unsupported.td
@@ -28,4 +28,4 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 
 # Todo: add test for detail and hint once testdrive supports that
 ! CREATE SOURCE mz_source FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source') FOR ALL TABLES;
-contains: column "person.current_mood" uses unrecognized type
+regex: the following columns contain unsupported types:\npostgres\.public\.person\.current_mood \(OID \d+\)

--- a/test/upgrade/check-from-current_source-pg-cdc.td
+++ b/test/upgrade/check-from-current_source-pg-cdc.td
@@ -8,9 +8,16 @@
 # by the Apache License, Version 2.0.
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
-INSERT INTO upgrade_pg_cdc_table VALUES (11),(12),(13),(14),(15);
+INSERT INTO cdc_int_table VALUES (11),(12),(13),(14),(15);
+INSERT INTO cdc_enum_table VALUES ('var1'), ('var0');
 
-> SELECT * FROM upgrade_pg_cdc_table_v_0_27_0;
+> SELECT * FROM cdc_enum_table;
+var0
+var0
+var1
+var1
+
+> SELECT * FROM cdc_int_table_for_tables;
 1
 2
 3
@@ -23,4 +30,5 @@ INSERT INTO upgrade_pg_cdc_table VALUES (11),(12),(13),(14),(15);
 15
 
 # Drop source so that the replication slot can be reclaimed.
-> DROP SOURCE upgrade_pg_cdc_source CASCADE
+> DROP SOURCE upgrade_pg_cdc_source_for_all_tables CASCADE
+> DROP SOURCE upgrade_pg_cdc_source_for_tables CASCADE

--- a/test/upgrade/create-in-current_source-pg-cdc.td
+++ b/test/upgrade/create-in-current_source-pg-cdc.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+
+DROP PUBLICATION IF EXISTS upgrade_pg_cdc_publication;
+CREATE PUBLICATION upgrade_pg_cdc_publication FOR ALL TABLES;
+
+DROP TABLE IF EXISTS unused_pub_table;
+CREATE TABLE unused_pub_table (f1 INTEGER);
+ALTER TABLE unused_pub_table REPLICA IDENTITY FULL;
+INSERT INTO unused_pub_table VALUES (1);
+
+DROP TABLE IF EXISTS cdc_int_table;
+CREATE TABLE cdc_int_table (f1 INTEGER);
+ALTER TABLE cdc_int_table REPLICA IDENTITY FULL;
+INSERT INTO cdc_int_table VALUES (1),(2),(3),(4),(5);
+
+DROP TABLE IF EXISTS cdc_enum_table;
+DROP TYPE IF EXISTS an_enum;
+
+CREATE TYPE an_enum AS ENUM ('var0', 'var1');
+CREATE TABLE cdc_enum_table (a an_enum);
+INSERT INTO cdc_enum_table VALUES ('var1'), ('var0');
+ALTER TABLE cdc_enum_table REPLICA IDENTITY FULL;
+
+# Specifying `TEXT COLUMNS` lets us ingest enum data.
+> CREATE SECRET IF NOT EXISTS pgpass AS 'postgres';
+> CREATE CONNECTION IF NOT EXISTS pgconn FOR POSTGRES
+  HOST postgres,
+  USER postgres,
+  PASSWORD SECRET pgpass,
+  DATABASE postgres;
+
+> CREATE SOURCE upgrade_pg_cdc_source_for_all_tables
+  FROM POSTGRES
+  CONNECTION pgconn
+  (
+    PUBLICATION 'upgrade_pg_cdc_publication',
+    TEXT COLUMNS (cdc_enum_table.a)
+  )
+  FOR ALL TABLES;
+
+> SELECT * FROM cdc_enum_table;
+var1
+var0
+
+# If we do not specify a table with an unsupported data type, we do not need to
+# specify `TEXT COLUMNS`, even though the table is in the publication.
+
+> CREATE SOURCE upgrade_pg_cdc_source_for_tables
+  FROM POSTGRES
+  CONNECTION pgconn
+  (
+    PUBLICATION 'upgrade_pg_cdc_publication'
+  )
+  FOR TABLES
+  (
+    cdc_int_table AS cdc_int_table_for_tables
+  );
+
+> SELECT * FROM cdc_int_table_for_tables;
+1
+2
+3
+4
+5

--- a/test/upgrade/create-in-v0.27.0-pg-cdc.td
+++ b/test/upgrade/create-in-v0.27.0-pg-cdc.td
@@ -9,17 +9,17 @@
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 
-DROP PUBLICATION IF EXISTS upgrade_pg_cdc_publication;
-CREATE PUBLICATION upgrade_pg_cdc_publication FOR ALL TABLES;
-
+DROP PUBLICATION IF EXISTS upgrade_pg_cdc_publication_v_0_27_0;
 
 DROP TABLE IF EXISTS upgrade_pg_cdc_table;
 CREATE TABLE upgrade_pg_cdc_table (f1 INTEGER);
 ALTER TABLE upgrade_pg_cdc_table REPLICA IDENTITY FULL;
 INSERT INTO upgrade_pg_cdc_table VALUES (1),(2),(3),(4),(5);
 
-> CREATE SECRET pgpass AS 'postgres';
-> CREATE CONNECTION pgconn FOR POSTGRES
+CREATE PUBLICATION upgrade_pg_cdc_publication_v_0_27_0 FOR TABLE upgrade_pg_cdc_table;
+
+> CREATE SECRET IF NOT EXISTS pgpass AS 'postgres';
+> CREATE CONNECTION IF NOT EXISTS pgconn FOR POSTGRES
   HOST postgres,
   USER postgres,
   PASSWORD SECRET pgpass,
@@ -27,10 +27,12 @@ INSERT INTO upgrade_pg_cdc_table VALUES (1),(2),(3),(4),(5);
 > CREATE SOURCE upgrade_pg_cdc_source
   FROM POSTGRES
   CONNECTION pgconn
-  (PUBLICATION 'upgrade_pg_cdc_publication')
-  FOR ALL TABLES;
+  (PUBLICATION 'upgrade_pg_cdc_publication_v_0_27_0')
+  FOR TABLES (
+    upgrade_pg_cdc_table AS upgrade_pg_cdc_table_v_0_27_0
+  );
 
-> SELECT * FROM upgrade_pg_cdc_table;
+> SELECT * FROM upgrade_pg_cdc_table_v_0_27_0;
 1
 2
 3

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -186,8 +186,7 @@ def test_upgrade_from_version(
 
     with c.override(
         Testdrive(
-            validate_postgres_stash=True,
-            volumes_extra=["secrets:/share/secrets"],
+            validate_postgres_stash=True, volumes_extra=["secrets:/share/secrets"]
         )
     ):
         c.run(


### PR DESCRIPTION
Redo of #15856

### Motivation

This PR adds a known-desirable feature.
- Closes #15716

This PR fixes a recognized bug.
- Fixes #15889

### Tips for reviewers

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Support ingesting unsupported types' data from PostgreSQL sources as text using the new `TEXT COLUMNS` option. For example:

  ```sql
  CREATE SOURCE pg_source
  FROM POSTGRES
  CONNECTION pgconn
  (
    PUBLICATION 'pg_pub',
    TEXT COLUMNS (tbl.col_of_unsupported_type)
  )
  FOR ALL TABLES;
  ```

  This statement will decode the column `tbl.col_of_unsupported_type` into its
  `text` representation. For example, with the PostgreSQL enum type, this ingests
   the actual strings that comprise the enum's values.
