### PR TITLE
ci: Use larger EC2 instances for some Nightly CI jobs

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -184,7 +184,9 @@ steps:
   - id: limits-instance-size
     label: "Instance size limits"
     agents:
-      queue: linux-x86_64
+      # A larger instance is needed due to the
+      # many containers that are being created
+      queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: limits
@@ -261,7 +263,9 @@ steps:
     label: "Zippy Kafka Sources"
     timeout_in_minutes: 120
     agents:
-      queue: linux-x86_64
+      # Workload takes slightly more than 8Gb, so it OOMs
+      # on the instances from the linux-x86_64 queue
+      queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy


### PR DESCRIPTION
The 'instance-size-limits' and 'zippy-kafka-sources' jobs can not properly complete within the 8Gb of RAM habitually used for the other CI jobs.

### Motivation

  * This PR fixes a previously unreported bug.

Jobs from the Nightly were failing and I got tired from nerfing them down to fit in 8Gb of RAM.

### Tips for reviewer

@benesch this poses the general question of how we set up Buildkite queues and size our machines. For any Release Qualification Tests a larger machine would also be needed. Are you OK if I continue to use the `builder-linux-x86_64` queue,
even though the name would not be correct in the context of a CI test, or you prefer some other approach? Thanks!