### PR TITLE
Add function to get linker-supplied build IDs for all loaded images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,6 +3987,7 @@ dependencies = [
  "headers",
  "http",
  "include_dir",
+ "libc",
  "mime",
  "mz-build-info",
  "mz-http-util",

--- a/src/ore/src/bits.rs
+++ b/src/ore/src/bits.rs
@@ -17,7 +17,7 @@
 
 /// Increases `p` as little as possible (including possibly 0)
 /// such that it becomes a multiple of `N`.
-pub const fn align_up<const N: usize >(p: usize) -> usize {
+pub const fn align_up<const N: usize>(p: usize) -> usize {
     if p % N == 0 {
         p
     } else {

--- a/src/ore/src/bits.rs
+++ b/src/ore/src/bits.rs
@@ -1,0 +1,26 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for bit and byte manipulation
+
+/// Increases `p` as little as possible (including possibly 0)
+/// such that it becomes a multiple of `N`.
+pub const fn align_up<const N: usize >(p: usize) -> usize {
+    if p % N == 0 {
+        p
+    } else {
+        p + (N - (p % N))
+    }
+}

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -25,6 +25,7 @@
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "test")))]
 #[cfg(feature = "test")]
 pub mod assert;
+pub mod bits;
 pub mod cast;
 pub mod cgroup;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "cli")))]

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -15,6 +15,7 @@ cfg-if = "1.0.0"
 headers = "0.3.7"
 http = "0.2.8"
 include_dir = "0.7.3"
+libc = "0.2.135"
 once_cell = "1.15.0"
 mime = "0.3.16"
 mz-build-info = { path = "../build-info" }

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -7,15 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{
-    collections::BTreeMap,
-    ffi::c_void,
-    path::{Path, PathBuf},
-    sync::atomic::AtomicBool,
-    time::Instant,
-};
-
-use anyhow::Context;
+use std::{collections::BTreeMap, ffi::c_void, sync::atomic::AtomicBool, time::Instant};
 
 pub mod http;
 #[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
@@ -62,19 +54,21 @@ pub struct StackProfile {
 /// the only known safety requirements are:
 ///
 /// (1) It must not be called multiple times concurrently, as `dl_iterate_phdr`
-/// is not documented as being thread-safe
+/// is not documented as being thread-safe.
 /// (2) The running binary must be in ELF format and running on Linux.
 #[cfg(not(target_os = "macos"))]
-pub unsafe fn all_build_ids() -> Result<std::collections::HashMap<PathBuf, Vec<u8>>, anyhow::Error>
-{
+pub unsafe fn all_build_ids(
+) -> Result<std::collections::HashMap<std::path::PathBuf, Vec<u8>>, anyhow::Error> {
     // local imports to avoid polluting the namespace for macOS builds
     use std::collections::hash_map::Entry;
     use std::collections::HashMap;
     use std::ffi::{c_int, CStr, OsStr};
     use std::os::unix::ffi::OsStrExt;
+    use std::path::{Path, PathBuf};
 
     use mz_ore::cast::CastFrom;
 
+    use anyhow::Context;
     use libc::{dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_NOTE};
 
     struct CallbackState {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -8,15 +8,18 @@
 // by the Apache License, Version 2.0.
 
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap},
+    collections::{hash_map::Entry, BTreeMap},
     ffi::{c_int, c_void, CStr, OsStr},
     os::unix::prelude::OsStrExt,
     path::{Path, PathBuf},
     sync::atomic::AtomicBool,
     time::Instant,
 };
+#[cfg(not(target_os = "macos"))]
+use std::collections::HashMap;
 
 use anyhow::Context;
+#[cfg(not(target_os = "macos"))]
 use libc::{dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_NOTE};
 use mz_ore::cast::CastFrom;
 

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -105,14 +105,12 @@ pub unsafe fn all_build_ids(
                     return -1;
                 }
             }
+        } else if info.dlpi_name.is_null() {
+            None
         } else {
-            if info.dlpi_name.is_null() {
-                None
-            } else {
-                // SAFETY: `dl_iterate_phdr` documents this as being a null-terminated string.
-                let fname = unsafe { CStr::from_ptr(info.dlpi_name) };
-                Some(Path::new(OsStr::from_bytes(fname.to_bytes())).to_path_buf())
-            }
+            // SAFETY: `dl_iterate_phdr` documents this as being a null-terminated string.
+            let fname = unsafe { CStr::from_ptr(info.dlpi_name) };
+            Some(Path::new(OsStr::from_bytes(fname.to_bytes())).to_path_buf())
         };
         state.is_first = false;
         if let Some(fname) = fname {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -7,7 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{collections::BTreeMap, ffi::c_void, sync::atomic::AtomicBool, time::Instant};
+use std::{
+    collections::{hash_map::Entry, BTreeMap, HashMap},
+    ffi::{c_int, c_void, CStr, OsStr},
+    os::unix::prelude::OsStrExt,
+    path::{Path, PathBuf},
+    sync::atomic::AtomicBool,
+    time::Instant,
+};
+
+use anyhow::Context;
+use libc::{dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_NOTE};
+use mz_ore::cast::CastFrom;
 
 pub mod http;
 #[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
@@ -33,6 +44,142 @@ pub struct StackProfile {
     annotations: Vec<String>,
     // The second element is the index in `annotations`, if one exists.
     stacks: Vec<(WeightedStack, Option<usize>)>,
+}
+
+pub fn all_build_ids() -> Result<HashMap<PathBuf, Vec<u8>>, anyhow::Error> {
+    struct CallbackState {
+        map: HashMap<PathBuf, Vec<u8>>,
+        is_first: bool,
+        fatal_error: Option<anyhow::Error>,
+    }
+    extern "C" fn iterate_cb(info: *mut dl_phdr_info, _size: size_t, data: *mut c_void) -> c_int {
+        // SAFETY: `data` is a pointer to a `CallbackState`, and no mutable reference
+        // aliases with it in Rust. Furthermore, `dl_iterate_phdr` doesn't do anything
+        // with `data` other than pass it to this callback, so nothing will be mutating
+        // the object it points to while we're inside here.
+        let state: &mut CallbackState = unsafe {
+            (data as *mut CallbackState)
+                .as_mut()
+                .expect("`data` cannot be null")
+        };
+        // SAFETY: similarly, `dl_iterate_phdr` isn't mutating `info`
+        // while we're here.
+        let info = unsafe { info.as_ref() }.expect("`dl_phdr_info` cannot be null");
+        let fname = if state.is_first {
+            // From `man dl_iterate_phdr`:
+            // "The first object visited by callback is the main program.  For the main
+            // program, the dlpi_name field will be an empty string."
+            match std::env::current_exe()
+                .context("failed to read the name of the current executable")
+            {
+                Ok(pb) => Some(pb),
+                Err(e) => {
+                    // Profiles will be of dubious usefulness
+                    // if we can't get the build ID for the main executable,
+                    // so just bail here.
+                    state.fatal_error = Some(e);
+                    return -1;
+                }
+            }
+        } else {
+            if info.dlpi_name.is_null() {
+                None
+            } else {
+                // SAFETY: `dl_iterate_phdr` documents this as being a null-terminated string.
+                let fname = unsafe { CStr::from_ptr(info.dlpi_name) };
+                Some(Path::new(OsStr::from_bytes(fname.to_bytes())).to_path_buf())
+            }
+        };
+        state.is_first = false;
+        if let Some(fname) = fname {
+            if let Entry::Vacant(ve) = state.map.entry(fname) {
+                // Walk the headers of this image, looking for a segment containing notes
+
+                // SAFETY: `dl_iterate_phdr` is documented as setting `dlpi_phnum` to the
+                // length of the array pointed to by `dlpi_phdr`.
+                let program_headers =
+                    unsafe { std::slice::from_raw_parts(info.dlpi_phdr, info.dlpi_phnum.into()) };
+                let mut found_build_id = None;
+                'outer: for ph in program_headers {
+                    if ph.p_type == PT_NOTE {
+                        // From `man elf`:
+                        // typedef struct {
+                        //   Elf64_Word n_namesz;
+                        //   Elf64_Word n_descsz;
+                        //   Elf64_Word n_type;
+                        // } Elf64_Nhdr;
+                        #[repr(C)]
+                        struct NoteHeader {
+                            n_namesz: Elf64_Word,
+                            n_descsz: Elf64_Word,
+                            n_type: Elf64_Word,
+                        }
+                        // This is how `man dl_iterate_phdr` says to find the segment headers in memory.
+                        let mut offset = usize::cast_from(ph.p_vaddr + info.dlpi_addr);
+                        let orig_offset = offset;
+
+                        while offset + std::mem::size_of::<NoteHeader>() + 4
+                            <= orig_offset + usize::cast_from(ph.p_memsz)
+                        {
+                            let nh = unsafe { (offset as *const NoteHeader).as_ref() }
+                                .expect("the program headers must be well-formed");
+                            // from elf.h
+                            const NT_GNU_BUILD_ID: Elf64_Word = 3;
+                            if nh.n_type == NT_GNU_BUILD_ID && nh.n_descsz != 0 && nh.n_namesz == 4
+                            {
+                                let p_name =
+                                    (offset + std::mem::size_of::<NoteHeader>()) as *const [u8; 4];
+                                // SAFETY: since `n_namesz` is 4, the name is a four-byte value.
+                                let name = unsafe { p_name.as_ref() }.expect("this can't be null");
+                                if name == b"GNU\0" {
+                                    // We found what we're looking for!
+                                    let p_desc = (p_name as usize + 4) as *const u8;
+                                    // SAFETY: This is the documented meaning of `n_descsz`.
+                                    let desc = unsafe {
+                                        std::slice::from_raw_parts(
+                                            p_desc,
+                                            usize::cast_from(nh.n_descsz),
+                                        )
+                                    };
+                                    found_build_id = Some(desc.to_vec());
+                                    break 'outer;
+                                }
+                            }
+                            const fn align_up<const N: usize>(p: usize) -> usize {
+                                if p % N == 0 {
+                                    p
+                                } else {
+                                    p + (N - (p % N))
+                                }
+                            }
+                            offset = offset
+                                + std::mem::size_of::<NoteHeader>()
+                                + align_up::<4>(usize::cast_from(nh.n_namesz))
+                                + align_up::<4>(usize::cast_from(nh.n_descsz));
+                        }
+                    }
+                }
+                if let Some(build_id) = found_build_id {
+                    ve.insert(build_id);
+                }
+            }
+        }
+        0
+    }
+    let mut state = CallbackState {
+        map: HashMap::new(),
+        is_first: true,
+        fatal_error: None,
+    };
+    // SAFETY: `dl_iterate_phdr` has no documented restrictions on when
+    // it can be called.
+    unsafe {
+        dl_iterate_phdr(
+            Some(iterate_cb),
+            (&mut state) as *mut CallbackState as *mut c_void,
+        );
+    }
+    Ok(state.map)
 }
 
 impl StackProfile {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -200,8 +200,12 @@ pub unsafe fn all_build_ids() -> Result<HashMap<PathBuf, Vec<u8>>, anyhow::Error
             Some(iterate_cb),
             (&mut state) as *mut CallbackState as *mut c_void,
         );
+    };
+    if let Some(err) = state.fatal_error {
+        Err(err)
+    } else {
+        Ok(state.map)
     }
-    Ok(state.map)
 }
 
 impl StackProfile {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -8,20 +8,14 @@
 // by the Apache License, Version 2.0.
 
 use std::{
-    collections::{hash_map::Entry, BTreeMap},
-    ffi::{c_int, c_void, CStr, OsStr},
-    os::unix::prelude::OsStrExt,
+    collections::BTreeMap,
+    ffi::c_void,
     path::{Path, PathBuf},
     sync::atomic::AtomicBool,
     time::Instant,
 };
-#[cfg(not(target_os = "macos"))]
-use std::collections::HashMap;
 
 use anyhow::Context;
-#[cfg(not(target_os = "macos"))]
-use libc::{dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_NOTE};
-use mz_ore::cast::CastFrom;
 
 pub mod http;
 #[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
@@ -71,7 +65,18 @@ pub struct StackProfile {
 /// is not documented as being thread-safe
 /// (2) The running binary must be in ELF format and running on Linux.
 #[cfg(not(target_os = "macos"))]
-pub unsafe fn all_build_ids() -> Result<HashMap<PathBuf, Vec<u8>>, anyhow::Error> {
+pub unsafe fn all_build_ids() -> Result<std::collections::HashMap<PathBuf, Vec<u8>>, anyhow::Error>
+{
+    // local imports to avoid polluting the namespace for macOS builds
+    use std::collections::hash_map::Entry;
+    use std::collections::HashMap;
+    use std::ffi::{c_int, CStr, OsStr};
+    use std::os::unix::ffi::OsStrExt;
+
+    use mz_ore::cast::CastFrom;
+
+    use libc::{dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_NOTE};
+
     struct CallbackState {
         map: HashMap<PathBuf, Vec<u8>>,
         is_first: bool,


### PR DESCRIPTION
This has two advantages over the `buildid` crate:

1. That crate only gets the build ID for the current binary, not for all the dynamically loaded images,
2. That crate is MPL-licensed, which would probably be fine if we thought hard about the details, but which we currently reject as copyleft.

It uses `dl_iterate_phdr` to walk the program headers of all images, and iterates over them looking for note segments. It then searches the discovered note segments for a note of type `NT_GNU_BUILD_ID` (aka "3") and name "GNU\0", and records the description of that segment. For more details, please see the comments in and around the `all_build_ids` function.

As an alternative, we could have a discussion about whether MPL-licensed code is okay, and use the `buildid` crate if so. This would also mean we have to live with only getting the ID of the main binary (or upstream some changes to that crate). 

### Motivation

  * This PR adds a known-desirable feature.

    Part of cloud#4590. We need this, or something like it, in order to be able to symbolicate allocation traces offline. 

### Tips for reviewer

The data structures used here are documented in `man dl_iterate_phdr` and `man elf` (on Linux). Also, https://github.com/mattst88/build-id/blob/master/build-id.c is a good reference.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

No tests, this code is unused for now

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
