### PR TITLE
deps: bump to latest AWS SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b309b2154d224728d845a958c580834f24213037ed61b195da80c0b0fc7469fa"
+checksum = "56a636c44c77fa18bdba56126a34d30cfe5538fe88f7d34988fa731fee143ddd"
 dependencies = [
  "aws-http",
  "aws-sdk-sso",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f35c8f5877ad60db4f0d9dcdfbcb2233a8cc539f9e568df39ee0581ec62e89"
+checksum = "6ca8f374874f6459aaa88dc861d7f5d834ca1ff97668eae190e97266b5f6c3fb"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5422c9632d887968ccb66e2871a6d190d6104e276034912bee72ef58a5d890"
+checksum = "78d41e19e779b73463f5f0c21b3aacc995f4ba783ab13a7ae9f5dfb159a551b4"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cea2a2981341e496fa615628df5b3480ebb95a4b408531a77841b89bb72ee00"
+checksum = "37766fdf50feab317b4f939b1c9ee58a2a1c51785974328ce84cff1eea7a1bb8"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d31765abb258c501d5572ebce43dee524b4b3b6256cb8b4c78534898dc205b"
+checksum = "a9f08665c8e03aca8cb092ef01e617436ebfa977fddc1240e1b062488ab5d48a"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69fd6a9e4af3991d105a83bfa72f3c1dcaab395c7eaf8b70cda4c3c7fe5167b"
+checksum = "8b26bb3d12238492cb12bde0de8486679b007daada21fdb110913b32a2a38275"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cc8b50281e1350d0b5c7207c2ce53c6721186ad196472caff4f20fa4b42e96"
+checksum = "86dcb1cb71aa8763b327542ead410424515cff0cde5b753eedd2917e09c63734"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6179f13c9fbab3226860f377354dece860e34ff129b69c7c1b0fa828d1e9c76"
+checksum = "fdfcf584297c666f6b472d5368a78de3bc714b6e0a53d7fbf76c3e347c292ab1"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16f4d70c9c865af392eb40cacfe2bec3fa18f651fbdf49919cfc1dda13b189e"
+checksum = "12cbe7b2be9e185c1fbce27fc9c41c66b195b32d89aa099f98768d9544221308"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-eventstream",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d33790cecae42b999d197074c8a19e9b96b9e346284a6f93989e7489c9fa0f5"
+checksum = "03ff4cff8c4a101962d593ba94e72cd83891aecd423f0c6e3146bff6fb92c9e3"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc604f278bae64bbd15854baa9c46ed69a56dfb0669d04aab80974749f2d6599"
+checksum = "7b3442b4c5d3fc39891a2e5e625735fba6b24694887d49c6518460fde98247a9"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b402da39bc5aae618b70a9b8d828acad21fe4a3a73b82c0205b89db55d71ce8"
+checksum = "cc227e36e346f45298288359f37123e1a92628d1cec6b11b5eb335553278bd9e"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec39585f8274fa543ad5c63cc09cbd435666be16b2cf99e4e07be5cf798bc050"
+checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c2a7b9490fd2bc7af3a1c486ae921102d7234d1fa5e7d91039068e7af48a01"
+checksum = "d7ea0df7161ce65b5c8ca6eb709a1a907376fa18226976e41c748ce02ccccf24"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014a0ef5c4508fc2f6a9d3925c214725af19f020ea388db48e20196cc4cc9d6d"
+checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -588,6 +588,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "pin-utils",
  "tokio",
  "tokio-util",
  "tracing",
@@ -595,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deecb478dc3cc40203e0e97ac0fb92947e0719754bbafd0026bdc49318e2fd03"
+checksum = "20c96d7bd35e7cf96aca1134b2f81b1b59ffe493f7c6539c051791cbbf7a42d3"
 dependencies = [
  "aws-smithy-http",
  "bytes",
@@ -610,18 +611,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6593456af93c4a39724f7dc9d239833102ab96c1d1e94c35ea79f0e55f9fd54c"
+checksum = "d8324ba98c8a94187723cc16c37aefa09504646ee65c3d2c3af495bab5ea701b"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b803460b71645dfa9f6be47c4f00f91632f01e5bb01f9dc43890cd6cba983f08"
+checksum = "83834ed2ff69ea6f6657baf205267dc2c0abe940703503a3e5d60ce23be3d306"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -629,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93b0c93a3b963da946a0b8ef3853a7252298eb75cdbfb21dad60f5ed0ded861"
+checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
 dependencies = [
  "itoa",
  "num-integer",
@@ -641,18 +642,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b9efb4855b4acb29961a776d45680f3cbdd7c4783cbbae078da54c342575dd"
+checksum = "246e9f83dd1fdf5d347fa30ae4ad30a9d1d42ce4cd74a93d94afa874646f94cd"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f3f349b39781849261db1c727369923bb97007cf7bd0deb3a6e9e461c8d38f"
+checksum = "05701d32da168b44f7ee63147781aed8723e792cc131cb9b18363b5393f17f70"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-client",
@@ -7519,9 +7520,9 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xmlparser"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "yaml-rust"

--- a/src/kinesis-util/Cargo.toml
+++ b/src/kinesis-util/Cargo.toml
@@ -7,4 +7,4 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-aws-sdk-kinesis = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -22,11 +22,11 @@ bench = false
 anyhow = { version = "1.0.65", features = ["backtrace"] }
 arrow2 = { version = "0.14.2", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.57"
-aws-config = { version = "0.49.0", default-features = false, features = ["native-tls"] }
-aws-sdk-s3 = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"]  }
-aws-smithy-http = "0.49.0"
-aws-smithy-types = "0.49.0"
-aws-types = { version = "0.49.0", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"] }
+aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"]  }
+aws-smithy-http = "0.51.0"
+aws-smithy-types = "0.51.0"
+aws-types = { version = "0.51.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
 bytes = "1.2.1"
 deadpool-postgres = "0.10.2"

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.65"
-aws-config = { version = "0.49.0", default-features = false, features = ["native-tls"] }
-aws-sdk-s3 = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"] }
+aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 bytefmt = "0.1.7"
 clap = { version = "3.2.20", features = ["derive"] }
 futures = "0.3.24"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.65"
 aws-arn = "0.3.1"
-aws-sdk-sts = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sts = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std"] }
 enum-kinds = "0.5.1"
 globset = "0.4.9"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 anyhow = "1.0.65"
 async-stream = "0.3.3"
 async-trait = "0.1.57"
-aws-config = { version = "0.49.0", default-features = false, features = ["native-tls"] }
-aws-smithy-http = "0.49.0"
-aws-types = { version = "0.49.0", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"] }
+aws-smithy-http = "0.51.0"
+aws-types = { version = "0.51.0", features = ["hardcoded-credentials"] }
 bytes = "1.2.1"
 derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -11,9 +11,9 @@ anyhow = "1.0.65"
 async-compression = { version = "0.3.15", features = ["tokio", "gzip"] }
 async-stream = "0.3.3"
 async-trait = "0.1.57"
-aws-sdk-kinesis = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-s3 = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-sqs = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sqs = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 axum = "0.5.16"
 chrono = { version = "0.4.22", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive", "env"] }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -11,13 +11,13 @@ anyhow = "1.0.65"
 async-compression = { version = "0.3.15", features = ["tokio", "gzip"] }
 async-trait = "0.1.57"
 atty = "0.2.0"
-aws-config = { version = "0.49.0", default-features = false, features = ["native-tls"] }
-aws-sdk-kinesis = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-s3 = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-sqs = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-sts = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-smithy-http = "0.49.0"
-aws-types = { version = "0.49.0", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"] }
+aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sqs = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sts = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-smithy-http = "0.51.0"
+aws-types = { version = "0.51.0", features = ["hardcoded-credentials"] }
 byteorder = "1.4.3"
 bytes = "1.2.1"
 chrono = { version = "0.4.22", default-features = false, features = ["std"] }

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.65"
-aws-config = { version = "0.49.0", default-features = false, features = ["native-tls"] }
-aws-sdk-kinesis = { version = "0.19.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-types = "0.49.0"
+aws-config = { version = "0.51.0", default-features = false, features = ["native-tls"] }
+aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-types = "0.51.0"
 bytes = "1.2.1"
 clap = { version = "3.2.20", features = ["derive"] }
 futures = "0.3.24"


### PR DESCRIPTION
@danhhz or @pH14: can you review the AWS SDK timeout configuration changes in `persist`? I added a connect timeout and a read timeout and resolved the TODO in the code, but not sure if that was the correct thing to do.

### Motivation

* Periodic AWS SDK bump.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
