### PR TITLE
persist: fix rustdoc of `compare_and_downgrace_since`

### DIFF
--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -251,8 +251,8 @@ where
     }
 
     /// Forwards the since capability of this handle to `new_since` iff the opaque value of this
-    /// handle's [CriticalReaderId] is `expected`, and [Self::maybe_compare_and_downgrade_since]
-    /// chooses to perform the downgrade.
+    /// handle's [CriticalReaderId] is `expected`, and `new_since` is beyond the
+    /// current `since`.
     ///
     /// Users are expected to call this function only when a guaranteed downgrade is necessary. All
     /// other downgrades should preferably go through [Self::maybe_compare_and_downgrade_since]


### PR DESCRIPTION
This was a copy-paste leftover.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
