### PR TITLE
compute*: remove the DropInstance command

### DIFF
--- a/doc/developer/platform/reconciliation.md
+++ b/doc/developer/platform/reconciliation.md
@@ -49,7 +49,6 @@ The command protocol exposes the following verbs to communicate state updates fr
 For each, we describe the associated action applied by CR.
 * `CreateInstance`: If the instance is unknown, remember it and forward the command.
   Start tracking the frontiers of the logging dataflows if enabled.
-* `DropInstance`: Forget the instance, stop tracking all associated frontiers.
 * `CreateDataflows`: For each dataflow, start tracking the frontiers of all items it exports.
   Lookup existing dataflow by its `GlobalId` (see [Quirks](#quirks)), and remember the dataflow if it is new.
   If the identifier is bound, assert that the existing dataflow is compatible with the new definition.

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -47,15 +47,14 @@ message ProtoComputeCommand {
     }
 
     oneof kind {
-        ProtoInstanceConfig create_instance = 1;
-        google.protobuf.Empty drop_instance = 2;
+        ProtoCreateTimely create_timely = 1;
+        ProtoInstanceConfig create_instance = 2;
         ProtoCreateDataflows create_dataflows = 3;
         mz_storage_client.client.ProtoAllowCompaction allow_compaction = 4;
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
         google.protobuf.Empty initialization_complete = 7;
         ProtoUpdateMaxResultSize update_max_result_size = 8;
-        ProtoCreateTimely create_timely = 9;
     }
 }
 

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use proptest::prelude::{any, Arbitrary, Just};
+use proptest::prelude::{any, Arbitrary};
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
@@ -63,8 +63,6 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.command.rs"));
 /// commands. If a new cluster is created, InitializationComplete will follow immediately after
 /// CreateInstance. If a replica is added to a cluster or environmentd restarts and rehydrates a
 /// computed, a potentially long command sequence will be sent before InitializationComplete.
-///
-/// DropInstance will undo both CreateTimely and CreateInstance.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Create the timely runtime according to the supplied CommunicationConfig. Must be the first
@@ -78,9 +76,6 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Setup and logging sources within a running timely instance. Must be the second command
     /// after CreateTimely.
     CreateInstance(InstanceConfig),
-
-    /// Indicates the termination of an instance, and is the last command for its compute instance.
-    DropInstance,
 
     /// Indicates that the controller has sent all commands reflecting its
     /// initial state.
@@ -121,7 +116,6 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
         ProtoComputeCommand {
             kind: Some(match self {
                 ComputeCommand::CreateInstance(config) => CreateInstance(config.into_proto()),
-                ComputeCommand::DropInstance => DropInstance(()),
                 ComputeCommand::InitializationComplete => InitializationComplete(()),
                 ComputeCommand::CreateDataflows(dataflows) => {
                     CreateDataflows(ProtoCreateDataflows {
@@ -159,7 +153,6 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
         use proto_compute_command::*;
         match proto.kind {
             Some(CreateInstance(config)) => Ok(ComputeCommand::CreateInstance(config.into_rust()?)),
-            Some(DropInstance(())) => Ok(ComputeCommand::DropInstance),
             Some(InitializationComplete(())) => Ok(ComputeCommand::InitializationComplete),
             Some(CreateDataflows(ProtoCreateDataflows { dataflows })) => {
                 Ok(ComputeCommand::CreateDataflows(dataflows.into_rust()?))
@@ -199,7 +192,6 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         prop_oneof![
             any::<InstanceConfig>().prop_map(ComputeCommand::CreateInstance),
-            Just(ComputeCommand::DropInstance),
             proptest::collection::vec(
                 any::<DataflowDescription<crate::plan::Plan, CollectionMetadata, mz_repr::Timestamp>>(),
                 1..4
@@ -1110,7 +1102,6 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
 
         let mut create_inst_command = None;
         let mut create_timely_command = None;
-        let mut drop_command = None;
         let mut update_max_result_size_command = None;
 
         let mut initialization_complete = false;
@@ -1125,10 +1116,6 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
                 create_inst @ ComputeCommand::CreateInstance(_) => {
                     assert!(create_inst_command.is_none());
                     create_inst_command = Some(create_inst);
-                }
-                cmd @ ComputeCommand::DropInstance => {
-                    assert!(drop_command.is_none());
-                    drop_command = Some(cmd);
                 }
                 ComputeCommand::InitializationComplete => {
                     initialization_complete = true;
@@ -1201,9 +1188,6 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         command_count += final_frontiers.len();
         command_count += live_peeks.len();
         command_count += live_cancels.len();
-        if drop_command.is_some() {
-            command_count += 1;
-        }
         if update_max_result_size_command.is_some() {
             command_count += 1;
         }
@@ -1235,9 +1219,6 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         }
         if initialization_complete {
             self.commands.push(ComputeCommand::InitializationComplete);
-        }
-        if let Some(drop_command) = drop_command {
-            self.commands.push(drop_command);
         }
         if let Some(update_max_result_size_command) = update_max_result_size_command {
             self.commands.push(update_max_result_size_command)

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -381,10 +381,6 @@ where
             .get_mut(&id)
             .ok_or(ReplicaDropError::ReplicaMissing(id))?;
 
-        if let Err(e) = replica.send(ComputeCommand::DropInstance) {
-            tracing::warn!("Could not send DropInstance to replica {:?}: {}", &id, &e)
-        }
-
         // If the replica is managed we have to remove it from the orchestrator. We spawn
         // a background task that waits until the termination of the message handler task and
         // then removes it from the orchestrator.

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -131,7 +131,6 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         match cmd {
             CreateTimely { .. } => panic!("CreateTimely must be captured before"),
             CreateInstance(config) => self.handle_create_instance(config),
-            DropInstance => (),
             InitializationComplete => (),
             CreateDataflows(dataflows) => self.handle_create_dataflows(dataflows),
             AllowCompaction(list) => self.handle_allow_compaction(list),


### PR DESCRIPTION
The `DropInstance` command is not needed and its functionality has mostly been dead code. So this PR removes it.

### Motivation

* This PR refactors existing code.

This change simplifies the compute command protocol, and thus will simply the effort of reviewing the compute communication stack. Closes #16086.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
