### PR TITLE
adapter: measure envd to coord ready time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
  "postgres-protocol",
  "postgres_array",
  "predicates",
+ "prometheus",
  "rand",
  "rdkafka-sys",
  "regex",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -57,6 +57,7 @@ num_cpus = "1.13.1"
 openssl = { version = "0.10.42", features = ["vendored"] }
 openssl-sys = { version = "0.9.76", features = ["vendored"] }
 os_info = "3.5.1"
+prometheus = { version = "0.13.2", default-features = false }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 rand = "0.8.5"
 reqwest = { version = "0.11.12", features = ["json"] }


### PR DESCRIPTION
We have a soft goal of sub 1s. Start understanding how hard that might be by measuring.

See #15906

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a