### PR TITLE
test: Increase max table limit in all slt tests

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1178,6 +1178,14 @@ pub async fn run_string(
     let mut state = Runner::start(config).await.unwrap();
     let mut parser = crate::parser::Parser::new(source, input);
     writeln!(config.stdout, "==> {}", source);
+    // Some sqllogic tests require more than the default amount of tables, so we increase the
+    // limit for all tests.
+    {
+        let client = state.get_conn(Some("mz_system"), Some("mz_system")).await;
+        client
+            .simple_query("ALTER SYSTEM SET max_tables = 100")
+            .await?;
+    }
     for record in parser.parse_records()? {
         // In maximal-verbosity mode, print the query before attempting to run
         // it. Running the query might panic, so it is important to print out


### PR DESCRIPTION
A test in our sqllogic git submodule,
test/sqllogictest/sqlite/test/select5.test, was failing because it was trying to create more tables than the default max table limit. Since this submodule is a fork and we try not to alter the tests, especially with Materialize specific syntax, we couldn't increase the max table limit in the test itself. Instead this commit increases the max table limit for all sqllogic tests.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
