### PR TITLE
storage: in (compute) persist_sink, only consolidate updates when needed

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -717,16 +717,6 @@ where
                             );
                         }
                     }
-                    // Consolidate updates within.
-                    consolidate_updates(&mut correction);
-
-                    if sink_id.is_user() {
-                        trace!(
-                            "correction: {:?}, in-flight: {:?}",
-                            correction,
-                            in_flight_batches
-                        );
-                    }
 
                     trace!(
                         "persist_sink {sink_id}/{shard_id}: \
@@ -759,6 +749,14 @@ where
                         ready batches: {:?}",
                         ready_batches,
                     );
+
+                    if !ready_batches.is_empty() {
+                        // Consolidate updates only when they are required by an
+                        // attempt to write out new updates. Otherwise, we might
+                        // spend a lot of time "consolidating" the same updates
+                        // over and over again, with no changes.
+                        consolidate_updates(&mut correction);
+                    }
 
                     for batch_description in ready_batches.into_iter() {
                         let cap = in_flight_batches.remove(&batch_description).unwrap();


### PR DESCRIPTION
### Motivation

Fixes #16146

I'm not yet sure this fixes the problem completely (or at all) because I can't easily reproduce this. We might have to apply this to a testing/staging environment that exhibits the bug and see if it fixes it.

### Tips for reviewer

Before, we were consolidating on every invocation of the operator, evenin case nothing changed and in case where we're not currently interested in the consolidated result (because we're not planning to write out updates). Now, we only consolidate when we need it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
