### PR TITLE
adapter: EXPLAIN TIMESTAMP improvements

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -24,7 +24,6 @@ use mz_compute_client::command::{BuildDesc, DataflowDesc, IndexDesc, ReplicaId};
 use mz_compute_client::controller::{
     ComputeInstanceId, ComputeReplicaConfig, ComputeReplicaLogging,
 };
-use mz_compute_client::explain::{TimestampExplanation, TimestampSource};
 use mz_compute_client::sinks::{
     ComputeSinkConnection, ComputeSinkDesc, SinkAsOf, SubscribeSinkConnection,
 };
@@ -85,6 +84,8 @@ use crate::session::{
 use crate::subscribe::PendingSubscribe;
 use crate::util::{send_immediate_rows, ClientTransmitter, ComputeSinkId};
 use crate::{guard_write_critical_section, session, PeekResponseUnary};
+
+use super::timestamp_selection::{TimestampExplanation, TimestampSource};
 
 impl<S: Append + 'static> Coordinator<S> {
     #[tracing::instrument(level = "debug", skip_all)]
@@ -2103,13 +2104,15 @@ impl<S: Append + 'static> Coordinator<S> {
                         compute_instance,
                         &timeline,
                     )?;
-                    let read_holds = self.acquire_read_holds(timestamp, id_bundle).await;
+                    let read_holds = self
+                        .acquire_read_holds(timestamp.timestamp, id_bundle)
+                        .await;
                     let txn_reads = TxnReads {
                         timestamp_independent,
                         read_holds,
                     };
                     self.txn_reads.insert(conn_id, txn_reads);
-                    timestamp
+                    timestamp.timestamp
                 }
             };
 
@@ -2162,6 +2165,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .index_oracle(compute_instance)
                 .sufficient_collections(&source_ids);
             self.determine_timestamp(session, &id_bundle, &when, compute_instance, &timeline)?
+                .timestamp
         };
 
         // before we have the corrected timestamp ^
@@ -2300,13 +2304,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 .sufficient_collections(uses);
             let timeline = coord.validate_timeline(id_bundle.iter())?;
             // If a timestamp was explicitly requested, use that.
-            let timestamp = coord.determine_timestamp(
-                session,
-                &id_bundle,
-                &when,
-                compute_instance_id,
-                &timeline,
-            )?;
+            let timestamp = coord
+                .determine_timestamp(session, &id_bundle, &when, compute_instance_id, &timeline)?
+                .timestamp;
 
             Ok::<_, AdapterError>(ComputeSinkDesc {
                 from,
@@ -2593,21 +2593,16 @@ impl<S: Append + 'static> Coordinator<S> {
         let id_bundle = self
             .index_oracle(compute_instance)
             .sufficient_collections(&source_ids);
-        // TODO: determine_timestamp takes a mut self to track linearizability,
-        // so explaining a plan involving tables has side effects. Removing those side
-        // effects would be good.
-        // TODO(jkosh44): Would be a nice addition to include the timeline in output.
-        let timestamp = self.determine_timestamp(
+        // TODO: determine_timestamp takes a mut self to modify the oracle
+        // timestamp, so explaining a plan involving tables has side effects.
+        // Removing those side effects would be good.
+        let determination = self.determine_timestamp(
             session,
             &id_bundle,
             &QueryWhen::Immediately,
             compute_instance,
             &timeline,
         )?;
-        let since = self.least_valid_read(&id_bundle).elements().to_vec();
-        let upper = self.least_valid_write(&id_bundle);
-        let respond_immediately = !upper.less_equal(&timestamp);
-        let upper = upper.elements().to_vec();
         let mut sources = Vec::new();
         {
             for id in id_bundle.storage_ids.iter() {
@@ -2656,11 +2651,7 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
         let explanation = TimestampExplanation {
-            timestamp,
-            since,
-            upper,
-            global_timestamp: self.get_local_read_ts(),
-            respond_immediately,
+            determination,
             sources,
             timeline,
         };

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -711,7 +711,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // advance of any object's upper. This is the largest timestamp that is closed
                 // to writes.
                 let id_bundle = self.ids_in_timeline(&timeline);
-                self.largest_not_in_advance_of_upper(&id_bundle)
+                self.largest_not_in_advance_of_upper(&self.least_valid_write(&id_bundle))
             };
             oracle
                 .apply_write(now, |ts| self.catalog.persist_timestamp(&timeline, ts))

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -29,7 +29,6 @@
 
 use std::fmt;
 
-use chrono::NaiveDateTime;
 use mz_expr::explain::{Indices, ViewExplanation};
 use mz_expr::MapFilterProject;
 use mz_expr::{OptimizedMirRelationExpr, RowSetFinishing};
@@ -37,7 +36,6 @@ use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
 use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::GlobalId;
-use mz_storage_client::types::sources::Timeline;
 
 use crate::command::DataflowDescription;
 
@@ -230,133 +228,5 @@ impl<'a> ViewFormatter<OptimizedMirRelationExpr> for DataflowGraphFormatter<'a> 
             explain.explain_types();
         }
         fmt::Display::fmt(&explain, f)
-    }
-}
-
-/// Information used when determining the timestamp for a query.
-pub struct TimestampExplanation<T> {
-    /// The chosen timestamp from `determine_timestamp`.
-    pub timestamp: T,
-    /// The timeline that the timestamp corresponds to.
-    pub timeline: Option<Timeline>,
-    /// The read frontier of all involved sources.
-    pub since: Vec<T>,
-    /// The write frontier of all involved sources.
-    pub upper: Vec<T>,
-    /// Whether the query can responded immediately or if it has to block.
-    pub respond_immediately: bool,
-    /// The current value of the global timestamp.
-    pub global_timestamp: T,
-    /// Details about each source.
-    pub sources: Vec<TimestampSource<T>>,
-}
-
-pub struct TimestampSource<T> {
-    pub name: String,
-    pub read_frontier: Vec<T>,
-    pub write_frontier: Vec<T>,
-}
-
-pub trait DisplayableInTimeline {
-    fn fmt(&self, timeline: Option<&Timeline>, f: &mut fmt::Formatter) -> fmt::Result;
-    fn display<'a>(&'a self, timeline: Option<&'a Timeline>) -> DisplayInTimeline<'a, Self> {
-        DisplayInTimeline { t: self, timeline }
-    }
-}
-
-impl DisplayableInTimeline for mz_repr::Timestamp {
-    fn fmt(&self, timeline: Option<&Timeline>, f: &mut fmt::Formatter) -> fmt::Result {
-        match timeline {
-            Some(Timeline::EpochMilliseconds) => {
-                let ts_ms: u64 = self.into();
-                let ts = ts_ms / 1000;
-                let nanos = ((ts_ms % 1000) as u32) * 1000000;
-                let ndt = NaiveDateTime::from_timestamp(ts as i64, nanos);
-                write!(f, "{:13} ({})", self, ndt.format("%Y-%m-%d %H:%M:%S%.3f"))
-            }
-            None | Some(_) => {
-                write!(f, "{:13}", self)
-            }
-        }
-    }
-}
-
-pub struct DisplayInTimeline<'a, T: ?Sized> {
-    t: &'a T,
-    timeline: Option<&'a Timeline>,
-}
-impl<'a, T> fmt::Display for DisplayInTimeline<'a, T>
-where
-    T: DisplayableInTimeline,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.t.fmt(self.timeline, f)
-    }
-}
-
-impl<'a, T> fmt::Debug for DisplayInTimeline<'a, T>
-where
-    T: DisplayableInTimeline,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
-
-impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
-    for TimestampExplanation<T>
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let timeline = self.timeline.as_ref();
-        writeln!(
-            f,
-            "          query timestamp: {}",
-            self.timestamp.display(timeline)
-        )?;
-        writeln!(
-            f,
-            "                    since:{:?}",
-            self.since
-                .iter()
-                .map(|t| t.display(timeline))
-                .collect::<Vec<_>>()
-        )?;
-        writeln!(
-            f,
-            "                    upper:{:?}",
-            self.upper
-                .iter()
-                .map(|t| t.display(timeline))
-                .collect::<Vec<_>>()
-        )?;
-        writeln!(
-            f,
-            "         global timestamp: {}",
-            self.global_timestamp.display(timeline)
-        )?;
-        writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
-        for source in &self.sources {
-            writeln!(f, "")?;
-            writeln!(f, "source {}:", source.name)?;
-            writeln!(
-                f,
-                "            read frontier:{:?}",
-                source
-                    .read_frontier
-                    .iter()
-                    .map(|t| t.display(timeline))
-                    .collect::<Vec<_>>()
-            )?;
-            writeln!(
-                f,
-                "           write frontier:{:?}",
-                source
-                    .write_frontier
-                    .iter()
-                    .map(|t| t.display(timeline))
-                    .collect::<Vec<_>>()
-            )?;
-        }
-        Ok(())
     }
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1027,41 +1027,39 @@ fn test_temporary_views() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-// Test EXPLAIN TIMESTAMP with tables. Mock time to verify initial table since
-// is now(), not 0.
+// Test EXPLAIN TIMESTAMP with tables.
 #[test]
 fn test_explain_timestamp_table() -> Result<(), Box<dyn Error>> {
     mz_ore::test::init_logging();
-    let timestamp = Arc::new(Mutex::new(1_000));
-    let now = {
-        let timestamp = Arc::clone(&timestamp);
-        NowFn::from(move || *timestamp.lock().unwrap())
-    };
-    let config = util::Config::default().with_now(now);
+    let config = util::Config::default();
     let server = util::start_server(config)?;
     let mut client = server.connect(postgres::NoTls)?;
-    let timestamp_re = Regex::new(r"\s*(\d{4}|0) \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)").unwrap();
+    let timestamp_re = Regex::new(r"\s*(\d+) \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)").unwrap();
     let bool_re = Regex::new(r"true|false").unwrap();
 
     client.batch_execute("CREATE TABLE t1 (i1 INT)")?;
 
-    let expect = "          query timestamp:<TIMESTAMP>
-                    since:[<TIMESTAMP>]
-                    upper:[<TIMESTAMP>]
-         global timestamp:<TIMESTAMP>
-  can respond immediately: <BOOL>
+    let expect = "                query timestamp:<TIMESTAMP>
+          oracle read timestamp:<TIMESTAMP>
+largest not in advance of upper:<TIMESTAMP>
+                          upper:[<TIMESTAMP>]
+                          since:[<TIMESTAMP>]
+        can respond immediately: <BOOL>
+                       timeline: Some(EpochMilliseconds)
 
 source materialize.public.t1 (u1, storage):
-            read frontier:[<TIMESTAMP>]
-           write frontier:[<TIMESTAMP>]\n";
+                  read frontier:[<TIMESTAMP>]
+                 write frontier:[<TIMESTAMP>]\n";
 
     let row = client
         .query_one("EXPLAIN TIMESTAMP FOR SELECT * FROM t1;", &[])
         .unwrap();
     let explain: String = row.get(0);
     let explain = timestamp_re.replace_all(&explain, "<TIMESTAMP>");
+    // TODO: annoyingly "can respond immediately" does seem to change if you,
+    // say, inject a sleep. Is it supposed to be deterministic? See #16115.
     let explain = bool_re.replace_all(&explain, "<BOOL>");
-    assert_eq!(explain, expect);
+    assert_eq!(explain, expect, "{explain}\n\n{expect}");
 
     Ok(())
 }
@@ -1651,9 +1649,7 @@ fn get_explain_timestamp(table: &str, client: &mut postgres::Client) -> EpochMil
         .query_one(&format!("EXPLAIN TIMESTAMP FOR SELECT * FROM {table}"), &[])
         .unwrap();
     let explain: String = row.get(0);
-    let timestamp_re =
-        Regex::new(r"^\s+query timestamp:\s+(\d+) \(\d+-\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d\)\n")
-            .unwrap();
+    let timestamp_re = Regex::new(r"^\s+query timestamp:\s*(\d+)").unwrap();
     let timestamp_caps = timestamp_re.captures(&explain).unwrap();
     timestamp_caps.get(1).unwrap().as_str().parse().unwrap()
 }

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -98,9 +98,9 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=(\d{13}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[]\n"
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <>\n                          upper:[]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.static_csv (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -16,9 +16,9 @@ $ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true
 # Strict serializable doesn't look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'STRICT SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.t1 (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
 
 # Serializable also doesn't look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
+"                query timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.t1 (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"

--- a/test/testdrive/testscript_source.td
+++ b/test/testdrive/testscript_source.td
@@ -11,7 +11,7 @@
 # Basic test for `TEST SCRIPT` sources.
 
 # replace timestamps
-$ set-regex match=(\d{13}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 
 
 > CREATE CONNECTION c_conn
@@ -35,7 +35,7 @@ fish          value2
 fish2         hmm
 
 > EXPLAIN TIMESTAMP FOR SELECT * FROM unit
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.unit (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[<> <>]\n"
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <> <>\n                          upper:[<> <>]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.unit (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[<> <>]\n"
 
 > CREATE SOURCE unit_terminated
   FROM TEST SCRIPT
@@ -54,4 +54,4 @@ fish          value
 
 # Terminal sources have empty uppers
 > EXPLAIN TIMESTAMP FOR SELECT * FROM unit_terminated
-"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.unit_terminated (<>, storage):\n            read frontier:[<> <>]\n           write frontier:[]\n"
+"                query timestamp: <> <>\n          oracle read timestamp: <> <>\nlargest not in advance of upper: <>\n                          upper:[]\n                          since:[<> <>]\n        can respond immediately: <>\n                       timeline: Some(EpochMilliseconds)\n\nsource materialize.public.unit_terminated (<>, storage):\n                  read frontier:[<> <>]\n                 write frontier:[]\n"


### PR DESCRIPTION
Add timeline and largest_not_in_advance_of_upper. Use `determine_timestamp()` more directly in EXPLAIN so we don't calculate things incorrectly. Move explain structs out of compute and into timestamp_selection. They were only there for historical reasons (that's where all the other explain code is). But since determine_timestamp now outputs a struct, the compute code would have had to import it, causing an import cycle.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a