### PR TITLE
storage: streaming tpch load generator

### DIFF
--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -111,6 +111,8 @@ is placed in the currently ongoing auction.
 
 The TPCH load generator implements the [TPC-H benchmark specification](https://www.tpc.org/tpch/default5.asp).
 The TPCH source must be used with `FOR ALL TABLES`, which will create the standard TPCH relations.
+If `TICK INTERVAL` is specified, after the initial data load, an order and its lineitems will be changed at this interval.
+If not specified, the dataset will not change over time.
 
 ## Examples
 

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -1994,7 +1994,7 @@ pub trait Generator {
         &self,
         now: NowFn,
         seed: Option<u64>,
-    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row)>>;
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>>;
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -71,7 +71,7 @@ impl Generator for Auction {
         &self,
         now: NowFn,
         seed: Option<u64>,
-    ) -> Box<(dyn Iterator<Item = (usize, GeneratorMessageType, Row)>)> {
+    ) -> Box<(dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>)> {
         let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let organizations = COMPANIES.iter().enumerate().map(|(offset, name)| {
@@ -157,7 +157,7 @@ impl Generator for Auction {
                     } else {
                         GeneratorMessageType::InProgress
                     };
-                    (output, typ, row)
+                    (output, typ, row, 1)
                 })
             }
         }))

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -20,7 +20,7 @@ impl Generator for Counter {
         &self,
         _now: NowFn,
         _seed: Option<u64>,
-    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row)>> {
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
         let mut counter = 0;
         Box::new(iter::repeat_with(move || {
             counter += 1;
@@ -28,6 +28,7 @@ impl Generator for Counter {
                 0,
                 GeneratorMessageType::Finalized,
                 Row::pack_slice(&[Datum::Int64(counter)]),
+                1,
             )
         }))
     }

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -20,7 +20,7 @@ impl Generator for Datums {
         &self,
         _: NowFn,
         _seed: Option<u64>,
-    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row)>> {
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()
@@ -57,7 +57,7 @@ impl Generator for Datums {
             } else {
                 GeneratorMessageType::InProgress
             };
-            Some((0, message, row))
+            Some((0, message, row, 1))
         }))
     }
 }

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -12,7 +12,7 @@ use std::iter;
 use std::ops::RangeInclusive;
 
 use chrono::NaiveDate;
-use dec::OrderedDecimal;
+use dec::{Context as DecimalContext, OrderedDecimal};
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::rngs::StdRng;
@@ -49,34 +49,31 @@ impl Generator for Tpch {
         _: NowFn,
         seed: Option<u64>,
     ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row)>> {
-        let Self {
-            count_supplier,
-            count_part,
-            count_customer,
-            count_orders,
-            count_clerk,
-        } = self.clone();
+        let mut rng = StdRng::seed_from_u64(seed.unwrap_or_default());
+        let mut ctx = Context {
+            tpch: self.clone(),
+            decimal_one: Numeric::from(1),
+            decimal_neg_one: Numeric::from(-1),
+            cx: numeric::cx_datum(),
+            // TODO: Use a text generator closer to the spec.
+            text_string_source: Alphanumeric.sample_string(&mut rng, 3 << 20),
+        };
+
         let count_nation: i64 = NATIONS.len().try_into().unwrap();
         let count_region: i64 = REGIONS.len().try_into().unwrap();
 
-        let mut rows = (0..count_supplier)
+        let mut rows = (0..ctx.tpch.count_supplier)
             .map(|i| (SUPPLIER_OUTPUT, i))
-            .chain((1..=count_part).map(|i| (PART_OUTPUT, i)))
-            .chain((1..=count_customer).map(|i| (CUSTOMER_OUTPUT, i)))
-            .chain((1..=count_orders).map(|i| (ORDERS_OUTPUT, i)))
+            .chain((1..=ctx.tpch.count_part).map(|i| (PART_OUTPUT, i)))
+            .chain((1..=ctx.tpch.count_customer).map(|i| (CUSTOMER_OUTPUT, i)))
+            .chain((1..=ctx.tpch.count_orders).map(|i| (ORDERS_OUTPUT, i)))
             .chain((0..count_nation).map(|i| (NATION_OUTPUT, i)))
             .chain((0..count_region).map(|i| (REGION_OUTPUT, i)))
             .peekable();
 
-        let mut rng = StdRng::seed_from_u64(seed.unwrap_or_default());
         // Some rows need to generate other rows from their values; hold those
         // here.
         let mut pending = Vec::new();
-        let mut cx = numeric::cx_datum();
-        let decimal_one = Numeric::lossy_from(1);
-        let decimal_neg_one = Numeric::lossy_from(-1);
-        // TODO: Use a text generator closer to the spec.
-        let text_string_source = Alphanumeric.sample_string(&mut rng, 3 << 20);
 
         Box::new(iter::from_fn(move || {
             if let Some((output, row)) = pending.pop() {
@@ -94,9 +91,9 @@ impl Generator for Tpch {
                             Datum::String(&v_string(&mut rng, 10, 40)), // address
                             Datum::Int64(nation),
                             Datum::String(&phone(&mut rng, nation)),
-                            Datum::Numeric(decimal(&mut rng, &mut cx, -999_99, 9_999_99, 100)), // acctbal
+                            Datum::Numeric(decimal(&mut rng, &mut ctx.cx, -999_99, 9_999_99, 100)), // acctbal
                             // TODO: add customer complaints and recommends, see 4.2.3.
-                            Datum::String(text_string(&mut rng, &text_string_source, 25, 100)),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 25, 100)),
                         ])
                     }
                     PART_OUTPUT => {
@@ -110,15 +107,21 @@ impl Generator for Tpch {
                         for _ in 1..=4 {
                             let suppkey = (key
                                 + (rng.gen_range(0..=3)
-                                    * ((count_supplier / 4) + (key - 1) / count_supplier)))
-                                % count_supplier
+                                    * ((ctx.tpch.count_supplier / 4)
+                                        + (key - 1) / ctx.tpch.count_supplier)))
+                                % ctx.tpch.count_supplier
                                 + 1;
                             let row = Row::pack_slice(&[
                                 Datum::Int64(key),
                                 Datum::Int64(suppkey),
                                 Datum::Int32(rng.gen_range(1..=9_999)), // availqty
-                                Datum::Numeric(decimal(&mut rng, &mut cx, 1_00, 1_000_00, 100)), // supplycost
-                                Datum::String(text_string(&mut rng, &text_string_source, 49, 198)),
+                                Datum::Numeric(decimal(&mut rng, &mut ctx.cx, 1_00, 1_000_00, 100)), // supplycost
+                                Datum::String(text_string(
+                                    &mut rng,
+                                    &ctx.text_string_source,
+                                    49,
+                                    198,
+                                )),
                             ]);
                             pending.push((PARTSUPP_OUTPUT, row));
                         }
@@ -131,7 +134,7 @@ impl Generator for Tpch {
                             Datum::Int32(rng.gen_range(1..=50)), // size
                             Datum::String(&syllables(&mut rng, CONTAINERS)),
                             Datum::Numeric(partkey_retailprice(key)),
-                            Datum::String(text_string(&mut rng, &text_string_source, 49, 198)),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 49, 198)),
                         ])
                     }
                     CUSTOMER_OUTPUT => {
@@ -142,87 +145,18 @@ impl Generator for Tpch {
                             Datum::String(&v_string(&mut rng, 10, 40)), // address
                             Datum::Int64(nation),
                             Datum::String(&phone(&mut rng, nation)),
-                            Datum::Numeric(decimal(&mut rng, &mut cx, -999_99, 9_999_99, 100)), // acctbal
+                            Datum::Numeric(decimal(&mut rng, &mut ctx.cx, -999_99, 9_999_99, 100)), // acctbal
                             Datum::String(SEGMENTS.choose(&mut rng).unwrap()),
-                            Datum::String(text_string(&mut rng, &text_string_source, 29, 116)),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 29, 116)),
                         ])
                     }
                     ORDERS_OUTPUT => {
-                        let key = order_key(key);
-                        let custkey = loop {
-                            let custkey = rng.gen_range(1..=count_customer);
-                            if custkey % 3 != 0 {
-                                break custkey;
-                            }
-                        };
-                        let orderdate = date(&mut rng, &*START_DATE, 1..=*ORDER_END_DAYS);
-                        let mut totalprice = Numeric::lossy_from(0);
-                        let mut orderstatus = None;
-
-                        for linenumber in 1..=rng.gen_range(1..=7) {
-                            let partkey = rng.gen_range(1..=count_part);
-                            let suppkey = (partkey
-                                + (rng.gen_range(0..=3)
-                                    * ((count_supplier / 4) + (partkey - 1) / count_supplier)))
-                                % count_supplier
-                                + 1;
-                            let quantity = Numeric::from(rng.gen_range(1..=50));
-                            let mut extendedprice = quantity;
-                            cx.mul(&mut extendedprice, &partkey_retailprice(partkey).0);
-                            let mut discount = decimal(&mut rng, &mut cx, 0, 8, 100);
-                            let mut tax = decimal(&mut rng, &mut cx, 0, 10, 100);
-                            let shipdate = date(&mut rng, &orderdate, 1..=121);
-                            let receiptdate = date(&mut rng, &shipdate, 1..=30);
-                            let linestatus = if shipdate > *CURRENT_DATE { "O" } else { "F" };
-                            let row = Row::pack_slice(&[
-                                Datum::Int64(key),
-                                Datum::Int64(partkey),
-                                Datum::Int64(suppkey),
-                                Datum::Int32(linenumber),
-                                Datum::Numeric(OrderedDecimal(quantity)),
-                                Datum::Numeric(OrderedDecimal(extendedprice)),
-                                Datum::Numeric(discount),
-                                Datum::Numeric(tax),
-                                Datum::String(if receiptdate <= *CURRENT_DATE {
-                                    ["R", "A"].choose(&mut rng).unwrap()
-                                } else {
-                                    "N"
-                                }), // returnflag
-                                Datum::String(linestatus),
-                                Datum::Date(shipdate),
-                                Datum::Date(date(&mut rng, &orderdate, 30..=90)), // commitdate
-                                Datum::Date(receiptdate),
-                                Datum::String(INSTRUCTIONS.choose(&mut rng).unwrap()),
-                                Datum::String(MODES.choose(&mut rng).unwrap()),
-                                Datum::String(text_string(&mut rng, &text_string_source, 10, 43)),
-                            ]);
+                        let seed = rng.gen();
+                        let (order, lineitems) = ctx.order_row(seed, key);
+                        for row in lineitems {
                             pending.push((LINEITEM_OUTPUT, row));
-                            // totalprice += extendedprice * (1.0 + tax) * (1.0 - discount)
-                            cx.add(&mut tax.0, &decimal_one);
-                            cx.sub(&mut discount.0, &decimal_neg_one);
-                            cx.abs(&mut discount.0);
-                            cx.mul(&mut extendedprice, &tax.0);
-                            cx.mul(&mut extendedprice, &discount.0);
-                            cx.add(&mut totalprice, &extendedprice);
-                            if let Some(status) = orderstatus {
-                                if status != linestatus {
-                                    orderstatus = Some("P");
-                                }
-                            } else {
-                                orderstatus = Some(linestatus);
-                            }
                         }
-                        Row::pack_slice(&[
-                            Datum::Int64(key),
-                            Datum::Int64(custkey),
-                            Datum::String(orderstatus.unwrap()),
-                            Datum::Numeric(OrderedDecimal(totalprice)),
-                            Datum::Date(orderdate),
-                            Datum::String(PRIORITIES.choose(&mut rng).unwrap()),
-                            Datum::String(&pad_nine("Clerk", rng.gen_range(1..=count_clerk))),
-                            Datum::Int32(0), // shippriority
-                            Datum::String(text_string(&mut rng, &text_string_source, 19, 78)),
-                        ])
+                        order
                     }
                     NATION_OUTPUT => {
                         let (name, region) = NATIONS[key as usize];
@@ -230,13 +164,13 @@ impl Generator for Tpch {
                             Datum::Int64(key),
                             Datum::String(name),
                             Datum::Int64(region),
-                            Datum::String(text_string(&mut rng, &text_string_source, 31, 114)),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 114)),
                         ])
                     }
                     REGION_OUTPUT => Row::pack_slice(&[
                         Datum::Int64(key),
                         Datum::String(REGIONS[key as usize]),
-                        Datum::String(text_string(&mut rng, &text_string_source, 31, 115)),
+                        Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 115)),
                     ]),
                     _ => unreachable!("{output}"),
                 };
@@ -248,6 +182,104 @@ impl Generator for Tpch {
                 (output, typ, row)
             })
         }))
+    }
+}
+
+struct Context {
+    tpch: Tpch,
+    decimal_one: Numeric,
+    decimal_neg_one: Numeric,
+    cx: DecimalContext<Numeric>,
+    text_string_source: String,
+}
+
+impl Context {
+    /// Generate a row based on its key and seed. Used for order retraction
+    /// without having to hold onto the full row for the order and its
+    /// lineitems.
+    fn order_row(&mut self, seed: u64, key: i64) -> (Row, Vec<Row>) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let key = order_key(key);
+        let custkey = loop {
+            let custkey = rng.gen_range(1..=self.tpch.count_customer);
+            if custkey % 3 != 0 {
+                break custkey;
+            }
+        };
+        let orderdate = date(&mut rng, &*START_DATE, 1..=*ORDER_END_DAYS);
+        let mut totalprice = Numeric::lossy_from(0);
+        let mut orderstatus = None;
+        let lineitem_count = rng.gen_range(1..=7);
+        let mut lineitems = Vec::with_capacity(lineitem_count);
+
+        for linenumber in 1..=lineitem_count {
+            let partkey = rng.gen_range(1..=self.tpch.count_part);
+            let suppkey = (partkey
+                + (rng.gen_range(0..=3)
+                    * ((self.tpch.count_supplier / 4) + (partkey - 1) / self.tpch.count_supplier)))
+                % self.tpch.count_supplier
+                + 1;
+            let quantity = Numeric::from(rng.gen_range(1..=50));
+            let mut extendedprice = quantity;
+            self.cx
+                .mul(&mut extendedprice, &partkey_retailprice(partkey).0);
+            let mut discount = decimal(&mut rng, &mut self.cx, 0, 8, 100);
+            let mut tax = decimal(&mut rng, &mut self.cx, 0, 10, 100);
+            let shipdate = date(&mut rng, &orderdate, 1..=121);
+            let receiptdate = date(&mut rng, &shipdate, 1..=30);
+            let linestatus = if shipdate > *CURRENT_DATE { "O" } else { "F" };
+            let row = Row::pack_slice(&[
+                Datum::Int64(key),
+                Datum::Int64(partkey),
+                Datum::Int64(suppkey),
+                Datum::Int32(linenumber.try_into().expect("must fit")),
+                Datum::Numeric(OrderedDecimal(quantity)),
+                Datum::Numeric(OrderedDecimal(extendedprice)),
+                Datum::Numeric(discount),
+                Datum::Numeric(tax),
+                Datum::String(if receiptdate <= *CURRENT_DATE {
+                    ["R", "A"].choose(&mut rng).unwrap()
+                } else {
+                    "N"
+                }), // returnflag
+                Datum::String(linestatus),
+                Datum::Date(shipdate),
+                Datum::Date(date(&mut rng, &orderdate, 30..=90)), // commitdate
+                Datum::Date(receiptdate),
+                Datum::String(INSTRUCTIONS.choose(&mut rng).unwrap()),
+                Datum::String(MODES.choose(&mut rng).unwrap()),
+                Datum::String(text_string(&mut rng, &self.text_string_source, 10, 43)),
+            ]);
+            // totalprice += extendedprice * (1.0 + tax) * (1.0 - discount)
+            self.cx.add(&mut tax.0, &self.decimal_one);
+            self.cx.sub(&mut discount.0, &self.decimal_neg_one);
+            self.cx.abs(&mut discount.0);
+            self.cx.mul(&mut extendedprice, &tax.0);
+            self.cx.mul(&mut extendedprice, &discount.0);
+            self.cx.add(&mut totalprice, &extendedprice);
+            if let Some(status) = orderstatus {
+                if status != linestatus {
+                    orderstatus = Some("P");
+                }
+            } else {
+                orderstatus = Some(linestatus);
+            }
+            lineitems.push(row);
+        }
+
+        let order = Row::pack_slice(&[
+            Datum::Int64(key),
+            Datum::Int64(custkey),
+            Datum::String(orderstatus.unwrap()),
+            Datum::Numeric(OrderedDecimal(totalprice)),
+            Datum::Date(orderdate),
+            Datum::String(PRIORITIES.choose(&mut rng).unwrap()),
+            Datum::String(&pad_nine("Clerk", rng.gen_range(1..=self.tpch.count_clerk))),
+            Datum::Int32(0), // shippriority
+            Datum::String(text_string(&mut rng, &self.text_string_source, 19, 78)),
+        ]);
+
+        (order, lineitems)
     }
 }
 

--- a/test/testdrive/tpch.td
+++ b/test/testdrive/tpch.td
@@ -117,7 +117,7 @@ true
   ORDER BY
     l_returnflag,
     l_linestatus;
-4 values hashing to a7dd389a2d447201b18915e8aefa6ece
+4 values hashing to e350d21706985f8be572176f2301222f
 
 # Query 02
 > SELECT
@@ -179,7 +179,7 @@ true
   ORDER BY
       revenue DESC,
       o_orderdate;
-119 values hashing to 68d3ae75653e81e1b4ded8e9b14dac11
+127 values hashing to 637be0ff3f50cd612b004a69958bfccb
 
 # Query 04
 > SELECT
@@ -203,7 +203,7 @@ true
       o_orderpriority
   ORDER BY
       o_orderpriority;
-4 values hashing to 9c9139fe642f2a3ab3c151dcfef4f3f0
+4 values hashing to 320decef503bc240bc73101fc659a1db
 
 # Query 05
 > SELECT
@@ -230,7 +230,7 @@ true
       n_name
   ORDER BY
       revenue DESC;
-5 values hashing to 0c8219cc57219d9d3462441df16b8112
+5 values hashing to 8e24fa90f7160fb0dc1e7bfaaa3e9c73
 
 # Query 06
 > SELECT
@@ -242,7 +242,7 @@ true
       AND l_shipdate >= DATE '1994-01-01'
       AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
       AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
-1 values hashing to 34350c2d18d4c3607df2e48361faeb5b
+1 values hashing to d9c979f1eed5940788ff3653321acac4
 
 # Query 07
 > SELECT
@@ -284,7 +284,7 @@ true
       supp_nation,
       cust_nation,
       l_year;
-4 values hashing to 3fa442567ee218fd56c71afcebe22558
+4 values hashing to 0ab7e162c0d17f7fbdebbcb6e6eb4e7f
 
 # Query 08
 > SELECT
@@ -359,7 +359,7 @@ true
   ORDER BY
       nation,
       o_year DESC;
-174 values hashing to f9fe9448bbf58bf7bc6d030f07b0cb12
+172 values hashing to b0fbcce5ec14e4786bb47cc6a365d7e3
 
 # Query 10
 > SELECT
@@ -394,7 +394,7 @@ true
       c_comment
   ORDER BY
       revenue DESC;
-400 values hashing to 5aff97ea00cdcf957e5382269bf303a5
+366 values hashing to 23dd20e994576aec9e5898b128a6b5a5
 
 # Query 11
 > SELECT
@@ -455,7 +455,7 @@ true
       l_shipmode
   ORDER BY
       l_shipmode;
-2 values hashing to 073eefcd66f3621883f99713bfcca326
+2 values hashing to 3c31b94c99bd77e96003c2059416ed7a
 
 # Query 13
 > SELECT
@@ -478,7 +478,7 @@ true
   ORDER BY
       custdist DESC,
       c_count DESC;
-27 values hashing to 4db7211f1bec42092d8f3dfea7f385e2
+24 values hashing to 0425a49d65f09ba044a8ae4e34fe2fef
 
 # Query 14
 > SELECT
@@ -494,7 +494,7 @@ true
       l_partkey = p_partkey
       AND l_shipdate >= DATE '1995-09-01'
       AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
-1 values hashing to f14bf0e7e0cf534cca34f52d32f34ba3
+1 values hashing to 52009b01ec2cea22a360dbb1de1e5acf
 
 # Query 15
 > SELECT
@@ -516,7 +516,7 @@ true
       )
   ORDER BY
       s_suppkey;
-1 values hashing to e38533aeeb7f6fdfd3c4c95247ef052a
+1 values hashing to cef6c8859cb05a1680529bf4b688bbdb
 
 # Query 16
 > SELECT
@@ -569,7 +569,7 @@ true
       WHERE
         l_partkey = p_partkey
     );
-1 values hashing to ff8016d8983e2de3c211e66fbfaecf04
+1 values hashing to 6ea48615d6dd1ff31045cd67a15ef60a
 
 # Query 18
 > SELECT
@@ -604,7 +604,7 @@ true
   ORDER BY
       o_totalprice DESC,
       o_orderdate;
-3 values hashing to 0a0929b4453ef769efd3665c57fdee2d
+3 values hashing to 321256b5aef1aedab78f125c5925de92
 
 # Query 19
 > SELECT
@@ -642,7 +642,7 @@ true
           AND l_shipmode IN ('AIR', 'AIR REG')
           AND l_shipinstruct = 'DELIVER IN PERSON'
       );
-1 values hashing to 260226981739c518e3611adbe5764c77
+1 values hashing to 7df1074bd6f415369eb335bff3ad1781
 
 # Query 20
 > SELECT
@@ -682,7 +682,7 @@ true
       AND n_name = 'CANADA'
   ORDER BY
       s_name;
-1 values hashing to c33785f534c9d1a0abc37e05972a624d
+2 values hashing to d093f99c74b217399be0eccc998662af
 
 # Query 21
 > SELECT
@@ -724,7 +724,7 @@ true
   ORDER BY
       numwait DESC,
       s_name;
-2 values hashing to 9a281f0b2da0c7a03a0b0f447c420733
+2 values hashing to fd48e843525a4c80b8fe0b7064b35254
 
 # Query 22
 > SELECT
@@ -838,7 +838,7 @@ true
   ORDER BY
     l_returnflag,
     l_linestatus;
-4 values hashing to a7dd389a2d447201b18915e8aefa6ece
+4 values hashing to e350d21706985f8be572176f2301222f
 
 # Query 02
 > SELECT
@@ -900,7 +900,7 @@ true
   ORDER BY
       revenue DESC,
       o_orderdate;
-119 values hashing to 68d3ae75653e81e1b4ded8e9b14dac11
+127 values hashing to 637be0ff3f50cd612b004a69958bfccb
 
 # Query 04
 > SELECT
@@ -924,7 +924,7 @@ true
       o_orderpriority
   ORDER BY
       o_orderpriority;
-4 values hashing to 9c9139fe642f2a3ab3c151dcfef4f3f0
+4 values hashing to 320decef503bc240bc73101fc659a1db
 
 # Query 05
 > SELECT
@@ -951,7 +951,7 @@ true
       n_name
   ORDER BY
       revenue DESC;
-5 values hashing to 0c8219cc57219d9d3462441df16b8112
+5 values hashing to 8e24fa90f7160fb0dc1e7bfaaa3e9c73
 
 # Query 06
 > SELECT
@@ -963,7 +963,7 @@ true
       AND l_shipdate >= DATE '1994-01-01'
       AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
       AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
-1 values hashing to 34350c2d18d4c3607df2e48361faeb5b
+1 values hashing to d9c979f1eed5940788ff3653321acac4
 
 # Query 07
 > SELECT
@@ -1005,7 +1005,7 @@ true
       supp_nation,
       cust_nation,
       l_year;
-4 values hashing to 3fa442567ee218fd56c71afcebe22558
+4 values hashing to 0ab7e162c0d17f7fbdebbcb6e6eb4e7f
 
 # Query 08
 > SELECT
@@ -1080,7 +1080,7 @@ true
   ORDER BY
       nation,
       o_year DESC;
-174 values hashing to f9fe9448bbf58bf7bc6d030f07b0cb12
+172 values hashing to b0fbcce5ec14e4786bb47cc6a365d7e3
 
 # Query 10
 > SELECT
@@ -1115,7 +1115,7 @@ true
       c_comment
   ORDER BY
       revenue DESC;
-400 values hashing to 5aff97ea00cdcf957e5382269bf303a5
+366 values hashing to 23dd20e994576aec9e5898b128a6b5a5
 
 # Query 11
 > SELECT
@@ -1176,7 +1176,7 @@ true
       l_shipmode
   ORDER BY
       l_shipmode;
-2 values hashing to 073eefcd66f3621883f99713bfcca326
+2 values hashing to 3c31b94c99bd77e96003c2059416ed7a
 
 # Query 13
 > SELECT
@@ -1199,7 +1199,7 @@ true
   ORDER BY
       custdist DESC,
       c_count DESC;
-27 values hashing to 4db7211f1bec42092d8f3dfea7f385e2
+24 values hashing to 0425a49d65f09ba044a8ae4e34fe2fef
 
 # Query 14
 > SELECT
@@ -1215,7 +1215,7 @@ true
       l_partkey = p_partkey
       AND l_shipdate >= DATE '1995-09-01'
       AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
-1 values hashing to f14bf0e7e0cf534cca34f52d32f34ba3
+1 values hashing to 52009b01ec2cea22a360dbb1de1e5acf
 
 # Query 15
 > SELECT
@@ -1237,7 +1237,7 @@ true
       )
   ORDER BY
       s_suppkey;
-1 values hashing to e38533aeeb7f6fdfd3c4c95247ef052a
+1 values hashing to cef6c8859cb05a1680529bf4b688bbdb
 
 # Query 16
 > SELECT
@@ -1290,7 +1290,7 @@ true
       WHERE
         l_partkey = p_partkey
     );
-1 values hashing to ff8016d8983e2de3c211e66fbfaecf04
+1 values hashing to 6ea48615d6dd1ff31045cd67a15ef60a
 
 # Query 18
 > SELECT
@@ -1325,7 +1325,7 @@ true
   ORDER BY
       o_totalprice DESC,
       o_orderdate;
-3 values hashing to 0a0929b4453ef769efd3665c57fdee2d
+3 values hashing to 321256b5aef1aedab78f125c5925de92
 
 # Query 19
 > SELECT
@@ -1363,7 +1363,7 @@ true
           AND l_shipmode IN ('AIR', 'AIR REG')
           AND l_shipinstruct = 'DELIVER IN PERSON'
       );
-1 values hashing to 260226981739c518e3611adbe5764c77
+1 values hashing to 7df1074bd6f415369eb335bff3ad1781
 
 # Query 20
 > SELECT
@@ -1403,7 +1403,7 @@ true
       AND n_name = 'CANADA'
   ORDER BY
       s_name;
-1 values hashing to c33785f534c9d1a0abc37e05972a624d
+2 values hashing to d093f99c74b217399be0eccc998662af
 
 # Query 21
 > SELECT
@@ -1445,7 +1445,7 @@ true
   ORDER BY
       numwait DESC,
       s_name;
-2 values hashing to 9a281f0b2da0c7a03a0b0f447c420733
+2 values hashing to fd48e843525a4c80b8fe0b7064b35254
 
 # Query 22
 > SELECT


### PR DESCRIPTION
Teach the tpch load generator to produce changed orders every tick interval.

This is based on the technique described in https://www.cs.ox.ac.uk/files/9137/vldbj2014-dbtoaster-extended.pdf:

> The TPC-H benchmark queries Q1-Q22, and SSB4 were run on a stream of updates adapted from a database generated by DBGEN[42]. We simulate a system that monitors a set of “active” orders by randomly interleaving insertions on all relations and injecting random deletions of Orders and Lineitem rows to keep the Orders and Lineitem tables at around 30000 tuples and 120000 tuples, respectively. All updates preserve the foreign key constraints that exist between the TPC-H tables. Most experiments use a stream synthesized from a scaling factor 0.1 database (100 MB), while our scaling experiments extend these results up to a scaling factor of 10 (10 GB).

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Support `TICK INTERVAL` in the `TPCH` load generator.