### PR TITLE
Fix double localizing in `consequence_for_input`

### DIFF
--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -400,7 +400,7 @@ impl JoinInputMapper {
         index: usize,
     ) -> Option<MirScalarExpr> {
         if self.is_localized(expr, index) {
-            Some(expr.clone())
+            Some(self.map_expr_to_local(expr.clone()))
         } else {
             match expr {
                 MirScalarExpr::CallVariadic {
@@ -414,10 +414,10 @@ impl JoinInputMapper {
                             mz_ore::stack::maybe_grow(|| self.consequence_for_input(or_arg, index))
                         })
                         .collect::<Option<Vec<_>>>()?; // return None if any of them are None
-                    Some(self.map_expr_to_local(MirScalarExpr::CallVariadic {
+                    Some(MirScalarExpr::CallVariadic {
                         func: VariadicFunc::Or,
                         exprs: consequences_per_arg,
-                    }))
+                    })
                 }
                 MirScalarExpr::CallVariadic {
                     func: VariadicFunc::And,
@@ -435,10 +435,10 @@ impl JoinInputMapper {
                     if consequences_per_arg.is_empty() {
                         None
                     } else {
-                        Some(self.map_expr_to_local(MirScalarExpr::CallVariadic {
+                        Some(MirScalarExpr::CallVariadic {
                             func: VariadicFunc::And,
                             exprs: consequences_per_arg,
-                        }))
+                        })
                     }
                 }
                 _ => None,

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -357,3 +357,71 @@ Used Indexes:
   - materialize.public.t2_f1_ind
 
 EOF
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/16128
+
+statement ok
+CREATE TABLE tt1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+statement ok
+CREATE TABLE tt2 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
+
+query T multiline
+EXPLAIN WITH(arity, join_impls) SELECT *
+FROM tt2 ,
+(
+    SELECT AVG(1) AS f1 , COUNT (1) AS f2
+    FROM tt2
+    WHERE f2 IS NULL
+) AS a2
+WHERE a2.f1 = 1
+OR a2.f1 + 4 = 8
+AND tt2.f2 = 1;
+----
+Explained Query (fast path):
+  Constant <empty>
+
+EOF
+
+# Another test for https://github.com/MaterializeInc/materialize/issues/16128
+
+query T multiline
+EXPLAIN WITH(arity, join_impls) SELECT
+        s.name, r.name
+FROM
+        mz_schemas s,
+        mz_relations r
+WHERE
+        r.schema_id = s.id AND (r.type = 'materialized-view' OR (r.type = 'view' AND s.name != 'doesntmatter'))
+----
+Explained Query:
+  Project (#1, #3) // { arity: 2 }
+    Filter ((#4 = "materialized-view") OR ((#4 = "view") AND (#1 != "doesntmatter"))) // { arity: 5 }
+      Join on=(#0 = #2) type=differential // { arity: 5 }
+        implementation
+          %1 » %0:mz_schemas[#0]KAef
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Project (#0, #3) // { arity: 2 }
+            Get mz_catalog.mz_schemas // { arity: 4 }
+        ArrangeBy keys=[[#0]] // { arity: 3 }
+          Union // { arity: 3 }
+            Project (#2, #3, #5) // { arity: 3 }
+              Map ("view") // { arity: 6 }
+                Get mz_catalog.mz_views // { arity: 5 }
+            Project (#2, #3, #6) // { arity: 3 }
+              Map ("materialized-view") // { arity: 7 }
+                Get mz_catalog.mz_materialized_views // { arity: 6 }
+
+Source mz_catalog.mz_schemas
+  project=(#0, #4, #5, #3)
+  map=(dummy, dummy)
+Source mz_catalog.mz_views
+  project=(#5, #6, #2, #3, #7)
+  filter=(true)
+  map=(dummy, dummy, dummy)
+Source mz_catalog.mz_materialized_views
+  project=(#6, #7, #2, #3, #8, #9)
+  filter=(true)
+  map=(dummy, dummy, dummy, dummy)
+
+EOF


### PR DESCRIPTION
`JoinInputMapper::consequence_for_input` was calling `map_expr_to_local` too many times: If the recursion digs out a subexpression from somewhere deep inside an expression, then we were calling `map_expr_to_local` at every level of the recursion. These calls were on overlapping subexpressions, so calls after the first call were sometimes trying to localize an already (partially) localized subexpression.

I removed all calls to `map_expr_to_local` from inside the recursion, and added a new call outside the recursion.  

(The bug was not noticed before, because it is not so easy to trigger: the first `map_expr_to_local` call often makes the index small enough that any subsequent call is a no-op, because the index is already on the first input if we interpret the index in the global context. To trigger the bug, the input that we are localizing into should have more fields than the first input, and the expression should be referring to one of the later columns. @philip-stoev, I'm wondering if you can maybe tweak something on your random SQL generator based on this experience, e.g., have more variation in the number of fields of different input tables.)

The randomly chosen reviewer is @antiguru.

### Motivation

  * This PR fixes a recognized bug. Fixes #16128

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - [ ] Added Philip's test from the issue and Frank's query from the other PR
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fixed a bug in predicate pushdown.