### PR TITLE
adapter: add determine_timestamp metrics

### DIFF
--- a/src/adapter/src/coord/metrics.rs
+++ b/src/adapter/src/coord/metrics.rs
@@ -18,6 +18,7 @@ pub struct Metrics {
     pub active_sessions: IntGauge,
     pub active_subscribes: IntGauge,
     pub queue_busy_time: HistogramVec,
+    pub determine_timestamp: IntCounterVec,
 }
 
 impl Metrics {
@@ -39,6 +40,11 @@ impl Metrics {
             queue_busy_time: registry.register(metric!(
                 name: "mz_coord_queue_busy_time",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
+            )),
+            determine_timestamp: registry.register(metric!(
+                name: "mz_determine_timestamp",
+                help: "The total number of calls to determine_timestamp.",
+                var_labels:["respond_immediately", "isolation_level", "compute_instance"],
             )),
         }
     }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -1741,7 +1741,7 @@ pub enum IsolationLevel {
 }
 
 impl IsolationLevel {
-    pub(super) fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::ReadUncommitted => "read uncommitted",
             Self::ReadCommitted => "read committed",


### PR DESCRIPTION
This produces metrics like:

```
mz_determine_timestamp{compute_instance_type="system",isolation_level="serializable",respond_immediately="false"} 1
mz_determine_timestamp{compute_instance_type="system",isolation_level="serializable",respond_immediately="true"} 2
mz_determine_timestamp{compute_instance_type="system",isolation_level="strict serializable",respond_immediately="true"} 1
mz_determine_timestamp{compute_instance_type="user",isolation_level="strict serializable",respond_immediately="true"} 4
```

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a