### PR TITLE
dbt-materialize: release v1.3.1

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,13 @@
 # dbt-materialize Changelog
 
+## 1.3.1 - 2022-11-15
+
+* **Breaking change.** Use `mz_introspection` as the initial active cluster on
+    connection to ensure optimal performance for introspection queries.
+
+  This change requires [Materialize >=0.28.0](https://materialize.com/docs/releases/v0.28/).
+  **Users of older versions should pin `dbt-materialize` to `v1.3.0`.**
+
 ## 1.3.0 - 2022-11-09
 
 * Upgrade to `dbt-postgres` v1.3.0.
@@ -38,7 +46,7 @@
   ```
 
 * Enable configuration of [clusters](https://materialize.com/docs/unstable/sql/create-cluster/#conceptual-framework),
-  which are a feature in a forthcoming version of Materialize Cloud, via:
+  which are a feature in a forthcoming version of Materialize, via:
 
   * A new `cluster` connection parameter, which specifies the default cluster
     for the connection.
@@ -207,10 +215,8 @@
 ## 0.18.1.post3 - 2021-06-17
 
 * Support the `sslcert`, `sslkey`, and `sslrootcert` parameters for specifying a
-  TLS client certificate. Notably, this permits using dbt-materialize with
-  [Materialize Cloud].
-
-[Materialize Cloud]: https://cloud.materialize.com
+  TLS client certificate. Notably, this allows using `dbt-materialize` with the
+  new architecture of [Materialize](https://cloud.materialize.com).
 
 ## 0.18.1.post2 - 2021-04-21
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.3.0"
+version = "1.3.1"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.3.0",
+    version="1.3.1",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a new release of `dbt-materialize`, as a result of #16079. This introduces a breaking change, and users of Materialize versions <0.28.0 should pin their dbt installation to `v1.3.0`.