### PR TITLE
Adapter: add notice when user drops active database or cluster

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -198,7 +198,10 @@ impl<S: Append + 'static> Coordinator<S> {
                 );
             }
             Plan::DropDatabase(plan) => {
-                tx.send(self.sequence_drop_database(&session, plan).await, session);
+                tx.send(
+                    self.sequence_drop_database(&mut session, plan).await,
+                    session,
+                );
             }
             Plan::DropSchema(plan) => {
                 tx.send(self.sequence_drop_schema(&session, plan).await, session);
@@ -208,7 +211,8 @@ impl<S: Append + 'static> Coordinator<S> {
             }
             Plan::DropComputeInstances(plan) => {
                 tx.send(
-                    self.sequence_drop_compute_instances(&session, plan).await,
+                    self.sequence_drop_compute_instances(&mut session, plan)
+                        .await,
                     session,
                 );
             }
@@ -1652,11 +1656,23 @@ impl<S: Append + 'static> Coordinator<S> {
 
     async fn sequence_drop_database(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         plan: DropDatabasePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        let database_name = plan
+            .id
+            .map(|id| self.catalog.get_database(&id))
+            .map(|db| db.name.clone());
+
         let ops = self.catalog.drop_database_ops(plan.id);
         self.catalog_transact(Some(session), ops).await?;
+
+        if let Some(name) = database_name {
+            if name.as_str() == session.vars().database() {
+                session.add_notice(AdapterNotice::DroppedActiveDatabase { name });
+            }
+        }
+
         Ok(ExecuteResponse::DroppedDatabase)
     }
 
@@ -1686,11 +1702,12 @@ impl<S: Append + 'static> Coordinator<S> {
 
     async fn sequence_drop_compute_instances(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         plan: DropComputeInstancesPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let mut ops = Vec::new();
         let mut instance_replica_drop_sets = Vec::with_capacity(plan.names.len());
+        let mut is_active_instance = false;
         for compute_name in plan.names {
             let instance = self.catalog.resolve_compute_instance(&compute_name)?;
             instance_replica_drop_sets.push((
@@ -1728,6 +1745,10 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
             }
 
+            if compute_name.as_str() == session.vars().cluster() {
+                is_active_instance = true;
+            }
+
             ops.extend(self.catalog.drop_items_ops(&ids_to_drop));
             ops.push(catalog::Op::DropComputeInstance { name: compute_name });
         }
@@ -1738,6 +1759,12 @@ impl<S: Append + 'static> Coordinator<S> {
                 self.drop_replica(instance_id, replica_id).await.unwrap();
             }
             self.controller.compute.drop_instance(instance_id);
+        }
+
+        if is_active_instance {
+            session.add_notice(AdapterNotice::DroppedActiveCluster {
+                name: session.vars().cluster().to_string(),
+            });
         }
 
         Ok(ExecuteResponse::DroppedComputeInstance)

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -48,6 +48,12 @@ pub enum AdapterNotice {
         replica: String,
         status: ComputeInstanceStatus,
     },
+    DroppedActiveDatabase {
+        name: String,
+    },
+    DroppedActiveCluster {
+        name: String,
+    },
 }
 
 impl AdapterNotice {
@@ -61,6 +67,8 @@ impl AdapterNotice {
         match self {
             AdapterNotice::DatabaseDoesNotExist { name: _ } => Some("Create the database with CREATE DATABASE or pick an extant database with SET DATABASE = name. List available databases with SHOW DATABASES.".into()),
             AdapterNotice::ClusterDoesNotExist { name: _ } => Some("Create the cluster with CREATE CLUSTER or pick an extant cluster with SET CLUSTER = name. List available clusters with SHOW CLUSTERS.".into()),
+            AdapterNotice::DroppedActiveDatabase { name: _ } => Some("Choose a new active database by executing SET DATABASE = <name>.".into()),
+            AdapterNotice::DroppedActiveCluster { name: _ } => Some("Choose a new active cluster by executing SET CLUSTER = <name>.".into()),
             _ => None
         }
     }
@@ -106,6 +114,12 @@ impl fmt::Display for AdapterNotice {
                     "cluster replica {}.{} changed status to: {:?}",
                     cluster, replica, status,
                 )
+            }
+            AdapterNotice::DroppedActiveDatabase { name } => {
+                write!(f, "active database {} has been dropped", name.quoted())
+            }
+            AdapterNotice::DroppedActiveCluster { name } => {
+                write!(f, "active cluster {} has been dropped", name.quoted())
             }
         }
     }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -429,6 +429,8 @@ impl ErrorResponse {
             }
             AdapterNotice::UserRequested { .. } => SqlState::WARNING,
             AdapterNotice::ClusterReplicaStatusChanged { .. } => SqlState::WARNING,
+            AdapterNotice::DroppedActiveDatabase { .. } => SqlState::WARNING,
+            AdapterNotice::DroppedActiveCluster { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -578,6 +580,8 @@ impl Severity {
                 NoticeSeverity::Warning => Severity::Warning,
             },
             AdapterNotice::ClusterReplicaStatusChanged { .. } => Severity::Notice,
+            AdapterNotice::DroppedActiveDatabase { .. } => Severity::Notice,
+            AdapterNotice::DroppedActiveCluster { .. } => Severity::Notice,
         }
     }
 }

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -106,15 +106,17 @@ ReadyForQuery {"status":"I"}
 send
 Query {"query": "create database d1"}
 Query {"query": "create database d2"}
-Query {"query": "create database d3"}
+Query {"query": "create database DB3"}
 Query {"query": "set database = d1"}
 Query {"query": "drop database d2"}
 Query {"query": "drop database d1"}
-Query {"query": "set database = d3"}
-Query {"query": "drop DATABASE D3"}
+Query {"query": "set database = dB3"}
+Query {"query": "show database"}
+Query {"query": "drop DATABASE Db3"}
 ----
 
 until
+ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -139,7 +141,11 @@ CommandComplete {"tag":"DROP DATABASE"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d3\" has been dropped"}]}
+RowDescription {"fields":[{"name":"database"}]}
+DataRow {"fields":["db3"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"db3\" has been dropped"}]}
 CommandComplete {"tag":"DROP DATABASE"}
 ReadyForQuery {"status":"I"}
 
@@ -147,15 +153,17 @@ ReadyForQuery {"status":"I"}
 send
 Query {"query": "create cluster c1 REPLICAS ()"}
 Query {"query": "create cluster c2 REPLICAS ()"}
-Query {"query": "create cluster c3 REPLICAS (r1 (SIZE = '1'))"}
+Query {"query": "create cluster CL3 REPLICAS (r1 (SIZE = '1'))"}
 Query {"query": "set cluster = c1"}
 Query {"query": "drop cluster c2"}
 Query {"query": "drop cluster c1"}
-Query {"query": "set cluster = c3"}
-Query {"query": "drop CLUSTER C3"}
+Query {"query": "set cluster = cL3"}
+Query {"query": "show cluster"}
+Query {"query": "drop CLUSTER Cl3"}
 ----
 
 until
+ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ReadyForQuery
@@ -180,6 +188,10 @@ CommandComplete {"tag":"DROP CLUSTER"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c3\" has been dropped"}]}
+RowDescription {"fields":[{"name":"cluster"}]}
+DataRow {"fields":["cl3"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"cl3\" has been dropped"}]}
 CommandComplete {"tag":"DROP CLUSTER"}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -101,3 +101,85 @@ RowDescription {"fields":[{"name":"cluster"}]}
 DataRow {"fields":["default"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
+
+# Test dropping active database
+send
+Query {"query": "create database d1"}
+Query {"query": "create database d2"}
+Query {"query": "create database d3"}
+Query {"query": "set database = d1"}
+Query {"query": "drop database d2"}
+Query {"query": "drop database d1"}
+Query {"query": "set database = d3"}
+Query {"query": "drop DATABASE D3"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d1\" has been dropped"}]}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d3\" has been dropped"}]}
+CommandComplete {"tag":"DROP DATABASE"}
+ReadyForQuery {"status":"I"}
+
+# Test dropping active cluster
+send
+Query {"query": "create cluster c1 REPLICAS ()"}
+Query {"query": "create cluster c2 REPLICAS ()"}
+Query {"query": "create cluster c3 REPLICAS (r1 (SIZE = '1'))"}
+Query {"query": "set cluster = c1"}
+Query {"query": "drop cluster c2"}
+Query {"query": "drop cluster c1"}
+Query {"query": "set cluster = c3"}
+Query {"query": "drop CLUSTER C3"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c1\" has been dropped"}]}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"SET"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c3\" has been dropped"}]}
+CommandComplete {"tag":"DROP CLUSTER"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Resolves the second part of https://github.com/MaterializeInc/materialize/issues/12926. If a user drops their active database or cluster, we should still allow them to perform the action, but should provide a notice.

### Motivation

### Tips for reviewer
* For some reason I was getting a segfault in this block
```
        let database_name = plan
            .id
            .map(|id| self.catalog.get_database(&id))
            .map(|db| db.name.clone());
```
on startup if I didn't move `.name.clone()` into a second map (and instead chained it on the `.get_database(&id)` call above. I have no idea why...

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
