### PR TITLE
ore: add `Vec::drain_filter_swapping` method

### DIFF
--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -77,6 +77,121 @@ where
     }
 }
 
+/// Extention methods for `std::vec::Vec`
+pub trait VecExt<T> {
+    /// Creates an iterator which uses a closure to determine if an element should be removed.
+    ///
+    /// If the closure returns true, then the element is removed and yielded.
+    /// If the closure returns false, the element will remain in the vector and will not be yielded
+    /// by the iterator.
+    ///
+    /// Using this method is equivalent to the following code:
+    ///
+    /// ```
+    /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
+    /// # let mut vec = vec![1, 2, 3, 4, 5, 6];
+    /// let mut i = 0;
+    /// while i < vec.len() {
+    ///     if some_predicate(&mut vec[i]) {
+    ///         let val = vec.swap_remove(i);
+    ///         // your code here
+    ///     } else {
+    ///         i += 1;
+    ///     }
+    /// }
+    ///
+    /// # assert_eq!(vec, vec![1, 5, 4]);
+    /// ```
+    ///
+    /// But `drain_filter_swapping` is easier to use.
+    ///
+    /// Note that `drain_filter_swapping` also lets you mutate every element in the filter closure,
+    /// regardless of whether you choose to keep or remove it.
+    ///
+    /// # Note
+    ///
+    /// Because the elements are removed using [`Vec::swap_remove`] the order of elements yielded
+    /// by the iterator and the order of the remaining elements in the original vector is **not**
+    /// maintained.
+    ///
+    /// # Examples
+    ///
+    /// Splitting an array into evens and odds, reusing the original allocation. Notice how the
+    /// order is not preserved in either results:
+    ///
+    /// ```
+    /// use mz_ore::vec::VecExt;
+    ///
+    /// let mut numbers = vec![1, 2, 3, 4, 5, 6, 8, 9, 11, 13, 14, 15];
+    ///
+    /// let evens = numbers.drain_filter_swapping(|x| *x % 2 == 0).collect::<Vec<_>>();
+    /// let odds = numbers;
+    ///
+    /// assert_eq!(evens, vec![2, 4, 14, 6, 8]);
+    /// assert_eq!(odds, vec![1, 15, 3, 13, 5, 11, 9]);
+    /// ```
+    fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
+    where
+        F: FnMut(&mut T) -> bool;
+}
+
+impl<T> VecExt<T> for Vec<T> {
+    fn drain_filter_swapping<F>(&mut self, filter: F) -> DrainFilterSwapping<'_, T, F>
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        DrainFilterSwapping {
+            vec: self,
+            idx: 0,
+            pred: filter,
+        }
+    }
+}
+
+/// An iterator which uses a closure to determine if an element should be removed.
+///
+/// This struct is created by [`VecExt::drain_filter_swapping`].
+/// See its documentation for more.
+///
+/// # Example
+///
+/// ```
+/// use mz_ore::vec::VecExt;
+///
+/// let mut v = vec![0, 1, 2];
+/// let iter: mz_ore::vec::DrainFilterSwapping<_, _> = v.drain_filter_swapping(|x| *x % 2 == 0);
+/// ```
+#[derive(Debug)]
+pub struct DrainFilterSwapping<'a, T, F> {
+    vec: &'a mut Vec<T>,
+    /// The index of the item that will be inspected by the next call to `next`.
+    idx: usize,
+    /// The filter test predicate.
+    pred: F,
+}
+
+impl<'a, T, F> Iterator for DrainFilterSwapping<'a, T, F>
+where
+    F: FnMut(&mut T) -> bool,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let item = self.vec.get_mut(self.idx)?;
+            if (self.pred)(item) {
+                return Some(self.vec.swap_remove(self.idx));
+            } else {
+                self.idx += 1;
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.vec.len() - self.idx))
+    }
+}
+
 /// Remove the elements from `v` at the positions indicated by `indexes`, and return the removed
 /// elements in a new vector.
 ///


### PR DESCRIPTION
### Motivation

This is logic was being used in a few places in the codebase and I wanted to use it in some more so better to keep it
in one place.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
