### PR TITLE
Add back a log message for when the network is successfully established

### DIFF
--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -46,7 +46,7 @@ use mz_compute_client::command::ComputeStartupEpoch;
 use mz_ore::cast::CastFrom;
 use timely::communication::allocator::zero_copy::initialize::initialize_networking_from_sockets;
 use timely::communication::allocator::GenericBuilder;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use mz_compute_client::command::CommunicationConfig;
 

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -90,7 +90,7 @@ pub async fn initialize_networking(
             ))
         }
         Err(err) => {
-            error!(process = process, "failed to initialize network: {err}");
+            warn!(process = process, "failed to initialize network: {err}");
             Err(anyhow::Error::from(err).context("failed to initialize networking from sockets"))
         }
     }

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -90,7 +90,7 @@ pub async fn initialize_networking(
             ))
         }
         Err(err) => {
-            warn!(process = process, "failed to initialize network: {err}");
+            warn!(process, "failed to initialize network: {err}");
             Err(anyhow::Error::from(err).context("failed to initialize networking from sockets"))
         }
     }


### PR DESCRIPTION
These messages got lost in the refactor.

### Motivation

  * This PR fixes a previously unreported bug.

    It is no longer easy to tell from logs whether the Timely network has finished setting up 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

(None)
