### PR TITLE
storage: add basic source progress metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,6 +4346,7 @@ dependencies = [
  "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist-client",
+ "mz-persist-types",
  "mz-pgcopy",
  "mz-pid-file",
  "mz-postgres-util",

--- a/misc/prometheus/README.md
+++ b/misc/prometheus/README.md
@@ -1,0 +1,14 @@
+# Local Prometheus testing
+
+### Usage
+
+```
+docker run -p 9090:9090 -v $(pwd)/misc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus
+```
+
+Note: on linux you will additionally need `--add-host host.docker.internal:host-gateway`!
+
+You can adjust `prometheus.yml` to add specific `storaged` and `computed` instances.
+
+
+Go to <http://localhost:9090/graph> for the Prometheus UI.

--- a/misc/prometheus/prometheus.yml
+++ b/misc/prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: environmentd
+    static_configs:
+    - targets: ["host.docker.internal:6878"]
+      labels:
+        namespace: localhost
+        pod: environmentd

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -39,6 +39,7 @@ mz-kinesis-util = { path = "../kinesis-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
+mz-persist-types = { path = "../persist-types" }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pid-file = { path = "../pid-file" }
 mz-postgres-util = { path = "../postgres-util" }

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -264,6 +264,7 @@ pub fn render<G>(
                             .expect("cannot append updates")
                             .expect("invalid/outdated upper");
 
+                        metrics.processed_batches.inc();
                         metrics.row_inserts.inc_by(batch_builder.inserts);
                         metrics.row_retractions.inc_by(batch_builder.retractions);
                         metrics.error_inserts.inc_by(batch_builder.error_inserts);

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -84,6 +84,13 @@ impl KinesisMetrics {
 pub(super) struct SourceSpecificMetrics {
     pub(super) capability: UIntGaugeVec,
     pub(super) resume_upper: IntGaugeVec,
+    /// A timestamp gauge representing forward progress
+    /// in the data shard.
+    pub(super) progress: IntGaugeVec,
+    pub(super) rows: IntCounterVec,
+    /// A counter representing the actual numbers of
+    /// errors being committed to the data shard.
+    pub(super) errors: IntCounterVec,
 }
 
 impl SourceSpecificMetrics {
@@ -99,6 +106,21 @@ impl SourceSpecificMetrics {
                 // TODO(guswynn): should this also track the resumption frontier operator?
                 help: "The timestamp-domain resumption frontier chosen for a source's ingestion",
                 var_labels: ["source_id"],
+            )),
+            progress: registry.register(metric!(
+                name: "mz_source_progress",
+                help: "A timestamp gauge representing forward progess in the data shard",
+                var_labels: ["source_id", "output", "shard"],
+            )),
+            rows: registry.register(metric!(
+                name: "mz_source_rows",
+                help: "A counter representing the actual number of rows being committed to the data shard",
+                var_labels: ["source_id", "output", "shard"],
+            )),
+            errors: registry.register(metric!(
+                name: "mz_source_errors",
+                help: "A counter representing the actual number of errors being committed to the data shard",
+                var_labels: ["source_id", "output", "shard"],
             )),
         }
     }

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -91,6 +91,7 @@ pub(super) struct SourceSpecificMetrics {
     pub(super) row_retractions: IntCounterVec,
     pub(super) error_inserts: IntCounterVec,
     pub(super) error_retractions: IntCounterVec,
+    pub(super) persist_sink_processed_batches: IntCounterVec,
 }
 
 impl SourceSpecificMetrics {
@@ -130,6 +131,12 @@ impl SourceSpecificMetrics {
             error_retractions: registry.register(metric!(
                 name: "mz_source_error_retractions",
                 help: "A counter representing the actual number of errors being retracted from the data shard",
+                var_labels: ["source_id", "output", "shard"],
+            )),
+            persist_sink_processed_batches: registry.register(metric!(
+                name: "mz_source_processed_batches",
+                help: "A counter representing the number of persist sink batches with actual data \
+                we have successfully processed.",
                 var_labels: ["source_id", "output", "shard"],
             )),
         }

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -87,10 +87,10 @@ pub(super) struct SourceSpecificMetrics {
     /// A timestamp gauge representing forward progress
     /// in the data shard.
     pub(super) progress: IntGaugeVec,
-    pub(super) rows: IntCounterVec,
-    /// A counter representing the actual numbers of
-    /// errors being committed to the data shard.
-    pub(super) errors: IntCounterVec,
+    pub(super) row_inserts: IntCounterVec,
+    pub(super) row_retractions: IntCounterVec,
+    pub(super) error_inserts: IntCounterVec,
+    pub(super) error_retractions: IntCounterVec,
 }
 
 impl SourceSpecificMetrics {
@@ -112,14 +112,24 @@ impl SourceSpecificMetrics {
                 help: "A timestamp gauge representing forward progess in the data shard",
                 var_labels: ["source_id", "output", "shard"],
             )),
-            rows: registry.register(metric!(
-                name: "mz_source_rows",
-                help: "A counter representing the actual number of rows being committed to the data shard",
+            row_inserts: registry.register(metric!(
+                name: "mz_source_row_inserts",
+                help: "A counter representing the actual number of rows being inserted to the data shard",
                 var_labels: ["source_id", "output", "shard"],
             )),
-            errors: registry.register(metric!(
-                name: "mz_source_errors",
-                help: "A counter representing the actual number of errors being committed to the data shard",
+            row_retractions: registry.register(metric!(
+                name: "mz_source_row_retractions",
+                help: "A counter representing the actual number of rows being retracted from the data shard",
+                var_labels: ["source_id", "output", "shard"],
+            )),
+            error_inserts: registry.register(metric!(
+                name: "mz_source_error_inserts",
+                help: "A counter representing the actual number of errors being inserted to the data shard",
+                var_labels: ["source_id", "output", "shard"],
+            )),
+            error_retractions: registry.register(metric!(
+                name: "mz_source_error_retractions",
+                help: "A counter representing the actual number of errors being retracted from the data shard",
                 var_labels: ["source_id", "output", "shard"],
             )),
         }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -341,8 +341,10 @@ impl From<anyhow::Error> for SourceReaderError {
 /// Source-specific metrics in the persist sink
 pub struct SourcePersistSinkMetrics {
     pub(crate) progress: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
-    pub(crate) rows: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub(crate) errors: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) row_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) row_retractions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) error_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) error_retractions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
 
 impl SourcePersistSinkMetrics {
@@ -360,16 +362,38 @@ impl SourcePersistSinkMetrics {
                 output_index.to_string(),
                 shard.clone(),
             ]),
-            rows: base.source_specific.rows.get_delete_on_drop_counter(vec![
-                source_id.to_string(),
-                output_index.to_string(),
-                shard.clone(),
-            ]),
-            errors: base.source_specific.errors.get_delete_on_drop_counter(vec![
-                source_id.to_string(),
-                output_index.to_string(),
-                shard,
-            ]),
+            row_inserts: base
+                .source_specific
+                .row_inserts
+                .get_delete_on_drop_counter(vec![
+                    source_id.to_string(),
+                    output_index.to_string(),
+                    shard.clone(),
+                ]),
+            row_retractions: base
+                .source_specific
+                .row_retractions
+                .get_delete_on_drop_counter(vec![
+                    source_id.to_string(),
+                    output_index.to_string(),
+                    shard.clone(),
+                ]),
+            error_inserts: base
+                .source_specific
+                .error_inserts
+                .get_delete_on_drop_counter(vec![
+                    source_id.to_string(),
+                    output_index.to_string(),
+                    shard.clone(),
+                ]),
+            error_retractions: base
+                .source_specific
+                .error_retractions
+                .get_delete_on_drop_counter(vec![
+                    source_id.to_string(),
+                    output_index.to_string(),
+                    shard,
+                ]),
         }
     }
 }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -345,6 +345,7 @@ pub struct SourcePersistSinkMetrics {
     pub(crate) row_retractions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) error_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) error_retractions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) processed_batches: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
 
 impl SourcePersistSinkMetrics {
@@ -389,6 +390,14 @@ impl SourcePersistSinkMetrics {
             error_retractions: base
                 .source_specific
                 .error_retractions
+                .get_delete_on_drop_counter(vec![
+                    source_id.to_string(),
+                    output_index.to_string(),
+                    shard.clone(),
+                ]),
+            processed_batches: base
+                .source_specific
+                .persist_sink_processed_batches
                 .get_delete_on_drop_counter(vec![
                     source_id.to_string(),
                     output_index.to_string(),

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -338,6 +338,42 @@ impl From<anyhow::Error> for SourceReaderError {
     }
 }
 
+/// Source-specific metrics in the persist sink
+pub struct SourcePersistSinkMetrics {
+    pub(crate) progress: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
+    pub(crate) rows: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) errors: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+}
+
+impl SourcePersistSinkMetrics {
+    /// Initialises source metrics for a given (source_id, worker_id)
+    pub fn new(
+        base: &SourceBaseMetrics,
+        shard_id: &mz_persist_client::ShardId,
+        source_id: GlobalId,
+        output_index: usize,
+    ) -> SourcePersistSinkMetrics {
+        let shard = shard_id.to_string();
+        SourcePersistSinkMetrics {
+            progress: base.source_specific.progress.get_delete_on_drop_gauge(vec![
+                source_id.to_string(),
+                output_index.to_string(),
+                shard.clone(),
+            ]),
+            rows: base.source_specific.rows.get_delete_on_drop_counter(vec![
+                source_id.to_string(),
+                output_index.to_string(),
+                shard.clone(),
+            ]),
+            errors: base.source_specific.errors.get_delete_on_drop_counter(vec![
+                source_id.to_string(),
+                output_index.to_string(),
+                shard,
+            ]),
+        }
+    }
+}
+
 /// Source-specific Prometheus metrics
 pub struct SourceMetrics {
     /// Value of the capability associated with this source


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/15904

Some important notes:
- this pr interprets "Source ingestion rate" as "rows/s" (and "error/s"), where the interval is defined in the promql query. The `rows` and `errors` counters are meaningless across storage restarts
  - Its possible people want `bytes/s`, but ideally persist would handle this. Unfortunately `goodbytes` is a progress-scoped, not shard-scoped right now, cc @pH14 
- I added as many labels as possible without increasing cardinality (`shard` seems really useful to me!)
- This pr interprets "source progress" and "ingestion rate" as "actual progress at the end of the source pipeline", and does not instrument progress as we read data from upstream. That could also be useful, and can be added later.
- the bottom commit is just to make testing stuff easier. My use of `host.docker.internal` might just be bad cc @benesch 
- This pr does not implement progress for storage sinks, but that will be a similar implementation
- These are engineering/support specific, and not related to (similar) metrics that will be exposed to users through system tables

### Motivation


  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - tested locally 
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

