### PR TITLE
sql[-parser]: remove STATISTICS INTERVAL MS Kafka option

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -871,7 +871,6 @@ pub enum KafkaConfigOptionName {
     FetchMessageMaxBytes,
     GroupIdPrefix,
     IsolationLevel,
-    StatisticsIntervalMs,
     Topic,
     TopicMetadataRefreshIntervalMs,
     TransactionTimeoutMs,
@@ -892,7 +891,6 @@ impl AstDisplay for KafkaConfigOptionName {
             KafkaConfigOptionName::FetchMessageMaxBytes => "FETCH MESSAGE MAX BYTES",
             KafkaConfigOptionName::GroupIdPrefix => "GROUP ID PREFIX",
             KafkaConfigOptionName::IsolationLevel => "ISOLATION LEVEL",
-            KafkaConfigOptionName::StatisticsIntervalMs => "STATISTICS INTERVAL MS",
             KafkaConfigOptionName::Topic => "TOPIC",
             KafkaConfigOptionName::TopicMetadataRefreshIntervalMs => {
                 "TOPIC METADATA REFRESH INTERVAL MS"

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -314,7 +314,6 @@ Sqs
 Ssh
 Ssl
 Start
-Statistics
 Stdin
 Stdout
 Strategy

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2181,10 +2181,6 @@ impl<'a> Parser<'a> {
                 MS => KafkaConfigOptionName::RetentionMs,
                 _ => unreachable!(),
             },
-            STATISTICS => {
-                self.expect_keywords(&[INTERVAL, MS])?;
-                KafkaConfigOptionName::StatisticsIntervalMs
-            }
             TOPIC => {
                 if self.parse_keyword(METADATA) {
                     self.expect_keywords(&[REFRESH, INTERVAL, MS])?;

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2143,7 +2143,6 @@ impl<'a> Parser<'a> {
             RETENTION,
             SNAPSHOT,
             START,
-            STATISTICS,
             TOPIC,
             TRANSACTION,
         ])? {

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -51,7 +51,6 @@ pub fn validate_options_for_context<T: AstInfo>(
             FetchMessageMaxBytes => None,
             GroupIdPrefix => None,
             IsolationLevel => None,
-            StatisticsIntervalMs => None,
             Topic => None,
             TopicMetadataRefreshIntervalMs => None,
             TransactionTimeoutMs => None,
@@ -89,7 +88,6 @@ generate_extracted_config!(
         String,
         Default(String::from("read_committed"))
     ),
-    (StatisticsIntervalMs, i32, Default(1_000)),
     (Topic, String),
     (TopicMetadataRefreshIntervalMs, i32),
     (TransactionTimeoutMs, i32),
@@ -114,7 +112,6 @@ impl TryFrom<&KafkaConfigOptionExtracted> for LibRdKafkaConfig {
             enable_idempotence,
             fetch_message_max_bytes,
             isolation_level,
-            statistics_interval_ms,
             topic_metadata_refresh_interval_ms,
             transaction_timeout_ms,
             ..
@@ -141,12 +138,6 @@ impl TryFrom<&KafkaConfigOptionExtracted> for LibRdKafkaConfig {
 
         fill_options!(acks, "acks");
         fill_options!(client_id, "client.id");
-        fill_options!(
-            Some(statistics_interval_ms),
-            "statistics.interval.ms",
-            |i: &i32| { 0 <= *i && *i <= 86_400_000 },
-            "STATISTICS INTERVAL MS must be within [0, 86,400,000]"
-        );
         fill_options!(
             topic_metadata_refresh_interval_ms,
             "topic.metadata.refresh.interval.ms",


### PR DESCRIPTION
The STATISTICS INTERVAL MS option controls how often librdkafka statistics are dumped to stderr via an `info!` log. This is no longer a useful option to expose to end users, as they do not have access to Materialize's stderr logs. So just remove it.

In the future, we may want to force-enable the statistics callback with something smarter, that extracts relevant stats in librdkafka as Prometheus metrics in Materialize, but that's a project for another day.

Fix #16050.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
