### PR TITLE
Use arrangement as first join input

### DIFF
--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1127,8 +1127,14 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                         );
                         (JoinPlan::Linear(ljp), missing)
                     }
-                    Differential((start, _start_arr), order) => {
-                        let source_arrangement = input_keys[*start].arbitrary_arrangement();
+                    Differential((start, start_arr), order) => {
+                        let source_arrangement = start_arr.as_ref().and_then(|key| {
+                            input_keys[*start]
+                                .arranged
+                                .iter()
+                                .find(|(k, _, _)| k == key)
+                                .clone()
+                        });
                         let (ljp, missing) = LinearJoinPlan::create_from(
                             *start,
                             source_arrangement,

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -1,0 +1,81 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/16036
+mode cockroach
+
+statement ok
+CREATE TABLE t1 (v1 TEXT, k1 INTEGER, k2 INTEGER);
+
+statement ok
+CREATE TABLE t2 (v2 TEXT, k1 INTEGER);
+
+statement ok
+CREATE TABLE t3 (v3 TEXT, k2 INTEGER);
+
+statement ok
+CREATE INDEX i1 ON t1 (k1);
+
+statement ok
+CREATE INDEX i2 ON t2 (k1);
+
+statement ok
+CREATE INDEX i3 ON t3 (k2);
+
+statement ok
+CREATE VIEW test AS SELECT v1, v2, v3 FROM t1, t2, t3 where t1.k1 = t2.k1 and t1.k2 = t3.k2;
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR SELECT * FROM test;
+----
+Explained Query:
+  Join::Linear
+    linear_stage[1]
+      closure
+        project=(#1..=#3)
+      lookup={ relation=2, key=[#1] }
+      stream={ key=[#1], thinning=(#0, #2) }
+    linear_stage[0]
+      closure
+        project=(#2, #3, #1)
+        filter=((#0) IS NOT NULL AND (#3) IS NOT NULL)
+      lookup={ relation=0, key=[#1] }
+      stream={ key=[#1], thinning=(#0) }
+    source={ relation=1, key=[#1] }
+    ArrangeBy
+      input_key=[#1]
+      project=(#1, #0, #2)
+      raw=false
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }
+      Get::PassArrangements materialize.public.t1
+        raw=false
+        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }
+    ArrangeBy
+      input_key=[#1]
+      project=(#1, #0)
+      raw=false
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+      Get::PassArrangements materialize.public.t2
+        raw=false
+        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    ArrangeBy
+      input_key=[#1]
+      project=(#1, #0)
+      raw=false
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+      Get::PassArrangements materialize.public.t3
+        raw=false
+        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+
+Used Indexes:
+  - materialize.public.i1
+  - materialize.public.i2
+  - materialize.public.i3
+
+EOF


### PR DESCRIPTION
Our `LinearJoin` plans have for a while had the defect that if the first input comes from an arrangement that requires a non-trivial permutation to undo its thinning, we don't use the arrangement and instead reduce it to a stream and re-arrange it instead. This results in non-trivial waste, and keeps us from introducing bespoke arrangements for the first input (as they may be discarded).

This PR fixes this behavior, mostly by deleting code. We would already perform logic to determine how the streamed collection should be arranged if it were un-arranged, and we now just use any pre-existing arrangement information if it exists and fall into the above logic only if required.

For a test, I used a three way join among tables with a `text` column first with indexes built on subsequent equated integer columns, to prompt non-trivial permutations. On main, with one record in each collection, the dataflow has six arrangements (three indexes, an output arrangement, an intermediate arrangement, and the bogus input arrangement).
```
materialize=> select * from mz_internal.mz_arrangement_sizes;
 operator_id | worker_id | records | batches 
-------------+-----------+---------+---------
 293         | 0         |       1 |       2
 302         | 0         |       1 |       2
 318         | 0         |       1 |       2
 200         | 0         |       1 |       2
 224         | 0         |       1 |       2
 248         | 0         |       1 |       2
(6 rows)
```
whereas in this PR it is five arrangements, the above minus the last one:
```
materialize=> select * from mz_internal.mz_arrangement_sizes;
 operator_id | worker_id | records | batches 
-------------+-----------+---------+---------
 294         | 0         |       1 |       2
 308         | 0         |       1 |       2
 200         | 0         |       1 |       2
 224         | 0         |       1 |       2
 248         | 0         |       1 |       2
(5 rows)
```

I did not change join planning to be more likely to arrange its first input, but we should consider that next (@ggevay).

This has not been tested more than `joins.slt` and the manual test above, and it is scary code so who knows what will happen!

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Ignore whitespace.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
