### PR TITLE
timely-util: ode to the polonius crab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4528,6 +4528,7 @@ dependencies = [
  "differential-dataflow",
  "futures-util",
  "mz-ore",
+ "polonius-the-crab",
  "proptest",
  "serde",
  "timely",
@@ -5211,6 +5212,12 @@ checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "polonius-the-crab"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0119ad75060c93b2017796396280ab9c1870738bf3b66a8cb20deb3c9075426"
 
 [[package]]
 name = "portable-atomic"

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -14,6 +14,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.147", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing"] }
+polonius-the-crab = "0.3.1"
 
 [dev-dependencies]
 tokio = { version = "1.20.2", features = ["macros", "rt-multi-thread", "time"] }


### PR DESCRIPTION
### Motivation


This PR is using an insane crate to simplify and increase confidence on the soundness of the implementation that was previously working around a borrow checker limitation manually.

This crate puts some guardrails and ensures that only this particular safe case is allowed to be expressed which in turns means that we won't accidentally introduce unsoundness in the future as we're changing this method.

Absolutely crazy.

h/t to Gus that showed me this crate



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
