### PR TITLE
coord: Protect timestamp from crash loop

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1119,7 +1119,7 @@ pub async fn serve<S: Append + 'static>(
                         );
                         error!(
                             "Coordinator tried to start with initial timestamp of \
-                            {initial_timestamp}, which is more than\
+                            {initial_timestamp}, which is more than \
                             {TIMESTAMP_INTERVAL_UPPER_BOUND} intervals of size {} larger than \
                             now, {now_ts}. Sleeping for {remaining_ms} ms.",
                             *TIMESTAMP_PERSIST_INTERVAL

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -83,7 +83,7 @@ use rand::seq::SliceRandom;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
-use tracing::{info, span, warn, Level};
+use tracing::{error, info, span, warn, Level};
 use uuid::Uuid;
 
 use mz_build_info::BuildInfo;
@@ -125,7 +125,9 @@ use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::metrics::Metrics;
 use crate::coord::peek::PendingPeek;
 use crate::coord::read_policy::ReadCapability;
-use crate::coord::timeline::{TimelineState, WriteTimestamp};
+use crate::coord::timeline::{
+    TimelineState, WriteTimestamp, TIMESTAMP_INTERVAL_UPPER_BOUND, TIMESTAMP_PERSIST_INTERVAL,
+};
 use crate::error::AdapterError;
 use crate::session::{EndTransactionAction, Session};
 use crate::subscribe::PendingSubscribe;
@@ -1103,7 +1105,29 @@ pub async fn serve<S: Append + 'static>(
             let mut timestamp_oracles = BTreeMap::new();
             for (timeline, mut initial_timestamp) in initial_timestamps {
                 if timeline == Timeline::EpochMilliseconds {
-                    initial_timestamp = std::cmp::max(initial_timestamp, (now)().into());
+                    let mut now_ts = now();
+                    initial_timestamp = std::cmp::max(initial_timestamp, now_ts.into());
+                    let mut upper_bound = timeline::upper_bound(&Timestamp::from(now_ts));
+                    while initial_timestamp > upper_bound {
+                        // Cap retry time to 1s. In cases where the system clock has retreated by
+                        // some large amount of time, this prevents against then waiting for that
+                        // large amount of time in case the system clock then advances back to near
+                        // what it was.
+                        let remaining_ms = std::cmp::min(
+                            initial_timestamp.saturating_sub(upper_bound),
+                            1_000.into(),
+                        );
+                        error!(
+                            "Coordinator tried to start with initial timestamp of \
+                            {initial_timestamp}, which is more than\
+                            {TIMESTAMP_INTERVAL_UPPER_BOUND} intervals of size {} larger than \
+                            now, {now_ts}. Sleeping for {remaining_ms} ms.",
+                            *TIMESTAMP_PERSIST_INTERVAL
+                        );
+                        std::thread::sleep(Duration::from_millis(remaining_ms.into()));
+                        now_ts = now();
+                        upper_bound = timeline::upper_bound(&Timestamp::from(now_ts));
+                    }
                 }
                 handle.block_on(Coordinator::<S>::ensure_timeline_state_with_initial_time(
                     &timeline,

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -149,6 +149,12 @@ impl Timestamp {
         }
     }
 
+    pub fn saturating_mul<I: Into<Self>>(self, rhs: I) -> Self {
+        Self {
+            internal: self.internal.saturating_mul(rhs.into().internal),
+        }
+    }
+
     pub fn checked_add<I: Into<Self>>(self, rhs: I) -> Option<Self> {
         self.internal
             .checked_add(rhs.into().internal)


### PR DESCRIPTION
Whenever a new Coordinator starts it resserves a new timestamp range in
the stash, larger than any previous timestamp range. This usually
results in the Coordinator resrving a range ahead of the system clock's
current time, because the range with the current time is owned by the
previous Coordinator. This will usually correct itself fairly quickly
because the Coordinator can advance it's timestamp much slower than
real time. However, if the Coordinator enters a crash loop, then the
the persisted timestamp can start to significantly exceed the system
clock as each new Coordinator reserves an even greater timestamp range.

This commit prevents a new Coordinator from starting with a timestamp
larger than a certain amount ahead of the system clock. Instead the
Coordinator sleeps and waits for the system clock to catch up. The
range was selected so that startup is not affected in the common case,
but in a crash loop or other error scenario no permanent damage is done
to the persisted timestamp.

Additionally, while running if the timestamp exceeds the system clock
by that same amount, we print an error.

Fixes #16007
Works towards resolving #14899

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
