### PR TITLE
run an init container for computed and storaged if requested

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -341,12 +341,17 @@ impl<T> ComputeController<T> {
         build_info: &'static BuildInfo,
         orchestrator: Arc<dyn NamespacedOrchestrator>,
         computed_image: String,
+        init_container_image: Option<String>,
         envd_epoch: i64,
     ) -> Self {
         Self {
             instances: BTreeMap::new(),
             build_info,
-            orchestrator: ComputeOrchestrator::new(orchestrator, computed_image),
+            orchestrator: ComputeOrchestrator::new(
+                orchestrator,
+                computed_image,
+                init_container_image,
+            ),
             initialized: false,
             stashed_response: None,
             replica_heartbeats: BTreeMap::new(),

--- a/src/compute-client/src/controller/orchestrator.rs
+++ b/src/compute-client/src/controller/orchestrator.rs
@@ -31,13 +31,19 @@ use super::{
 pub(super) struct ComputeOrchestrator {
     inner: Arc<dyn NamespacedOrchestrator>,
     computed_image: String,
+    init_container_image: Option<String>,
 }
 
 impl ComputeOrchestrator {
-    pub(super) fn new(inner: Arc<dyn NamespacedOrchestrator>, computed_image: String) -> Self {
+    pub(super) fn new(
+        inner: Arc<dyn NamespacedOrchestrator>,
+        computed_image: String,
+        init_container_image: Option<String>,
+    ) -> Self {
         Self {
             inner,
             computed_image,
+            init_container_image,
         }
     }
     pub(super) async fn ensure_replica_location(
@@ -97,6 +103,7 @@ impl ComputeOrchestrator {
                 &service_name,
                 ServiceConfig {
                     image: self.computed_image.clone(),
+                    init_container_image: self.init_container_image.clone(),
                     args: &|assigned| {
                         let mut compute_opts = vec![
                             format!(

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -71,6 +71,8 @@ pub struct ControllerConfig {
     pub storaged_image: String,
     /// The computed image to use when starting new compute processes.
     pub computed_image: String,
+    /// The init container image to use for storaged and computed.
+    pub init_container_image: Option<String>,
     /// The now function to advance the controller's introspection collections.
     pub now: NowFn,
 }
@@ -219,6 +221,7 @@ where
             config.persist_clients,
             config.orchestrator.namespace("storage"),
             config.storaged_image,
+            config.init_container_image.clone(),
             config.now,
         )
         .await;
@@ -227,6 +230,7 @@ where
             config.build_info,
             config.orchestrator.namespace("compute"),
             config.computed_image,
+            config.init_container_image,
             envd_epoch,
         );
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -304,6 +304,11 @@ pub struct Args {
     )]
     orchestrator_process_data_directory: PathBuf,
 
+    /// The init container to use for computed and storaged when using the
+    /// kubernetes orchestrator.
+    #[clap(long)]
+    k8s_init_container_image: Option<String>,
+
     // === Storage options. ===
     /// Where the persist library should store its blob data.
     #[clap(long, env = "PERSIST_BLOB_URL")]
@@ -624,6 +629,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         storage_stash_url: args.storage_stash_url,
         storaged_image: args.storaged_image.expect("clap enforced"),
         computed_image: args.computed_image.expect("clap enforced"),
+        init_container_image: args.k8s_init_container_image,
         now: SYSTEM_TIME.clone(),
     };
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -205,6 +205,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             orchestrator: Arc::clone(&orchestrator) as Arc<dyn Orchestrator>,
             storaged_image: "storaged".into(),
             computed_image: "computed".into(),
+            init_container_image: None,
             persist_location: PersistLocation {
                 blob_uri: format!("file://{}/persist/blob", data_directory.display()),
                 consensus_uri,

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -19,8 +19,9 @@ use clap::ArgEnum;
 use futures::stream::{BoxStream, StreamExt};
 use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetSpec};
 use k8s_openapi::api::core::v1::{
-    Affinity, Container, ContainerPort, Pod, PodAffinityTerm, PodAntiAffinity, PodSpec,
-    PodTemplateSpec, ResourceRequirements, Secret, Service as K8sService, ServicePort, ServiceSpec,
+    Affinity, Container, ContainerPort, EnvVar, EnvVarSource, ObjectFieldSelector, Pod,
+    PodAffinityTerm, PodAntiAffinity, PodSpec, PodTemplateSpec, ResourceRequirements, Secret,
+    Service as K8sService, ServicePort, ServiceSpec,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement};
@@ -209,6 +210,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         id: &str,
         ServiceConfig {
             image,
+            init_container_image,
             args,
             ports: ports_in,
             memory_limit,
@@ -357,6 +359,50 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             .context("`image` is not ORG/NAME:VERSION")?
             .to_string();
 
+        let init_containers = init_container_image.map(|image| {
+            vec![Container {
+                name: "k8s-init-container".to_string(),
+                image: Some(image),
+                image_pull_policy: Some(self.config.image_pull_policy.to_string()),
+                env: Some(vec![
+                    EnvVar {
+                        name: "MZ_NAMESPACE".to_string(),
+                        value_from: Some(EnvVarSource {
+                            field_ref: Some(ObjectFieldSelector {
+                                field_path: "metadata.namespace".to_string(),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    EnvVar {
+                        name: "MZ_POD_NAME".to_string(),
+                        value_from: Some(EnvVarSource {
+                            field_ref: Some(ObjectFieldSelector {
+                                field_path: "metadata.name".to_string(),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    EnvVar {
+                        name: "MZ_NODE_NAME".to_string(),
+                        value_from: Some(EnvVarSource {
+                            field_ref: Some(ObjectFieldSelector {
+                                field_path: "spec.nodeName".to_string(),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }]
+        });
+
         let mut pod_template_spec = PodTemplateSpec {
             metadata: Some(ObjectMeta {
                 labels: Some(labels.clone()),
@@ -364,6 +410,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 ..Default::default()
             }),
             spec: Some(PodSpec {
+                init_containers,
                 containers: vec![Container {
                     name: container_name,
                     image: Some(image),

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -146,6 +146,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
         id: &str,
         ServiceConfig {
             image,
+            init_container_image: _,
             args,
             ports: ports_in,
             memory_limit: _,

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -142,6 +142,9 @@ pub struct ServiceConfig<'a> {
     ///
     /// Often names a container on Docker Hub or a path on the local machine.
     pub image: String,
+    /// For the Kubernetes orchestrator, this is an init container to
+    /// configure for the pod running the service.
+    pub init_container_image: Option<String>,
     /// A function that generates the arguments for each process of the service
     /// given the assignments that the orchestrator has made.
     #[derivative(Debug = "ignore")]

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -665,6 +665,7 @@ impl Runner {
                 orchestrator: Arc::clone(&orchestrator) as Arc<dyn Orchestrator>,
                 storaged_image: "storaged".into(),
                 computed_image: "computed".into(),
+                init_container_image: None,
                 persist_location: PersistLocation {
                     blob_uri: format!("file://{}/persist/blob", temp_dir.path().display()),
                     consensus_uri,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1392,6 +1392,7 @@ where
         persist_clients: Arc<Mutex<PersistClientCache>>,
         orchestrator: Arc<dyn NamespacedOrchestrator>,
         storaged_image: String,
+        init_container_image: Option<String>,
         now: NowFn,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1403,6 +1404,7 @@ where
                     build_info,
                     orchestrator,
                     storaged_image,
+                    init_container_image,
                 },
                 Arc::clone(&persist_clients),
             ),

--- a/src/storage-client/src/controller/hosts.rs
+++ b/src/storage-client/src/controller/hosts.rs
@@ -51,6 +51,8 @@ pub struct StorageHostsConfig {
     pub orchestrator: Arc<dyn NamespacedOrchestrator>,
     /// The storaged image to use when starting new storage hosts.
     pub storaged_image: String,
+    /// The init container image to use for storaged.
+    pub init_container_image: Option<String>,
 }
 
 /// Manages provisioning of storage hosts and assignment of storage objects
@@ -65,6 +67,8 @@ pub struct StorageHosts<T> {
     orchestrator: Arc<dyn NamespacedOrchestrator>,
     /// The storaged image to use when starting new storage hosts.
     storaged_image: String,
+    /// The init container image to use for storaged.
+    init_container_image: Option<String>,
     /// The known storage hosts, identified by network address.
     hosts: HashMap<StorageHostAddr, StorageHost<T>>,
     /// The assignment of storage objects to storage hosts.
@@ -100,6 +104,7 @@ where
             build_info: config.build_info,
             orchestrator: config.orchestrator,
             storaged_image: config.storaged_image,
+            init_container_image: config.init_container_image,
             objects: HashMap::new(),
             hosts: HashMap::new(),
             initialized: false,
@@ -232,6 +237,7 @@ where
                 &id.to_string(),
                 ServiceConfig {
                     image: self.storaged_image.clone(),
+                    init_container_image: self.init_container_image.clone(),
                     args: &|assigned| {
                         vec![
                             format!("--workers={}", allocation.workers),


### PR DESCRIPTION
### Motivation

the immediate use of this will be to tag pods with their availability zone to help route network traffic better (see https://github.com/MaterializeInc/cloud/issues/4531).

once this is deployed next week, i will follow up with cloud prs to set the flag and use the new labels.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - no user facing changes
