### PR TITLE
dbt-materialize: release v1.3.2

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dbt-materialize Changelog
 
+## 1.3.2 - 2022-11-17
+
+* Add the `IN CLUSTER` clause to the custom seed materialization to ensure that
+  seeds are created in the target cluster, rather than in the active cluster.
+  This fixes a bug in 1.3.1 where seeds would run against the
+  `mz_introspection` cluster, causing an error.
+
 ## 1.3.1 - 2022-11-15
 
 * **Breaking change.** Use `mz_introspection` as the initial active cluster on
@@ -12,7 +19,10 @@
 
 * Upgrade to `dbt-postgres` v1.3.0.
 
-* Migrate cross-database macros from [`materialize-dbt-utils`](https://github.com/MaterializeInc/materialize-dbt-utils) into the adapter, as a result of [dbt-core #5298](https://github.com/dbt-labs/dbt-core/pull/5298). The `utils` macros will be deprecated in the upcoming release of the package, and removed in a subsequent release.
+* Migrate cross-database macros from [`materialize-dbt-utils`](https://github.com/MaterializeInc/materialize-dbt-utils)
+  into the adapter, as a result of [dbt-core #5298](https://github.com/dbt-labs/dbt-core/pull/5298).
+  The `utils` macros will be deprecated in the upcoming release of the package,
+  and removed in a subsequent release.
 
 ## 1.2.1 - 2022-11-01
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.3.1"
+version = "1.3.2"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.3.1",
+    version="1.3.2",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a new release of `dbt-materialize` to fix `dbt seed` and re-enable tests.