### PR TITLE
Add service_metrics API to namespaced orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,8 +3680,10 @@ dependencies = [
  "mz-orchestrator",
  "mz-repr",
  "mz-secrets",
+ "serde",
  "serde_json",
  "sha2",
+ "tracing",
 ]
 
 [[package]]

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -19,5 +19,7 @@ mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
 k8s-openapi = { version = "0.15.0", features = ["v1_22"] }
 kube = { version = "0.74.0", features = ["runtime", "ws"] }
+serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.86"
 sha2 = "0.10.6"
+tracing = "0.1.37"

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -640,13 +640,19 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 }
             }
         }
-        self.service_scales.lock().expect("poisoned lock").insert(id.to_string(), scale);
+        self.service_scales
+            .lock()
+            .expect("poisoned lock")
+            .insert(id.to_string(), scale);
         Ok(Box::new(KubernetesService { hosts, ports }))
     }
 
     /// Drops the identified service, if it exists.
     async fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
-        self.service_scales.lock().expect("poisoned lock").remove(id);
+        self.service_scales
+            .lock()
+            .expect("poisoned lock")
+            .remove(id);
         let name = format!("{}-{id}", self.namespace);
         let res = self
             .stateful_set_api

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -256,7 +256,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             anyhow::bail!("spec.replicas not found for statefulset {id}");
         };
         /// Get metrics for a particular service and process, converting them into a sane (i.e., numeric) format.
-        /// 
+        ///
         /// Note that we want to keep going even if a lookup fails for whatever reason,
         /// so this function is infallible. If we fail to get cpu or memory for a particular pod,
         /// we just log a warning and install `None` in the returned struct.

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -321,14 +321,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         let ret = futures::future::join_all((0..scale).map(|i| get_metrics(self, id, i)));
 
         Ok(ret.await)
-        // Ok(ret)
-        // let mut ret = vec![];
-        // for i in 0..scale {
-        //     let name = format!("{id}-{i}");
-
-        // }
-        // let metrics = self.metrics_api.get("environmentd-0").await.unwrap();
-        // dbg!(metrics);
     }
 
     async fn ensure_service(

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -31,15 +31,17 @@ use kube::error::Error;
 use kube::runtime::{watcher, WatchStreamExt};
 use kube::ResourceExt;
 use maplit::btreemap;
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use tracing::warn;
 
 use mz_cloud_resources::crd::vpc_endpoint::v1::VpcEndpoint;
 use mz_cloud_resources::AwsExternalIdPrefix;
-use mz_orchestrator::LabelSelector as MzLabelSelector;
 use mz_orchestrator::{
     LabelSelectionLogic, NamespacedOrchestrator, Orchestrator, Service, ServiceAssignments,
     ServiceConfig, ServiceEvent, ServiceStatus,
 };
+use mz_orchestrator::{LabelSelector as MzLabelSelector, ServiceProcessMetrics};
 
 pub mod cloud_resource_controller;
 pub mod secrets;
@@ -121,6 +123,7 @@ impl KubernetesOrchestrator {
 impl Orchestrator for KubernetesOrchestrator {
     fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator> {
         Arc::new(NamespacedKubernetesOrchestrator {
+            metrics_api: Api::default_namespaced(self.client.clone()),
             service_api: Api::default_namespaced(self.client.clone()),
             stateful_set_api: Api::default_namespaced(self.client.clone()),
             pod_api: Api::default_namespaced(self.client.clone()),
@@ -133,6 +136,7 @@ impl Orchestrator for KubernetesOrchestrator {
 
 #[derive(Clone)]
 struct NamespacedKubernetesOrchestrator {
+    metrics_api: Api<PodMetrics>,
     service_api: Api<K8sService>,
     stateful_set_api: Api<StatefulSet>,
     pod_api: Api<Pod>,
@@ -148,6 +152,48 @@ impl fmt::Debug for NamespacedKubernetesOrchestrator {
             .field("namespace", &self.namespace)
             .field("config", &self.config)
             .finish()
+    }
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PodMetricsContainer {
+    pub name: String,
+    pub usage: PodMetricsContainerUsage,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PodMetricsContainerUsage {
+    pub cpu: Quantity,
+    pub memory: Quantity,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PodMetrics {
+    pub metadata: ObjectMeta,
+    pub timestamp: String,
+    pub window: String,
+    pub containers: Vec<PodMetricsContainer>,
+}
+
+impl k8s_openapi::Resource for PodMetrics {
+    const GROUP: &'static str = "metrics.k8s.io";
+    const KIND: &'static str = "PodMetrics";
+    const VERSION: &'static str = "v1beta1";
+    const API_VERSION: &'static str = "metrics.k8s.io/v1beta1";
+    const URL_PATH_SEGMENT: &'static str = "pods";
+
+    type Scope = k8s_openapi::NamespaceResourceScope;
+}
+
+impl k8s_openapi::Metadata for PodMetrics {
+    type Ty = ObjectMeta;
+
+    fn metadata(&self) -> &Self::Ty {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut Self::Ty {
+        &mut self.metadata
     }
 }
 
@@ -205,6 +251,86 @@ impl NamespacedKubernetesOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
+    async fn service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+        let StatefulSet { spec: Some(StatefulSetSpec { replicas: Some(scale), ..}), .. } = self.stateful_set_api.get(id).await? else {
+            anyhow::bail!("spec.replicas not found for statefulset {id}");
+        };
+        /// Get metrics for a particular service and process, converting them into a sane (i.e., numeric) format.
+        /// 
+        /// Note that we want to keep going even if a lookup fails for whatever reason,
+        /// so this function is infallible. If we fail to get cpu or memory for a particular pod,
+        /// we just log a warning and install `None` in the returned struct.
+        async fn get_metrics(
+            self_: &NamespacedKubernetesOrchestrator,
+            id: &str,
+            i: i32,
+        ) -> ServiceProcessMetrics {
+            let name = format!("{id}-{i}");
+            let metrics = match self_.metrics_api.get(&name).await {
+                Ok(metrics) => metrics,
+                Err(e) => {
+                    warn!("Failed to get metrics for {name}: {e}");
+                    return ServiceProcessMetrics::default();
+                }
+            };
+            let Some(PodMetricsContainer { usage: PodMetricsContainerUsage { cpu: Quantity(cpu_str), memory: Quantity(mem_str) }, .. }) = metrics.containers.get(0) else {
+                warn!("metrics result contained no containers for {name}");
+                return ServiceProcessMetrics::default();
+            };
+            // Parsing a k8s Quantity is kind of complicated:
+            // See https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
+            // for details. We can rewrite this correct parsing code in Rust if needed in the future, but let's see if we can get away with
+            // just assuming CPU is always a positive integer number of nano-CPUs and memory is always in KiB for now.
+            //
+            // Note that https://github.com/sombralibre/k8s-quantity-parser doesn't support the (undocumented) `n` suffix,
+            // so we can't use it.
+            let cpu = if cpu_str.ends_with("n") {
+                let rest = &cpu_str[0..cpu_str.len() - 1];
+                match rest.parse::<u64>() {
+                    Ok(val) => Some(val),
+                    Err(_e) => {
+                        tracing::warn!("metrics-server CPU value in unexpected format: {cpu_str}");
+                        None
+                    }
+                }
+            } else {
+                tracing::warn!("metrics-server CPU value in unexpected format: {cpu_str}");
+                None
+            };
+            let memory = if mem_str.ends_with("Ki") {
+                let rest = &cpu_str[0..mem_str.len() - 2];
+                match rest.parse::<u64>() {
+                    Ok(val) => Some(val),
+                    Err(_e) => {
+                        tracing::warn!(
+                            "metrics-server memory value in unexpected format: {mem_str}"
+                        );
+                        None
+                    }
+                }
+            } else {
+                tracing::error!("metrics-server memory value in unexpected format: {mem_str}");
+                None
+            }
+            .map(|kib| kib * 1024);
+            ServiceProcessMetrics {
+                nano_cpus: cpu,
+                bytes_memory: memory,
+            }
+        }
+        let ret = futures::future::join_all((0..scale).map(|i| get_metrics(self, id, i)));
+
+        Ok(ret.await)
+        // Ok(ret)
+        // let mut ret = vec![];
+        // for i in 0..scale {
+        //     let name = format!("{id}-{i}");
+
+        // }
+        // let metrics = self.metrics_api.get("environmentd-0").await.unwrap();
+        // dbg!(metrics);
+    }
+
     async fn ensure_service(
         &self,
         id: &str,

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -284,7 +284,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             //
             // Note that https://github.com/sombralibre/k8s-quantity-parser doesn't support the (undocumented) `n` suffix,
             // so we can't use it.
-            let cpu = if cpu_str.ends_with("n") {
+            let cpu = if cpu_str.ends_with('n') {
                 let rest = &cpu_str[0..cpu_str.len() - 1];
                 match rest.parse::<u64>() {
                     Ok(val) => Some(val),

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -32,7 +32,7 @@ use tracing::{error, info};
 
 use mz_orchestrator::{
     NamespacedOrchestrator, Orchestrator, Service, ServiceAssignments, ServiceConfig, ServiceEvent,
-    ServiceStatus,
+    ServiceStatus, ServiceProcessMetrics,
 };
 use mz_ore::id_gen::PortAllocator;
 use mz_pid_file::PidFile;
@@ -141,6 +141,9 @@ struct NamespacedProcessOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
+    async fn service_metrics(&self, _id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+        anyhow::bail!("metrics are not supported on the process orchestrator");
+    }
     async fn ensure_service(
         &self,
         id: &str,

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -141,12 +141,13 @@ struct NamespacedProcessOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
-    async fn service_metrics(
+    async fn fetch_service_metrics(
         &self,
         _id: &str,
     ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
         anyhow::bail!("metrics are not supported on the process orchestrator");
     }
+
     async fn ensure_service(
         &self,
         id: &str,

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -32,7 +32,7 @@ use tracing::{error, info};
 
 use mz_orchestrator::{
     NamespacedOrchestrator, Orchestrator, Service, ServiceAssignments, ServiceConfig, ServiceEvent,
-    ServiceStatus, ServiceProcessMetrics,
+    ServiceProcessMetrics, ServiceStatus,
 };
 use mz_ore::id_gen::PortAllocator;
 use mz_pid_file::PidFile;
@@ -141,7 +141,10 @@ struct NamespacedProcessOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
-    async fn service_metrics(&self, _id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+    async fn service_metrics(
+        &self,
+        _id: &str,
+    ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
         anyhow::bail!("metrics are not supported on the process orchestrator");
     }
     async fn ensure_service(

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -277,7 +277,10 @@ struct NamespacedTracingOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
-    async fn fetch_service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+    async fn fetch_service_metrics(
+        &self,
+        id: &str,
+    ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
         self.inner.fetch_service_metrics(id).await
     }
 

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -277,9 +277,10 @@ struct NamespacedTracingOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
-    async fn service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
-        self.inner.service_metrics(id).await
+    async fn fetch_service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+        self.inner.fetch_service_metrics(id).await
     }
+
     async fn ensure_service(
         &self,
         id: &str,

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -30,6 +30,7 @@ use tracing_subscriber::filter::Targets;
 use mz_orchestrator::ServicePort;
 use mz_orchestrator::{
     NamespacedOrchestrator, Orchestrator, Service, ServiceAssignments, ServiceConfig, ServiceEvent,
+    ServiceProcessMetrics,
 };
 use mz_ore::cli::{DefaultTrue, KeyValueArg};
 #[cfg(feature = "tokio-console")]
@@ -276,6 +277,9 @@ struct NamespacedTracingOrchestrator {
 
 #[async_trait]
 impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
+    async fn service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
+        self.inner.service_metrics(id).await
+    }
     async fn ensure_service(
         &self,
         id: &str,

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -68,13 +68,13 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
     /// Watch for status changes of all known services.
     fn watch_services(&self) -> BoxStream<'static, Result<ServiceEvent, anyhow::Error>>;
 
-    /// Get resource usage metrics for all processes associated with a service.
+    /// Gets resource usage metrics for all processes associated with a service.
     ///
     /// Returns `Err` if the entire process failed. Returns `Ok(v)` otherwise,
     /// with one element in `v` for each process of the service,
     /// even in not all metrics could be collected for all processes.
     /// In such a case, the corresponding fields of `ServiceProcessMetrics` will be `None`.
-    async fn service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error>;
+    async fn fetch_service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error>;
 }
 
 /// An event describing a status change of an orchestrated service.

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -74,7 +74,10 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
     /// with one element in `v` for each process of the service,
     /// even in not all metrics could be collected for all processes.
     /// In such a case, the corresponding fields of `ServiceProcessMetrics` will be `None`.
-    async fn fetch_service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error>;
+    async fn fetch_service_metrics(
+        &self,
+        id: &str,
+    ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error>;
 }
 
 /// An event describing a status change of an orchestrated service.

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -67,6 +67,14 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
 
     /// Watch for status changes of all known services.
     fn watch_services(&self) -> BoxStream<'static, Result<ServiceEvent, anyhow::Error>>;
+
+    /// Get resource usage metrics for all processes associated with a service.
+    ///
+    /// Returns `Err` if the entire process failed. Returns `Ok(v)` otherwise,
+    /// with one element in `v` for each process of the service,
+    /// even in not all metrics could be collected for all processes.
+    /// In such a case, the corresponding fields of `ServiceProcessMetrics` will be `None`.
+    async fn service_metrics(&self, id: &str) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error>;
 }
 
 /// An event describing a status change of an orchestrated service.
@@ -96,6 +104,12 @@ pub trait Service: fmt::Debug + Send + Sync {
     ///
     /// Panics if `port` does not name a valid port.
     fn addresses(&self, port: &str) -> Vec<String>;
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ServiceProcessMetrics {
+    pub nano_cpus: Option<u64>,
+    pub bytes_memory: Option<u64>,
 }
 
 /// A simple language for describing assertions about a label's existence and value.


### PR DESCRIPTION
This API allows clients to collect CPU and memory metrics from the pods associated with a service. It is unused as of yet, but I wanted to put it up now so other people could comment on it.

### Motivation

  * This PR adds a known-desirable feature.

    Partial implementation of https://github.com/MaterializeInc/materialize/issues/15808


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
