### PR TITLE
miscellaneous fixes from #16010

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,7 +3962,6 @@ dependencies = [
  "anyhow",
  "mz-cloud-resources",
  "mz-ore",
- "mz-pgrepr",
  "mz-proto",
  "mz-repr",
  "mz-ssh-util",

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 anyhow = "1.0.65"
 mz-cloud-resources = { path = "../cloud-resources" }
 mz-ore = { path = "../ore", features = ["task"] }
-mz-pgrepr = { path = "../pgrepr" }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -158,7 +158,7 @@ impl PlanError {
             Self::UnrecognizedTypeInPostgresSource {
                 cols: _,
             } => Some(
-                "Use the TEXT COLUMNS option naming the listed columns, and Materialize can ingest their values\
+                "Use the TEXT COLUMNS option naming the listed columns, and Materialize can ingest their values \
                 as text."
                     .into(),
             ),


### PR DESCRIPTION
@philip-stoev kindly alerted me to a few lingering issues remaining from #16010 

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
