### PR TITLE
[DO NOT MERGE] adapter: turn window_functions off by default

### DIFF
--- a/misc/python/materialize/checks/window_functions.py
+++ b/misc/python/materialize/checks/window_functions.py
@@ -18,6 +18,10 @@ class WindowFunctions(Check):
         return Testdrive(
             dedent(
                 """
+            $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            $ postgres-execute connection=mz_system
+            ALTER SYSTEM SET window_functions = 'on'
+
             > CREATE TABLE window_functions_table (f1 INTEGER, f2 INTEGER);
             > INSERT INTO window_functions_table VALUES (1,1), (2, 1), (3, 1);
         """

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -280,7 +280,7 @@ static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<String>>> = Lazy::new(|
 /// Feature flag indicating whether window functions are enabled.
 static WINDOW_FUNCTIONS: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("window_functions"),
-    value: &true,
+    value: &false,
     description: "Feature flag indicating whether window functions are enabled.",
 };
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -12,6 +12,13 @@
 
 mode cockroach
 
+# Assert that window functions are not supported if the feature flag is off.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET window_functions = false
+----
+COMPLETE 0
+
 statement error window function row_number requires an OVER clause
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT row_number() FROM t
@@ -19,6 +26,18 @@ SELECT row_number() FROM t
 statement error aggregate window functions not yet supported
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT array_agg(x) OVER () FROM t
+
+statement error window functions not yet supported
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT EXISTS(
+  SELECT row_number() OVER (ORDER BY x), x FROM t
+  ORDER BY row_number
+)
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET window_functions = true
+----
+COMPLETE 0
 
 query IT
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -44,7 +44,7 @@ standard_conforming_strings             on                     "Causes '...' str
 statement_timeout                       "10 s"                 "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
 TimeZone                                UTC                    "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation                   "strict serializable"  "Sets the current transaction's isolation level (PostgreSQL)."
-window_functions                        on                     "Feature flag indicating whether window functions are enabled."
+window_functions                        off                    "Feature flag indicating whether window functions are enabled."
 
 
 > SET application_name = 'foo'


### PR DESCRIPTION
This is a follow up of #15969, see "Tips for reviewer" there for details.

Assigning this to @antiguru until we know how to proceed with this.

### Motivation

  * This PR adds a feature that has not yet been specified.

It's not clear how we want to handle the rollout of #15957. PMs, DevEx, and FieldEng. should reach consensus on that. If we decide to turn off the `window_functions` gate by default, we need to merge this.

### Tips for reviewer

- This just turns `window_functions` by default and fixes tests. @benesch: you already reviewed this in #15969, I just factored this bit out as a separate PR.
- If we agree to merge this, we will have to first figure out what to do with existing environments in `prod` and `staging`.
- If we agree to merge this, we will have to either:
    -  create an issue to be referenced in the `bail_unsupported!("window functions");` call in `optimize_and_lower`, or
    -  introduce a dedicated error type and macro (similar to `PlanError::Unsupported`) for gated features and use it instead.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Window functions are now turned off by default.
