### PR TITLE
kafka-util: add info! log when rewriting a broker address

### DIFF
--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -124,7 +124,13 @@ where
     fn rewrite_broker_addr(&self, addr: BrokerAddr) -> BrokerAddr {
         match self.overrides.get(&addr) {
             None => addr,
-            Some(o) => o.clone(),
+            Some(o) => {
+                info!(
+                    "rewriting broker {}:{} to {}:{}",
+                    addr.host, addr.port, o.host, o.port
+                );
+                o.clone()
+            }
         }
     }
 


### PR DESCRIPTION
To make it easier to debug AWS PrivateLink issues

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
