### PR TITLE
Add the unique replica ID to `mz_audit_events`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4088,6 +4088,7 @@ impl<S: Append> Catalog<S> {
                             mz_audit_log::CreateComputeReplicaV1 {
                                 cluster_id: compute_instance_id.to_string(),
                                 cluster_name: on_cluster_name.clone(),
+                                replica_id: Some(replica_id.to_string()),
                                 replica_name: name.clone(),
                                 logical_size: size.clone(),
                             },
@@ -4364,6 +4365,7 @@ impl<S: Append> Catalog<S> {
                         EventDetails::DropComputeReplicaV1(mz_audit_log::DropComputeReplicaV1 {
                             cluster_id: instance.id.to_string(),
                             cluster_name: instance.name.clone(),
+                            replica_id: Some(replica_id.to_string()),
                             replica_name: name.clone(),
                         });
                     state.add_to_audit_log(

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -328,6 +328,7 @@ async fn migrate<S: Append>(
                                 cluster_id: DEFAULT_USER_COMPUTE_INSTANCE_ID.to_string(),
                                 cluster_name: default_instance.name,
                                 replica_name: default_replica.name,
+                                replica_id: Some(DEFAULT_REPLICA_ID.to_string()),
                                 logical_size: bootstrap_args.default_cluster_replica_size.clone(),
                             },
                         ),

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -181,6 +181,9 @@ pub struct RenameItemV1 {
 pub struct DropComputeReplicaV1 {
     pub cluster_id: String,
     pub cluster_name: String,
+    // Events that predate v0.32.0 will not have this field set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replica_id: Option<String>,
     pub replica_name: String,
 }
 
@@ -188,6 +191,9 @@ pub struct DropComputeReplicaV1 {
 pub struct CreateComputeReplicaV1 {
     pub cluster_id: String,
     pub cluster_name: String,
+    // Events that predate v0.32.0 will not have this field set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replica_id: Option<String>,
     pub replica_name: String,
     pub logical_size: String,
 }

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -84,7 +84,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 2  create  schema  {"database_name":"materialize","id":"3","name":"public"}  NULL
 3  create  role  {"id":"1","name":"materialize"}  NULL
 4  create  cluster  {"id":"u1","name":"default"}  NULL
-5  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_name":"r1"}  NULL
+5  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
 6  create  database  {"id":"2","name":"test"}  materialize
 7  create  schema  {"database_name":"test","id":"6","name":"public"}  materialize
 8  create  schema  {"database_name":"test","id":"7","name":"sc1"}  materialize
@@ -96,7 +96,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 14  create  role  {"id":"u2","name":"foo"}  materialize
 15  drop  role  {"id":"u2","name":"foo"}  materialize
 16  create  cluster  {"id":"u2","name":"foo"}  materialize
-17  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+17  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
 18  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
 19  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
 20  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
@@ -116,5 +116,5 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 34  create  source  {"database":"materialize","id":"u11","item":"organizations","schema":"public","size":null}  materialize
 35  create  source  {"database":"materialize","id":"u12","item":"users","schema":"public","size":null}  materialize
 36  create  source  {"database":"materialize","id":"u13","item":"multiplex","schema":"public","size":"1"}  materialize
-37  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_name":"r"}  materialize
+37  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_id":"4","replica_name":"r"}  materialize
 38  drop  cluster  {"id":"u2","name":"foo"}  materialize


### PR DESCRIPTION
As @benesch noted in discussing our billing queries, we have unique IDs for each replica, but we're not able to use them for billing because they're not exposed in `mz_audit_events` -- we're using a combination of cluster name and replica name instead.

This adds the `replica_id` field to `CreateComputeReplicaV1` and `DropComputeReplicaV1`. 

One thing I'm unsure of: as this is a simple additive change, is it OK to leave the structs as `V1`, or should I be creating a `V2`?