### PR TITLE
persist_source: stop using DropSafeLeaseStream

### DIFF
--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -16,7 +16,6 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use differential_dataflow::Hashable;
-use futures::stream::StreamExt;
 use futures::Stream as FuturesStream;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -30,7 +29,7 @@ use mz_expr::MfpPlan;
 use mz_ore::cast::CastFrom;
 use mz_persist::location::ExternalError;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::fetch::{LeasedBatchPart, SerdeLeasedBatchPart};
+use mz_persist_client::fetch::SerdeLeasedBatchPart;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 
@@ -80,87 +79,6 @@ where
         Err(err) => Err((err, t, r)),
     });
     (ok_stream, err_stream, token)
-}
-
-/// The stream of batches from persist cannot be dropped at the discretion of
-/// the program unaided without potentially panicking (check `LeasedBatchPart`).
-/// To prevent panics, ensure that all of the stream's values are consumed,
-/// irrespective of the source getting dropped.
-struct DropSafeLeaseStream {
-    // `pin` is an `Option` only so we can move it into a task on drop.
-    pinned_stream: Option<
-        std::pin::Pin<
-            Box<
-                dyn FuturesStream<
-                        Item = Result<
-                            (Vec<LeasedBatchPart<Timestamp>>, Antichain<Timestamp>),
-                            ExternalError,
-                        >,
-                    > + Send,
-            >,
-        >,
-    >,
-}
-
-impl DropSafeLeaseStream {
-    fn new(
-        pinned_stream: std::pin::Pin<
-            Box<
-                dyn FuturesStream<
-                        Item = Result<
-                            (Vec<LeasedBatchPart<Timestamp>>, Antichain<Timestamp>),
-                            ExternalError,
-                        >,
-                    > + Send,
-            >,
-        >,
-    ) -> DropSafeLeaseStream {
-        DropSafeLeaseStream {
-            pinned_stream: Some(pinned_stream),
-        }
-    }
-
-    fn poll_next(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<(Vec<LeasedBatchPart<Timestamp>>, Antichain<Timestamp>), ExternalError>>>
-    {
-        self.pinned_stream
-            .as_mut()
-            .expect("while being polled, pin is in place")
-            .as_mut()
-            .poll_next(cx)
-    }
-}
-
-impl Drop for DropSafeLeaseStream {
-    fn drop(&mut self) {
-        let mut pin = self.pinned_stream.take().expect("pin only taken on drop");
-
-        mz_ore::task::spawn(|| "LeaseStreamDrainer", async move {
-            // Drain the remainder of the items from the stream; this ensures
-            // that nothing gets dropped while in flight.
-            //
-            // Note that at the end of this task, we expect the internal stream
-            // to have spawned another task that receives any leases returned to
-            // the subscribe.
-            while let Some(item) = pin.as_mut().next().await {
-                match item {
-                    Ok((parts, _)) => {
-                        for part in parts {
-                            // We don't expect this task to run for long, so we
-                            // don't bother sending leases back to `subscribe`;
-                            // this delays compaction slightly, so could instead
-                            // be optimized to meaningfully return batches
-                            // instead of dropping their leases on the floor.
-                            let _ = part.into_exchangeable_part();
-                        }
-                    }
-                    Err::<_, ExternalError>(_) => {}
-                }
-            }
-        });
-    }
 }
 
 /// Creates a new source that reads from a persist shard, distributing the work
@@ -343,7 +261,7 @@ where
         });
     });
 
-    let mut pinned_stream = DropSafeLeaseStream::new(Box::pin(async_stream));
+    let mut pinned_stream = Box::pin(async_stream);
 
     let (inner, token) = crate::source::util::source(
         scope,
@@ -357,7 +275,7 @@ where
             move |cap_set, output| {
                 let mut context = Context::from_waker(&waker);
 
-                while let Poll::Ready(item) = pinned_stream.poll_next(&mut context) {
+                while let Poll::Ready(item) = pinned_stream.as_mut().poll_next(&mut context) {
                     match item {
                         Some(Ok((parts, progress))) => {
                             let session_cap = cap_set.delayed(&current_ts);


### PR DESCRIPTION
We observed that the "LeaseStreamDrainer" task spawned by `DropSafeLeaseStream::drop` sometimes never terminates because the stream it is reading from is never exhausted, leading to a bunch of tasks being left behind whenever a materialized view dataflow is dropped. Since #15868, draining leased batches is not necessary anymore to prevent panics, so just removing the `DropSafeLeaseStream` is fine (https://github.com/MaterializeInc/materialize/issues/15952#issuecomment-1317303834).

### Motivation

  * This PR fixes a recognized bug.

Fixes #15952.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
