### PR TITLE
adapter: measure coord select busy time

### DIFF
--- a/src/adapter/src/coord/metrics.rs
+++ b/src/adapter/src/coord/metrics.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use prometheus::{IntCounterVec, IntGauge};
+use prometheus::{HistogramVec, IntCounterVec, IntGauge};
 
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
@@ -17,6 +17,7 @@ pub struct Metrics {
     pub query_total: IntCounterVec,
     pub active_sessions: IntGauge,
     pub active_subscribes: IntGauge,
+    pub queue_busy_time: HistogramVec,
 }
 
 impl Metrics {
@@ -34,6 +35,10 @@ impl Metrics {
             active_subscribes: registry.register(metric!(
                 name: "mz_active_subscribes",
                 help: "The number of active SUBSCRIBE queries.",
+            )),
+            queue_busy_time: registry.register(metric!(
+                name: "mz_coord_queue_busy_time",
+                help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
             )),
         }
     }


### PR DESCRIPTION
This produces measurements like:

```
mz_coord_queue_busy_time_bucket{le="0.000128"} 0
mz_coord_queue_busy_time_bucket{le="0.000256"} 0
mz_coord_queue_busy_time_bucket{le="0.000512"} 96
mz_coord_queue_busy_time_bucket{le="0.001"} 160
mz_coord_queue_busy_time_bucket{le="0.002"} 166
mz_coord_queue_busy_time_bucket{le="0.004"} 166
mz_coord_queue_busy_time_bucket{le="0.008"} 166
mz_coord_queue_busy_time_bucket{le="0.016"} 166
mz_coord_queue_busy_time_bucket{le="0.032"} 180
mz_coord_queue_busy_time_bucket{le="0.064"} 180
mz_coord_queue_busy_time_bucket{le="0.128"} 182
mz_coord_queue_busy_time_bucket{le="0.256"} 182
mz_coord_queue_busy_time_bucket{le="0.512"} 183
mz_coord_queue_busy_time_bucket{le="1"} 183
mz_coord_queue_busy_time_bucket{le="2"} 183
mz_coord_queue_busy_time_bucket{le="4"} 183
mz_coord_queue_busy_time_bucket{le="8"} 183
mz_coord_queue_busy_time_bucket{le="+Inf"} 183
mz_coord_queue_busy_time_sum 0.993094353
mz_coord_queue_busy_time_count 183
```

See: https://github.com/MaterializeInc/materialize/issues/15906

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a