### PR TITLE
doc: Add Serializable query guarantees to docs

### DIFF
--- a/doc/user/content/overview/isolation-level.md
+++ b/doc/user/content/overview/isolation-level.md
@@ -111,7 +111,13 @@ linearizable transactions, then you should downgrade to the Serializable isolati
 
 Strict Serializable provides stronger consistency guarantees but may have slower reads than Serializable. This is
 because Strict Serializable may need to wait for writes to propagate through materialized views and indexes, while
-Serializable does not.
+Serializable does not. 
+
+In Serializable mode, If a consistent snapshot is not available across all objects in a query, the query will be
+blocked until one becomes available. On the other hand, if a consistent snapshot is available, the query will be
+executed immediately. A consistent snapshot is guaranteed to be available for queries that involve a single object
+(which includes queries against a single materialized view that was created using multiple objects). Such queries will
+therefore never block, and always be executed immediately.
 
 
 ## Learn more

--- a/doc/user/content/overview/isolation-level.md
+++ b/doc/user/content/overview/isolation-level.md
@@ -83,6 +83,13 @@ large propagation delays. For example, if SQL-transaction T1 happens before SQL-
 table t, and T2 queries materialized view mv where mv is an expensive materialized view including t, then T2 may not see
 all the rows that were seen by T1 if they are executed close enough together in real time.
 
+If there is not a consistent snapshot available across all objects in a query, then the query will be blocked until a
+consistent snapshot becomes available. If there is a consistent snapshot available then the query will not block and be
+executed immediately. There is guaranteed to always be a consistent snapshot available for queries that only involve a
+single object and therefore these queries will always be executed immediately. Note, queries against a single
+Materialized View that was creating using multiple objects is considered a query involving a single object. Therefore,
+these queries will not block and be executed immediately.
+
 ## Strict serializable
 
 The Strict Serializable isolation level provides all the same guarantees as Serializable, with the addition that

--- a/doc/user/content/overview/isolation-level.md
+++ b/doc/user/content/overview/isolation-level.md
@@ -83,12 +83,7 @@ large propagation delays. For example, if SQL-transaction T1 happens before SQL-
 table t, and T2 queries materialized view mv where mv is an expensive materialized view including t, then T2 may not see
 all the rows that were seen by T1 if they are executed close enough together in real time.
 
-If there is not a consistent snapshot available across all objects in a query, then the query will be blocked until a
-consistent snapshot becomes available. If there is a consistent snapshot available then the query will not block and be
-executed immediately. There is guaranteed to always be a consistent snapshot available for queries that only involve a
-single object and therefore these queries will always be executed immediately. Note, queries against a single
-Materialized View that was creating using multiple objects is considered a query involving a single object. Therefore,
-these queries will not block and be executed immediately.
+If a consistent snapshot is not available across all objects in a query, the query will be blocked until one becomes available. On the other hand, if a consistent snapshot is available, the query will be executed immediately. A consistent snapshot is guaranteed to be available for queries that involve a single object (which includes queries against a single materialized view that was created using multiple objects). Such queries will therefore never block, and always be executed immediately.
 
 ## Strict serializable
 

--- a/doc/user/content/overview/isolation-level.md
+++ b/doc/user/content/overview/isolation-level.md
@@ -111,7 +111,7 @@ linearizable transactions, then you should downgrade to the Serializable isolati
 
 Strict Serializable provides stronger consistency guarantees but may have slower reads than Serializable. This is
 because Strict Serializable may need to wait for writes to propagate through materialized views and indexes, while
-Serializable does not. 
+Serializable does not.
 
 In Serializable mode, If a consistent snapshot is not available across all objects in a query, the query will be
 blocked until one becomes available. On the other hand, if a consistent snapshot is available, the query will be


### PR DESCRIPTION
This commit adds documentation to specify what guarantees we provide in the Serializable isolation level with regards to timestamp selection.


### Motivation
Adds docs

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A