### PR TITLE
kafka-util,ssh-util: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,10 +3567,7 @@ dependencies = [
  "mz-avro",
  "mz-ccsr",
  "mz-ore",
- "mz-proto",
  "num_cpus",
- "proptest",
- "proptest-derive",
  "prost",
  "prost-build",
  "protobuf-src",
@@ -4256,7 +4253,6 @@ name = "mz-ssh-util"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "mz-ore",
  "openssh",
  "openssl",
  "rand",

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -14,10 +14,7 @@ crossbeam = "0.8.2"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["network"] }
-mz-proto = { path = "../proto" }
 num_cpus = "1.13.1"
-proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
 prost = { version = "0.11.2", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1.0.65" }
-mz-ore = { path = "../ore" }
 openssh = "0.9.7"
 openssl = { version = "0.10.42", features = ["vendored"] }
 rand = "0.8.5"


### PR DESCRIPTION

### Motivation

  * This PR fixes a previously unreported bug.

Nightly CI was complaining.