### PR TITLE
doc/user: polish v0.32 release notes

### DIFF
--- a/doc/user/content/releases/v0.31.md
+++ b/doc/user/content/releases/v0.31.md
@@ -23,6 +23,6 @@ released: true
   ```
 
 * Fix a bug where subsources were counted towards resource limits for existing
-  sources {{% gh 15958 %}}. This resulted in an error for users of the Postgres
+  sources {{% gh 15958 %}}. This resulted in an error for users of the PostgreSQL
   source if the number of replicated tables exceeded the default value for
   `max_sources` (25).

--- a/doc/user/content/releases/v0.32.md
+++ b/doc/user/content/releases/v0.32.md
@@ -25,7 +25,7 @@ This version of Materialize is not yet released.
   Any columns specified via this option will be treated as `text` in
   Materialize regardless of the original PostgreSQL type. Examples of
   unsupported types that can now be ingested are `enum`,
-  arbitrary precision `numeric`, `money`, and `hstore`.
+  arbitrary precision `numeric`, `money`, and `citext`.
 
 * Improve error message for unexpected or mismatched type catalog errors,
   specifying the catalog item type:

--- a/doc/user/content/releases/v0.32.md
+++ b/doc/user/content/releases/v0.32.md
@@ -19,7 +19,8 @@ This version of Materialize is not yet released.
 	FROM POSTGRES CONNECTION pg_connection (
 	  PUBLICATION 'mz_source',
 	  TEXT COLUMNS (tbl.col_of_unsupported_type)
-	) FOR ALL TABLES;
+	) FOR ALL TABLES
+  WITH (SIZE = '3xsmall');
   ```
 
   Any columns specified via this option will be treated as `text` in

--- a/doc/user/content/releases/v0.32.md
+++ b/doc/user/content/releases/v0.32.md
@@ -1,7 +1,7 @@
 ---
 title: "Materialize v0.32"
 date: 2022-11-16
-released: false
+released: true
 ---
 
 {{< warning >}}
@@ -10,4 +10,36 @@ This version of Materialize is not yet released.
 
 ## Changes
 
-* No documented changes yet.
+* Add support for replicating tables that contain unsupported types in the
+  [PostgreSQL source](/sql/create-source/postgres/), using the new `TEXT
+  COLUMNS` option:
+
+  ```sql
+  CREATE SOURCE mz_source
+	FROM POSTGRES CONNECTION pg_connection (
+	  PUBLICATION 'mz_source',
+	  TEXT COLUMNS (tbl.col_of_unsupported_type)
+	) FOR ALL TABLES;
+  ```
+
+  Any columns specified via this option will be treated as `text` in
+  Materialize regardless of the original PostgreSQL type. Examples of
+  unsupported types that can now be ingested are `enum`,
+  arbitrary precision `numeric`, `money`, and `hstore`.
+
+* Improve error message for unexpected or mismatched type catalog errors,
+  specifying the catalog item type:
+
+  ```sql
+  DROP VIEW mz_table;
+
+  ERROR:  "materialize.public.mz_table" is a table not a view
+  ```
+
+* Fix a bug in the [`#>>` `jsonb` operator](/sql/types/jsonb/#operators) that
+  caused an error when specifying an array index that does not exist, instead
+  of returning `NULL` {{% gh 15978 %}}.
+
+* Fix a bug where relations in `pg_catalog` and `information_schema` would
+  contain information about all databases, rather than just the current
+  database {{% gh 15841 %}}.

--- a/doc/user/content/releases/v0.33.md
+++ b/doc/user/content/releases/v0.33.md
@@ -1,0 +1,13 @@
+---
+title: "Materialize v0.33"
+date: 2022-11-30
+released: false
+---
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}
+
+## Changes
+
+* No documented changes yet.


### PR DESCRIPTION
Release notes for v0.32.0. 🚢 

The new `TEXT COLUMNS` option in the PostgreSQL source is undocumented. I will address #16085 ahead of the release rollout tomorrow (after confirming with @sploiselle whether he has these changes locally).