### PR TITLE
storage: cleanup stored sink state on drop response

### DIFF
--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -346,6 +346,7 @@ where
             StorageResponse::DroppedIds(dropped_ids) => {
                 for id in dropped_ids.iter() {
                     self.sources.remove(id);
+                    self.sinks.remove(id);
                     self.uppers.remove(id);
                 }
                 Some(StorageResponse::DroppedIds(dropped_ids))


### PR DESCRIPTION
### Motivation

We were previously never cleaning up sink commands from the Rehydrating client state which can cause panics when we are actually rehydrating. 

This was discovered by @bkirwi after observing reported panics in Honeycomb so h/to Ben for paying attention at those dashboards!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
