### PR TITLE
config: synchronize `ALTER SYSTEM` parameters with LaunchDarkly

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -868,6 +868,11 @@ impl CatalogState {
         self.system_configuration = SystemVars::default();
     }
 
+    /// Returns the `config_has_synced_once` configuration parameter.
+    pub fn set_config_has_synced_once(&mut self) -> Result<(), AdapterError> {
+        self.system_configuration.set_config_has_synced_once()
+    }
+
     /// Gets the schema map for the database matching `database_spec`.
     fn resolve_schema_in_database(
         &self,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -854,12 +854,22 @@ impl CatalogState {
     }
 
     /// Insert system configuration `name` with `value`.
-    fn insert_system_configuration(&mut self, name: &str, value: &str) -> Result<(), AdapterError> {
+    ///
+    /// Return a `bool` value indicating whether the configuration was modified
+    /// by the call.
+    fn insert_system_configuration(
+        &mut self,
+        name: &str,
+        value: &str,
+    ) -> Result<bool, AdapterError> {
         self.system_configuration.set(name, value)
     }
 
-    /// Remove system configuration `name`.
-    fn remove_system_configuration(&mut self, name: &str) -> Result<(), AdapterError> {
+    /// Reset system configuration `name`.
+    ///
+    /// Return a `bool` value indicating whether the configuration was modified
+    /// by the call.
+    fn remove_system_configuration(&mut self, name: &str) -> Result<bool, AdapterError> {
         self.system_configuration.reset(name)
     }
 
@@ -869,7 +879,7 @@ impl CatalogState {
     }
 
     /// Returns the `config_has_synced_once` configuration parameter.
-    pub fn set_config_has_synced_once(&mut self) -> Result<(), AdapterError> {
+    pub fn set_config_has_synced_once(&mut self) -> Result<bool, AdapterError> {
         self.system_configuration.set_config_has_synced_once()
     }
 

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -23,6 +23,7 @@ use mz_secrets::SecretsReader;
 use mz_storage_client::types::hosts::StorageHostResourceAllocation;
 
 use crate::catalog::storage;
+use crate::config::SystemParameterFrontend;
 
 /// Configures a catalog.
 #[derive(Debug)]
@@ -60,6 +61,10 @@ pub struct Config<'a, S> {
     pub egress_ips: Vec<Ipv4Addr>,
     /// Context for generating an AWS Principal.
     pub aws_principal_context: Option<AwsPrincipalContext>,
+    /// A optional frontend used to pull system parameters for initial sync in
+    /// Catalog::open. A `None` value indicates that the initial sync should be
+    /// skipped.
+    pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -180,7 +180,7 @@ pub enum ExecuteResponse {
     /// The index was altered.
     AlteredIndexLogicalCompaction,
     /// The system configuration was altered.
-    AlteredSystemConfiguraion,
+    AlteredSystemConfiguration,
     /// The query was canceled.
     Canceled,
     /// The requested cursor was closed.
@@ -313,7 +313,7 @@ impl ExecuteResponse {
         match self {
             AlteredObject(o) => Some(format!("ALTER {}", o)),
             AlteredIndexLogicalCompaction => Some("ALTER INDEX".into()),
-            AlteredSystemConfiguraion => Some("ALTER SYSTEM".into()),
+            AlteredSystemConfiguration => Some("ALTER SYSTEM".into()),
             Canceled => None,
             ClosedCursor => Some("CLOSE CURSOR".into()),
             CopyTo { .. } => None,
@@ -393,7 +393,7 @@ impl ExecuteResponse {
                 vec![AlteredObject, AlteredIndexLogicalCompaction]
             }
             AlterSystemSet | AlterSystemReset | AlterSystemResetAll => {
-                vec![AlteredSystemConfiguraion]
+                vec![AlteredSystemConfiguration]
             }
             Close => vec![ClosedCursor],
             PlanKind::CopyFrom => vec![ExecuteResponseKind::CopyFrom],

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -1,0 +1,100 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::SocketAddr;
+
+use futures::future::join_all;
+use tokio_postgres::tls::NoTls;
+
+use super::SynchronizedParameters;
+
+/// A backend client for pushing and pulling [SynchronizedParameters].
+///
+/// Pulling is required in order to catch concurrent changes before pushing
+/// modified values in the [crate::config::system_parameter_sync].
+pub struct SystemParameterBackend {
+    client: tokio_postgres::Client,
+}
+
+impl SystemParameterBackend {
+    pub async fn new(addr: SocketAddr) -> Result<Self, anyhow::Error> {
+        let (client, connection) = tokio_postgres::connect(
+            &format!("host={} port={} user=mz_system", addr.ip(), addr.port()),
+            NoTls,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+
+        // The connection object performs the actual communication with the database,
+        // so spawn it off to run on its own.
+        mz_ore::task::spawn(|| "sys_param_sync:postgres", async move {
+            if let Err(e) = connection.await {
+                // TODO (15956): can/should I just log this as a tracing error here?
+                // We should probably handle try to reconnect in order to recover.
+                tracing::error!("SystemParameterBackend Postgres connection error: {}", e);
+            }
+        });
+
+        Ok(Self { client })
+    }
+
+    /// Push all current values from the given [SynchronizedParameters] that are
+    /// marked as modified to the [SystemParameterBackend] and reset the their
+    /// modified flags.
+    pub async fn push(&self, params: &mut SynchronizedParameters) {
+        let mut requests = vec![];
+        let mut updates = vec![];
+
+        requests.push(params.window_functions.as_request());
+        requests.push(params.allowed_cluster_replica_sizes.as_request());
+        requests.push(params.max_result_size.as_request());
+
+        for request in requests.into_iter().flatten() {
+            let client = &self.client;
+            let update = async move {
+                match client.execute(request.sql_statement().as_str(), &[]).await {
+                    Ok(_updated_rows) => {
+                        *request.parameter_flag = false;
+                    }
+                    Err(e) => {
+                        tracing::error!("SystemParameterBackend::push error: {}", e);
+                    }
+                }
+            };
+            updates.push(update);
+        }
+
+        join_all(updates).await;
+    }
+
+    /// Pull the current values for all [SynchronizedParameters] from the
+    /// [SystemParameterBackend].
+    pub async fn pull(&self, params: &mut SynchronizedParameters) {
+        match self.client.query("SHOW ALL", &[]).await {
+            Ok(result) => {
+                for row in result {
+                    let name: &str = row.get("name");
+                    if name == params.window_functions.name {
+                        let value = row.get("setting");
+                        params.window_functions.modify(value);
+                    } else if name == params.allowed_cluster_replica_sizes.name {
+                        let value = row.get("setting");
+                        params.allowed_cluster_replica_sizes.modify(value);
+                    } else if name == params.max_result_size.name {
+                        let value = row.get("setting");
+                        params.max_result_size.modify(value);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("SystemParameterBackend::pull error: {}", e);
+            }
+        }
+    }
+}

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::SocketAddr;
+use mz_repr::Row;
+use mz_sql::ast::{Ident, Raw, ShowStatement, ShowVariableStatement, Statement};
 
-use futures::future::join_all;
-use tokio_postgres::tls::NoTls;
+use crate::catalog::SYSTEM_USER;
+use crate::session::{EndTransactionAction, Session};
+use crate::{AdapterError, Client, ExecuteResponse, PeekResponseUnary, SessionClient};
 
 use super::SynchronizedParameters;
 
@@ -19,82 +21,143 @@ use super::SynchronizedParameters;
 /// Pulling is required in order to catch concurrent changes before pushing
 /// modified values in the [crate::config::system_parameter_sync].
 pub struct SystemParameterBackend {
-    client: tokio_postgres::Client,
+    session_client: SessionClient,
 }
 
 impl SystemParameterBackend {
-    pub async fn new(addr: SocketAddr) -> Result<Self, anyhow::Error> {
-        let (client, connection) = tokio_postgres::connect(
-            &format!("host={} port={} user=mz_system", addr.ip(), addr.port()),
-            NoTls,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-
-        // The connection object performs the actual communication with the database,
-        // so spawn it off to run on its own.
-        mz_ore::task::spawn(|| "sys_param_sync:postgres", async move {
-            if let Err(e) = connection.await {
-                // TODO (15956): can/should I just log this as a tracing error here?
-                // We should probably handle try to reconnect in order to recover.
-                tracing::error!("SystemParameterBackend Postgres connection error: {}", e);
-            }
-        });
-
-        Ok(Self { client })
+    pub async fn new(client: Client) -> Result<Self, AdapterError> {
+        let conn_client = client.new_conn()?;
+        let session = Session::new(conn_client.conn_id(), SYSTEM_USER.clone());
+        let (session_client, _) = conn_client.startup(session, true).await?;
+        Ok(Self { session_client })
     }
 
     /// Push all current values from the given [SynchronizedParameters] that are
-    /// marked as modified to the [SystemParameterBackend] and reset the their
-    /// modified flags.
-    pub async fn push(&self, params: &mut SynchronizedParameters) {
-        let mut requests = vec![];
-        let mut updates = vec![];
-
-        requests.push(params.window_functions.as_request());
-        requests.push(params.allowed_cluster_replica_sizes.as_request());
-        requests.push(params.max_result_size.as_request());
-
-        for request in requests.into_iter().flatten() {
-            let client = &self.client;
-            let update = async move {
-                match client.execute(request.sql_statement().as_str(), &[]).await {
-                    Ok(_updated_rows) => {
-                        *request.parameter_flag = false;
-                    }
-                    Err(e) => {
-                        tracing::error!("SystemParameterBackend::push error: {}", e);
-                    }
+    /// marked as modified to the [SystemParameterBackend] and reset their
+    /// modified status.
+    pub async fn push(&mut self, params: &mut SynchronizedParameters) {
+        for param in params.modified() {
+            let alter_system = param.as_stmt();
+            match self.execute_alter_system(alter_system).await {
+                Ok(()) => {
+                    tracing::debug!(name = param.name, value = param.value, "sync parameter");
                 }
-            };
-            updates.push(update);
+                Err(error) => {
+                    tracing::error!("cannot execute `ALTER SYSTEM` query: {}", error);
+                }
+            }
         }
-
-        join_all(updates).await;
     }
 
     /// Pull the current values for all [SynchronizedParameters] from the
     /// [SystemParameterBackend].
-    pub async fn pull(&self, params: &mut SynchronizedParameters) {
-        match self.client.query("SHOW ALL", &[]).await {
-            Ok(result) => {
-                for row in result {
-                    let name: &str = row.get("name");
-                    if name == params.window_functions.name {
-                        let value = row.get("setting");
-                        params.window_functions.modify(value);
-                    } else if name == params.allowed_cluster_replica_sizes.name {
-                        let value = row.get("setting");
-                        params.allowed_cluster_replica_sizes.modify(value);
-                    } else if name == params.max_result_size.name {
-                        let value = row.get("setting");
-                        params.max_result_size.modify(value);
+    pub async fn pull(&mut self, params: &mut SynchronizedParameters) {
+        let show_all = Statement::Show(ShowStatement::ShowVariable(ShowVariableStatement {
+            variable: Ident::from("ALL"),
+        }));
+        match self.execute_query(show_all).await {
+            Ok(rows) => {
+                let mut datum_vec = mz_repr::DatumVec::new();
+                for row in rows {
+                    let datums = datum_vec.borrow_with(&row);
+                    let name = datums[NAME_COLUMN].unwrap_str();
+                    let value = datums[VALUE_COLUMN].unwrap_str();
+                    if params.is_synchronized(name) {
+                        params.modify(name, value);
                     }
                 }
             }
-            Err(e) => {
-                tracing::error!("SystemParameterBackend::pull error: {}", e);
+            Err(error) => {
+                tracing::error!("cannot execute `SHOW ALL` query: {}", error)
             }
         }
     }
+
+    /// Execute a single `ALTER SYSTEM` statement.
+    async fn execute_alter_system(&mut self, stmt: Statement<Raw>) -> Result<(), AdapterError> {
+        self.session_client.start_transaction(Some(1)).await?;
+
+        self.prepare(stmt).await?;
+        let result = match self.session_client.execute(EMPTY_PORTAL.into()).await? {
+            ExecuteResponse::AlteredSystemConfiguration => Ok(()),
+            _ => Err(AdapterError::Internal(UNEXPECTED_RESPONSE.to_string())),
+        };
+
+        if result.is_ok() {
+            self.session_client
+                .end_transaction(EndTransactionAction::Commit)
+                .await?;
+        } else {
+            self.session_client.fail_transaction();
+        }
+
+        result
+    }
+
+    /// Execute a single query and returns the results.
+    async fn execute_query(&mut self, stmt: Statement<Raw>) -> Result<Vec<Row>, AdapterError> {
+        self.session_client.start_transaction(Some(1)).await?;
+
+        self.prepare(stmt).await?;
+        let result = match self.session_client.execute(EMPTY_PORTAL.into()).await? {
+            ExecuteResponse::SendingRows { future: rows, .. } => match rows.await {
+                PeekResponseUnary::Rows(rows) => Ok(rows),
+                PeekResponseUnary::Error(e) => Err(AdapterError::Internal(e)),
+                PeekResponseUnary::Canceled => {
+                    Err(AdapterError::Internal(UNEXPECTED_RESPONSE.to_string()))
+                }
+            },
+            _ => Err(AdapterError::Internal(UNEXPECTED_RESPONSE.to_string())),
+        };
+
+        if result.is_ok() {
+            self.session_client
+                .end_transaction(EndTransactionAction::Commit)
+                .await?;
+        } else {
+            self.session_client.fail_transaction();
+        }
+
+        result
+    }
+
+    /// Prepare a statement for execution. After calling this, you can call
+    /// [SessionClient::execute] in order to execute the passed [Statement].
+    async fn prepare(&mut self, stmt: Statement<Raw>) -> Result<(), AdapterError> {
+        self.session_client
+            .describe(EMPTY_PORTAL.into(), Some(stmt.clone()), vec![])
+            .await?;
+
+        let prep_stmt = self
+            .session_client
+            .get_prepared_statement(EMPTY_PORTAL)
+            .await?;
+        let params = vec![];
+        let result_formats = vec![
+            mz_pgrepr::Format::Text;
+            prep_stmt
+                .desc()
+                .relation_desc
+                .clone()
+                .map(|desc| desc.typ().column_types.len())
+                .unwrap_or(0)
+        ];
+        let desc = prep_stmt.desc().clone();
+        let revision = prep_stmt.catalog_revision;
+        let stmt = prep_stmt.sql().cloned();
+
+        self.session_client.session().set_portal(
+            EMPTY_PORTAL.into(),
+            desc,
+            stmt,
+            params,
+            result_formats,
+            revision,
+        )
+    }
 }
+
+const NAME_COLUMN: usize = 0;
+const VALUE_COLUMN: usize = 1;
+const EMPTY_PORTAL: &str = "";
+const UNEXPECTED_RESPONSE: &str = "unexpected response to SessionClient::execute request";

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -7,15 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{borrow::Borrow, time::Duration};
+use std::time::Duration;
 
 use derivative::Derivative;
 use launchdarkly_server_sdk as ld;
 use tokio::time;
 
-use super::params::SynchronizedParameter;
 use super::SynchronizedParameters;
-use crate::session::vars::Value;
 
 /// A frontend client for pulling [SynchronizedParameters].
 #[derive(Derivative)]
@@ -30,19 +28,10 @@ impl SystemParameterFrontend {
     /// Construct a new [SystemParameterFrontend] instance.
     pub fn new(ld_sdk_key: &str, ld_user_key: &str) -> Result<Self, anyhow::Error> {
         let ld_config = ld::ConfigBuilder::new(ld_sdk_key).build();
-        let ld_client = ld::Client::build(ld_config).map_err(|e| anyhow::format_err!(e))?;
+        let ld_client = ld::Client::build(ld_config)?;
         let ld_user = ld::User::with_key(ld_user_key).build();
 
         Ok(Self { ld_client, ld_user })
-    }
-
-    /// Try to initialize the backing [ld::Client] once.
-    ///
-    /// Return `true` if the initialization was successful.
-    pub async fn start_and_initialize(&self) -> bool {
-        // Start and initialize LD client for the frontend.
-        self.ld_client.start_with_default_executor();
-        self.ld_client.initialized_async().await
     }
 
     /// Ensure the backing [ld::Client] is initialized.
@@ -58,7 +47,7 @@ impl SystemParameterFrontend {
         let max_backoff = Duration::from_secs(60);
         let mut backoff = Duration::from_secs(5);
         while !self.ld_client.initialized_async().await {
-            tracing::error!("SystemParameterFrontend failed to initialize");
+            tracing::warn!("SystemParameterFrontend failed to initialize");
             time::sleep(backoff).await;
             backoff = (backoff * 2).min(max_backoff);
         }
@@ -72,35 +61,21 @@ impl SystemParameterFrontend {
     pub fn pull(&self, params: &mut SynchronizedParameters) -> bool {
         let mut changed = false;
 
-        changed |= self.pull_parameter(&mut params.window_functions);
-        changed |= self.pull_parameter(&mut params.allowed_cluster_replica_sizes);
-        changed |= self.pull_parameter(&mut params.max_result_size);
+        for param_name in params.synchronized().into_iter() {
+            let flag_var =
+                self.ld_client
+                    .variation(&self.ld_user, param_name, params.get(param_name));
+
+            let flag_str = match flag_var {
+                ld::FlagValue::Bool(v) => v.to_string(),
+                ld::FlagValue::Str(v) => v,
+                ld::FlagValue::Number(v) => v.to_string(),
+                ld::FlagValue::Json(v) => v.to_string(),
+            };
+
+            changed |= params.modify(param_name, flag_str.as_str());
+        }
 
         changed
-    }
-
-    /// Pull the current value for the given [SynchronizedParameter] from
-    /// the [SystemParameterFrontend] and return `true` iff the parameter has been
-    /// modified.
-    fn pull_parameter<V: Value>(&self, param: &mut SynchronizedParameter<V>) -> bool
-    where
-        V::Owned: PartialEq + Eq,
-    {
-        let flag_var = self.ld_client.variation(
-            &self.ld_user,
-            param.name,
-            param.default_value.borrow().format(),
-        );
-
-        let flag_str = match flag_var {
-            ld::FlagValue::Bool(v) => v.to_string(),
-            ld::FlagValue::Str(v) => v,
-            ld::FlagValue::Number(v) => v.to_string(),
-            ld::FlagValue::Json(v) => v.to_string(),
-        };
-
-        param.modify(&flag_str);
-
-        param.modified_flag
     }
 }

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -1,0 +1,106 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{borrow::Borrow, time::Duration};
+
+use derivative::Derivative;
+use launchdarkly_server_sdk as ld;
+use tokio::time;
+
+use super::params::SynchronizedParameter;
+use super::SynchronizedParameters;
+use crate::session::vars::Value;
+
+/// A frontend client for pulling [SynchronizedParameters].
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct SystemParameterFrontend {
+    #[derivative(Debug = "ignore")]
+    ld_client: ld::Client,
+    ld_user: ld::User,
+}
+
+impl SystemParameterFrontend {
+    /// Construct a new [SystemParameterFrontend] instance.
+    pub fn new(ld_sdk_key: &str, ld_user_key: &str) -> Result<Self, anyhow::Error> {
+        let ld_config = ld::ConfigBuilder::new(ld_sdk_key).build();
+        let ld_client = ld::Client::build(ld_config).map_err(|e| anyhow::format_err!(e))?;
+        let ld_user = ld::User::with_key(ld_user_key).build();
+
+        Ok(Self { ld_client, ld_user })
+    }
+
+    /// Try to initialize the backing [ld::Client] once.
+    ///
+    /// Return `true` if the initialization was successful.
+    pub async fn start_and_initialize(&self) -> bool {
+        // Start and initialize LD client for the frontend.
+        self.ld_client.start_with_default_executor();
+        self.ld_client.initialized_async().await
+    }
+
+    /// Ensure the backing [ld::Client] is initialized.
+    ///
+    /// The [ld::Client::initialized_async] call will be attempted in a loop
+    /// with an exponential backoff with power `2s` and max duration `60s`.
+    pub async fn ensure_initialized(&self) {
+        tracing::info!("waiting for SystemParameterFrontend to initialize");
+
+        // Start and initialize LD client for the frontend.
+        self.ld_client.start_with_default_executor();
+
+        let max_backoff = Duration::from_secs(60);
+        let mut backoff = Duration::from_secs(5);
+        while !self.ld_client.initialized_async().await {
+            tracing::error!("SystemParameterFrontend failed to initialize");
+            time::sleep(backoff).await;
+            backoff = (backoff * 2).min(max_backoff);
+        }
+
+        tracing::info!("successfully initialized SystemParameterFrontend");
+    }
+
+    /// Pull the current values for all [SynchronizedParameters] from the
+    /// [SystemParameterFrontend] and return `true` iff at least one parameter
+    /// value was modified.
+    pub fn pull(&self, params: &mut SynchronizedParameters) -> bool {
+        let mut changed = false;
+
+        changed |= self.pull_parameter(&mut params.window_functions);
+        changed |= self.pull_parameter(&mut params.allowed_cluster_replica_sizes);
+        changed |= self.pull_parameter(&mut params.max_result_size);
+
+        changed
+    }
+
+    /// Pull the current value for the given [SynchronizedParameter] from
+    /// the [SystemParameterFrontend] and return `true` iff the parameter has been
+    /// modified.
+    fn pull_parameter<V: Value>(&self, param: &mut SynchronizedParameter<V>) -> bool
+    where
+        V::Owned: PartialEq + Eq,
+    {
+        let flag_var = self.ld_client.variation(
+            &self.ld_user,
+            param.name,
+            param.default_value.borrow().format(),
+        );
+
+        let flag_str = match flag_var {
+            ld::FlagValue::Bool(v) => v.to_string(),
+            ld::FlagValue::Str(v) => v,
+            ld::FlagValue::Number(v) => v.to_string(),
+            ld::FlagValue::Json(v) => v.to_string(),
+        };
+
+        param.modify(&flag_str);
+
+        param.modified_flag
+    }
+}

--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -7,24 +7,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time;
+
 mod backend;
 mod frontend;
 mod params;
 
-use std::{sync::Arc, time::Duration};
-
-use tokio::time;
-
 pub use backend::SystemParameterBackend;
 pub use frontend::SystemParameterFrontend;
-pub use params::SynchronizedParameters;
+pub use params::{ModifiedParameter, SynchronizedParameters};
 
 /// Run a loop that periodically pulls system parameters defined in the
 /// LaunchDarkly-backed [SystemParameterFrontend] and pushes modified values to the
 /// `ALTER SYSTEM`-backed [SystemParameterBackend].
 pub async fn system_parameter_sync(
     frontend: Arc<SystemParameterFrontend>,
-    backend: SystemParameterBackend,
+    mut backend: SystemParameterBackend,
     tick_interval: Duration,
 ) -> Result<(), anyhow::Error> {
     // Ensure the frontend client is initialized.

--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -6,3 +6,46 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+
+mod backend;
+mod frontend;
+mod params;
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::time;
+
+pub use backend::SystemParameterBackend;
+pub use frontend::SystemParameterFrontend;
+pub use params::SynchronizedParameters;
+
+/// Run a loop that periodically pulls system parameters defined in the
+/// LaunchDarkly-backed [SystemParameterFrontend] and pushes modified values to the
+/// `ALTER SYSTEM`-backed [SystemParameterBackend].
+pub async fn system_parameter_sync(
+    frontend: Arc<SystemParameterFrontend>,
+    backend: SystemParameterBackend,
+    tick_interval: Duration,
+) -> Result<(), anyhow::Error> {
+    // Ensure the frontend client is initialized.
+    frontend.ensure_initialized().await;
+
+    // Run the synchronization loop.
+    tracing::info!(
+        "synchronizing system parameter values every {} seconds",
+        tick_interval.as_secs()
+    );
+
+    // Tick every `tick_duration` ms, skipping missed ticks.
+    let mut interval = time::interval(tick_interval);
+    interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+    let mut params = SynchronizedParameters::default();
+    loop {
+        backend.pull(&mut params).await;
+        if frontend.pull(&mut params) {
+            backend.push(&mut params).await;
+        }
+        interval.tick().await;
+    }
+}

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -1,0 +1,148 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::borrow::Borrow;
+
+use crate::session::vars::Value;
+
+/// A struct that defines the system parameters that should be synchronized
+pub struct SynchronizedParameters {
+    pub(crate) window_functions: SynchronizedParameter<bool>,
+    pub(crate) allowed_cluster_replica_sizes: SynchronizedParameter<Vec<String>>,
+    pub(crate) max_result_size: SynchronizedParameter<u32>,
+}
+
+impl Default for SynchronizedParameters {
+    // TODO (15956): We probably should move the const ServerVar<T> declarations
+    // from adapter::session::vars to this crate so we can bind the
+    // `default_value` and `name` fields from those rather than copying them.
+    fn default() -> Self {
+        Self::new(true, Vec::<String>::new(), 1_073_741_824_u32)
+    }
+}
+
+impl SynchronizedParameters {
+    // TODO (15956): We probably should move the const ServerVar<T> declarations
+    // from adapter::session::vars to this crate so we can bind the
+    // `default_value` and `name` fields from those rather than copying them.
+    pub fn new(
+        window_functions: bool,
+        allowed_cluster_replica_sizes: Vec<String>,
+        max_result_size: u32,
+    ) -> Self {
+        Self {
+            window_functions: SynchronizedParameter {
+                name: "window_functions",
+                default_value: true,
+                current_value: window_functions,
+                modified_flag: false,
+            },
+            allowed_cluster_replica_sizes: SynchronizedParameter {
+                name: "allowed_cluster_replica_sizes",
+                default_value: Vec::<String>::new(),
+                current_value: allowed_cluster_replica_sizes,
+                modified_flag: false,
+            },
+            max_result_size: SynchronizedParameter {
+                name: "max_result_size",
+                default_value: 1_073_741_824_u32,
+                current_value: max_result_size,
+                modified_flag: false,
+            },
+        }
+    }
+
+    pub fn iter_modified(self) -> impl Iterator<Item = (String, String)> {
+        let mut modified = vec![];
+
+        if self.window_functions.modified_flag {
+            modified.push((
+                self.window_functions.name.to_owned(),
+                self.window_functions.current_value.format(),
+            ));
+        }
+        if self.allowed_cluster_replica_sizes.modified_flag {
+            modified.push((
+                self.allowed_cluster_replica_sizes.name.to_owned(),
+                self.allowed_cluster_replica_sizes.current_value.format(),
+            ));
+        }
+        if self.max_result_size.modified_flag {
+            modified.push((
+                self.max_result_size.name.to_owned(),
+                self.max_result_size.current_value.format(),
+            ));
+        }
+
+        modified.into_iter()
+    }
+}
+
+pub(crate) struct SynchronizedParameter<V: Value + 'static> {
+    pub(crate) name: &'static str,
+    pub(crate) default_value: V::Owned,
+    pub(crate) current_value: V::Owned,
+    pub(crate) modified_flag: bool,
+}
+
+impl<V: Value> SynchronizedParameter<V>
+where
+    V::Owned: Borrow<V> + PartialEq + Eq,
+{
+    /// Modify this parameter if the value can be parsed and is different than
+    /// the `current_value`, logging an error if the parsing fails.
+    pub(crate) fn modify(&mut self, value: &str) {
+        match V::parse(value) {
+            Ok(value) => {
+                if self.current_value != value {
+                    self.current_value = value;
+                    self.modified_flag = true;
+                }
+            }
+            Err(_error) => {
+                // Errors (including parsing errors) are reported and recovered
+                // from by not updating the parameter value.
+                tracing::error!("Cannot parse value '{}' for parameter {}", value, self.name);
+            }
+        }
+    }
+
+    /// Return a derived [PushParameterRequest] iff `self` has been marked as
+    /// modified.
+    pub(crate) fn as_request<'a>(&'a mut self) -> Option<PushParameterRequest<'a>> {
+        if self.modified_flag {
+            Some(PushParameterRequest {
+                parameter_flag: &mut self.modified_flag,
+                parameter_name: self.name,
+                parameter_value: if self.current_value != self.default_value {
+                    Some(self.current_value.borrow().format())
+                } else {
+                    None
+                },
+            })
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) struct PushParameterRequest<'a> {
+    pub(crate) parameter_flag: &'a mut bool,
+    pub(crate) parameter_name: &'static str,
+    pub(crate) parameter_value: Option<String>,
+}
+
+impl<'a> PushParameterRequest<'a> {
+    pub(crate) fn sql_statement(&self) -> String {
+        match &self.parameter_value {
+            Some(value) => format!("ALTER SYSTEM SET {} = {}", self.parameter_name, value),
+            None => format!("ALTER SYSTEM RESET {}", self.parameter_name),
+        }
+    }
+}

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -7,142 +7,160 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::borrow::Borrow;
+use std::collections::BTreeSet;
 
-use crate::session::vars::Value;
+use mz_sql::ast::{
+    AlterSystemResetStatement, AlterSystemSetStatement, Ident, Raw, SetVariableValue, Statement,
+    Value,
+};
+
+use crate::session::vars::SystemVars;
 
 /// A struct that defines the system parameters that should be synchronized
 pub struct SynchronizedParameters {
-    pub(crate) window_functions: SynchronizedParameter<bool>,
-    pub(crate) allowed_cluster_replica_sizes: SynchronizedParameter<Vec<String>>,
-    pub(crate) max_result_size: SynchronizedParameter<u32>,
+    /// The backing `SystemVars` instance. Synchronized parameters are exactly
+    /// those that are returned by [SystemVars::iter_synced].
+    system_vars: SystemVars,
+    /// A set of names identifying the synchronized variables from the above
+    /// `system_vars`.
+    ///
+    /// Derived from the above at construction time with the assumption that this
+    /// set cannot change during the lifecycle of the [SystemVars] instance.
+    synchronized: BTreeSet<&'static str>,
+    /// A set of names that identifies the synchronized parameters that have been
+    /// modified by the frontend and need to be pushed to backend.
+    modified: BTreeSet<&'static str>,
 }
 
 impl Default for SynchronizedParameters {
-    // TODO (15956): We probably should move the const ServerVar<T> declarations
-    // from adapter::session::vars to this crate so we can bind the
-    // `default_value` and `name` fields from those rather than copying them.
     fn default() -> Self {
-        Self::new(true, Vec::<String>::new(), 1_073_741_824_u32)
+        Self::new(SystemVars::default())
     }
 }
 
 impl SynchronizedParameters {
-    // TODO (15956): We probably should move the const ServerVar<T> declarations
-    // from adapter::session::vars to this crate so we can bind the
-    // `default_value` and `name` fields from those rather than copying them.
-    pub fn new(
-        window_functions: bool,
-        allowed_cluster_replica_sizes: Vec<String>,
-        max_result_size: u32,
-    ) -> Self {
+    pub fn new(system_vars: SystemVars) -> Self {
+        let synchronized = system_vars
+            .iter_synced()
+            .map(|v| v.name())
+            .collect::<BTreeSet<_>>();
         Self {
-            window_functions: SynchronizedParameter {
-                name: "window_functions",
-                default_value: true,
-                current_value: window_functions,
-                modified_flag: false,
-            },
-            allowed_cluster_replica_sizes: SynchronizedParameter {
-                name: "allowed_cluster_replica_sizes",
-                default_value: Vec::<String>::new(),
-                current_value: allowed_cluster_replica_sizes,
-                modified_flag: false,
-            },
-            max_result_size: SynchronizedParameter {
-                name: "max_result_size",
-                default_value: 1_073_741_824_u32,
-                current_value: max_result_size,
-                modified_flag: false,
-            },
+            system_vars,
+            synchronized,
+            modified: BTreeSet::new(),
         }
     }
 
-    pub fn iter_modified(self) -> impl Iterator<Item = (String, String)> {
-        let mut modified = vec![];
-
-        if self.window_functions.modified_flag {
-            modified.push((
-                self.window_functions.name.to_owned(),
-                self.window_functions.current_value.format(),
-            ));
-        }
-        if self.allowed_cluster_replica_sizes.modified_flag {
-            modified.push((
-                self.allowed_cluster_replica_sizes.name.to_owned(),
-                self.allowed_cluster_replica_sizes.current_value.format(),
-            ));
-        }
-        if self.max_result_size.modified_flag {
-            modified.push((
-                self.max_result_size.name.to_owned(),
-                self.max_result_size.current_value.format(),
-            ));
-        }
-
-        modified.into_iter()
+    pub fn is_synchronized(&self, name: &str) -> bool {
+        self.synchronized.contains(name)
     }
-}
 
-pub(crate) struct SynchronizedParameter<V: Value + 'static> {
-    pub(crate) name: &'static str,
-    pub(crate) default_value: V::Owned,
-    pub(crate) current_value: V::Owned,
-    pub(crate) modified_flag: bool,
-}
+    /// Return a clone of the set of names of synchronized values.
+    ///
+    /// Mostly useful when we need to iterate over each value, while still
+    /// maintaining a mutable reference of the surrounding
+    /// [SynchronizedParameters] instance.
+    pub fn synchronized(&self) -> BTreeSet<&'static str> {
+        self.synchronized.clone()
+    }
 
-impl<V: Value> SynchronizedParameter<V>
-where
-    V::Owned: Borrow<V> + PartialEq + Eq,
-{
-    /// Modify this parameter if the value can be parsed and is different than
-    /// the `current_value`, logging an error if the parsing fails.
-    pub(crate) fn modify(&mut self, value: &str) {
-        match V::parse(value) {
-            Ok(value) => {
-                if self.current_value != value {
-                    self.current_value = value;
-                    self.modified_flag = true;
+    /// Return a vector of [ModifiedParameter] instances that need to be pushed
+    /// to the backend and reset this set to the empty set.
+    pub fn modified(&mut self) -> Vec<ModifiedParameter> {
+        let mut modified = BTreeSet::new();
+        std::mem::swap(&mut self.modified, &mut modified);
+        self.system_vars
+            .iter_synced()
+            .filter(move |var| modified.contains(var.name()))
+            .map(|var| {
+                let name = var.name().to_string();
+                let value = var.value();
+                // This will never panic because both the name and the value come from a `Var` instance.
+                let is_default = self.system_vars.is_default(&name, &value).unwrap();
+                ModifiedParameter {
+                    name,
+                    value,
+                    is_default,
+                }
+            })
+            .collect()
+    }
+
+    /// Get the current in-memory value for the parameter identified by the
+    /// given `name`.
+    ///
+    /// # Panics
+    ///
+    /// The method will panic if the name does not refer to a valid parameter.
+    pub fn get(&self, name: &str) -> String {
+        self.system_vars
+            .get(name)
+            .expect("valid system parameter name")
+            .value()
+    }
+
+    /// Try to modify the in-memory `value` for `name` backing this
+    /// [SynchronizedParameters] instace, calling `SystemVars::reset` iff
+    /// `value` is the default for this `name` and `SystemVars::set` otherwise.
+    ///
+    /// Return `true` iff the backing in-memory value for this `name` has
+    /// changed.
+    pub fn modify(&mut self, name: &str, value: &str) -> bool {
+        // Resolve name to &'static str and assert that the system parameter can
+        // be indeed modified.
+        if let Some(name) = self.synchronized.get(name) {
+            // It's OK to call `unwrap_or(false)` here because for fixed `name`
+            // and `value` an error in `self.is_default(name, value)` implies
+            // the same error in `self.system_vars.set(name, value)`.
+            let modified = if self.system_vars.is_default(name, value).unwrap_or(false) {
+                self.system_vars.reset(name)
+            } else {
+                self.system_vars.set(name, value)
+            };
+            match modified {
+                Ok(true) => {
+                    self.modified.insert(name);
+                    true
+                }
+                Ok(false) => {
+                    // The value was the same as the current one.
+                    false
+                }
+                Err(e) => {
+                    tracing::error!("cannot modify system parameter {}: {}", name, e);
+                    false
                 }
             }
-            Err(_error) => {
-                // Errors (including parsing errors) are reported and recovered
-                // from by not updating the parameter value.
-                tracing::error!("Cannot parse value '{}' for parameter {}", value, self.name);
-            }
-        }
-    }
-
-    /// Return a derived [PushParameterRequest] iff `self` has been marked as
-    /// modified.
-    pub(crate) fn as_request<'a>(&'a mut self) -> Option<PushParameterRequest<'a>> {
-        if self.modified_flag {
-            Some(PushParameterRequest {
-                parameter_flag: &mut self.modified_flag,
-                parameter_name: self.name,
-                parameter_value: if self.current_value != self.default_value {
-                    Some(self.current_value.borrow().format())
-                } else {
-                    None
-                },
-            })
         } else {
-            None
+            tracing::error!("cannot modify unsynchronized system parameter {}", name);
+            false
         }
     }
 }
 
-pub(crate) struct PushParameterRequest<'a> {
-    pub(crate) parameter_flag: &'a mut bool,
-    pub(crate) parameter_name: &'static str,
-    pub(crate) parameter_value: Option<String>,
+pub struct ModifiedParameter {
+    pub name: String,
+    pub value: String,
+    pub is_default: bool,
 }
 
-impl<'a> PushParameterRequest<'a> {
-    pub(crate) fn sql_statement(&self) -> String {
-        match &self.parameter_value {
-            Some(value) => format!("ALTER SYSTEM SET {} = {}", self.parameter_name, value),
-            None => format!("ALTER SYSTEM RESET {}", self.parameter_name),
+impl ModifiedParameter {
+    pub fn as_alter_system(&self) -> String {
+        match self.is_default {
+            true => format!("ALTER SYSTEM RESET {}", self.name),
+            false => format!("ALTER SYSTEM SET {} = {}", self.name, self.value),
+        }
+    }
+
+    pub fn as_stmt(&self) -> Statement<Raw> {
+        match self.is_default {
+            true => Statement::AlterSystemReset(AlterSystemResetStatement {
+                name: Ident::from(self.name.clone()),
+            }),
+            false => Statement::AlterSystemSet(AlterSystemSetStatement {
+                name: Ident::from(self.name.clone()),
+                value: SetVariableValue::Literal(Value::String(self.value.clone())),
+            }),
         }
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -122,6 +122,7 @@ use crate::catalog::{
 };
 use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
+use crate::config::SystemParameterFrontend;
 use crate::coord::appends::{BuiltinTableUpdateSource, Deferred, PendingWriteTxn};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::PendingPeek;
@@ -253,6 +254,7 @@ pub struct Config<S> {
     pub storage_usage_collection_interval: Duration,
     pub segment_client: Option<mz_segment::Client>,
     pub egress_ips: Vec<Ipv4Addr>,
+    pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
     pub consolidations_tx: mpsc::UnboundedSender<Vec<mz_stash::Id>>,
     pub consolidations_rx: mpsc::UnboundedReceiver<Vec<mz_stash::Id>>,
     pub aws_account_id: Option<String>,
@@ -1037,6 +1039,7 @@ pub async fn serve<S: Append + 'static>(
         consolidations_tx,
         consolidations_rx,
         aws_account_id,
+        system_parameter_frontend,
     }: Config<S>,
 ) -> Result<(Handle, Client), AdapterError> {
     info!("coordinator init: beginning");
@@ -1088,6 +1091,7 @@ pub async fn serve<S: Append + 'static>(
             secrets_reader: secrets_controller.reader(),
             egress_ips,
             aws_principal_context,
+            system_parameter_frontend,
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1908,7 +1908,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .vars()
                 .iter()
                 .chain(self.catalog.system_config().iter())
-                .filter(|v| !v.experimental())
+                .filter(|v| !v.experimental() && v.visible(session.user()))
                 .map(|v| {
                     Row::pack_slice(&[
                         Datum::String(v.name()),
@@ -1929,8 +1929,13 @@ impl<S: Append + 'static> Coordinator<S> {
             .vars()
             .get(&plan.name)
             .or_else(|_| self.catalog.system_config().get(&plan.name))?;
-        let row = Row::pack_slice(&[Datum::String(&variable.value())]);
-        Ok(send_immediate_rows(vec![row]))
+
+        if variable.visible(session.user()) {
+            let row = Row::pack_slice(&[Datum::String(&variable.value())]);
+            Ok(send_immediate_rows(vec![row]))
+        } else {
+            Err(AdapterError::UnknownParameter(plan.name))
+        }
     }
 
     fn sequence_set_variable(

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -3504,7 +3504,7 @@ impl<S: Append + 'static> Coordinator<S> {
         if update_max_result_size {
             self.update_max_result_size();
         }
-        Ok(ExecuteResponse::AlteredSystemConfiguraion)
+        Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
     async fn sequence_alter_system_reset(
@@ -3519,7 +3519,7 @@ impl<S: Append + 'static> Coordinator<S> {
         if update_max_result_size {
             self.update_max_result_size();
         }
-        Ok(ExecuteResponse::AlteredSystemConfiguraion)
+        Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
     async fn sequence_alter_system_reset_all(
@@ -3531,7 +3531,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let op = catalog::Op::ResetAllSystemConfiguration {};
         self.catalog_transact(Some(session), vec![op]).await?;
         self.update_max_result_size();
-        Ok(ExecuteResponse::AlteredSystemConfiguraion)
+        Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
     fn is_user_allowed_to_alter_system(&self, session: &Session) -> Result<(), AdapterError> {

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -938,6 +938,13 @@ impl SystemVars {
         .into_iter()
     }
 
+    /// Returns an iterator over the configuration parameters and their current
+    /// values on disk.
+    pub fn iter_synced(&self) -> impl Iterator<Item = &dyn Var> {
+        self.iter()
+            .filter(|v| v.name() != CONFIG_HAS_SYNCED_ONCE.name)
+    }
+
     /// Returns a [`Var`] representing the configuration parameter with the
     /// specified name.
     ///

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -323,7 +323,7 @@ static WINDOW_FUNCTIONS: ServerVar<bool> = ServerVar {
 
 /// Boolean flag indicating that the remote configuration was synchronized at
 /// least once with the persistent [SessionVars].
-static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
+pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("config_has_synced_once"),
     value: &false,
     description: "Boolean flag indicating that the remote configuration was synchronized at least once (Materialize).",
@@ -1230,11 +1230,6 @@ impl SystemVars {
     /// Returns the `config_has_synced_once` configuration parameter.
     pub fn config_has_synced_once(&self) -> bool {
         *self.config_has_synced_once.value()
-    }
-
-    /// Returns the `config_has_synced_once` configuration parameter.
-    pub fn set_config_has_synced_once(&mut self) -> Result<bool, AdapterError> {
-        self.config_has_synced_once.set("true")
     }
 }
 

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -321,6 +321,15 @@ static WINDOW_FUNCTIONS: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
+/// Boolean flag indicating that the remote configuration was synchronized at
+/// least once with the persistent [SessionVars].
+static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("config_has_synced_once"),
+    value: &false,
+    description: "Boolean flag indicating that the remote configuration was synchronized at least once (Materialize).",
+    internal: true,
+};
+
 /// Session variables.
 ///
 /// Materialize roughly follows the PostgreSQL configuration model, which works
@@ -878,6 +887,7 @@ pub struct SystemVars {
     max_result_size: SystemVar<u32>,
     allowed_cluster_replica_sizes: SystemVar<Vec<String>>, // TODO: BTreeSet<String> will be better
     window_functions: SystemVar<bool>,
+    config_has_synced_once: SystemVar<bool>,
 }
 
 impl Default for SystemVars {
@@ -898,6 +908,7 @@ impl Default for SystemVars {
             max_result_size: SystemVar::new(&MAX_RESULT_SIZE),
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             window_functions: SystemVar::new(&WINDOW_FUNCTIONS),
+            config_has_synced_once: SystemVar::new(&CONFIG_HAS_SYNCED_ONCE),
         }
     }
 }
@@ -922,6 +933,7 @@ impl SystemVars {
             &self.max_result_size,
             &self.allowed_cluster_replica_sizes,
             &self.window_functions,
+            &self.config_has_synced_once,
         ]
         .into_iter()
     }
@@ -967,6 +979,8 @@ impl SystemVars {
             Ok(&self.allowed_cluster_replica_sizes)
         } else if name == WINDOW_FUNCTIONS.name {
             Ok(&self.window_functions)
+        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
+            Ok(&self.config_has_synced_once)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1010,6 +1024,8 @@ impl SystemVars {
             self.allowed_cluster_replica_sizes.set(value)
         } else if name == WINDOW_FUNCTIONS.name {
             self.window_functions.set(value)
+        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
+            self.config_has_synced_once.set(value)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1051,6 +1067,8 @@ impl SystemVars {
             self.allowed_cluster_replica_sizes.reset()
         } else if name == WINDOW_FUNCTIONS.name {
             self.window_functions.reset()
+        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
+            self.config_has_synced_once.reset()
         } else {
             return Err(AdapterError::UnknownParameter(name.into()));
         }
@@ -1130,6 +1148,16 @@ impl SystemVars {
     /// Returns the `window_functions` configuration parameter.
     pub fn window_functions(&self) -> bool {
         *self.window_functions.value()
+    }
+
+    /// Returns the `config_has_synced_once` configuration parameter.
+    pub fn config_has_synced_once(&self) -> bool {
+        *self.config_has_synced_once.value()
+    }
+
+    /// Returns the `config_has_synced_once` configuration parameter.
+    pub fn set_config_has_synced_once(&mut self) -> Result<(), AdapterError> {
+        self.config_has_synced_once.set("true")
     }
 }
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -42,6 +42,7 @@ use url::Url;
 use uuid::Uuid;
 
 use mz_adapter::catalog::{ClusterReplicaSizeMap, StorageHostSizeMap};
+use mz_adapter::config::{system_parameter_sync, SystemParameterBackend, SystemParameterFrontend};
 use mz_cloud_resources::{AwsExternalIdPrefix, CloudResourceController};
 use mz_controller::ControllerConfig;
 use mz_environmentd::{TlsConfig, TlsMode, BUILD_INFO};
@@ -56,6 +57,7 @@ use mz_ore::cgroup::{detect_memory_limit, MemoryLimit};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::task::RuntimeExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistConfig, PersistLocation};
 use mz_secrets::SecretsController;
@@ -414,6 +416,20 @@ pub struct Args {
         use_delimiter = true
     )]
     announce_egress_ip: Vec<Ipv4Addr>,
+    /// An SDK key for LaunchDarkly.
+    ///
+    /// Setting this will enable synchronization of LaunchDarkly features with
+    /// system configuration parameters.
+    #[clap(long, env = "LAUNCHDARKLY_SDK_KEY")]
+    launchdarkly_sdk_key: Option<String>,
+    /// The interval in seconds at which to synchronize system parameter values.
+    #[clap(
+        long,
+        env = "CONFIG_SYNC_LOOP_INTERVAL",
+        parse(try_from_str = humantime::parse_duration),
+        default_value = "15s"
+    )]
+    config_sync_loop_interval: Duration,
 
     /// The 12-digit AWS account id, which is used to generate an AWS Principal.
     #[clap(long, env = "AWS_ACCOUNT_ID")]
@@ -729,6 +745,25 @@ max log level: {max_log_level}",
         }
     }
 
+    // Initialize the system parameter frontend if `launchdarkly_sdk_key` is set.
+    let system_parameter_frontend = args
+        .launchdarkly_sdk_key
+        .as_ref()
+        .map(|ld_sdk_key| {
+            let ld_user_key = args
+                .frontegg_tenant
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "anonymous-dev@materialize.com".to_string());
+            SystemParameterFrontend::new(ld_sdk_key.as_str(), ld_user_key.as_str())
+        })
+        .transpose()
+        .unwrap_or_else(|e| {
+            eprintln!("Cannot initialize system parameter frontend: {:?}", e);
+            None
+        })
+        .map(Arc::new);
+
     let server = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         sql_listen_addr: args.sql_listen_addr,
         http_listen_addr: args.http_listen_addr,
@@ -767,6 +802,7 @@ max log level: {max_log_level}",
         segment_api_key: args.segment_api_key,
         egress_ips: args.announce_egress_ip,
         aws_account_id: args.aws_account_id,
+        system_parameter_frontend: system_parameter_frontend.clone(),
     }))?;
 
     metrics.start_time_environmentd.set(
@@ -791,6 +827,34 @@ max log level: {max_log_level}",
         " Internal HTTP address: {}",
         server.internal_http_local_addr()
     );
+
+    // Initialize the system parameter frontend and backend if
+    // `launchdarkly_sdk_key` is set.
+    let system_parameter_backend = args
+        .launchdarkly_sdk_key
+        .as_ref()
+        .map(|_ld_sdk_key| {
+            runtime.block_on(SystemParameterBackend::new(args.internal_sql_listen_addr))
+        })
+        .transpose()
+        .unwrap_or_else(|e| {
+            eprintln!("Cannot initialize system parameter backend: {:?}", e);
+            None
+        });
+
+    // If system_parameter_frontend is present, start the system_parameter_sync loop.
+    if let (Some(system_parameter_frontend), Some(system_parameter_backend)) =
+        (system_parameter_frontend, system_parameter_backend)
+    {
+        runtime.spawn_named(
+            || "system_parameter_sync",
+            system_parameter_sync(
+                system_parameter_frontend,
+                system_parameter_backend,
+                args.config_sync_loop_interval,
+            ),
+        );
+    }
 
     // Block forever.
     loop {

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -373,7 +373,7 @@ async fn execute_stmt(
         | ExecuteResponse::Updated(_)
         | ExecuteResponse::AlteredObject(_)
         | ExecuteResponse::AlteredIndexLogicalCompaction
-        | ExecuteResponse::AlteredSystemConfiguraion
+        | ExecuteResponse::AlteredSystemConfiguration
         | ExecuteResponse::Deallocate { .. }
         | ExecuteResponse::Prepare) => SqlResult::ok(client, res),
         ExecuteResponse::SendingRows {

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -252,6 +252,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         segment_api_key: None,
         egress_ips: vec![],
         aws_account_id: None,
+        system_parameter_frontend: None,
     }))?;
     let server = Server {
         inner,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -252,7 +252,8 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         segment_api_key: None,
         egress_ips: vec![],
         aws_account_id: None,
-        system_parameter_frontend: None,
+        launchdarkly_sdk_key: None,
+        config_sync_loop_interval: Duration::ZERO,
     }))?;
     let server = Server {
         inner,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1273,7 +1273,7 @@ where
 
             ExecuteResponse::AlteredIndexLogicalCompaction
             | ExecuteResponse::AlteredObject(..)
-            | ExecuteResponse::AlteredSystemConfiguraion
+            | ExecuteResponse::AlteredSystemConfiguration
             | ExecuteResponse::CreatedComputeInstance { .. }
             | ExecuteResponse::CreatedComputeReplica { .. }
             | ExecuteResponse::CreatedConnection { .. }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -838,7 +838,8 @@ impl RunnerInner {
             segment_api_key: None,
             egress_ips: vec![],
             aws_account_id: None,
-            system_parameter_frontend: None,
+            launchdarkly_sdk_key: None,
+            config_sync_loop_interval: Duration::ZERO,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -838,6 +838,7 @@ impl RunnerInner {
             segment_api_key: None,
             egress_ips: vec![],
             aws_account_id: None,
+            system_parameter_frontend: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -340,6 +340,7 @@ impl Usage {
             secrets_reader,
             egress_ips: vec![],
             aws_principal_context: None,
+            system_parameter_frontend: None,
         })
         .await?;
 

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -44,8 +44,7 @@ standard_conforming_strings             on                     "Causes '...' str
 statement_timeout                       "10 s"                 "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
 TimeZone                                UTC                    "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation                   "strict serializable"  "Sets the current transaction's isolation level (PostgreSQL)."
-window_functions                        on                     "Feature flag indicating whether window functions are enabled."
-
+window_functions                        on                     "Feature flag indicating whether window functions are enabled (Materialize)."
 
 > SET application_name = 'foo'
 


### PR DESCRIPTION
This implements the bulk of the work required to close #15230.

I'm currently working on migrating the `backend.rs` to the `SessionClient` based approach so so the sync task doesn't need to go through a `pgwire` connection (as discussed with @benesch offline). The rest of the code is more or less stable, so I'm open to review feedback.

### Motivation

  * This PR adds a known-desirable feature.

Closes #15956.

### Tips for reviewer

I've tried to split changes into digestible commits.

**Update**:
- The last two commits rework the implementation as suggested by @benesch.
  - I'm now using `SessionClient` for the backend in `backend.rs`.
  - I'm now using a direct dependency to `SystemVars` for the `SynchronizedParameters` in `params.rs`.
  - The `system_parameter_sync` is effectively unchanged compared to the original version.
- I had to move the setup code to `environmentd::serve` in order to get access to the `SystemVars` instance.

The starting point of the review should be:

- The setup code in the `environmentd::serve` method.
- The `system_parameter_sync` method in the new `mz_adapter::config` crate.
- After that, look at the `backend.rs`, `frontend.rs`, and `params.rs` in `mz_adapter::config`.

Regarding **changes of existing code**:
- ~I had to move the `Value` trait definition and some implementations from `mz_adapter::session::vars` to `mz_config::value`.~
- ~If we don't want to duplicate constants, I'll also have to do somethings similar with the `ServerVar<T>` declarations.~
- Alternatively, I can add all the code into a sub-folder of `src/adapter/src`. (done :heavy_check_mark:)

Regarding **testing**:
- So far I've tested locally, reproducing various failure scenarios, and the code seems to be working as expected.
- @philip-stoev created a stub for a test that I will extend tomorrow.

### TODOs

- [x] Move the forks of all patched libraries to `MaterializeInc`, open PRs for the patches, and refer to these PRs in `deny.toml`.
- [x] Fix conflicting dependency errors in the CI builds.
- [x] Fix the log messages so they adhere to [the recently adopted guidelines](https://github.com/MaterializeInc/materialize/commit/9423f03c44daee7aab4935802231530ae66d13f2).
- [x] Move all code to `adapter`.
- [x] Remove public methods that re not needed for now (`ensure_computed`, the `main` method that runs the sync task as a separate process).
- [x] Mark `config_has_synced_once` as a non-public feature (see [comment](https://github.com/MaterializeInc/materialize/pull/16089#discussion_r1034367971)).
- [x] Implement an alternative `SystemParameterBackend` that uses the `SessionClient` instead of a `tokio_postgres` connection.
- [ ] Add an end-to-end test (might be a separate PR).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
