### PR TITLE
orchestrator-kubernetes: use _ instead of / as separator

### DIFF
--- a/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
+++ b/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
@@ -51,7 +51,7 @@ impl CloudResourceController for KubernetesOrchestrator {
                 availability_zone_ids: config.availability_zone_ids,
                 role_suffix: match &self.config.aws_external_id_prefix {
                     None => id.to_string(),
-                    Some(external_id) => format!("{external_id}/{id}"),
+                    Some(external_id) => format!("{external_id}_{id}"),
                 },
             },
             status: None,


### PR DESCRIPTION
In AWS, a "/" is not a valid character in a role name. Use _ instead.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
