### PR TITLE
[storage] [healthcheck] Partially unify implementations

### DIFF
--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -9,27 +9,53 @@
 
 //! Healthcheck common
 
+use chrono::{DateTime, NaiveDateTime, Utc};
 use differential_dataflow::lattice::Lattice;
+use mz_ore::now::NowFn;
 use timely::progress::Antichain;
 
 use mz_persist_client::{PersistClient, ShardId, Upper};
-use mz_repr::{GlobalId, Row, Timestamp};
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_storage_client::types::sources::SourceData;
 use tracing::trace;
 
 pub async fn write_to_persist(
-    row: Row,
-    timestamp: Timestamp,
+    collection_id: GlobalId,
+    new_status: &str,
+    new_error: Option<&str>,
+    now: NowFn,
     client: &PersistClient,
     status_shard: ShardId,
-    collection_id: GlobalId,
 ) {
+    let now_ms = now();
+    let row = {
+        let timestamp = NaiveDateTime::from_timestamp(
+            (now_ms / 1000)
+                .try_into()
+                .expect("timestamp seconds does not fit into i64"),
+            (now_ms % 1000 * 1_000_000)
+                .try_into()
+                .expect("timestamp millis does not fit into a u32"),
+        );
+        let timestamp = Datum::TimestampTz(
+            DateTime::from_utc(timestamp, Utc)
+                .try_into()
+                .expect("must fit"),
+        );
+        let collection_id = collection_id.to_string();
+        let collection_id = Datum::String(&collection_id);
+        let status = Datum::String(new_status);
+        let error = new_error.into();
+        let metadata = Datum::Null;
+        Row::pack_slice(&[timestamp, collection_id, status, error, metadata])
+    };
+
     let mut handle = client.open_writer(status_shard).await.expect(
         "Invalid usage of the persist client for collection {collection_id} status history shard",
     );
 
     let mut recent_upper = handle.upper().clone();
-    let mut append_ts = timestamp;
+    let mut append_ts = Timestamp::from(now_ms);
     'retry_loop: loop {
         // We don't actually care so much about the timestamp we append at; it's best-effort.
         // Ensure that the append timestamp is not less than the current upper, and the new upper

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -1,0 +1,63 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Healthcheck common
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::Antichain;
+
+use mz_persist_client::{PersistClient, ShardId, Upper};
+use mz_repr::{GlobalId, Row, Timestamp};
+use mz_storage_client::types::sources::SourceData;
+use tracing::trace;
+
+pub async fn write_to_persist(
+    row: Row,
+    timestamp: Timestamp,
+    client: &PersistClient,
+    status_shard: ShardId,
+    collection_id: GlobalId,
+) {
+    let mut handle = client.open_writer(status_shard).await.expect(
+        "Invalid usage of the persist client for collection {collection_id} status history shard",
+    );
+
+    let mut recent_upper = handle.upper().clone();
+    let mut append_ts = timestamp;
+    'retry_loop: loop {
+        // We don't actually care so much about the timestamp we append at; it's best-effort.
+        // Ensure that the append timestamp is not less than the current upper, and the new upper
+        // is past that timestamp. (Unless we've advanced to the empty antichain, but in
+        // that case we're already in trouble.)
+        for t in recent_upper.elements() {
+            append_ts.join_assign(t);
+        }
+        let mut new_upper = Antichain::from_elem(append_ts.step_forward());
+        new_upper.join_assign(&recent_upper);
+
+        let updates = vec![((SourceData(Ok(row.clone())), ()), append_ts, 1i64)];
+        let cas_result = handle
+            .compare_and_append(updates, recent_upper.clone(), new_upper)
+            .await;
+        match cas_result {
+            Ok(Ok(Ok(()))) => break 'retry_loop,
+            Ok(Ok(Err(Upper(upper)))) => {
+                recent_upper = upper;
+            }
+            Ok(Err(e)) => {
+                panic!("Invalid usage of the persist client for collection {collection_id} status history shard: {e:?}");
+            }
+            Err(e) => {
+                trace!("compare_and_append in update_status failed: {e}");
+            }
+        }
+    }
+
+    handle.expire().await
+}

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -18,5 +18,7 @@ pub mod sink;
 pub mod source;
 pub mod storage_state;
 
+mod healthcheck;
+
 pub use decode::metrics::DecodeMetrics;
 pub use server::{serve, Config, Server};

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -12,7 +12,6 @@ use std::fmt::Display;
 use std::sync::Arc;
 
 use anyhow::Context;
-use chrono::{DateTime, NaiveDateTime, Utc};
 use tokio::sync::Mutex;
 use tracing::trace;
 
@@ -20,7 +19,7 @@ use mz_ore::halt;
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistClient, PersistLocation, ShardId};
-use mz_repr::{Datum, GlobalId, Row, Timestamp};
+use mz_repr::GlobalId;
 
 use crate::healthcheck::write_to_persist;
 
@@ -93,41 +92,18 @@ impl Healthchecker {
 
         // Only update status if it is a valid transition
         if SinkStatus::can_transition(self.current_status.as_ref(), &status_update) {
-            let ts = (self.now)();
-            let row = self.prepare_row(&status_update, ts);
             write_to_persist(
-                row,
-                Timestamp::from(ts),
+                self.sink_id,
+                status_update.name(),
+                status_update.error(),
+                self.now.clone(),
                 &self.persist_client,
                 self.status_shard,
-                self.sink_id,
             )
             .await;
 
             self.current_status = Some(status_update);
         }
-    }
-
-    fn prepare_row(&self, status_update: &SinkStatus, ts: u64) -> Row {
-        let timestamp = NaiveDateTime::from_timestamp(
-            (ts / 1000)
-                .try_into()
-                .expect("timestamp seconds does not fit into i64"),
-            (ts % 1000 * 1_000_000)
-                .try_into()
-                .expect("timestamp millis does not fit into a u32"),
-        );
-        let timestamp = Datum::TimestampTz(
-            DateTime::from_utc(timestamp, Utc)
-                .try_into()
-                .expect("must fit"),
-        );
-        let sink_id = self.sink_id.to_string();
-        let sink_id = Datum::String(&sink_id);
-        let status = Datum::String(status_update.name());
-        let error = status_update.error().into();
-        let metadata = Datum::Null;
-        Row::pack_slice(&[timestamp, sink_id, status, error, metadata])
     }
 }
 
@@ -206,6 +182,7 @@ mod tests {
     use std::time::Duration;
 
     use itertools::Itertools;
+    use mz_repr::Row;
     use timely::progress::Antichain;
 
     use once_cell::sync::Lazy;

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -13,18 +13,16 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use chrono::{DateTime, NaiveDateTime, Utc};
-use differential_dataflow::lattice::Lattice;
-use timely::progress::Antichain;
 use tokio::sync::Mutex;
 use tracing::trace;
 
 use mz_ore::halt;
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{PersistLocation, ShardId, Upper};
+use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_repr::{Datum, GlobalId, Row, Timestamp};
-use mz_storage_client::types::sources::SourceData;
+
+use crate::healthcheck::write_to_persist;
 
 /// The Healthchecker is responsible for tracking the current state
 /// of a Timely worker for a source, as well as updating the relevant
@@ -35,12 +33,10 @@ pub struct Healthchecker {
     sink_id: GlobalId,
     /// Current status of this source
     current_status: Option<SinkStatus>,
-    /// Last observed upper
-    upper: Antichain<Timestamp>,
-    /// Write handle of the Healthchecker persist shard
-    ///
-    /// The schema used matches the one used in regular sources and tables.
-    write_handle: WriteHandle<SourceData, (), Timestamp, i64>,
+    /// PersistClient of the Healthchecker persist location
+    persist_client: PersistClient,
+    /// Status shard for the healthchecker
+    status_shard: ShardId,
     /// The function that should be used to get the current time when updating upper
     now: NowFn,
 }
@@ -54,7 +50,7 @@ impl Healthchecker {
         sink_id: GlobalId,
         persist_clients: &Arc<Mutex<PersistClientCache>>,
         persist_location: PersistLocation,
-        status_shard_id: ShardId,
+        status_shard: ShardId,
         now: NowFn,
     ) -> anyhow::Result<Self> {
         trace!("Initializing healthchecker for sink {sink_id}");
@@ -65,18 +61,11 @@ impl Healthchecker {
             .await
             .context("error creating persist client for Healthchecker")?;
 
-        let write_handle = persist_client
-            .open_writer(status_shard_id)
-            .await
-            .context("error opening Healthchecker persist shard")?;
-
-        let upper = write_handle.upper().clone();
-
         Ok(Self {
             sink_id,
             current_status: None,
-            upper,
-            write_handle,
+            persist_client,
+            status_shard,
             now,
         })
     }
@@ -101,60 +90,25 @@ impl Healthchecker {
             "Processing status update: {status_update:?}, current status is {current_status:?}",
             current_status = &self.current_status
         );
+
         // Only update status if it is a valid transition
         if SinkStatus::can_transition(self.current_status.as_ref(), &status_update) {
             let ts = (self.now)();
-            let update = self.prepare_row(&status_update, ts);
-            let mut ts = Timestamp::from(ts);
-            loop {
-                // Make sure `ts` is at least at self.upper
-                for elem in self.upper.elements() {
-                    ts.join_assign(elem);
-                }
-                let new_upper = Antichain::from_elem(ts.step_forward());
+            let row = self.prepare_row(&status_update, ts);
+            write_to_persist(
+                row,
+                Timestamp::from(ts),
+                &self.persist_client,
+                self.status_shard,
+                self.sink_id,
+            )
+            .await;
 
-                let updates = vec![((update.clone(), ()), ts, 1)];
-                match self
-                    .write_handle
-                    .compare_and_append(updates.iter(), self.upper.clone(), new_upper.clone())
-                    .await
-                {
-                    Ok(Ok(Ok(()))) => {
-                        self.upper = new_upper;
-                        // Update internal status only after a successful append
-                        self.current_status = Some(status_update);
-                        break;
-                    }
-                    Ok(Ok(Err(Upper(actual_upper)))) => {
-                        trace!(
-                            "Had to retry updating status, old upper {:?}, new upper {:?}",
-                            &self.upper,
-                            &actual_upper
-                        );
-                        // Try again with the new upper.
-                        // N.B.  This works because we only have one active worker per sink so don't have to worry about
-                        //       transitions for a particular sink being valid.  If we have multiple workers, we'd need
-                        //       to keep track of the current state and re-aggregate / check if transition is valid --
-                        //       like we do for sources.
-                        self.upper = actual_upper;
-                    }
-                    Ok(Err(invalid_use)) => panic!("compare_and_append failed: {invalid_use}"),
-                    // An external error means that the operation might have succeeded or failed but we
-                    // don't know. In either case it is safe to retry because:
-                    // * If it succeeded, then on retry we'll get an `Upper(_)` error as if some other
-                    //   process raced us. This is safe and will just cause the healthchecker to sync
-                    //   again, and on retry it will notice that the new state was already processed and
-                    //   finish successfully.
-                    // * If it failed, then we'll succeed on retry and proceed normally.
-                    Err(external_err) => {
-                        trace!("compare_and_append in update_status failed: {external_err}");
-                    }
-                };
-            }
+            self.current_status = Some(status_update);
         }
     }
 
-    fn prepare_row(&self, status_update: &SinkStatus, ts: u64) -> SourceData {
+    fn prepare_row(&self, status_update: &SinkStatus, ts: u64) -> Row {
         let timestamp = NaiveDateTime::from_timestamp(
             (ts / 1000)
                 .try_into()
@@ -173,9 +127,7 @@ impl Healthchecker {
         let status = Datum::String(status_update.name());
         let error = status_update.error().into();
         let metadata = Datum::Null;
-        let row = Row::pack_slice(&[timestamp, sink_id, status, error, metadata]);
-
-        SourceData(Ok(row))
+        Row::pack_slice(&[timestamp, sink_id, status, error, metadata])
     }
 }
 
@@ -254,12 +206,15 @@ mod tests {
     use std::time::Duration;
 
     use itertools::Itertools;
-    use mz_build_info::DUMMY_BUILD_INFO;
-    use mz_ore::now::SYSTEM_TIME;
+    use timely::progress::Antichain;
+
     use once_cell::sync::Lazy;
 
+    use mz_build_info::DUMMY_BUILD_INFO;
     use mz_ore::metrics::MetricsRegistry;
+    use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
+    use mz_storage_client::types::sources::SourceData;
 
     // Test suite
     #[tokio::test(start_paused = true)]

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -30,7 +30,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
 use futures::future::Either;
 use itertools::Itertools;
@@ -54,18 +53,18 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::Upper;
-use mz_repr::{GlobalId, Row, Timestamp};
+use mz_repr::{GlobalId, Timestamp};
 use mz_storage_client::controller::{CollectionMetadata, ResumptionFrontierCalculator};
 use mz_storage_client::source::util::async_source;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::SourceError;
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
-use mz_storage_client::types::sources::{AsyncSourceToken, MzOffset, SourceData, SourceToken};
+use mz_storage_client::types::sources::{AsyncSourceToken, MzOffset, SourceToken};
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 use mz_timely_util::operator::StreamExt as _;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
+use crate::healthcheck::write_to_persist;
 use crate::source::antichain::{MutableOffsetAntichain, OffsetAntichain};
 use crate::source::healthcheck;
 use crate::source::healthcheck::{SourceStatus, SourceStatusUpdate};
@@ -902,70 +901,26 @@ where
         move |mut _capabilities, _frontiers, scheduler| async move {
             let mut buffer = Vec::new();
 
-            let mut persist_clients = persist_clients.lock().await;
-            let persist_client = persist_clients
-                .open(storage_metadata.persist_location.clone())
-                .await
-                .expect("error creating persist client for Healthchecker");
-            drop(persist_clients);
+            let status_shard = if let Some(status_shard) = storage_metadata.status_shard {
+                status_shard
+            } else {
+                // If there's no status shard, this operator has no work to do.
+                return
+            };
 
-            let client_ref = &persist_client;
-
-            let write_to_persist = |row: Row, timestamp: Timestamp| async move {
-                let status_shard = match storage_metadata.status_shard {
-                    Some(s) => s,
-                    None => return,
-                };
-                let handle = client_ref
-                    .open_writer(status_shard)
-                    .await;
-
-                let mut handle = match handle {
-                    Ok(stuff) => stuff,
-                    Err(e) => {
-                        panic!("Invalid usage of the persist client for source {source_id} status history shard: {e:?}");
-                    }
-                };
-
-                let mut recent_upper = handle.upper().clone();
-                let mut append_ts = timestamp;
-                'retry_loop: loop {
-                    // We don't actually care so much about the timestamp we append at; it's best-effort.
-                    // Ensure that the append timestamp is not less than the current upper, and the new upper
-                    // is past that timestamp. (Unless we've advanced to the empty antichain, but in
-                    // that case we're already in trouble.)
-                    for t in recent_upper.elements() {
-                        append_ts.join_assign(t);
-                    }
-                    let mut new_upper = Antichain::from_elem(append_ts.step_forward());
-                    new_upper.join_assign(&recent_upper);
-
-                    let updates = vec![
-                        ((SourceData(Ok(row.clone())), ()), append_ts, 1i64)
-                    ];
-                    let cas_result = handle.compare_and_append(updates, recent_upper.clone(), new_upper).await;
-                    match cas_result {
-                        Ok(Ok(Ok(()))) => break 'retry_loop,
-                        Ok(Ok(Err(Upper(upper)))) => {
-                            recent_upper = upper;
-                        }
-                        Ok(Err(e)) => {
-                            panic!("Invalid usage of the persist client for source {source_id} status history shard: {e:?}");
-                        }
-                        Err(e) => {
-                            trace!("compare_and_append in update_status failed: {e}");
-                        }
-                    }
-                }
-
-                handle.expire().await
+            let persist_client = {
+                let mut persist_clients = persist_clients.lock().await;
+                persist_clients
+                    .open(storage_metadata.persist_location.clone())
+                    .await
+                    .expect("error creating persist client for Healthchecker")
             };
 
             if is_active_worker {
                 info!("Health for source {source_id} initialized to: {last_reported_status:?}");
                 let now_ms = now();
                 let row = healthcheck::pack_status_row(source_id, last_reported_status.name(), last_reported_status.error(), now_ms);
-                write_to_persist(row, Timestamp::from(now_ms)).await;
+                write_to_persist(row, Timestamp::from(now_ms), &persist_client, status_shard, source_id).await;
             }
 
             while scheduler.notified().await {
@@ -988,7 +943,7 @@ where
                     info!("Health transition for source {source_id}: {last_reported_status:?} -> {new_status:?}");
                     let now_ms = now();
                     let row = healthcheck::pack_status_row(source_id, new_status.name(), new_status.error(), now_ms);
-                    write_to_persist(row, Timestamp::from(now_ms)).await;
+                    write_to_persist(row, Timestamp::from(now_ms), &persist_client, status_shard, source_id).await;
 
                     last_reported_status = new_status.clone();
                 }


### PR DESCRIPTION
Use the same loop for both healthcheckers.  I believe they should stay embedded differently (sources as a timely operator but sinks remaining integrated into the sink itself) so I haven't completely aligned the implementations -- but I think this is a good way to ensure the core of the implementations stay aligned

### Motivation

Refactor

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - none