### PR TITLE
testdrive: Fortify cvs-sources.td against #16048

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -31,7 +31,7 @@ place""",CA,92679
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
 ! SELECT * FROM mismatched_column_count
-contains:CSV error at record number 1: expected 2 columns, got 3.
+contains:expected 2 columns, got 3
 
 > CREATE SOURCE matching_column_names
   FROM S3 CONNECTION s3_conn
@@ -53,19 +53,28 @@ a b c
 ----------------
 Rochester NY 14618
 
+# We test the two errors below on a 1-row source in order
+# to avoid the non-determinism in #16048
+
+$ s3-create-bucket bucket=test-one-record
+
+$ s3-put-object bucket=test-one-record key=static-one-record.csv
+city,state,zip
+Rochester,NY,14618
+
 > CREATE SOURCE mismatched_column_names
   FROM S3 CONNECTION s3_conn
-  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  DISCOVER OBJECTS MATCHING 'static-one-record.csv' USING BUCKET SCAN 'testdrive-test-one-record-${testdrive.seed}'
   FORMAT CSV WITH HEADER (cities, country, zip)
 ! SELECT * FROM mismatched_column_names
 contains:first mismatched column at index 1 expected=cities actual="city"
 
 > CREATE SOURCE mismatched_column_names_count
   FROM S3 CONNECTION s3_conn
-  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  DISCOVER OBJECTS MATCHING 'static-one-record.csv' USING BUCKET SCAN 'testdrive-test-one-record-${testdrive.seed}'
   FORMAT CSV WITH HEADER (cities, state)
 ! SELECT * FROM mismatched_column_names_count
-contains:CSV error at record number 1: expected 2 columns, got 3
+contains:expected 2 columns, got 3
 
 # Static CSV without headers.
 > CREATE SOURCE static_csv


### PR DESCRIPTION
To avoid the non-determinism observed in #16048, use a dedicated 1-row source for some portions of the test.

Relates to: #16048

### Motivation

  * This PR fixes a previously unreported bug.
Random CI failures