### PR TITLE
[sources] Thread more errors through to the health check

### DIFF
--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -346,8 +346,8 @@ impl TryFrom<&str> for SourceStatus {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceStatusUpdate {
-    status: SourceStatus,
-    error: Option<String>,
+    pub status: SourceStatus,
+    pub error: Option<String>,
     // TODO(andrioni): figure out later how to accept a JSON as metadata
 }
 

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -314,7 +314,8 @@ impl SourceReader for KafkaSourceReader {
                     self.source_name, self.topic_name, e
                 ),
                 Ok(message) => {
-                    let source_message = construct_source_message(&message, self.include_headers)?;
+                    let source_message = construct_source_message(&message, self.include_headers)
+                        .map_err(SourceReaderError::other_definite)?;
                     next_message = self.handle_message(source_message);
                 }
             }
@@ -332,7 +333,9 @@ impl SourceReader for KafkaSourceReader {
                 break;
             }
 
-            let message = self.poll_from_next_queue()?;
+            let message = self
+                .poll_from_next_queue()
+                .map_err(SourceReaderError::other_definite)?;
             attempts += 1;
 
             if let Some(message) = message {

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -33,6 +33,7 @@ use mz_storage_client::types::sources::encoding::SourceDataEncoding;
 use mz_storage_client::types::sources::{KafkaSourceConnection, MzOffset};
 
 use crate::source::commit::LogCommitter;
+use crate::source::healthcheck::{SourceStatus, SourceStatusUpdate};
 use crate::source::types::{OffsetCommitter, SourceConnectionBuilder};
 use crate::source::{
     NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
@@ -333,13 +334,23 @@ impl SourceReader for KafkaSourceReader {
                 break;
             }
 
-            let message = self
-                .poll_from_next_queue()
-                .map_err(SourceReaderError::other_definite)?;
+            let message = self.poll_from_next_queue()?;
             attempts += 1;
 
-            if let Some(message) = message {
-                next_message = self.handle_message(message);
+            match message {
+                Ok(Some(message)) => {
+                    next_message = self.handle_message(message);
+                }
+                Err(error) => {
+                    next_message =
+                        NextMessage::Ready(SourceMessageType::SourceStatus(SourceStatusUpdate {
+                            status: SourceStatus::Stalled,
+                            error: Some(error),
+                        }))
+                }
+                Ok(None) => {
+                    // no message in this queue; keep looping
+                }
             }
         }
 
@@ -544,29 +555,30 @@ impl KafkaSourceReader {
     /// fair manner.
     fn poll_from_next_queue(
         &mut self,
-    ) -> Result<Option<SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>, ()>>, anyhow::Error> {
+    ) -> Result<
+        Result<Option<SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>, ()>>, String>,
+        SourceReaderError,
+    > {
         let mut partition_queue = self.partition_consumers.pop_front().unwrap();
 
-        let message = match partition_queue.get_next_message()? {
-            Err(e) => {
+        let message = partition_queue
+            .get_next_message()
+            .map_err(SourceReaderError::other_definite)?
+            .map_err(|e| {
                 let pid = partition_queue.pid();
                 let last_offset = self
                     .last_offsets
                     .get(&pid)
                     .expect("partition known to be installed");
-
-                error!(
+                format!(
                     "kafka error consuming from source: {} topic: {}: partition: {} last processed offset: {} : {}",
                     self.source_name,
                     self.topic_name,
                     pid,
                     last_offset,
                     e
-                    );
-                None
-            }
-            Ok(m) => m,
-        };
+                )
+            });
 
         self.partition_consumers.push_back(partition_queue);
 

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -213,7 +213,7 @@ impl SourceReader for KinesisSourceReader {
                 .block_on(self.update_shard_information())
             {
                 error!("{:#?}", e);
-                return Err(e.into());
+                return Err(SourceReaderError::other_definite(e));
             }
             self.last_checked_shards = std::time::Instant::now();
         }

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -966,7 +966,7 @@ impl SourceReader for S3SourceReader {
                     Ok(NextMessage::Pending)
                 }
                 e @ (S3Error::ListObjectsFailed { .. } | S3Error::IoError { .. }) => {
-                    Err(anyhow::Error::new(e).into())
+                    Err(SourceReaderError::other_definite(anyhow::Error::new(e)))
                 }
             },
             None => Ok(NextMessage::Pending),

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -377,7 +377,10 @@ where
                                         SourceStatusUpdate { status: SourceStatus::Starting, ..} => Some(HealthStatus::Starting),
                                         SourceStatusUpdate { status: SourceStatus::Running, ..} => Some(HealthStatus::Running),
                                         SourceStatusUpdate { status: SourceStatus::Stalled, error: Some(e)} => Some(HealthStatus::StalledWithError(e)),
-                                        _ => None,
+                                        other => {
+                                            warn!("Received currently-unhandled source status update: {other:?}");
+                                            None
+                                        },
                                     };
                                     status_update = update.or(status_update);
                                 }
@@ -815,8 +818,8 @@ where
                             // a (temporary) stall.
                             Some(status.clone())
                         }
-                        (_, _, true) => Some(HealthStatus::Running),
-                        (None, _, false) => None,
+                        (None, None, true) => Some(HealthStatus::Running),
+                        (None, None, false) => None,
                     };
 
                     if let Some(health) = maybe_health {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -67,6 +67,7 @@ use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::source::antichain::{MutableOffsetAntichain, OffsetAntichain};
 use crate::source::healthcheck;
+use crate::source::healthcheck::{SourceStatus, SourceStatusUpdate};
 
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::{ReclockBatch, ReclockFollower, ReclockOperator};
@@ -118,6 +119,8 @@ struct SourceMessageBatch<Key, Value, Diff> {
     /// be _definite_: re-running the source will produce the same error. If an error
     /// is added to this collection, the source will be permanently wedged.
     source_errors: Vec<SourceError>,
+    /// The latest status update for the batch, if any.
+    status_update: Option<HealthStatus>,
     /// The current upper of the `SourceReader`, at the time this batch was
     /// emitted. Source uppers emitted via batches must never regress.
     source_upper: OffsetAntichain,
@@ -241,6 +244,8 @@ type MessageAndOffset<S> = (
 struct SourceReaderOperatorOutput<S: SourceReader> {
     /// Messages and their offsets from the source reader.
     messages: HashMap<PartitionId, Vec<MessageAndOffset<S>>>,
+    /// The latest status update for this worker, if any.
+    status_update: Option<HealthStatus>,
     /// See `SourceMessageBatch`.
     source_errors: Vec<SourceReaderError>,
     /// A list of partitions that this source reader instance
@@ -292,6 +297,7 @@ where
         // not advance its downstream frontier.
         yield Some(SourceReaderOperatorOutput {
             messages: HashMap::new(),
+            status_update: None,
             source_errors: Vec::new(),
             unconsumed_partitions: Vec::new(),
             source_upper: initial_source_upper,
@@ -311,6 +317,7 @@ where
         let mut untimestamped_messages = HashMap::<_, Vec<_>>::new();
         let mut unconsumed_partitions = Vec::new();
         let mut source_errors = vec![];
+        let mut status_update = None;
         loop {
             // TODO(guswyn): move lots of this out of the macro so rustfmt works better
             tokio::select! {
@@ -365,7 +372,14 @@ where
                                     }
                                     untimestamped_messages.entry(pid).or_default().push((message, offset));
                                 }
-                                SourceMessageType::SourceStatus(_update) => {
+                                SourceMessageType::SourceStatus(update) => {
+                                    let update = match update {
+                                        SourceStatusUpdate { status: SourceStatus::Starting, ..} => Some(HealthStatus::Starting),
+                                        SourceStatusUpdate { status: SourceStatus::Running, ..} => Some(HealthStatus::Running),
+                                        SourceStatusUpdate { status: SourceStatus::Stalled, error: Some(e)} => Some(HealthStatus::StalledWithError(e)),
+                                        _ => None,
+                                    };
+                                    status_update = update.or(status_update);
                                 }
                             }
                         }
@@ -382,6 +396,7 @@ where
                             yield Some(
                                 SourceReaderOperatorOutput {
                                     messages: std::mem::take(&mut untimestamped_messages),
+                                    status_update,
                                     source_errors: source_errors.drain(..).collect_vec(),
                                     unconsumed_partitions,
                                     source_upper: source_upper.clone(),
@@ -418,6 +433,7 @@ where
                     yield Some(
                         SourceReaderOperatorOutput {
                             messages: std::mem::take(&mut untimestamped_messages),
+                            status_update: status_update.take(),
                             source_errors: source_errors.drain(..).collect_vec(),
                             unconsumed_partitions: unconsumed_partitions.clone(),
                             source_upper: source_upper.clone(),
@@ -664,6 +680,7 @@ where
                     };
                     let SourceReaderOperatorOutput {
                         messages,
+                        status_update,
                         source_errors,
                         unconsumed_partitions,
                         source_upper,
@@ -726,6 +743,7 @@ where
 
                     let message_batch = SourceMessageBatch {
                         messages,
+                        status_update,
                         source_errors,
                         source_upper: extended_source_upper,
                         batch_upper: batch_upper.clone(),
@@ -784,16 +802,21 @@ where
                     let has_errors = batch.source_errors.first();
                     let has_messages = batch.messages.values().any(|vs| !vs.is_empty());
 
-                    let maybe_health = match (has_errors, has_messages) {
-                        (Some(error), _) => {
+                    let maybe_health = match (has_errors, &batch.status_update, has_messages) {
+                        (Some(error), _, _) => {
                             // Arguably this case should be "failed", since generally a source
                             // cannot recover by the time an error reaches this far down the pipe.
                             // However, we don't actually shut down the source on error yet, so
                             // treating this as a possibly-temporary stall for now.
                             Some(HealthStatus::StalledWithError(error.error.to_string()))
                         }
-                        (_, true) => Some(HealthStatus::Running),
-                        (None, false) => None,
+                        (_, Some(status), _) => {
+                            // This is the transient error case, and is correctly represented as
+                            // a (temporary) stall.
+                            Some(status.clone())
+                        }
+                        (_, _, true) => Some(HealthStatus::Running),
+                        (None, _, false) => None,
                     };
 
                     if let Some(health) = maybe_health {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -399,7 +399,7 @@ where
                             yield Some(
                                 SourceReaderOperatorOutput {
                                     messages: std::mem::take(&mut untimestamped_messages),
-                                    status_update,
+                                    status_update: status_update.take(),
                                     source_errors: source_errors.drain(..).collect_vec(),
                                     unconsumed_partitions,
                                     source_upper: source_upper.clone(),

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -322,16 +322,17 @@ pub struct DecodeResult {
     pub metadata: Row,
 }
 
-/// A structured error for `SourceReader::get_next_message`
-/// implementors. Also implements `From<anyhow::Error>`
-/// for convenience.
+/// A structured error for `SourceReader::get_next_message` implementors.
 #[derive(Debug)]
 pub struct SourceReaderError {
     pub inner: SourceErrorDetails,
 }
 
-impl From<anyhow::Error> for SourceReaderError {
-    fn from(e: anyhow::Error) -> Self {
+impl SourceReaderError {
+    /// This is an unclassified but definite error. This is typically only appropriate
+    /// when the error is permanently fatal for the source... some critical invariant
+    /// is violated or data is corrupted, for example.
+    pub fn other_definite(e: anyhow::Error) -> SourceReaderError {
         SourceReaderError {
             inner: SourceErrorDetails::Other(format!("{}", e)),
         }


### PR DESCRIPTION
Three related things:
- Makes all source error conversions explicit. In the future, we'd like users to be more explicit about what errrors may exist, since those stick around in durable storage.
- Thread source-status updates through the timely dataflow through to the health op.
- Actually report health status in one case in the Kafka source.

There are a lot of other errors that are secretly retried within each source implementation. I expect to get a few more of them in followups, but I wanted to include at least one here so the plumbing was exercised.

### Motivation

This PR adds a known-desirable feature. #12864

### Tips for reviewer

For colour, here's what happens if I block the source from reading with ACLs, restart it a few times, and then fix the ACLs:

```
materialize=> select * from mz_internal.mz_source_status_history order by occurred_at;
        occurred_at         | source_id |  status  |                                                                                            error                                                                                            | details 
----------------------------+-----------+----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------
 2022-11-14 17:09:21.912+00 | u2        | starting |                                                                                                                                                                                             | 
 2022-11-14 17:10:01.104+00 | u2        | running  |                                                                                                                                                                                             | 
 2022-11-14 17:24:12.118+00 | u2        | stalled  | kafka error consuming from source: kafka-u2 topic: events: partition: 0 last processed offset: 4 : Message consumption error: TopicAuthorizationFailed (Broker: Topic authorization failed) | 
 2022-11-14 17:27:20.074+00 | u2        | starting |                                                                                                                                                                                             | 
 2022-11-14 17:27:22.367+00 | u2        | stalled  | kafka error consuming from source: kafka-u2 topic: events: partition: 0 last processed offset: 4 : Message consumption error: TopicAuthorizationFailed (Broker: Topic authorization failed) | 
 2022-11-14 17:29:34.105+00 | u2        | starting |                                                                                                                                                                                             | 
 2022-11-14 17:29:36.396+00 | u2        | stalled  | kafka error consuming from source: kafka-u2 topic: events: partition: 0 last processed offset: 4 : Message consumption error: TopicAuthorizationFailed (Broker: Topic authorization failed) | 
 2022-11-14 17:30:55.796+00 | u2        | running  |                                                                                                                                                                                             | 
(8 rows)
```

I'd like to add an automated test, but I'm not sure the right way to approach it. I think this may be mergeable without additional tests -- the existing tests provide some evidence that I haven't broken the source pipeline or anything -- but am happy to take feedback on that of course.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
