### PR TITLE
storage: in persist_source, fix locking

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -51,7 +51,7 @@ where
 
     // Ensures that `BatchFetcher` is of the same type as the `ReadHandle` it's
     // derived from.
-    _phantom: PhantomData<(K, V, T, D)>,
+    pub(crate) _phantom: PhantomData<(K, V, T, D)>,
 }
 
 impl<K, V, T, D> BatchFetcher<K, V, T, D>

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -425,10 +425,9 @@ where
             std::mem::drop(persist_clients);
 
             persist_client
-                .open_leased_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(data_shard)
-                .await
-                .expect("could not open persist shard")
-                .batch_fetcher()
+                .create_batch_fetcher::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(
+                    data_shard,
+                )
                 .await
         };
 

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -250,11 +250,10 @@ where
             return;
         }
 
-        let read = persist_clients_stream
-            .lock()
-            .await
-            .open(persist_location_stream)
-            .await;
+        let read = {
+            let mut persist_clients = persist_clients_stream.lock().await;
+            persist_clients.open(persist_location_stream).await
+        };
 
         // This is a moment where we may have dropped our source if our token
         // has been dropped, but if we still hold it we should be good to go.
@@ -414,17 +413,24 @@ where
     let mut row_builder = Row::default();
 
     fetcher_builder.build(move |_capabilities| async move {
-        let fetcher = persist_clients
-            .lock()
-            .await
-            .open(metadata.persist_location.clone())
-            .await
-            .expect("could not open persist client")
-            .open_leased_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(data_shard)
-            .await
-            .expect("could not open persist shard")
-            .batch_fetcher()
-            .await;
+        let fetcher = {
+            let mut persist_clients = persist_clients.lock().await;
+
+            let persist_client = persist_clients
+                .open(metadata.persist_location.clone())
+                .await
+                .expect("could not open persist client");
+
+            // Unlock the client cache before we do any async work.
+            std::mem::drop(persist_clients);
+
+            persist_client
+                .open_leased_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(data_shard)
+                .await
+                .expect("could not open persist shard")
+                .batch_fetcher()
+                .await
+        };
 
         let mut buffer = Vec::new();
 


### PR DESCRIPTION
### Motivation

Fixes #16090


### Tips for reviewer

The first commit (fixing locking) does mitigate things, but the bad scaling is still easy to observe locally. The second commit (creating a `BatchFetcher` without going through a `ReadHandle`) makes the bad scaling almost unnoticeable but seems more controversial because it adds a new method to `PersistClient` that seems easy to mis-use.

Btw, I reproduced this locally by just creating a 1-worker cluster and a 32-worker cluster:
```
materialize=> CREATE CLUSTER c32 REPLICAS (r1 (SIZE '32'));
materialize=> CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'));
```
switching between them, and observing the runtime of `SHOW VIEWS`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
