### PR TITLE
persist: read a bounded # of rows from CRDB when fetching latest state

### DIFF
--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -118,7 +118,7 @@ impl Consensus for MaelstromConsensus {
                 Ok(x) => Value::from(&MaelstromVersionedData::from(x)),
                 Err(_) => {
                     let from = expected.next();
-                    return Ok(Err(self.scan(key, from).await?));
+                    return Ok(Err(self.scan_all(key, from).await?));
                 }
             },
             None => Value::Null,
@@ -147,14 +147,19 @@ impl Consensus for MaelstromConsensus {
                 ..
             }) => {
                 let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-                let current = self.scan(key, from).await?;
+                let current = self.scan_all(key, from).await?;
                 Ok(Err(current))
             }
             Err(err) => Err(ExternalError::from(anyhow::Error::new(err))),
         }
     }
 
-    async fn scan(&self, _key: &str, _from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        _key: &str,
+        _from: SeqNo,
+        _limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         unimplemented!("TODO")
     }
 

--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData,
+    Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData, SCAN_ALL,
 };
 
 use crate::maelstrom::api::{ErrorCode, MaelstromError};
@@ -118,7 +118,7 @@ impl Consensus for MaelstromConsensus {
                 Ok(x) => Value::from(&MaelstromVersionedData::from(x)),
                 Err(_) => {
                     let from = expected.next();
-                    return Ok(Err(self.scan_all(key, from).await?));
+                    return Ok(Err(self.scan(key, from, SCAN_ALL).await?));
                 }
             },
             None => Value::Null,
@@ -147,7 +147,7 @@ impl Consensus for MaelstromConsensus {
                 ..
             }) => {
                 let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-                let current = self.scan_all(key, from).await?;
+                let current = self.scan(key, from, SCAN_ALL).await?;
                 Ok(Err(current))
             }
             Err(err) => Err(ExternalError::from(anyhow::Error::new(err))),

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -623,6 +623,8 @@ impl Service for TransactorService {
         // to simplify some downstream logic (+ a bit more stress testing),
         // always downgrade the since of critical handles when asked
         config.critical_downgrade_interval = Duration::from_secs(0);
+        // set a live diff scan limit such that we'll explore both the fast and slow paths
+        config.state_versions_recent_live_diffs_limit = 5;
         let metrics = Arc::new(Metrics::new(&config, &MetricsRegistry::new()));
         let consensus = match &args.consensus_uri {
             Some(consensus_uri) => {

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -60,7 +60,7 @@ pub async fn fetch_latest_state(
         .await;
 
     let state = match state_versions
-        .fetch_current_state::<K, V, u64, D>(&shard_id, versions.clone())
+        .fetch_current_state::<K, V, u64, D>(&shard_id, versions.0.clone())
         .await
     {
         Ok(s) => s.into_proto(),
@@ -70,7 +70,7 @@ pub async fn fetch_latest_state(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_current_state::<K, V, u64, D>(&shard_id, versions)
+                .fetch_current_state::<K, V, u64, D>(&shard_id, versions.0)
                 .await
                 .expect("codecs match")
                 .into_proto()

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -55,7 +55,9 @@ pub async fn fetch_latest_state(
     let blob = blob.clone().open().await?;
 
     let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
-    let versions = state_versions.fetch_live_diffs(&shard_id).await;
+    let versions = state_versions
+        .fetch_recent_live_diffs::<u64>(&shard_id)
+        .await;
 
     let state = match state_versions
         .fetch_current_state::<K, V, u64, D>(&shard_id, versions.clone())
@@ -132,7 +134,7 @@ pub async fn fetch_state_rollups(
     let state_versions =
         StateVersions::new(cfg, consensus, Arc::clone(&blob), Arc::clone(&metrics));
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(&shard_id)
+        .fetch_all_live_states::<K, V, u64, D>(&shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -142,7 +144,7 @@ pub async fn fetch_state_rollups(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(&shard_id)
+                .fetch_all_live_states::<K, V, u64, D>(&shard_id)
                 .await?
         }
     };
@@ -191,7 +193,7 @@ pub async fn fetch_state_diffs(
 
     let mut live_states = vec![];
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(&shard_id)
+        .fetch_all_live_states::<K, V, u64, D>(&shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -201,7 +203,7 @@ pub async fn fetch_state_diffs(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(&shard_id)
+                .fetch_all_live_states::<K, V, u64, D>(&shard_id)
                 .await?
         }
     };
@@ -292,7 +294,7 @@ pub async fn unreferenced_blobs(
 
     let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(shard_id)
+        .fetch_all_live_states::<K, V, u64, D>(shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -302,7 +304,7 @@ pub async fn unreferenced_blobs(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(shard_id)
+                .fetch_all_live_states::<K, V, u64, D>(shard_id)
                 .await?
         }
     };

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -196,7 +196,7 @@ where
 
         let mut states = machine
             .state_versions
-            .fetch_live_states::<K, V, T, D>(&req.shard_id)
+            .fetch_all_live_states::<K, V, T, D>(&req.shard_id)
             .await
             .expect("shard codecs should not change");
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1776,15 +1776,15 @@ pub mod tests {
             .fetch_all_live_diffs(&write.machine.shard_id())
             .await;
         // Make sure we constructed the key correctly.
-        assert!(live_diffs.len() > 0);
+        assert!(live_diffs.0.len() > 0);
         // Make sure the number of entries is bounded. (I think we could work
         // out a tighter bound than this, but the point is only that it's
         // bounded).
         let max_live_diffs = 2 * usize::cast_from(NUM_BATCHES.next_power_of_two().trailing_zeros());
         assert!(
-            live_diffs.len() < max_live_diffs,
+            live_diffs.0.len() < max_live_diffs,
             "{} vs {}",
-            live_diffs.len(),
+            live_diffs.0.len(),
             max_live_diffs
         );
     }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1162,7 +1162,7 @@ pub mod datadriven {
 
         let mut states = datadriven
             .state_versions
-            .fetch_live_states::<String, (), u64, i64>(&datadriven.shard_id)
+            .fetch_all_live_states::<String, (), u64, i64>(&datadriven.shard_id)
             .await
             .expect("shard codecs should not change");
         let mut s = String::new();
@@ -1773,7 +1773,7 @@ pub mod tests {
         let live_diffs = write
             .machine
             .state_versions
-            .fetch_live_diffs(&write.machine.shard_id())
+            .fetch_all_live_diffs(&write.machine.shard_id())
             .await;
         // Make sure we constructed the key correctly.
         assert!(live_diffs.len() > 0);

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -900,6 +900,8 @@ pub struct StateMetrics {
     pub(crate) update_state_fast_path: IntCounter,
     pub(crate) update_state_slow_path: IntCounter,
     pub(crate) rollup_at_seqno_migration: IntCounter,
+    pub(crate) fetch_recent_live_diffs_fast_path: IntCounter,
+    pub(crate) fetch_recent_live_diffs_slow_path: IntCounter,
 }
 
 impl StateMetrics {
@@ -936,6 +938,14 @@ impl StateMetrics {
             rollup_at_seqno_migration: registry.register(metric!(
                 name: "mz_persist_state_rollup_at_seqno_migration",
                 help: "count of fetch_rollup_at_seqno calls that only worked because of the migration",
+            )),
+            fetch_recent_live_diffs_fast_path: registry.register(metric!(
+                name: "mz_persist_state_fetch_recent_live_diffs_fast_path",
+                help: "count of fetch_recent_live_diffs that hit the fast path",
+            )),
+            fetch_recent_live_diffs_slow_path: registry.register(metric!(
+                name: "mz_persist_state_fetch_recent_live_diffs_slow_path",
+                help: "count of fetch_recent_live_diffs that hit the slow path",
             )),
         }
     }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1486,12 +1486,17 @@ impl Consensus for MetricsConsensus {
         res
     }
 
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         let res = self
             .metrics
             .consensus
             .scan
-            .run_op(|| self.consensus.scan(key, from), Self::on_err)
+            .run_op(|| self.consensus.scan(key, from, limit), Self::on_err)
             .await;
         if let Ok(dataz) = res.as_ref() {
             let bytes = dataz.iter().map(|x| x.data.len()).sum();

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -439,8 +439,8 @@ impl StateVersions {
     }
 
     /// Fetches all live_diffs for a shard. Intended only for when a caller needs to reconstruct
-    /// _all_ states still referenced by Consensus. Prefer [fetch_recent_live_diffs] when the
-    /// caller simply needs to fetch the latest state.
+    /// _all_ states still referenced by Consensus. Prefer [Self::fetch_recent_live_diffs] when
+    /// the caller simply needs to fetch the latest state.
     ///
     /// Returns an empty Vec iff called on an uninitialized shard.
     pub async fn fetch_all_live_diffs(&self, shard_id: &ShardId) -> AllLiveDiffs {

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 use bytes::Bytes;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
+use mz_ore::cast::CastFrom;
 use mz_persist::location::{Atomicity, Blob, Consensus, Indeterminate, SeqNo, VersionedData};
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
@@ -460,7 +461,7 @@ impl StateVersions {
         //
         // NB: we make this a function of `NEED_ROLLUP_THRESHOLD` to approximate when we expect
         // rollups to be written and therefore when old states will be truncated by GC.
-        let scan_limit = 1; //30 * usize::cast_from(PersistConfig::NEED_ROLLUP_THRESHOLD);
+        let scan_limit = 30 * usize::cast_from(PersistConfig::NEED_ROLLUP_THRESHOLD);
         let oldest_diffs =
             retry_external(&self.metrics.retries.external.fetch_state_scan, || async {
                 self.consensus

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -614,8 +614,8 @@ impl StateVersions {
 
     /// Fetches a rollup for the given SeqNo, if it exists.
     ///
-    /// Uses the provided hint, which is a possibly outdated copy of all live
-    /// diffs, to avoid fetches where possible.
+    /// Uses the provided hint, which is a possibly outdated copy of all
+    /// or recent live diffs, to avoid fetches where possible.
     ///
     /// Panics if called on an uninitialized shard.
     async fn fetch_rollup_at_seqno<K, V, T, D>(

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -17,7 +17,6 @@ use std::time::SystemTime;
 use bytes::Bytes;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use mz_ore::cast::CastFrom;
 use mz_persist::location::{
     Atomicity, Blob, Consensus, Indeterminate, SeqNo, VersionedData, SCAN_ALL,
 };

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_build_info::BuildInfo;
+use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig, ConsensusKnobs};
 use mz_persist::location::{Blob, Consensus, ExternalError};
@@ -250,6 +251,16 @@ pub struct PersistConfig {
     /// is likely a good place to start so that all connections are rotated when the
     /// pool is fully used.
     pub consensus_connection_pool_ttl_stagger: Duration,
+    /// The # of diffs to initially scan when fetching the latest consensus state, to
+    /// determine which requests go down the fast vs slow path. Should be large enough
+    /// to fetch all live diffs in the steady-state, and small enough to query Consensus
+    /// at high volume. Steady-state usage should accommodate readers that require
+    /// seqno-holds for reasonable amounts of time, which to start we say is 10s of minutes.
+    ///
+    /// This value ought to be defined in terms of `NEED_ROLLUP_THRESHOLD` to approximate
+    /// when we expect rollups to be written and therefore when old states will be truncated
+    /// by GC.
+    pub state_versions_recent_live_diffs_limit: usize,
     /// Length of time after a writer's last operation after which the writer
     /// may be expired.
     pub writer_lease_duration: Duration,
@@ -323,6 +334,9 @@ impl PersistConfig {
             consensus_connection_pool_max_size: 50,
             consensus_connection_pool_ttl: Duration::from_secs(300),
             consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
+            state_versions_recent_live_diffs_limit: usize::cast_from(
+                30 * Self::NEED_ROLLUP_THRESHOLD,
+            ),
             writer_lease_duration: 60 * Duration::from_secs(60),
             reader_lease_duration: Self::DEFAULT_READ_LEASE_DURATION,
             critical_downgrade_interval: Duration::from_secs(30),

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
+use mz_ore::cast::u64_to_usize;
 use mz_persist_types::Codec;
 use mz_proto::RustType;
 use serde::{Deserialize, Serialize};
@@ -326,6 +327,10 @@ impl<T: Codec> TryFrom<&VersionedData> for (SeqNo, T) {
     }
 }
 
+/// Helper constant to scan all states in [Consensus::scan].
+/// The maximum possible SeqNo is i64::MAX.
+pub const SCAN_ALL: usize = u64_to_usize(i64::MAX as u64);
+
 /// An abstraction for [VersionedData] held in a location in persistent storage
 /// where the data are conditionally updated by version.
 ///
@@ -335,7 +340,7 @@ impl<T: Codec> TryFrom<&VersionedData> for (SeqNo, T) {
 /// storage easier, sequence numbers used with [Consensus] need to be restricted to the
 /// range [0, i64::MAX].
 #[async_trait]
-pub trait Consensus: std::fmt::Debug + Sync {
+pub trait Consensus: std::fmt::Debug {
     /// Returns a recent version of `data`, and the corresponding sequence number, if
     /// one exists at this location.
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError>;
@@ -370,19 +375,6 @@ pub trait Consensus: std::fmt::Debug + Sync {
         from: SeqNo,
         limit: usize,
     ) -> Result<Vec<VersionedData>, ExternalError>;
-
-    /// Return all versions of data stored for this `key` at sequence numbers
-    /// >= `from`, in ascending order of sequence number.
-    ///
-    /// Returns an empty vec if `from` is greater than the current sequence
-    /// number or if there is no data at this key.
-    async fn scan_all(
-        self: &Self,
-        key: &str,
-        from: SeqNo,
-    ) -> Result<Vec<VersionedData>, ExternalError> {
-        self.scan(key, from, usize::MAX).await
-    }
 
     /// Deletes all historical versions of the data stored at `key` that are <
     /// `seqno`, iff `seqno` <= the current sequence number.
@@ -632,7 +624,7 @@ pub mod tests {
         assert_eq!(consensus.head(&key).await, Ok(None));
 
         // Can scan a key that has no data.
-        assert_eq!(consensus.scan_all(&key, SeqNo(0)).await, Ok(vec![]));
+        assert_eq!(consensus.scan(&key, SeqNo(0), SCAN_ALL).await, Ok(vec![]));
 
         // Cannot truncate data from a key that doesn't have any data
         assert!(consensus.truncate(&key, SeqNo(0)).await.is_err(),);
@@ -661,19 +653,19 @@ pub mod tests {
 
         // Can scan a key that has data with a lower bound sequence number < head.
         assert_eq!(
-            consensus.scan_all(&key, SeqNo(0)).await,
+            consensus.scan(&key, SeqNo(0), SCAN_ALL).await,
             Ok(vec![state.clone()])
         );
 
         // Can scan a key that has data with a lower bound sequence number == head.
         assert_eq!(
-            consensus.scan_all(&key, SeqNo(5)).await,
+            consensus.scan(&key, SeqNo(5), SCAN_ALL).await,
             Ok(vec![state.clone()])
         );
 
         // Can scan a key that has data with a lower bound sequence number >
         // head.
-        assert_eq!(consensus.scan_all(&key, SeqNo(6)).await, Ok(vec![]));
+        assert_eq!(consensus.scan(&key, SeqNo(6), SCAN_ALL).await, Ok(vec![]));
 
         // Can truncate data with an upper bound <= head, even if there is no data in the
         // range [0, upper).
@@ -776,26 +768,26 @@ pub mod tests {
         // We can observe both states in the correct order with scan if pass
         // in a suitable lower bound.
         assert_eq!(
-            consensus.scan_all(&key, SeqNo(5)).await,
+            consensus.scan(&key, SeqNo(5), SCAN_ALL).await,
             Ok(vec![state.clone(), new_state.clone()])
         );
 
         // We can observe only the most recent state if the lower bound is higher
         // than the previous insertion's sequence number.
         assert_eq!(
-            consensus.scan_all(&key, SeqNo(6)).await,
+            consensus.scan(&key, SeqNo(6), SCAN_ALL).await,
             Ok(vec![new_state.clone()])
         );
 
         // We can still observe the most recent insert as long as the provided
         // lower bound == most recent 's sequence number.
         assert_eq!(
-            consensus.scan_all(&key, SeqNo(10)).await,
+            consensus.scan(&key, SeqNo(10), SCAN_ALL).await,
             Ok(vec![new_state.clone()])
         );
 
         // We can scan if the provided lower bound > head's sequence number.
-        assert_eq!(consensus.scan_all(&key, SeqNo(11)).await, Ok(vec![]));
+        assert_eq!(consensus.scan(&key, SeqNo(11), SCAN_ALL).await, Ok(vec![]));
 
         // We can scan with limits that don't cover all states
         assert_eq!(
@@ -824,7 +816,7 @@ pub mod tests {
 
         // Verify that the old write is indeed deleted.
         assert_eq!(
-            consensus.scan_all(&key, SeqNo(0)).await,
+            consensus.scan(&key, SeqNo(0), SCAN_ALL).await,
             Ok(vec![new_state.clone()])
         );
 

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -366,7 +366,12 @@ pub trait Consensus: std::fmt::Debug {
     ///
     /// Returns an empty vec if `from` is greater than the current sequence
     /// number or if there is no data at this key.
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError>;
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError>;
 
     /// Deletes all historical versions of the data stored at `key` that are <
     /// `seqno`, iff `seqno` <= the current sequence number.
@@ -375,6 +380,12 @@ pub trait Consensus: std::fmt::Debug {
     /// `seqno` is greater than the current sequence number, or if there is no
     /// data at this key.
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError>;
+
+    /// WIP: figure out where to put this given object safety
+    async fn scan_all(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+        // WIP: ugh, figure out the right types to plumb through. maybe limit should be u32 or i64
+        self.scan(key, from, usize::MAX / 2).await
+    }
 }
 
 /// Metadata about a particular blob stored by persist

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -338,8 +338,6 @@ impl<T: Codec> TryFrom<&VersionedData> for (SeqNo, T) {
 pub trait Consensus: std::fmt::Debug {
     /// Returns a recent version of `data`, and the corresponding sequence number, if
     /// one exists at this location.
-    ///
-    /// TODO: This is no longer used. Remove it?
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError>;
 
     /// Update the [VersionedData] stored at this location to `new`, iff the

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -165,8 +165,9 @@ impl MemConsensus {
     ) -> Result<Vec<VersionedData>, ExternalError> {
         let results = if let Some(values) = store.get(key) {
             let from_idx = values.partition_point(|x| x.seqno < from);
-            let to_idx = usize::min(values.len(), from_idx.saturating_add(limit));
-            values[from_idx..to_idx].to_vec()
+            let from_values = &values[from_idx..];
+            let from_values = &from_values[..usize::min(limit, from_values.len())];
+            from_values.to_vec()
         } else {
             Vec::new()
         };

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -161,10 +161,12 @@ impl MemConsensus {
         store: &HashMap<String, Vec<VersionedData>>,
         key: &str,
         from: SeqNo,
+        limit: usize,
     ) -> Result<Vec<VersionedData>, ExternalError> {
         let results = if let Some(values) = store.get(key) {
             let from_idx = values.partition_point(|x| x.seqno < from);
-            values[from_idx..].to_vec()
+            let to_idx = usize::min(values.len(), from_idx + limit);
+            values[from_idx..to_idx].to_vec()
         } else {
             Vec::new()
         };
@@ -215,7 +217,7 @@ impl Consensus for MemConsensus {
 
         if seqno != expected {
             let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-            return Ok(Err(Self::scan_store(&store, key, from)?));
+            return Ok(Err(Self::scan_store(&store, key, from, usize::MAX)?));
         }
 
         store.entry(key.to_string()).or_default().push(new);
@@ -223,9 +225,14 @@ impl Consensus for MemConsensus {
         Ok(Ok(()))
     }
 
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         let store = self.data.lock().map_err(Error::from)?;
-        Self::scan_store(&store, key, from)
+        Self::scan_store(&store, key, from, limit)
     }
 
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError> {

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -165,7 +165,7 @@ impl MemConsensus {
     ) -> Result<Vec<VersionedData>, ExternalError> {
         let results = if let Some(values) = store.get(key) {
             let from_idx = values.partition_point(|x| x.seqno < from);
-            let to_idx = usize::min(values.len(), from_idx + limit);
+            let to_idx = usize::min(values.len(), from_idx.saturating_add(limit));
             values[from_idx..to_idx].to_vec()
         } else {
             Vec::new()

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -457,9 +457,8 @@ impl Consensus for PostgresConsensus {
         let rows = {
             let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
-            client
-                .query(&statement, &[&key, &from, &i64::cast_from(limit as isize)])
-                .await?
+            let limit = limit.try_into().unwrap_or(i64::MAX);
+            client.query(&statement, &[&key, &from, &limit]).await?
         };
         let mut results = Vec::with_capacity(rows.len());
 

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -34,7 +34,7 @@ use std::time::{Duration, Instant};
 use tracing::debug;
 
 use crate::error::Error;
-use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
+use crate::location::{Consensus, ExternalError, SeqNo, VersionedData, SCAN_ALL};
 use crate::metrics::PostgresConsensusMetrics;
 
 const SCHEMA: &str = "
@@ -440,7 +440,7 @@ impl Consensus for PostgresConsensus {
             // 2. All operations that modify the (seqno, data) can only increase
             //    the sequence number.
             let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-            let current = self.scan_all(key, from).await?;
+            let current = self.scan(key, from, SCAN_ALL).await?;
             Ok(Err(current))
         }
     }

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -201,9 +201,14 @@ impl Consensus for UnreliableConsensus {
             .await
     }
 
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         self.handle
-            .run_op("scan", || self.consensus.scan(key, from))
+            .run_op("scan", || self.consensus.scan(key, from, limit))
             .await
     }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

We're very close to being insulated from the performance effects of long seqno holds (whether they're intentional or not), but with https://github.com/MaterializeInc/materialize/issues/15937 we've found that when they grow large, any operation that requires fetching all state (e.g. an ad-hoc query) can become very slow due to how much time is spent scanning in CRDB. This can also have adverse affects on CRDB in general, though so far less than I would have expected.

This PR splits out `StateVersions`'s ability to fetch the latest state into two flavors: fetching ALL states, and fetching the latest. The former is really only used for gc, and the latter is everything else. The insight here is that when fetching the latest state, we don't actually need to scan all states in Consensus, we just need the latest rollup and the diffs after it. We adjust the fetch-current call to have two paths:

1. the fast-path: we do a scan with a `limit` and hope we get every live diff. if so, we proceed like normal
2. the slow-path: if our `limit` scan shows we still had more states, rather than scanning all entries, we fetch `head`, learn the latest rollup, and then scan for all diffs from that rollup's seqno onward. This is more network calls total, but this path is only triggered when we believe there to be a very large number of seqno/states in Consensus. If we tune `limit` correctly, I think this can be a performance improvement in all cases, and will definitely insulate our perf/reliability in the tail cases when we'd otherwise scan a huge number of rows in CRDB.


### Motivation

  * This PR adds a known-desirable feature.

Mitigates the performance / reliability problems that result from long seqno holds (https://github.com/MaterializeInc/materialize/issues/15937)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
