### PR TITLE
doc/user: update memory visualizer URL for cloud

### DIFF
--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -142,8 +142,8 @@ grouped by dataflow. The amount of memory used
 by Materialize should correlate with the number of arrangement records that are
 displayed by either the visual interface or the SQL queries.
 
-The memory usage visualization is available at `http://<materialized
-host>:6876/memory`.
+You can access the memory usage visualization for your Materialize region at
+`https://<region host>/memory`.
 
 ## Is work distributed equally across workers?
 


### PR DESCRIPTION
This is hosted at :443 in Materialize Cloud, which is the standard HTTPS port--so no explicit port necessary!

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug in our documentation that was just reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
