### PR TITLE
[sinks] Unify parameters of StorageSinkDesc

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -20,7 +20,6 @@ use std::iter;
 
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
-use mz_persist_client::ShardId;
 use proptest::prelude::{any, Arbitrary};
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
@@ -39,7 +38,7 @@ use mz_timely_util::progress::any_antichain;
 use crate::client::proto_storage_client::ProtoStorageClient;
 use crate::client::proto_storage_server::ProtoStorage;
 use crate::controller::CollectionMetadata;
-use crate::types::sinks::StorageSinkDesc;
+use crate::types::sinks::{MetadataFilled, StorageSinkDesc};
 use crate::types::sources::IngestionDescription;
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage_client.client.rs"));
@@ -189,7 +188,7 @@ impl RustType<ProtoCreateSinkCommand> for CreateSinkCommand<mz_repr::Timestamp> 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct CreateSinkCommand<T> {
     pub id: GlobalId,
-    pub description: StorageSinkDesc<CollectionMetadata, ShardId, T>,
+    pub description: StorageSinkDesc<MetadataFilled, T>,
 }
 
 impl Arbitrary for CreateSinkCommand<mz_repr::Timestamp> {
@@ -199,7 +198,7 @@ impl Arbitrary for CreateSinkCommand<mz_repr::Timestamp> {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<GlobalId>(),
-            any::<StorageSinkDesc<CollectionMetadata, ShardId, mz_repr::Timestamp>>(),
+            any::<StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>>(),
         )
             .prop_map(|(id, description)| Self { id, description })
             .boxed()

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -20,8 +20,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
-use std::fmt;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -59,7 +58,9 @@ use crate::client::{
 use crate::controller::hosts::{StorageHosts, StorageHostsConfig};
 use crate::types::errors::DataflowError;
 use crate::types::hosts::StorageHostConfig;
-use crate::types::sinks::{ProtoDurableExportMetadata, SinkAsOf, StorageSinkDesc};
+use crate::types::sinks::{
+    MetadataUnfilled, ProtoDurableExportMetadata, SinkAsOf, StorageSinkDesc,
+};
 use crate::types::sources::{IngestionDescription, SourceExport};
 
 mod hosts;
@@ -142,7 +143,7 @@ impl<T> From<RelationDesc> for CollectionDescription<T> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExportDescription<T = mz_repr::Timestamp> {
-    pub sink: StorageSinkDesc<(), GlobalId, T>,
+    pub sink: StorageSinkDesc<MetadataUnfilled, T>,
     /// The address of a `storaged` process on which to install the sink or the
     /// settings for spinning up a controller-managed process.
     pub host_config: StorageHostConfig,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -107,10 +107,9 @@ use timely::dataflow::Scope;
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
-use mz_persist_client::ShardId;
 use mz_repr::GlobalId;
 use mz_storage_client::controller::CollectionMetadata;
-use mz_storage_client::types::sinks::StorageSinkDesc;
+use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::IngestionDescription;
 
 use crate::storage_state::StorageState;
@@ -175,7 +174,7 @@ pub fn build_export_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     storage_state: &mut StorageState,
     id: GlobalId,
-    description: StorageSinkDesc<CollectionMetadata, ShardId, mz_repr::Timestamp>,
+    description: StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -25,10 +25,11 @@ use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistLocation, ShardId};
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
-use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
 use mz_storage_client::types::errors::DataflowError;
-use mz_storage_client::types::sinks::{SinkEnvelope, StorageSinkConnection, StorageSinkDesc};
+use mz_storage_client::types::sinks::{
+    MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
+};
 
 use crate::storage_state::{SinkToken, StorageState};
 
@@ -41,7 +42,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
     tokens: &mut std::collections::BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
     import_ids: BTreeSet<GlobalId>,
     sink_id: GlobalId,
-    sink: &StorageSinkDesc<CollectionMetadata, ShardId>,
+    sink: &StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
 ) {
     let sink_render = get_sink_render_for(&sink.connection);
 
@@ -99,7 +100,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
 #[allow(clippy::borrowed_box)]
 fn apply_sink_envelope<G>(
     sink_id: GlobalId,
-    sink: &StorageSinkDesc<CollectionMetadata, ShardId>,
+    sink: &StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
     sink_render: &Box<dyn SinkRender<G>>,
     collection: Collection<G, Row, Diff>,
 ) -> Collection<G, (Option<Row>, Option<Row>), Diff>
@@ -235,7 +236,7 @@ where
     fn render_continuous_sink(
         &self,
         storage_state: &mut StorageState,
-        sink: &StorageSinkDesc<CollectionMetadata, ShardId>,
+        sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         err_collection: Collection<G, DataflowError, Diff>,

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -51,13 +51,12 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_ore::retry::Retry;
 use mz_ore::task;
-use mz_persist_client::ShardId;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
-use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sinks::{
-    KafkaSinkConnection, PublishedSchemaInfo, SinkAsOf, SinkEnvelope, StorageSinkDesc,
+    KafkaSinkConnection, MetadataFilled, PublishedSchemaInfo, SinkAsOf, SinkEnvelope,
+    StorageSinkDesc,
 };
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 
@@ -91,7 +90,7 @@ where
     fn render_continuous_sink(
         &self,
         storage_state: &mut StorageState,
-        sink: &StorageSinkDesc<CollectionMetadata, ShardId>,
+        sink: &StorageSinkDesc<MetadataFilled, Timestamp>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         // TODO(benesch): errors should stream out through the sink,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -31,7 +31,7 @@ use mz_repr::{Diff, GlobalId, Timestamp};
 use mz_storage_client::client::{StorageCommand, StorageResponse};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::connections::ConnectionContext;
-use mz_storage_client::types::sinks::StorageSinkDesc;
+use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::{IngestionDescription, SourceData};
 
 use crate::decode::metrics::DecodeMetrics;
@@ -73,8 +73,7 @@ pub struct StorageState {
     /// Descriptions of each installed ingestion.
     pub ingestions: HashMap<GlobalId, IngestionDescription<CollectionMetadata>>,
     /// Descriptions of each installed export.
-    pub exports:
-        HashMap<GlobalId, StorageSinkDesc<CollectionMetadata, ShardId, mz_repr::Timestamp>>,
+    pub exports: HashMap<GlobalId, StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>>,
     /// Undocumented
     pub now: NowFn,
     /// Metrics for the source-specific side of dataflows.


### PR DESCRIPTION
Just rust things.  Should have no substantive changes.  These parameters will always travel together so codify that

### Motivation
Follow-up from #15586 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - none
