### PR TITLE
Remove ArrangeBy nodes that enforce keys that already exist

### DIFF
--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -4473,37 +4473,13 @@ WHERE a = c AND d = e AND b + d > 42
         "Join": {
           "inputs": [
             {
-              "ArrangeBy": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Global": {
-                        "User": 1
-                      }
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
-                          [
-                            1
-                          ]
-                        ]
-                      ]
-                    },
-                    "plan": "PassArrangements"
+              "Get": {
+                "id": {
+                  "Global": {
+                    "User": 1
                   }
                 },
-                "forms": {
+                "keys": {
                   "raw": false,
                   "arranged": [
                     [
@@ -4522,20 +4498,7 @@ WHERE a = c AND d = e AND b + d > 42
                     ]
                   ]
                 },
-                "input_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                }
+                "plan": "PassArrangements"
               }
             },
             {
@@ -4875,37 +4838,13 @@ WHERE a = c AND d = e AND f = a
         "Join": {
           "inputs": [
             {
-              "ArrangeBy": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Global": {
-                        "User": 1
-                      }
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
-                          [
-                            1
-                          ]
-                        ]
-                      ]
-                    },
-                    "plan": "PassArrangements"
+              "Get": {
+                "id": {
+                  "Global": {
+                    "User": 1
                   }
                 },
-                "forms": {
+                "keys": {
                   "raw": false,
                   "arranged": [
                     [
@@ -4924,20 +4863,7 @@ WHERE a = c AND d = e AND f = a
                     ]
                   ]
                 },
-                "input_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                }
+                "plan": "PassArrangements"
               }
             },
             {
@@ -5266,37 +5192,13 @@ WHERE a = c and a = e
         "Join": {
           "inputs": [
             {
-              "ArrangeBy": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Global": {
-                        "User": 1
-                      }
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
-                          [
-                            1
-                          ]
-                        ]
-                      ]
-                    },
-                    "plan": "PassArrangements"
+              "Get": {
+                "id": {
+                  "Global": {
+                    "User": 1
                   }
                 },
-                "forms": {
+                "keys": {
                   "raw": false,
                   "arranged": [
                     [
@@ -5315,54 +5217,17 @@ WHERE a = c and a = e
                     ]
                   ]
                 },
-                "input_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                }
+                "plan": "PassArrangements"
               }
             },
             {
-              "ArrangeBy": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Global": {
-                        "User": 2
-                      }
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
-                          [
-                            1
-                          ]
-                        ]
-                      ]
-                    },
-                    "plan": "PassArrangements"
+              "Get": {
+                "id": {
+                  "Global": {
+                    "User": 2
                   }
                 },
-                "forms": {
+                "keys": {
                   "raw": false,
                   "arranged": [
                     [
@@ -5381,54 +5246,17 @@ WHERE a = c and a = e
                     ]
                   ]
                 },
-                "input_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                }
+                "plan": "PassArrangements"
               }
             },
             {
-              "ArrangeBy": {
-                "input": {
-                  "Get": {
-                    "id": {
-                      "Global": {
-                        "User": 3
-                      }
-                    },
-                    "keys": {
-                      "raw": false,
-                      "arranged": [
-                        [
-                          [
-                            {
-                              "Column": 0
-                            }
-                          ],
-                          {
-                            "0": 0,
-                            "1": 1
-                          },
-                          [
-                            1
-                          ]
-                        ]
-                      ]
-                    },
-                    "plan": "PassArrangements"
+              "Get": {
+                "id": {
+                  "Global": {
+                    "User": 3
                   }
                 },
-                "forms": {
+                "keys": {
                   "raw": false,
                   "arranged": [
                     [
@@ -5447,20 +5275,7 @@ WHERE a = c and a = e
                     ]
                   ]
                 },
-                "input_key": [
-                  {
-                    "Column": 0
-                  }
-                ],
-                "input_mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0,
-                    1
-                  ],
-                  "input_arity": 2
-                }
+                "plan": "PassArrangements"
               }
             }
           ],

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -654,13 +654,9 @@ Explained Query:
       lookup={ relation=1, key=[#1] }
       stream={ key=[#0], thinning=() }
     source={ relation=2, key=[] }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
@@ -713,13 +709,9 @@ Explained Query:
       lookup={ relation=1, key=[#0, #1] }
       stream={ key=[#1, #0], thinning=() }
     source={ relation=2, key=[] }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
     ArrangeBy
       raw=true
       arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
@@ -792,27 +784,15 @@ Explained Query:
         lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=(#1) }
       source={ relation=2, key=[#0] }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.u
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.u
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.v
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.v
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t_a_idx

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -48,30 +48,15 @@ Explained Query:
       lookup={ relation=0, key=[#1] }
       stream={ key=[#1], thinning=(#0) }
     source={ relation=1, key=[#1] }
-    ArrangeBy
-      input_key=[#1]
-      project=(#1, #0, #2)
+    Get::PassArrangements materialize.public.t1
       raw=false
       arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }
-      Get::PassArrangements materialize.public.t1
-        raw=false
-        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }
-    ArrangeBy
-      input_key=[#1]
-      project=(#1, #0)
+    Get::PassArrangements materialize.public.t2
       raw=false
       arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      Get::PassArrangements materialize.public.t2
-        raw=false
-        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
-    ArrangeBy
-      input_key=[#1]
-      project=(#1, #0)
+    Get::PassArrangements materialize.public.t3
       raw=false
       arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
-      Get::PassArrangements materialize.public.t3
-        raw=false
-        arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
 
 Used Indexes:
   - materialize.public.i1

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -73,44 +73,36 @@ Explained Query:
       source={ relation=0, key=[] }
       Get::PassArrangements l0
         raw=true
-      ArrangeBy
-        input_key=[#0]
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        Reduce::Distinct
-          val_plan
-            project=()
-          key_plan=id
-          Join::Linear
-            linear_stage[1]
-              closure
-                project=(#0)
-                filter=(((#3 = 1997-07-06) OR (date_to_timestamp(#2) = (#1 - 7 days))))
-              lookup={ relation=0, key=[] }
-              stream={ key=[], thinning=(#0, #1) }
-            linear_stage[0]
-              lookup={ relation=1, key=[#0] }
-              stream={ key=[#0], thinning=(#1) }
-            source={ relation=2, key=[] }
-            ArrangeBy
+      Reduce::Distinct
+        val_plan
+          project=()
+        key_plan=id
+        Join::Linear
+          linear_stage[1]
+            closure
+              project=(#0)
+              filter=(((#3 = 1997-07-06) OR (date_to_timestamp(#2) = (#1 - 7 days))))
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          linear_stage[0]
+            lookup={ relation=1, key=[#0] }
+            stream={ key=[#0], thinning=(#1) }
+          source={ relation=2, key=[] }
+          ArrangeBy
+            raw=true
+            arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+            Get::Collection materialize.public.lineitem
+              project=(#1, #2)
               raw=true
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
-              Get::Collection materialize.public.lineitem
-                project=(#1, #2)
-                raw=true
-            ArrangeBy
-              input_key=[#0]
-              raw=false
-              arrangements[0]={ key=[#0], permutation=id, thinning=() }
-              Reduce::Distinct
-                val_plan
-                  project=()
-                key_plan=id
-                Get::PassArrangements l0
-                  raw=true
-            Get::Collection materialize.public.orders
-              filter=((#0) IS NOT NULL)
+          Reduce::Distinct
+            val_plan
+              project=()
+            key_plan=id
+            Get::PassArrangements l0
               raw=true
+          Get::Collection materialize.public.orders
+            filter=((#0) IS NOT NULL)
+            raw=true
   Where
     cte l0 =
       Join::Linear

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -357,20 +357,12 @@ Explained Query:
         filter=((#2 OR #3))
         map=((#1 = 4), (#1 = 6))
       source={ relation=1, key=[#0] }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.t1
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.t1
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-    ArrangeBy
-      input_key=[#0]
+    Get::PassArrangements materialize.public.t2
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      Get::PassArrangements materialize.public.t2
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
   - materialize.public.t1_f1_ind


### PR DESCRIPTION
This PR changes the MIR -> LIR action for `ArrangeBy` to scan for requested keys that are not already present in the input, and form only those. When this set is empty, we remove the operator. This has a few additional side-effects: previously if a key existed but not with the default thinning, we would create a new arrangement. Moreover, we would potentially remove reference to the prior one. Now, we just use the prior one and the issue is avoided (strictly speaking, we no longer dedup potential duplicates in our input, but arguably if they are there we have been told for a reason and should respect that).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

    * The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
