### PR TITLE
[sources / sinks] Status history views

### DIFF
--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -30,7 +30,7 @@ SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1' AND
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name LIKE '%_1');
 ----
-30
+32
 
 
 # The default and system clusters also have log sources, thus we should have 3 set active at boot.

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -694,8 +694,16 @@ mz_show_materialized_views
 VIEW
 materialize
 mz_internal
+mz_sink_status
+VIEW
+materialize
+mz_internal
 mz_sink_status_history
 SOURCE
+materialize
+mz_internal
+mz_source_status
+VIEW
 materialize
 mz_internal
 mz_source_status_history

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -550,6 +550,8 @@ mz_records_per_dataflow_global
 mz_records_per_dataflow_operator
 mz_scheduling_elapsed
 mz_scheduling_parks
+mz_sink_status
+mz_source_status
 mz_worker_compute_delays
 mz_show_cluster_replicas
 mz_show_indexes

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -19,6 +19,9 @@ $ kafka-create-topic topic=status-history
     URL '${testdrive.schema-registry-url}'
   );
 
+## The basics: create a source and sink, pass in some data, and confirm that we see the status
+## entries we expect.
+
 > CREATE SOURCE kafka_source
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
   FORMAT TEXT
@@ -75,3 +78,36 @@ $ kafka-verify-data format=avro sink=materialize.public.kafka_sink sort-messages
 
 > select * from mz_internal.mz_source_status where id = '${source_id}';
 "${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
+
+## Confirm that the tables report statuses for multiple sources and sinks.
+
+> CREATE SOURCE kafka_source_2
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-status-history-${testdrive.seed}')
+  FORMAT TEXT
+
+> CREATE SINK kafka_sink_2 FROM kafka_source_2
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-2-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ set-from-sql var=source_id_2
+SELECT id FROM mz_sources WHERE name = 'kafka_source_2'
+
+$ set-from-sql var=sink_id_2
+SELECT id FROM mz_sinks WHERE name = 'kafka_sink_2'
+
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id_2}' ORDER BY occurred_at;
+"<TIMESTAMP> UTC" ${sink_id_2} starting <null> <null>
+"<TIMESTAMP> UTC" ${sink_id_2} running <null> <null>
+
+> select * from mz_internal.mz_source_status_history where source_id = '${source_id_2}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id_2} starting <null> <null>
+"<TIMESTAMP> UTC" ${source_id_2} running <null> <null>
+
+> select * from mz_internal.mz_sink_status where id in ('${sink_id}', '${sink_id_2}') order by id;
+"${sink_id}" kafka_sink kafka "<TIMESTAMP> UTC" running <null> <null>
+"${sink_id_2}" kafka_sink_2 kafka "<TIMESTAMP> UTC" running <null> <null>
+
+> select * from mz_internal.mz_source_status where id in ('${source_id}', '${source_id_2}') order by id;
+"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
+"${source_id_2}" kafka_source_2 kafka "<TIMESTAMP> UTC" running <null> <null>

--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -34,11 +34,14 @@ SELECT id FROM mz_sources WHERE name = 'kafka_source'
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
 "<TIMESTAMP> UTC" ${source_id} starting <null> <null>
 
+> select * from mz_internal.mz_source_status where id = '${source_id}';
+"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" starting <null> <null>
+
 $ set-from-sql var=sink_id
 SELECT id FROM mz_sinks WHERE name = 'kafka_sink'
 
 # Verify we get a starting -- it's possible we move to running by the time this query runs.
-> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' AND status = 'starting' ORDER BY occurred_at;
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at LIMIT 1;
 "<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
 
 $ kafka-ingest format=bytes topic=status-history
@@ -63,6 +66,12 @@ $ kafka-verify-data format=avro sink=materialize.public.kafka_sink sort-messages
 "<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
 "<TIMESTAMP> UTC" ${sink_id} running <null> <null>
 
+> select * from mz_internal.mz_sink_status where id = '${sink_id}';
+"${sink_id}" kafka_sink kafka "<TIMESTAMP> UTC" running <null> <null>
+
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
 "<TIMESTAMP> UTC" ${source_id} starting <null> <null>
 "<TIMESTAMP> UTC" ${source_id} running <null> <null>
+
+> select * from mz_internal.mz_source_status where id = '${source_id}';
+"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>


### PR DESCRIPTION
Adds two new views to the `mz_internal` schema, which roll up the `status_history` collections for sources and sinks into a "current status" view.

### Motivation

https://github.com/MaterializeInc/materialize/issues/15166

### Tips for reviewer

For example:

```materialize=> select * from mz_internal.mz_source_status;
 id |    name     | type  |   last_status_change_at    |  status  | error | details 
----+-------------+-------+----------------------------+----------+-------+---------
 u2 | ksource     | kafka | 2022-11-15 19:46:05.272+00 | running  |       | 
 u4 | ksource_3   | kafka | 2022-11-15 19:45:47.691+00 | starting |       | 
 u3 | ksource_bad | kafka | 2022-11-15 19:45:48.284+00 | starting |       | 
```

Status names and definitions are enumerated at the [internal design doc](https://www.notion.so/materialize/Exposing-source-sink-errors-via-SQL-1c83b2070b5a48db967b829b7ccd88dc#0f93175a1fe84133be7e1b531c64e938).

Note that the `error` and `details` columns are nullable (because there might not be an error) but also the `last_status_change_at` column (because before the first history entry is presented we don't have a timestamp to display).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
