### PR TITLE
Improve compute controller error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,6 +3310,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "thiserror",
  "timely",
  "tokio",
  "tokio-stream",

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -15,7 +15,7 @@ use dec::TryFromDecimalError;
 use mz_repr::adt::timestamp::TimestampError;
 use tokio::sync::oneshot;
 
-use mz_compute_client::controller::ComputeError;
+use mz_compute_client::controller::error as compute_error;
 use mz_expr::{EvalError, UnmaterializableFunc};
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::str::StrExt;
@@ -188,7 +188,7 @@ pub enum AdapterError {
     /// An error occurred in the storage layer
     Storage(mz_storage_client::controller::StorageError),
     /// An error occurred in the compute layer
-    Compute(mz_compute_client::controller::ComputeError),
+    Compute(anyhow::Error),
 }
 
 impl AdapterError {
@@ -564,9 +564,9 @@ impl From<StorageError> for AdapterError {
     }
 }
 
-impl From<ComputeError> for AdapterError {
-    fn from(e: ComputeError) -> Self {
-        AdapterError::Compute(e)
+impl From<compute_error::InstanceExists> for AdapterError {
+    fn from(e: compute_error::InstanceExists) -> Self {
+        AdapterError::Compute(e.into())
     }
 }
 

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -31,6 +31,7 @@ prost = { version = "0.11.2", features = ["no-recursion-limit"] }
 regex = "1.6.0"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.86"
+thiserror = "1.0.37"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.20.2"
 tokio-stream = "0.1.11"

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -30,7 +30,6 @@
 //! recover each dataflow to its current state in case of failure or other reconfiguration.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::error::Error;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
@@ -59,6 +58,10 @@ use crate::logging::{LogVariant, LogView, LoggingConfig};
 use crate::response::{ComputeResponse, PeekResponse, SubscribeResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
+use self::error::{
+    CollectionLookupError, CollectionMissing, CollectionUpdateError, DataflowCreationError,
+    InstanceExists, InstanceMissing, PeekError, ReplicaCreationError, ReplicaDropError,
+};
 use self::instance::{ActiveInstance, Instance};
 use self::orchestrator::ComputeOrchestrator;
 
@@ -66,7 +69,10 @@ mod instance;
 mod orchestrator;
 mod replica;
 
+pub mod error;
+
 pub use mz_orchestrator::ServiceStatus as ComputeInstanceStatus;
+
 /// An abstraction allowing us to name different compute instances.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum ComputeInstanceId {
@@ -135,88 +141,6 @@ pub enum ComputeControllerResponse<T> {
     /// A notification that we heard a response from the given replica at the
     /// given time.
     ReplicaHeartbeat(ReplicaId, DateTime<Utc>),
-}
-
-/// Errors arising from compute commands.
-#[derive(Debug)]
-pub enum ComputeError {
-    /// Command referenced an instance that was not present.
-    InstanceMissing(ComputeInstanceId),
-    /// Command referenced an identifier that was not present.
-    IdentifierMissing(GlobalId),
-    /// Command referenced a replica that was not present.
-    ReplicaMissing(ReplicaId),
-    /// The identified instance exists already.
-    InstanceExists(ComputeInstanceId),
-    /// Dataflow was malformed (e.g. missing `as_of`).
-    DataflowMalformed,
-    /// The dataflow `as_of` was not greater than the `since` of the identifier.
-    DataflowSinceViolation(GlobalId),
-    /// The peek `timestamp` was not greater than the `since` of the identifier.
-    PeekSinceViolation(GlobalId),
-    /// An error from the underlying client.
-    ClientError(anyhow::Error),
-    /// An error during an interaction with Storage
-    StorageError(StorageError),
-}
-
-impl Error for ComputeError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::InstanceMissing(_)
-            | Self::IdentifierMissing(_)
-            | Self::ReplicaMissing(_)
-            | Self::InstanceExists(_)
-            | Self::DataflowMalformed
-            | Self::DataflowSinceViolation(_)
-            | Self::PeekSinceViolation(_) => None,
-            Self::ClientError(err) => Some(err.root_cause()),
-            Self::StorageError(err) => err.source(),
-        }
-    }
-}
-
-impl fmt::Display for ComputeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("compute error: ")?;
-        match self {
-            Self::InstanceMissing(id) => write!(
-                f,
-                "command referenced an instance that was not present: {id}"
-            ),
-            Self::ReplicaMissing(id) => {
-                write!(f, "command referenced a replica that was not present: {id}")
-            }
-            Self::IdentifierMissing(id) => write!(
-                f,
-                "command referenced an identifier that was not present: {id}"
-            ),
-            Self::InstanceExists(id) => write!(f, "an instance with this ID exists already: {id}"),
-            Self::DataflowMalformed => write!(f, "dataflow was malformed"),
-            Self::DataflowSinceViolation(id) => write!(
-                f,
-                "dataflow as_of was not greater than the `since` of the identifier: {id}"
-            ),
-            Self::PeekSinceViolation(id) => write!(
-                f,
-                "peek timestamp was not greater than the `since` of the identifier: {id}"
-            ),
-            Self::ClientError(err) => write!(f, "underlying client error: {err}"),
-            Self::StorageError(err) => write!(f, "storage interaction error: {err}"),
-        }
-    }
-}
-
-impl From<StorageError> for ComputeError {
-    fn from(error: StorageError) -> Self {
-        Self::StorageError(error)
-    }
-}
-
-impl From<anyhow::Error> for ComputeError {
-    fn from(error: anyhow::Error) -> Self {
-        Self::ClientError(error)
-    }
 }
 
 /// Replica configuration
@@ -359,24 +283,20 @@ impl<T> ComputeController<T> {
     }
 
     /// Return a reference to the indicated compute instance.
-    fn instance(&self, id: ComputeInstanceId) -> Result<&Instance<T>, ComputeError> {
-        self.instances
-            .get(&id)
-            .ok_or(ComputeError::InstanceMissing(id))
+    fn instance(&self, id: ComputeInstanceId) -> Result<&Instance<T>, InstanceMissing> {
+        self.instances.get(&id).ok_or(InstanceMissing(id))
     }
 
     /// Return a mutable reference to the indicated compute instance.
-    fn instance_mut(&mut self, id: ComputeInstanceId) -> Result<&mut Instance<T>, ComputeError> {
-        self.instances
-            .get_mut(&id)
-            .ok_or(ComputeError::InstanceMissing(id))
+    fn instance_mut(&mut self, id: ComputeInstanceId) -> Result<&mut Instance<T>, InstanceMissing> {
+        self.instances.get_mut(&id).ok_or(InstanceMissing(id))
     }
 
     /// Return a read-only handle to the indicated compute instance.
     pub fn instance_ref(
         &self,
         id: ComputeInstanceId,
-    ) -> Result<ComputeInstanceRef<T>, ComputeError> {
+    ) -> Result<ComputeInstanceRef<T>, InstanceMissing> {
         self.instance(id).map(|instance| ComputeInstanceRef {
             instance_id: id,
             instance,
@@ -388,8 +308,9 @@ impl<T> ComputeController<T> {
         &self,
         instance_id: ComputeInstanceId,
         collection_id: GlobalId,
-    ) -> Result<&CollectionState<T>, ComputeError> {
-        self.instance(instance_id)?.collection(collection_id)
+    ) -> Result<&CollectionState<T>, CollectionLookupError> {
+        let collection = self.instance(instance_id)?.collection(collection_id)?;
+        Ok(collection)
     }
 
     /// Acquire an [`ActiveComputeController`] by supplying a storage connection.
@@ -415,9 +336,9 @@ where
         id: ComputeInstanceId,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
         max_result_size: u32,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), InstanceExists> {
         if self.instances.contains_key(&id) {
-            return Err(ComputeError::InstanceExists(id));
+            return Err(InstanceExists(id));
         }
 
         self.instances.insert(
@@ -531,12 +452,12 @@ impl<T> ActiveComputeController<'_, T> {
         &self,
         instance_id: ComputeInstanceId,
         collection_id: GlobalId,
-    ) -> Result<&CollectionState<T>, ComputeError> {
+    ) -> Result<&CollectionState<T>, CollectionLookupError> {
         self.compute.collection(instance_id, collection_id)
     }
 
     /// Return a handle to the indicated compute instance.
-    fn instance(&mut self, id: ComputeInstanceId) -> Result<ActiveInstance<T>, ComputeError> {
+    fn instance(&mut self, id: ComputeInstanceId) -> Result<ActiveInstance<T>, InstanceMissing> {
         self.compute
             .instance_mut(id)
             .map(|c| c.activate(self.storage))
@@ -554,7 +475,7 @@ where
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
         config: ComputeReplicaConfig,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), ReplicaCreationError> {
         let (enable_logging, interval_ns) = match config.logging.interval {
             Some(interval) => (true, interval.as_nanos()),
             None => (false, 1_000_000_000),
@@ -576,7 +497,8 @@ where
 
         self.instance(instance_id)?
             .add_replica(replica_id, config.location, logging_config)
-            .await
+            .await?;
+        Ok(())
     }
 
     /// Removes a replica from an instance, including its service in the orchestrator.
@@ -584,8 +506,11 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
-    ) -> Result<(), ComputeError> {
-        self.instance(instance_id)?.remove_replica(replica_id).await
+    ) -> Result<(), ReplicaDropError> {
+        self.instance(instance_id)?
+            .remove_replica(replica_id)
+            .await?;
+        Ok(())
     }
 
     /// Create and maintain the described dataflows, and initialize state for their output.
@@ -599,10 +524,11 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         dataflows: Vec<DataflowDescription<crate::plan::Plan<T>, (), T>>,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), DataflowCreationError> {
         self.instance(instance_id)?
             .create_dataflows(dataflows)
-            .await
+            .await?;
+        Ok(())
     }
 
     /// Drop the read capability for the given collections and allow their resources to be
@@ -611,10 +537,11 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         collection_ids: Vec<GlobalId>,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), CollectionUpdateError> {
         self.instance(instance_id)?
             .drop_collections(collection_ids)
-            .await
+            .await?;
+        Ok(())
     }
 
     /// Initiate a peek request for the contents of the given collection at `timestamp`.
@@ -628,7 +555,7 @@ where
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
         target_replica: Option<ReplicaId>,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), PeekError> {
         self.instance(instance_id)?
             .peek(
                 collection_id,
@@ -639,7 +566,8 @@ where
                 map_filter_project,
                 target_replica,
             )
-            .await
+            .await?;
+        Ok(())
     }
 
     /// Cancel existing peek requests.
@@ -657,7 +585,7 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         uuids: BTreeSet<Uuid>,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), InstanceMissing> {
         self.instance(instance_id)?.cancel_peeks(uuids);
         Ok(())
     }
@@ -674,8 +602,11 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         policies: Vec<(GlobalId, ReadPolicy<T>)>,
-    ) -> Result<(), ComputeError> {
-        self.instance(instance_id)?.set_read_policy(policies).await
+    ) -> Result<(), CollectionUpdateError> {
+        self.instance(instance_id)?
+            .set_read_policy(policies)
+            .await?;
+        Ok(())
     }
 
     /// Update the max size in bytes of any result.
@@ -683,7 +614,7 @@ where
         &mut self,
         instance_id: ComputeInstanceId,
         max_result_size: u32,
-    ) -> Result<(), ComputeError> {
+    ) -> Result<(), InstanceMissing> {
         self.instance(instance_id)?
             .update_max_result_size(max_result_size);
         Ok(())
@@ -696,7 +627,7 @@ where
     ///
     /// This method is **not** guaranteed to be cancellation safe. It **must**
     /// be awaited to completion.
-    pub async fn process(&mut self) -> Result<Option<ComputeControllerResponse<T>>, ComputeError> {
+    pub async fn process(&mut self) -> Result<Option<ComputeControllerResponse<T>>, StorageError> {
         // Rehydrate any failed replicas.
         for instance in self.compute.instances.values_mut() {
             instance
@@ -724,8 +655,16 @@ where
 
         // Process pending responses from replicas.
         if let Some((instance_id, replica_id, response)) = self.compute.stashed_response.take() {
-            let mut instance = self.instance(instance_id)?;
-            instance.handle_response(response, replica_id).await
+            if let Ok(mut instance) = self.instance(instance_id) {
+                instance.handle_response(response, replica_id).await
+            } else {
+                tracing::warn!(
+                    ?instance_id,
+                    ?response,
+                    "processed response from unknown instance"
+                );
+                Ok(None)
+            }
         } else {
             Ok(None)
         }
@@ -746,7 +685,7 @@ impl<T> ComputeInstanceRef<'_, T> {
     }
 
     /// Return a read-only handle to the indicated collection.
-    pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, ComputeError> {
+    pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, CollectionMissing> {
         self.instance.collection(id)
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -107,7 +107,7 @@ impl FromStr for ComputeInstanceId {
         match s.chars().next().unwrap() {
             's' => Ok(Self::System(val)),
             'u' => Ok(Self::User(val)),
-            _ => Err(anyhow!("couldn't parse role id {}", s)),
+            _ => Err(anyhow!("couldn't parse compute instance id {}", s)),
         }
     }
 }
@@ -366,7 +366,8 @@ where
     /// Remove a compute instance.
     ///
     /// # Panics
-    /// - If the identified `instance` still has active replicas.
+    ///
+    /// Panics if the identified `instance` still has active replicas.
     pub fn drop_instance(&mut self, id: ComputeInstanceId) {
         if let Some(compute_state) = self.instances.remove(&id) {
             compute_state.drop();
@@ -633,8 +634,7 @@ where
             instance
                 .activate(self.storage)
                 .rehydrate_failed_replicas()
-                .await
-                .expect("error rehydrating failed replicas");
+                .await?;
         }
 
         // Process pending ready responses.

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -1,0 +1,208 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Errors returned by the compute controller.
+//!
+//! The guiding principle for error handling in the compute controller is that each public method
+//! should return an error type that defines exactly the error variants the method can return, and
+//! no additional ones. This precludes the usage of a single `ComputeControllerError` enum that
+//! simply includes the union of all error variants the compute controller can ever return (and
+//! possibly some internal ones that are never returned to external callers). Instead, compute
+//! controller methods return bespoke error types that serve as documentation for the failure modes
+//! of each method and make it easy for callers to ensure that all possible errors are handled.
+
+use thiserror::Error;
+
+use mz_repr::GlobalId;
+use mz_storage_client::controller::StorageError;
+
+use crate::command::ReplicaId;
+
+use super::{instance, ComputeInstanceId};
+
+/// Error returned in response to a reference to an unknown compute instance.
+#[derive(Error, Debug)]
+#[error("instance does not exist: {0}")]
+pub struct InstanceMissing(pub ComputeInstanceId);
+
+/// Error returned in response to a request to create a compute instance with an ID of an existing
+/// compute instance.
+#[derive(Error, Debug)]
+#[error("instance exists already: {0}")]
+pub struct InstanceExists(pub ComputeInstanceId);
+
+/// Error returned in response to a reference to an unknown compute collection.
+#[derive(Error, Debug)]
+#[error("collection does not exist: {0}")]
+pub struct CollectionMissing(pub GlobalId);
+
+/// Errors arising during compute collection lookup.
+#[derive(Error, Debug)]
+pub enum CollectionLookupError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("collection does not exist: {0}")]
+    CollectionMissing(GlobalId),
+}
+
+impl From<InstanceMissing> for CollectionLookupError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<CollectionMissing> for CollectionLookupError {
+    fn from(error: CollectionMissing) -> Self {
+        Self::CollectionMissing(error.0)
+    }
+}
+
+/// Errors arising during compute replica creation.
+#[derive(Error, Debug)]
+pub enum ReplicaCreationError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("replica exists already: {0}")]
+    ReplicaExists(ReplicaId),
+    #[error("storage interaction error: {0}")]
+    Storage(#[from] StorageError),
+}
+
+impl From<InstanceMissing> for ReplicaCreationError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<instance::ReplicaCreationError> for ReplicaCreationError {
+    fn from(error: instance::ReplicaCreationError) -> Self {
+        use instance::ReplicaCreationError::*;
+        match error {
+            ReplicaExists(id) => Self::ReplicaExists(id),
+            Storage(error) => error.into(),
+        }
+    }
+}
+
+/// Errors arising during compute replica removal.
+#[derive(Error, Debug)]
+pub enum ReplicaDropError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("replica does not exist: {0}")]
+    ReplicaMissing(ReplicaId),
+    #[error("storage interaction error: {0}")]
+    Storage(#[from] StorageError),
+}
+
+impl From<InstanceMissing> for ReplicaDropError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<instance::ReplicaDropError> for ReplicaDropError {
+    fn from(error: instance::ReplicaDropError) -> Self {
+        use instance::ReplicaDropError::*;
+        match error {
+            ReplicaMissing(id) => Self::ReplicaMissing(id),
+            Storage(error) => error.into(),
+        }
+    }
+}
+
+/// Errors arising during dataflow creation.
+#[derive(Error, Debug)]
+pub enum DataflowCreationError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("collection does not exist: {0}")]
+    CollectionMissing(GlobalId),
+    #[error("dataflow definition lacks an as_of value")]
+    MissingAsOf,
+    #[error("dataflow has an as_of not beyond the since of collection: {0}")]
+    SinceViolation(GlobalId),
+    #[error("storage interaction error: {0}")]
+    Storage(#[from] StorageError),
+}
+
+impl From<InstanceMissing> for DataflowCreationError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<instance::DataflowCreationError> for DataflowCreationError {
+    fn from(error: instance::DataflowCreationError) -> Self {
+        use instance::DataflowCreationError::*;
+        match error {
+            CollectionMissing(id) => Self::CollectionMissing(id),
+            MissingAsOf => Self::MissingAsOf,
+            SinceViolation(id) => Self::SinceViolation(id),
+            Storage(error) => error.into(),
+        }
+    }
+}
+
+/// Errors arising during peek processing.
+#[derive(Error, Debug)]
+pub enum PeekError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("collection does not exist: {0}")]
+    CollectionMissing(GlobalId),
+    #[error("peek timestamp is not beyond the since of collection: {0}")]
+    SinceViolation(GlobalId),
+    #[error("storage interaction error: {0}")]
+    Storage(#[from] StorageError),
+}
+
+impl From<InstanceMissing> for PeekError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<instance::PeekError> for PeekError {
+    fn from(error: instance::PeekError) -> Self {
+        use instance::PeekError::*;
+        match error {
+            CollectionMissing(id) => Self::CollectionMissing(id),
+            SinceViolation(id) => Self::CollectionMissing(id),
+            Storage(error) => error.into(),
+        }
+    }
+}
+
+/// Errors arising during collection updates.
+#[derive(Error, Debug)]
+pub enum CollectionUpdateError {
+    #[error("instance does not exist: {0}")]
+    InstanceMissing(ComputeInstanceId),
+    #[error("collection does not exist: {0}")]
+    CollectionMissing(GlobalId),
+    #[error("storage interaction error: {0}")]
+    Storage(#[from] StorageError),
+}
+
+impl From<InstanceMissing> for CollectionUpdateError {
+    fn from(error: InstanceMissing) -> Self {
+        Self::InstanceMissing(error.0)
+    }
+}
+
+impl From<instance::CollectionUpdateError> for CollectionUpdateError {
+    fn from(error: instance::CollectionUpdateError) -> Self {
+        use instance::CollectionUpdateError::*;
+        match error {
+            CollectionMissing(id) => Self::CollectionMissing(id),
+            Storage(error) => error.into(),
+        }
+    }
+}

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -229,7 +229,8 @@ where
     /// Drop this compute instance.
     ///
     /// # Panics
-    /// - If the compute instance still has active replicas.
+    ///
+    /// Panics if the compute instance still has active replicas.
     pub fn drop(self) {
         assert!(
             self.replicas.is_empty(),
@@ -418,6 +419,10 @@ where
     ///
     /// This method does not cause an orchestrator removal of the replica, so it is suitable for
     /// removing the replica temporarily, e.g., during rehydration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the specified replica does not exist in the compute state.
     async fn remove_replica_state(&mut self, id: ReplicaId) -> Result<(), StorageError> {
         // Remove frontier tracking for this replica.
         self.remove_write_frontiers(id).await?;
@@ -782,6 +787,10 @@ where
     }
 
     /// Accept write frontier updates from the compute layer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the `updates` references an absent collection.
     #[tracing::instrument(level = "debug", skip(self))]
     async fn update_write_frontiers(
         &mut self,
@@ -796,7 +805,7 @@ where
             let collection = self
                 .compute
                 .collection_mut(*id)
-                .expect("Reference to absent collection");
+                .expect("reference to absent collection");
 
             if PartialOrder::less_than(&collection.write_frontier, new_upper) {
                 advanced_collections.push(*id);


### PR DESCRIPTION
This PR refactors the error types returned by the compute controller methods. Instead of returning a big-ball-of-mud `ComputeError` from every method, making it impossible for callers to see which of the many error variants each method can actually produce, we now return bespoke error types that precisely enumerate each method's possible errors.

The change introduces some boilerplate code because Rust does not give us efficient means to deal with enums that have intersecting sets of variants. The `thiserror` crate makes the error definitions a bit less verbose. On the plus side, the compute controller API is now easier to use correctly. And being specific about error types also forces us to think about the errors we actually want to return to callers. Prior to this change, it was easy to just slap a `?` at the end of the line and  consider the error properly handled, even though it might have been the right thing to panic or ignore the error instead.

Right now, we return a lot of `StorageError`s that come from the storage controller calls we are making. My hope is that once we can refactor the storage controller's `update_read_capabilities` methods to not perform network calls anymore, the only actual storage errors that can still occur are ones caused by us specifying non-existing collections, in which case we probably have a bug and should panic. So there is a future in which we can remove `StorageError` from the compute controller API entirely.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Apart from splitting up the `ComputeError` type, the PR also changes some of the controller methods to handle errors differently in some cases. Some panics are converted to errors, some errors are converted to panics, and some previous errors and panics are only logged and otherwise ignored. I (obviously) think the changes make sense, but the more eyes we have on them the better.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
