### PR TITLE
Adapter: add notice for invalid database or cluster name in SET command

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -77,7 +77,7 @@ use crate::coord::{
 use crate::error::AdapterError;
 use crate::explain_new::optimizer_trace::OptimizerTrace;
 use crate::notice::AdapterNotice;
-use crate::session::vars::IsolationLevel;
+use crate::session::vars::{IsolationLevel, CLUSTER_VAR_NAME, DATABASE_VAR_NAME};
 use crate::session::{
     EndTransactionAction, PreparedStatement, Session, TransactionOps, TransactionStatus, Var,
     WriteOp,
@@ -1894,11 +1894,39 @@ impl<S: Append + 'static> Coordinator<S> {
 
         let vars = session.vars_mut();
         let (name, local) = (plan.name, plan.local);
-        match plan.value {
-            SetVariableValue::Default => vars.reset(&name, local)?,
-            SetVariableValue::Literal(Value::String(s)) => vars.set(&name, &s, local)?, // pass-through unquoted strings
-            SetVariableValue::Ident(ident) => vars.set(&name, &ident.into_string(), local)?, // pass-through unquoted idents
-            value => vars.set(&name, &value.to_string(), local)?, // or else use the AstDisplay for SetVariableValue
+        let value = match plan.value {
+            SetVariableValue::Default => None,
+            SetVariableValue::Literal(Value::String(s)) => Some(s), // unquoted strings
+            SetVariableValue::Ident(ident) => Some(ident.into_string()), // pass-through unquoted idents
+            value => Some(value.to_string()), // or else use the AstDisplay for SetVariableValue
+        };
+
+        match &value {
+            Some(v) => {
+                vars.set(&name, v, local)?;
+
+                // Add notice if database or cluster value does not correspond to a catalog item.
+                if name.as_str() == DATABASE_VAR_NAME
+                    && matches!(
+                        self.catalog.resolve_database(v),
+                        Err(CatalogError::UnknownDatabase(_))
+                    )
+                {
+                    session.add_notice(AdapterNotice::DatabaseDoesNotExist {
+                        name: v.to_string(),
+                    });
+                } else if name.as_str() == CLUSTER_VAR_NAME
+                    && matches!(
+                        self.catalog.resolve_compute_instance(v),
+                        Err(CatalogError::UnknownComputeInstance(_))
+                    )
+                {
+                    session.add_notice(AdapterNotice::ClusterDoesNotExist {
+                        name: v.to_string(),
+                    });
+                }
+            }
+            None => vars.reset(&name, local)?,
         }
 
         Ok(ExecuteResponse::SetVariable { name, reset: false })

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -32,6 +32,12 @@ pub enum AdapterNotice {
         name: String,
         ty: &'static str,
     },
+    DatabaseDoesNotExist {
+        name: String,
+    },
+    ClusterDoesNotExist {
+        name: String,
+    },
     ExistingTransactionInProgress,
     ExplicitTransactionControlInImplicitTransaction,
     UserRequested {
@@ -52,7 +58,11 @@ impl AdapterNotice {
 
     /// Reports a hint for the user about how the notice could be addressed.
     pub fn hint(&self) -> Option<String> {
-        None
+        match self {
+            AdapterNotice::DatabaseDoesNotExist { name: _ } => Some("Create the database with CREATE DATABASE or pick an extant database with SET DATABASE = name. List available databases with SHOW DATABASES.".into()),
+            AdapterNotice::ClusterDoesNotExist { name: _ } => Some("Create the cluster with CREATE CLUSTER or pick an extant cluster with SET CLUSTER = name. List available clusters with SHOW CLUSTERS.".into()),
+            _ => None
+        }
     }
 }
 
@@ -70,6 +80,12 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::ObjectAlreadyExists { name, ty } => {
                 write!(f, "{} {} already exists, skipping", ty, name.quoted())
+            }
+            AdapterNotice::DatabaseDoesNotExist { name } => {
+                write!(f, "database {} does not exist", name.quoted())
+            }
+            AdapterNotice::ClusterDoesNotExist { name } => {
+                write!(f, "cluster {} does not exist", name.quoted())
             }
             AdapterNotice::ExistingTransactionInProgress => {
                 write!(f, "there is already a transaction in progress")

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -59,9 +59,10 @@ const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
     value: &ClientSeverity::Notice,
     description: "Sets the message levels that are sent to the client (PostgreSQL).",
 };
+pub const CLUSTER_VAR_NAME: &UncasedStr = UncasedStr::new("cluster");
 
 const CLUSTER: ServerVar<str> = ServerVar {
-    name: UncasedStr::new("cluster"),
+    name: CLUSTER_VAR_NAME,
     value: "default",
     description: "Sets the current cluster (Materialize).",
 };
@@ -72,8 +73,10 @@ const CLUSTER_REPLICA: ServerVar<Option<String>> = ServerVar {
     description: "Sets a target cluster replica for SELECT queries (Materialize).",
 };
 
+pub const DATABASE_VAR_NAME: &UncasedStr = UncasedStr::new("database");
+
 const DATABASE: ServerVar<str> = ServerVar {
-    name: UncasedStr::new("database"),
+    name: DATABASE_VAR_NAME,
     value: DEFAULT_DATABASE_NAME,
     description: "Sets the current database (CockroachDB).",
 };

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -418,6 +418,8 @@ impl ErrorResponse {
             AdapterNotice::SchemaAlreadyExists { .. } => SqlState::DUPLICATE_SCHEMA,
             AdapterNotice::TableAlreadyExists { .. } => SqlState::DUPLICATE_TABLE,
             AdapterNotice::ObjectAlreadyExists { .. } => SqlState::DUPLICATE_OBJECT,
+            AdapterNotice::DatabaseDoesNotExist { .. } => SqlState::WARNING,
+            AdapterNotice::ClusterDoesNotExist { .. } => SqlState::WARNING,
             AdapterNotice::ExistingTransactionInProgress => SqlState::ACTIVE_SQL_TRANSACTION,
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => {
                 SqlState::NO_ACTIVE_SQL_TRANSACTION
@@ -561,6 +563,8 @@ impl Severity {
             AdapterNotice::SchemaAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::TableAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::ObjectAlreadyExists { .. } => Severity::Notice,
+            AdapterNotice::DatabaseDoesNotExist { .. } => Severity::Notice,
+            AdapterNotice::ClusterDoesNotExist { .. } => Severity::Notice,
             AdapterNotice::ExistingTransactionInProgress => Severity::Warning,
             AdapterNotice::ExplicitTransactionControlInImplicitTransaction => Severity::Warning,
             AdapterNotice::UserRequested { severity } => match severity {

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -1,0 +1,103 @@
+# Test various NOTICE expectations.
+
+# Test setting session variables to nonexistant values
+# Scenarios tested: nonexistant values, exstant values, capitalized variables
+# double quotes, single quotes, default values
+send
+Query {"query": "set database = nonexistant"}
+Query {"query": "show database"}
+Query {"query": "set database = materialize"}
+Query {"query": "show database"}
+Query {"query": "set DATABASE = NONexistant2"}
+Query {"query": "set database = \"nonexistant3\""}
+Query {"query": "set database = \"materialize\""}
+Query {"query": "show database"}
+Query {"query": "set database = 'materialize'"}
+Query {"query": "show database"}
+Query {"query": "set database = default"}
+Query {"query": "show database"}
+Query {"query": "set cluster = nonexistant"}
+Query {"query": "show cluster"}
+Query {"query": "set CLUSTER = NONexistant2"}
+Query {"query": "show cluster"}
+Query {"query": "set cluster = \"default\""}
+Query {"query": "show cluster"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"database \"nonexistant\" does not exist"}]}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["nonexistant"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["materialize"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"database \"nonexistant2\" does not exist"}]}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"database \"nonexistant3\" does not exist"}]}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["materialize"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["materialize"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["materialize"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant\" does not exist"}]}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"cluster"}]}
+DataRow {"fields":["nonexistant"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"cluster \"nonexistant2\" does not exist"}]}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"cluster"}]}
+DataRow {"fields":["nonexistant2"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+RowDescription {"fields":[{"name":"cluster"}]}
+DataRow {"fields":["default"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Resolves one part of #12926. If a user types an invalid database or cluster name into `SET DATABASE` or `SET CLUSTER`, we should still allow them to set the value but provide a notice.

Remaining work for a separate PR: add this notice on `DROP` commands too.

### Tips for reviewer
* The hint message for clusters says "List available clusters with SHOW CLUSTERS.", but if you've already run `SET CLUSTER =  invalid_name`, you'll get the error `unknown cluster invalid_name` if you try to run `SHOW CLUSTERS`, since we already set the session variable to the invalid name. Should we remove that from the hint? Will any other query work or are you stuck if you don't know the name of any existing clusters?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
