### PR TITLE
test: fix select_introspection.slt

### DIFF
--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -40,17 +40,6 @@ a b
 statement ok
 SELECT * FROM mz_internal.mz_compute_exports
 
-# Verify that we see no prior peeks when targeting another replica.
-# FRANK: Commented out as an incorrect test; all replicas see all peeks.
-
-statement ok
-SET cluster_replica = replica_b
-
-# query I
-# SELECT sum(count) FROM mz_internal.mz_raw_peek_durations
-# ----
-# NULL
-
 # Verify that targeting an unknown replica fails.
 
 statement ok
@@ -59,7 +48,7 @@ SET cluster_replica = unknown
 query error cluster replica 'test.unknown' does not exist
 SELECT * FROM test
 
-# Verify that untargeted introspection queries are disallowd.
+# Verify that untargeted introspection queries are disallowed.
 
 statement ok
 RESET cluster_replica
@@ -70,7 +59,7 @@ SELECT * FROM mz_internal.mz_compute_exports
 # Verify that the logic does not apply to persisted logs
 
 statement ok
-SELECT * FROM mz_internal.mz_active_peeks_1
+SELECT * FROM mz_internal.mz_compute_exports_1
 
 # Verify that untargeted introspection queries on unreplicated clusters are
 # allowed.
@@ -98,14 +87,6 @@ CREATE CLUSTER test
 statement ok
 SET cluster_replica = replica_a
 
-# A query that has introspection views in its time domain but does not
-# specifically reference those introspection views should work even on a replica
-# with introspection disabled. This query would crash in v0.27.0-alpha.24.
-query I
-SELECT 1 FROM mz_sources LIMIT 1
-----
-1
-
 query error cannot read log sources of replica with disabled introspection
 SELECT * FROM mz_internal.mz_compute_exports
 
@@ -117,6 +98,14 @@ SET cluster_replica = replica_b
 
 statement ok
 SELECT * FROM mz_internal.mz_compute_exports
+
+# A query that has introspection views in its time domain but does not
+# specifically reference those introspection views should work even on a replica
+# with introspection disabled. This query would crash in v0.27.0-alpha.24.
+query I
+SELECT 1 FROM mz_sources LIMIT 1
+----
+1
 
 # Clean up.
 

--- a/test/testdrive/replica-targeted-select.td
+++ b/test/testdrive/replica-targeted-select.td
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that replica-targeted selects return results from the target replica.
+#
+# This test works by querying introspection sources, which are the only compute
+# collections that can have different contents between replicas. Specifically,
+# we look at the distinct `worker_id`s present in `mz_worker_compute_frontiers`
+# for replicas with different worker counts. We know that
+# `mz_worker_compute_frontiers` always contains entries, because it tracks the
+# frontiers of introspection sources as well.
+#
+# This test relies on testdrive's retry feature, as introspection data might
+# not be immediately available.
+
+> CREATE CLUSTER test REPLICAS (
+      r1 (SIZE '1'),
+      r2 (SIZE '2'),
+      r4 (SIZE '4'),
+      r8 (SIZE '8')
+  )
+
+> SET cluster = test
+
+> SET cluster_replica = r1
+
+> SELECT DISTINCT worker_id
+  FROM mz_internal.mz_worker_compute_frontiers
+  ORDER BY worker_id
+0
+
+> SET cluster_replica = r2
+
+> SELECT DISTINCT worker_id
+  FROM mz_internal.mz_worker_compute_frontiers
+  ORDER BY worker_id
+0
+1
+
+> SET cluster_replica = r4
+
+> SELECT DISTINCT worker_id
+  FROM mz_internal.mz_worker_compute_frontiers
+  ORDER BY worker_id
+0
+1
+2
+3
+
+> SET cluster_replica = r8
+
+> SELECT DISTINCT worker_id
+  FROM mz_internal.mz_worker_compute_frontiers
+  ORDER BY worker_id
+0
+1
+2
+3
+4
+5
+6
+7


### PR DESCRIPTION
The SLT testing replica-targeted peeks broke recently because of changes we made to how replica-targeted peeks work (previously, only one replica would handle the peek, now they all handle it but only one response is forwarded). This PR fixes that test and cleans up the SLT file in the process.

Querying introspection values in SLTs is problematic because it relies on timing. If the introspection results are not immediately available, the test becomes flaky. To solve this, this PR moves the check that has to look at the introspection results into testdrive instead.

### Motivation

  * This PR fixes a previously unreported bug.

@frankmcsherry reported `select_introspection.slt` to be broken [in Slack](https://materializeinc.slack.com/archives/C01LKF361MZ/p1668653301858469).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
