### PR TITLE
buildkite: Do not fail if 'docker-compose kill' fails in pre-exit hook

### DIFF
--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -20,6 +20,9 @@ run() {
 run logs --no-color > services.log
 buildkite-agent artifact upload services.log
 
-run kill
+# docker-compose kill may fail attempting to kill containers
+# that have just exited on their own because of the
+# "shared-fate" mechanism employed by Mz clusters
+run kill || true
 run rm --force -v
 run down --volumes


### PR DESCRIPTION
docker-compose kill may fail if a container that it is trying to kill has already exited, which may happen if this container has been the victim of Mz's "shared-fate" method of operation.

We continue to run `docker-compose kill` in hooks/pre-exit, but we eat the exit code.


### Motivation


  * This PR fixes a previously unreported bug.

Nightly CI was failing with:

```
Error response from daemon: Cannot kill container: fff0af78a868e3c735c69b99ef84286415361e21fa634e21a6f7af77211a6253: Container fff0af78a868e3c735c69b99ef84286415361e21fa634e21a6f7af77211a6253 is not running
```