### PR TITLE
test/cluster: Increase the timeout for the 'cluster' test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -172,10 +172,10 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: cluster-smoke
-    label: Cluster smoke test
+  - id: cluster-tests
+    label: Cluster tests
     depends_on: build-x86_64
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
     inputs: [test/cluster]
     plugins:
       - ./ci/plugins/mzcompose:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -54,7 +54,7 @@ SERVICES = [
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     for name in [
-        "test-cluster",
+        "test-smoke",
         "test-github-12251",
         "test-github-15531",
         "test-github-15535",
@@ -72,7 +72,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             c.workflow(name)
 
 
-def workflow_test_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
+def workflow_test_smoke(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Run testdrive in a variety of compute cluster configurations."""
 
     parser.add_argument(


### PR DESCRIPTION
The test is already pushing 8+ minutes, as it is testing so much stuff now. Increase the timeout to 20m.

Also remove 'smoke' from the name of the CI step, as it is no longer about just smoke testing the cluster. Instead, a sub-workflow is more aptly named 'smoke'.

### Motivation

  * This PR fixes a previously unreported bug.

The 'cluster-smoke' CI job was failing with a timeout but not because of a storaged or computed crash, but because the total execution time of the test indeed approached the 10min timeout.