### PR TITLE
coord: Refactor catalog_transact

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -51,7 +51,7 @@ pub struct CatalogTxn<'a, T> {
 }
 
 impl<S: Append + 'static> Coordinator<S> {
-    /// Same as [`catalog_transact_with`] without a closure passed in.
+    /// Same as [`Self::catalog_transact_with`] without a closure passed in.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn catalog_transact(
         &mut self,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -51,6 +51,16 @@ pub struct CatalogTxn<'a, T> {
 }
 
 impl<S: Append + 'static> Coordinator<S> {
+    /// Same as [`catalog_transact_with`] without a closure passed in.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn catalog_transact(
+        &mut self,
+        session: Option<&Session>,
+        ops: Vec<catalog::Op>,
+    ) -> Result<(), AdapterError> {
+        self.catalog_transact_with(session, ops, |_| Ok(())).await
+    }
+
     /// Perform a catalog transaction. The closure is passed a [`CatalogTxn`]
     /// made from the prospective [`CatalogState`] (i.e., the `Catalog` with `ops`
     /// applied but before the transaction is committed). The closure can return
@@ -62,7 +72,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// [`CatalogState`]: crate::catalog::CatalogState
     /// [`DataflowDesc`]: mz_compute_client::command::DataflowDesc
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn catalog_transact<F, R>(
+    pub(crate) async fn catalog_transact_with<F, R>(
         &mut self,
         session: Option<&Session>,
         mut ops: Vec<catalog::Op>,
@@ -437,7 +447,7 @@ impl<S: Append + 'static> Coordinator<S> {
         if ops.is_empty() {
             return;
         }
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
+        self.catalog_transact(Some(session), ops)
             .await
             .expect("unable to drop temporary items for conn_id");
     }
@@ -544,7 +554,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     name,
                     item: CatalogItem::Sink(sink.clone()),
                 });
-                match self.catalog_transact(session, ops, move |_| Ok(())).await {
+                match self.catalog_transact(session, ops).await {
                     Ok(()) => (),
                     catalog_err @ Err(_) => {
                         let () = self.drop_storage_sinks(vec![id]).await;
@@ -552,12 +562,10 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                 }
             }
-            storage_err @ Err(_) => {
-                match self.catalog_transact(session, ops, move |_| Ok(())).await {
-                    Ok(()) => storage_err?,
-                    catalog_err @ Err(_) => catalog_err?,
-                }
-            }
+            storage_err @ Err(_) => match self.catalog_transact(session, ops).await {
+                Ok(()) => storage_err?,
+                catalog_err @ Err(_) => catalog_err?,
+            },
         };
         Ok(())
     }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -119,7 +119,7 @@ impl<S: Append + 'static> Coordinator<S> {
             });
         }
 
-        if let Err(err) = self.catalog_transact(None, ops, |_| Ok(())).await {
+        if let Err(err) = self.catalog_transact(None, ops).await {
             tracing::warn!("Failed to update storage metrics: {:?}", err);
         }
         self.catalog
@@ -345,7 +345,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     self.catalog_transact(
                         session_and_tx.as_ref().map(|(ref session, _tx)| session),
                         vec![catalog::Op::DropItem(id)],
-                        |_| Ok(()),
                     )
                     .await
                     .expect("deleting placeholder sink cannot fail");
@@ -455,7 +454,6 @@ impl<S: Append + 'static> Coordinator<S> {
         self.catalog_transact(
             None,
             vec![catalog::Op::UpdateComputeInstanceStatus { event }],
-            |_| Ok(()),
         )
         .await
         .unwrap_or_terminate("updating compute instance status cannot fail");

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -509,10 +509,7 @@ impl<S: Append + 'static> Coordinator<S> {
             });
             sources.push((source_id, source));
         }
-        match self
-            .catalog_transact(Some(session), ops, move |_| Ok(()))
-            .await
-        {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(()) => {
                 for (source_id, source) in sources {
                     let source_status_collection_id = if self.catalog.config().unsafe_mode {
@@ -632,7 +629,7 @@ impl<S: Append + 'static> Coordinator<S> {
             }),
         }];
 
-        match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(_) => {
                 match connection {
                     mz_storage_client::types::connections::Connection::AwsPrivatelink(
@@ -678,7 +675,7 @@ impl<S: Append + 'static> Coordinator<S> {
             new_public_key_pair: new_key_set.public_keys(),
         }];
 
-        match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(_) => Ok(ExecuteResponse::AlteredObject(ObjectType::Connection)),
             Err(err) => Err(err),
         }
@@ -696,7 +693,7 @@ impl<S: Append + 'static> Coordinator<S> {
             oid: db_oid,
             public_schema_oid: schema_oid,
         }];
-        match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(_) => Ok(ExecuteResponse::CreatedDatabase),
             Err(AdapterError::Catalog(catalog::Error {
                 kind: catalog::ErrorKind::DatabaseAlreadyExists(_),
@@ -720,10 +717,7 @@ impl<S: Append + 'static> Coordinator<S> {
             schema_name: plan.schema_name.clone(),
             oid,
         };
-        match self
-            .catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await
-        {
+        match self.catalog_transact(Some(session), vec![op]).await {
             Ok(_) => Ok(ExecuteResponse::CreatedSchema),
             Err(AdapterError::Catalog(catalog::Error {
                 kind: catalog::ErrorKind::SchemaAlreadyExists(_),
@@ -748,7 +742,7 @@ impl<S: Append + 'static> Coordinator<S> {
             name: plan.name,
             oid,
         };
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
+        self.catalog_transact(Some(session), vec![op])
             .await
             .map(|_| ExecuteResponse::CreatedRole)
     }
@@ -887,8 +881,7 @@ impl<S: Append + 'static> Coordinator<S> {
             });
         }
 
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
 
         let persisted_introspection_source_ids: Vec<GlobalId> = persisted_introspection_sources
             .iter()
@@ -1053,8 +1046,7 @@ impl<S: Append + 'static> Coordinator<S> {
             on_cluster_name: of_cluster.clone(),
         };
 
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), vec![op]).await?;
 
         let instance = self.catalog.resolve_compute_instance(&of_cluster)?;
         let replica_id = instance.replica_id_by_name[&name];
@@ -1126,7 +1118,7 @@ impl<S: Append + 'static> Coordinator<S> {
             name: name.clone(),
             item: CatalogItem::Table(table.clone()),
         }];
-        match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(()) => {
                 // Determine the initial validity for the table.
                 let since_ts = self.peek_local_write_ts();
@@ -1195,7 +1187,7 @@ impl<S: Append + 'static> Coordinator<S> {
             item: CatalogItem::Secret(secret.clone()),
         }];
 
-        match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(()) => Ok(ExecuteResponse::CreatedSecret),
             Err(AdapterError::Catalog(catalog::Error {
                 kind: catalog::ErrorKind::ItemAlreadyExists(_, _),
@@ -1298,7 +1290,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let from_name = from.name().item.clone();
         let from_type = from.item().typ().to_string();
         let result = self
-            .catalog_transact(Some(&session), ops, move |txn| {
+            .catalog_transact_with(Some(&session), ops, move |txn| {
                 // Validate that the from collection is in fact a persist collection we can export.
                 txn.dataflow_client
                     .storage
@@ -1390,7 +1382,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 depends_on,
             )
             .await?;
-        match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
+        match self.catalog_transact(Some(session), ops).await {
             Ok(()) => Ok(ExecuteResponse::CreatedView),
             Err(AdapterError::Catalog(catalog::Error {
                 kind: catalog::ErrorKind::ItemAlreadyExists(_, _),
@@ -1519,7 +1511,7 @@ impl<S: Append + 'static> Coordinator<S> {
         });
 
         match self
-            .catalog_transact(Some(session), ops, |txn| {
+            .catalog_transact_with(Some(session), ops, |txn| {
                 // Create a dataflow that materializes the view query and sinks
                 // it to storage.
                 let df = txn
@@ -1602,7 +1594,7 @@ impl<S: Append + 'static> Coordinator<S> {
             item: CatalogItem::Index(index),
         };
         match self
-            .catalog_transact(Some(session), vec![op], |txn| {
+            .catalog_transact_with(Some(session), vec![op], |txn| {
                 let mut builder = txn.dataflow_builder(compute_instance);
                 let df = builder.build_index_dataflow(id)?;
                 Ok(df)
@@ -1652,10 +1644,7 @@ impl<S: Append + 'static> Coordinator<S> {
             name: plan.name,
             item: CatalogItem::Type(typ),
         };
-        match self
-            .catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await
-        {
+        match self.catalog_transact(Some(session), vec![op]).await {
             Ok(()) => Ok(ExecuteResponse::CreatedType),
             Err(err) => Err(err),
         }
@@ -1667,8 +1656,7 @@ impl<S: Append + 'static> Coordinator<S> {
         plan: DropDatabasePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let ops = self.catalog.drop_database_ops(plan.id);
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
         Ok(ExecuteResponse::DroppedDatabase)
     }
 
@@ -1678,8 +1666,7 @@ impl<S: Append + 'static> Coordinator<S> {
         plan: DropSchemaPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let ops = self.catalog.drop_schema_ops(plan.id);
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
         Ok(ExecuteResponse::DroppedSchema)
     }
 
@@ -1693,8 +1680,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .into_iter()
             .map(|name| catalog::Op::DropRole { name })
             .collect();
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
         Ok(ExecuteResponse::DroppedRole)
     }
 
@@ -1746,8 +1732,7 @@ impl<S: Append + 'static> Coordinator<S> {
             ops.push(catalog::Op::DropComputeInstance { name: compute_name });
         }
 
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
         for (instance_id, replicas) in instance_replica_drop_sets {
             for replica_id in replicas {
                 self.drop_replica(instance_id, replica_id).await.unwrap();
@@ -1809,8 +1794,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
         ops.extend(self.catalog.drop_items_ops(&ids_to_drop));
 
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
 
         for (compute_id, replica_id) in replicas_to_drop {
             self.drop_replica(compute_id, replica_id).await.unwrap();
@@ -1845,8 +1829,7 @@ impl<S: Append + 'static> Coordinator<S> {
         plan: DropItemsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let ops = self.catalog.drop_items_ops(&plan.items);
-        self.catalog_transact(Some(session), ops, |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), ops).await?;
         Ok(match plan.ty {
             ObjectType::Source => ExecuteResponse::DroppedSource,
             ObjectType::View => ExecuteResponse::DroppedView,
@@ -3178,10 +3161,7 @@ impl<S: Append + 'static> Coordinator<S> {
             current_full_name: plan.current_full_name,
             to_name: plan.to_name,
         };
-        match self
-            .catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await
-        {
+        match self.catalog_transact(Some(session), vec![op]).await {
             Ok(()) => Ok(ExecuteResponse::AlteredObject(plan.object_type)),
             Err(err) => Err(err),
         }
@@ -3260,8 +3240,7 @@ impl<S: Append + 'static> Coordinator<S> {
         AlterSinkPlan { id, size, remote }: AlterSinkPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let op = catalog::Op::AlterSink { id, size, remote };
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), vec![op]).await?;
 
         // Re-fetch the updated item from the catalog
         let entry = self.catalog.get_entry(&id);
@@ -3289,8 +3268,7 @@ impl<S: Append + 'static> Coordinator<S> {
         AlterSourcePlan { id, size, remote }: AlterSourcePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let op = catalog::Op::AlterSource { id, size, remote };
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), vec![op]).await?;
 
         // Re-fetch the updated item from the catalog
         let entry = self.catalog.get_entry(&id);
@@ -3387,8 +3365,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 value: value.to_string(),
             },
         };
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), vec![op]).await?;
         if update_max_result_size {
             self.update_max_result_size();
         }
@@ -3403,8 +3380,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.is_user_allowed_to_alter_system(session)?;
         let update_max_result_size = name == session::vars::MAX_RESULT_SIZE.name();
         let op = catalog::Op::ResetSystemConfiguration { name };
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), vec![op]).await?;
         if update_max_result_size {
             self.update_max_result_size();
         }
@@ -3418,8 +3394,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session)?;
         let op = catalog::Op::ResetAllSystemConfiguration {};
-        self.catalog_transact(Some(session), vec![op], |_| Ok(()))
-            .await?;
+        self.catalog_transact(Some(session), vec![op]).await?;
         self.update_max_result_size();
         Ok(ExecuteResponse::AlteredSystemConfiguraion)
     }


### PR DESCRIPTION
The `catalog_transact` function takes a closure that is executed before the transaction is committed. The vast majority of callers passed in an empty closure. This commit adds a helper function that doesn't accept a closure and passes an empty closure for the caller.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A