### PR TITLE
dbt-materialize: fix custom seed materialization, re-enable tests

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
@@ -35,17 +35,18 @@
 
   {% set sql %}
     -- {{ bindings | length }}
-    create materialized view {{ this.render() }} AS (
-      select {{ cols_sql }} from (VALUES
-      {% for chunk in agate_table.rows | batch(1)  -%}
-        ({%- for column in agate_table.column_names -%}
-            %s
-            {%- if not loop.last%},{%- endif %}
-        {%- endfor -%})
-        {%- if not loop.last%},{%- endif %}
-      {%- endfor %}
-      ) AS tbl
-    )
+    create materialized view {{ this.render() }}
+      in cluster {{ target.cluster }} AS (
+        select {{ cols_sql }} from (VALUES
+        {% for chunk in agate_table.rows | batch(1)  -%}
+          ({%- for column in agate_table.column_names -%}
+              %s
+              {%- if not loop.last%},{%- endif %}
+          {%- endfor -%})
+          {%- if not loop.last%},{%- endif %}
+        {%- endfor %}
+        ) AS tbl
+      )
   {% endset %}
 
   {% do adapter.add_query(sql, bindings=bindings, abridge_sql_log=True, auto_begin=False) %}

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -39,7 +39,6 @@ class TestCase:
     name: str
     dbt_env: Dict[str, str]
     materialized_options: List[str]
-    profile: str
     materialized_image: Optional[str] = None
 
 
@@ -48,13 +47,11 @@ test_cases = [
         name="no-tls-cloud",
         materialized_options=[],
         dbt_env={},
-        profile="materialize_cloud",
     ),
 ]
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    """Runs the dbt adapter test suite against Materialize in various configurations."""
     parser.add_argument(
         "filter", nargs="?", default="", help="limit to test cases matching filter"
     )
@@ -80,8 +77,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                         "dbt-test",
                         "pytest",
                         "dbt-materialize/tests",
-                        "--profile",
-                        test_case.profile,
                         env_extra={
                             "DBT_HOST": "materialized",
                             "KAFKA_ADDR": "redpanda:9092",

--- a/misc/dbt-materialize/tests/adapter/test_basic.py
+++ b/misc/dbt-materialize/tests/adapter/test_basic.py
@@ -48,12 +48,7 @@ from dbt.tests.util import (
 from fixtures import expected_base_relation_types
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestSimpleMaterializationsMaterialize(BaseSimpleMaterializations):
-    @pytest.fixture(autouse=True)
-    def _pass_profile_value(self, profile):
-        self._profile = profile
-
     # Custom base test that removes the incremental portion and overrides the expected relations
 
     def test_base(self, project):
@@ -68,10 +63,15 @@ class TestSimpleMaterializationsMaterialize(BaseSimpleMaterializations):
         # run result length
         assert len(results) == 3
 
-        expected = expected_base_relation_types[self._profile]
-
         # names exist in result nodes
         check_result_nodes_by_name(results, ["view_model", "table_model", "swappable"])
+
+        expected = {
+            "base": "materializedview",
+            "view_model": "view",
+            "table_model": "materializedview",
+            "swappable": "materializedview",
+        }
 
         check_relation_types(project.adapter, expected)
 
@@ -103,22 +103,18 @@ class TestSimpleMaterializationsMaterialize(BaseSimpleMaterializations):
         check_relation_types(project.adapter, expected)
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestSingularTestsMaterialize(BaseSingularTests):
     pass
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestSingularTestsEphemeralMaterialize(BaseSingularTestsEphemeral):
     pass
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestEmptyMaterialize(BaseEmpty):
     pass
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestEphemeral(BaseEphemeral):
     pass
 
@@ -128,7 +124,6 @@ class TestIncrementalMaterialize(BaseIncremental):
     pass
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestGenericTestsMaterialize(BaseGenericTests):
     pass
 
@@ -168,12 +163,6 @@ class TestBaseIncrementalNotSchemaChangeMaterialize(BaseIncrementalNotSchemaChan
     pass
 
 
-# We skip doc tests for binary versions of Materialize because the `materialize__get_catalog`
-# macro that is used to generate the docs must stay consistent with the latest Materialize release.
-# The `type` of a materialized view in changed to kebab-case in v0.29.
-# Users running earlier versions of Materialize will see seeds referenced as 'view'
-# types instead of 'materializedview' types in the generated docs.
-@pytest.mark.skip(reason="temporarily disable")
 class TestDocsGenerateMaterialize(BaseDocsGenerate):
     @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):
@@ -189,7 +178,6 @@ class TestDocsGenerateMaterialize(BaseDocsGenerate):
         )
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestDocsGenReferencesMaterialize(BaseDocsGenReferences):
     @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):

--- a/misc/dbt-materialize/tests/adapter/test_clusters.py
+++ b/misc/dbt-materialize/tests/adapter/test_clusters.py
@@ -77,7 +77,6 @@ join mz_clusters c on v.cluster_id = c.id and v.name = 'override_cluster'
 """
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestModelCluster:
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -109,7 +108,6 @@ class TestModelCluster:
         run_dbt(["run", "--models", "invalid_cluster"], expect_pass=False)
 
 
-@pytest.mark.skip(reason="temporarily disable")
 class TestProjectConfigCluster:
     @pytest.fixture(scope="class")
     def models(self):

--- a/misc/dbt-materialize/tests/adapter/test_utils.py
+++ b/misc/dbt-materialize/tests/adapter/test_utils.py
@@ -1,0 +1,57 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.adapter.utils.base_utils import BaseUtils
+from dbt.tests.adapter.utils.fixture_cast_bool_to_text import (
+    models__test_cast_bool_to_text_yml,
+)
+from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
+
+models__test_cast_bool_to_text_sql = """
+with data_bool as (
+    select 0=1 as input, 'false' as expected
+    UNION ALL
+    select 1=1 as input, 'true' as expected
+),
+data_null as (
+    select null as input, null as expected
+)
+select
+    {{ cast_bool_to_text("input") }} as actual,
+    expected
+from data_bool
+UNION ALL
+select
+    {{ cast_bool_to_text("input") }} as actual,
+    expected
+from data_null
+"""
+
+
+# The `cast_bool_to_text` macro works as expected, but we must alter the test case
+# because set operation type conversions do not work properly.
+# See https://github.com/MaterializeInc/materialize/issues/3331
+class TestCastBoolToText(BaseCastBoolToText):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_cast_bool_to_text.yml": models__test_cast_bool_to_text_yml,
+            "test_cast_bool_to_text.sql": self.interpolate_macro_namespace(
+                models__test_cast_bool_to_text_sql, "cast_bool_to_text"
+            ),
+        }
+
+    pass

--- a/misc/dbt-materialize/tests/conftest.py
+++ b/misc/dbt-materialize/tests/conftest.py
@@ -19,36 +19,10 @@ import pytest
 
 pytest_plugins = ["dbt.tests.fixtures.project"]
 
-
-def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="materialize_cloud", type=str)
-
-
-# Using @pytest.mark.skip_profile('materialize_binary') uses the 'skip_by_profile_type'
-# autouse fixture below
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers",
-        "skip_profile(profile): skip test for the given profile",
-    )
-
-
-@pytest.fixture(scope="session")
-def profile(request):
-    return request.config.getoption("--profile")
-
-
-@pytest.fixture(scope="session")
-def dbt_profile_target(request):
-    profile = request.config.getoption("--profile")
-    if profile == "materialize_cloud":
-        target = materialize_cloud_target()
-    else:
-        raise ValueError(f"Invalid profile type '{profile}'")
-    return target
-
-
-def materialize_cloud_target():
+# The profile dictionary, used to write out profiles.yml
+# dbt will supply a unique schema per test, so we do not specify 'schema' here
+@pytest.fixture(scope="class")
+def dbt_profile_target():
     return {
         "type": "materialize",
         "threads": 1,
@@ -59,12 +33,3 @@ def materialize_cloud_target():
         "cluster": "default",
         "port": "{{ env_var('DBT_PORT', 6875) }}",
     }
-
-
-@pytest.fixture(autouse=True)
-def skip_by_profile_type(request):
-    profile_type = request.config.getoption("--profile")
-    if request.node.get_closest_marker("skip_profile"):
-        for skip_profile_type in request.node.get_closest_marker("skip_profile").args:
-            if skip_profile_type == profile_type:
-                pytest.skip("skipped on '{profile_type}' profile")


### PR DESCRIPTION
The custom seed materialization (which translates to `materializedview` behind the scenes) doesn't pick up the cluster when creating the materialized view. This caused #16079 to break `dbt seed`, and the test suite as a consequence, as dbt attempted to create these materializations in the `mz_introspection` cluster.

```bash
❯ dbt seed
01:50:17  Running with dbt=1.3.0
01:50:17  Found 5 models, 2 tests, 0 snapshots, 0 analyses, 524 macros, 0 operations, 1 seed file, 2 sources, 0 exposures, 0 metrics
01:50:17
01:50:21  Concurrency: 1 threads (target='dev')
01:50:21
01:50:21  1 of 1 START seed file public.test ............................................. [RUN]
01:50:22  1 of 1 ERROR loading seed file public.test ..................................... [ERROR in 1.13s]
01:50:22
01:50:22  Finished running 1 seed in 0 hours 0 minutes and 5.16 seconds (5.16s).
01:50:22
01:50:22  Completed with 1 error and 0 warnings:
01:50:22
01:50:22  Database Error in seed test (seeds/test.csv)
01:50:22    system cluster 'mz_introspection' cannot be modified
01:50:22
01:50:22  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```

The fix was more trivial than expected (also more trivial than disabling all the tests, in hindsight :sigh:), and just required adding an `IN CLUSTER` clause to the custom seed materialization. In the future, we might want to extend the core seed configuration code to make the cluster configurable (see [Seed configurations](https://docs.getdbt.com/reference/seed-configs)), but I'd suggest we wait until there is a real need for this.