### PR TITLE
storage: deprovision hosts in `StorageController::process`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -509,7 +509,6 @@ impl<S: Append + 'static> Coordinator<S> {
                 self.controller
                     .active_compute()
                     .add_replica_to_instance(instance.id, replica_id, replica.config)
-                    .await
                     .unwrap();
             }
         }
@@ -518,16 +517,13 @@ impl<S: Append + 'static> Coordinator<S> {
         // Migrate builtin objects.
         self.controller
             .storage
-            .drop_sources_unvalidated(builtin_migration_metadata.previous_materialized_view_ids)
-            .await?;
+            .drop_sources_unvalidated(builtin_migration_metadata.previous_materialized_view_ids);
         self.controller
             .storage
-            .drop_sources_unvalidated(builtin_migration_metadata.previous_source_ids)
-            .await?;
+            .drop_sources_unvalidated(builtin_migration_metadata.previous_source_ids);
         self.controller
             .storage
-            .drop_sinks_unvalidated(builtin_migration_metadata.previous_sink_ids)
-            .await?;
+            .drop_sinks_unvalidated(builtin_migration_metadata.previous_sink_ids);
 
         let mut entries: Vec<_> = self.catalog.entries().cloned().collect();
         // Topologically sort entries based on the used_by relationship
@@ -661,7 +657,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         self.controller
                             .active_compute()
                             .create_dataflows(idx.compute_instance, dataflow_plan)
-                            .await
                             .unwrap();
                     }
                 }
@@ -707,7 +702,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         .controller
                         .storage
                         .prepare_export(id, sink.from)
-                        .await
                         .unwrap();
 
                     task::spawn(

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -143,7 +143,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 tx,
             } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
-                self.sequence_end_transaction(tx, session, action).await;
+                self.sequence_end_transaction(tx, session, action);
             }
 
             Command::VerifyPreparedStatement {
@@ -539,7 +539,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ///
     /// This cleans up any state in the coordinator associated with the session.
     async fn handle_terminate(&mut self, session: &mut Session) {
-        self.clear_transaction(session).await;
+        self.clear_transaction(session);
 
         self.drop_temp_items(session).await;
         self.catalog

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -103,7 +103,6 @@ impl<S: Append + 'static> Coordinator<S> {
         self.controller
             .active_compute()
             .create_dataflows(instance, dataflow_plans)
-            .await
             .unwrap();
         self.initialize_compute_read_policies(
             output_ids,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -238,24 +238,22 @@ impl<S: Append + 'static> Coordinator<S> {
                 .await;
 
             if !sources_to_drop.is_empty() {
-                self.drop_sources(sources_to_drop).await;
+                self.drop_sources(sources_to_drop);
             }
             if !log_sources_to_drop.is_empty() {
-                self.drop_sources(log_sources_to_drop.into_iter().map(|(_, id)| id).collect())
-                    .await;
+                self.drop_sources(log_sources_to_drop.into_iter().map(|(_, id)| id).collect());
             }
             if !tables_to_drop.is_empty() {
-                self.drop_sources(tables_to_drop).await;
+                self.drop_sources(tables_to_drop);
             }
             if !storage_sinks_to_drop.is_empty() {
-                self.drop_storage_sinks(storage_sinks_to_drop).await;
+                self.drop_storage_sinks(storage_sinks_to_drop);
             }
             if !indexes_to_drop.is_empty() {
-                self.drop_indexes(indexes_to_drop).await;
+                self.drop_indexes(indexes_to_drop);
             }
             if !materialized_views_to_drop.is_empty() {
-                self.drop_materialized_views(materialized_views_to_drop)
-                    .await;
+                self.drop_materialized_views(materialized_views_to_drop);
             }
             if !secrets_to_drop.is_empty() {
                 self.drop_secrets(secrets_to_drop).await;
@@ -321,14 +319,14 @@ impl<S: Append + 'static> Coordinator<S> {
         Ok(result)
     }
 
-    async fn drop_sources(&mut self, sources: Vec<GlobalId>) {
+    fn drop_sources(&mut self, sources: Vec<GlobalId>) {
         for id in &sources {
             self.drop_storage_read_policy(id);
         }
-        self.controller.storage.drop_sources(sources).await.unwrap();
+        self.controller.storage.drop_sources(sources).unwrap();
     }
 
-    pub(crate) async fn drop_compute_sinks(&mut self, sinks: Vec<ComputeSinkId>) {
+    pub(crate) fn drop_compute_sinks(&mut self, sinks: Vec<ComputeSinkId>) {
         let by_compute_instance = sinks
             .into_iter()
             .map(
@@ -342,22 +340,19 @@ impl<S: Append + 'static> Coordinator<S> {
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
             if compute.instance_exists(compute_instance) {
-                compute
-                    .drop_collections(compute_instance, ids)
-                    .await
-                    .unwrap();
+                compute.drop_collections(compute_instance, ids).unwrap();
             }
         }
     }
 
-    pub(crate) async fn drop_storage_sinks(&mut self, sinks: Vec<GlobalId>) {
+    pub(crate) fn drop_storage_sinks(&mut self, sinks: Vec<GlobalId>) {
         for id in &sinks {
             self.drop_storage_read_policy(id);
         }
-        self.controller.storage.drop_sinks(sinks).await.unwrap();
+        self.controller.storage.drop_sinks(sinks).unwrap();
     }
 
-    pub(crate) async fn drop_indexes(&mut self, indexes: Vec<(ComputeInstanceId, GlobalId)>) {
+    pub(crate) fn drop_indexes(&mut self, indexes: Vec<(ComputeInstanceId, GlobalId)>) {
         let mut by_compute_instance: HashMap<_, Vec<_>> = HashMap::new();
         for (compute_instance, id) in indexes {
             if self.drop_compute_read_policy(&id) {
@@ -373,12 +368,11 @@ impl<S: Append + 'static> Coordinator<S> {
             self.controller
                 .active_compute()
                 .drop_collections(compute_instance, ids)
-                .await
                 .unwrap();
         }
     }
 
-    async fn drop_materialized_views(&mut self, mviews: Vec<(ComputeInstanceId, GlobalId)>) {
+    fn drop_materialized_views(&mut self, mviews: Vec<(ComputeInstanceId, GlobalId)>) {
         let mut by_compute_instance: HashMap<_, Vec<_>> = HashMap::new();
         let mut source_ids = Vec::new();
         for (compute_instance, id) in mviews {
@@ -398,10 +392,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
             if compute.instance_exists(compute_instance) {
-                compute
-                    .drop_collections(compute_instance, ids)
-                    .await
-                    .unwrap();
+                compute.drop_collections(compute_instance, ids).unwrap();
             }
         }
 
@@ -409,11 +400,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for id in &source_ids {
             self.drop_storage_read_policy(id);
         }
-        self.controller
-            .storage
-            .drop_sources(source_ids)
-            .await
-            .unwrap();
+        self.controller.storage.drop_sources(source_ids).unwrap();
     }
 
     async fn drop_secrets(&mut self, secrets: Vec<GlobalId>) {
@@ -557,7 +544,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 match self.catalog_transact(session, ops).await {
                     Ok(()) => (),
                     catalog_err @ Err(_) => {
-                        let () = self.drop_storage_sinks(vec![id]).await;
+                        let () = self.drop_storage_sinks(vec![id]);
                         catalog_err?
                     }
                 }

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -357,8 +357,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 let () = self
                     .controller
                     .storage
-                    .cancel_prepare_export(create_export_token)
-                    .await;
+                    .cancel_prepare_export(create_export_token);
                 if let Some((session, tx)) = session_and_tx {
                     tx.send(Err(e), session);
                 }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -358,7 +358,6 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 self.controller
                     .active_compute()
                     .create_dataflows(compute_instance, vec![dataflow])
-                    .await
                     .unwrap();
                 self.initialize_compute_read_policies(
                     output_ids,
@@ -434,7 +433,6 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 map_filter_project,
                 target_replica,
             )
-            .await
             .unwrap();
 
         // Prepare the receiver to return as a response.
@@ -454,7 +452,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         // If it was created, drop the dataflow once the peek command is sent.
         if let Some(index_id) = drop_dataflow {
             self.remove_compute_ids_from_timeline(vec![(compute_instance, index_id)]);
-            self.drop_indexes(vec![(compute_instance, index_id)]).await;
+            self.drop_indexes(vec![(compute_instance, index_id)]);
         }
 
         Ok(crate::ExecuteResponse::SendingRows {

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -139,7 +139,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
     /// Handle removing in-progress transaction state regardless of the end action
     /// of the transaction.
-    pub(crate) async fn clear_transaction(
+    pub(crate) fn clear_transaction(
         &mut self,
         session: &mut Session,
     ) -> TransactionStatus<mz_repr::Timestamp> {
@@ -148,11 +148,11 @@ impl<S: Append + 'static> Coordinator<S> {
             .get_mut(&session.conn_id())
             .expect("must exist for active session");
         let drop_sinks = std::mem::take(&mut conn_meta.drop_sinks);
-        self.drop_compute_sinks(drop_sinks).await;
+        self.drop_compute_sinks(drop_sinks);
 
         // Release this transaction's compaction hold on collections.
         if let Some(txn_reads) = self.txn_reads.remove(&session.conn_id()) {
-            self.release_read_hold(&txn_reads.read_holds).await;
+            self.release_read_hold(&txn_reads.read_holds);
         }
 
         session.clear_transaction()

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -718,7 +718,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .await;
             let read_ts = oracle.read_ts();
             if read_holds.times().any(|time| time.less_than(&read_ts)) {
-                read_holds = self.update_read_hold(read_holds, read_ts).await;
+                read_holds = self.update_read_hold(read_holds, read_ts);
             }
             self.global_timelines
                 .insert(timeline, TimelineState { oracle, read_holds });

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -192,7 +192,7 @@ where
                 Ok(None)
             }
             Readiness::Compute => {
-                let response = self.active_compute().process().await?;
+                let response = self.active_compute().process();
                 Ok(response.map(Into::into))
             }
         }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -215,20 +215,20 @@ pub trait StorageController: Debug + Send {
     ) -> Result<(), StorageError>;
 
     /// Notify the storage controller to prepare for an export to be created
-    async fn prepare_export(
+    fn prepare_export(
         &mut self,
         id: GlobalId,
         from_id: GlobalId,
     ) -> Result<CreateExportToken, StorageError>;
 
     /// Cancel the pending export
-    async fn cancel_prepare_export(&mut self, token: CreateExportToken);
+    fn cancel_prepare_export(&mut self, token: CreateExportToken);
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
-    async fn drop_sources(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError>;
+    fn drop_sources(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sinks and allows their resources to be reclaimed.
-    async fn drop_sinks(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError>;
+    fn drop_sinks(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sinks and allows their resources to be reclaimed.
     ///
@@ -240,10 +240,7 @@ pub trait StorageController: Debug + Send {
     ///     created, but have been forgotten by the controller due to a restart.
     ///     Once command history becomes durable we can remove this method and use the normal
     ///     `drop_sinks`.
-    async fn drop_sinks_unvalidated(
-        &mut self,
-        identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError>;
+    fn drop_sinks_unvalidated(&mut self, identifiers: Vec<GlobalId>);
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
     ///
@@ -255,10 +252,7 @@ pub trait StorageController: Debug + Send {
     ///     created, but have been forgotten by the controller due to a restart.
     ///     Once command history becomes durable we can remove this method and use the normal
     ///     `drop_sources`.
-    async fn drop_sources_unvalidated(
-        &mut self,
-        identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError>;
+    fn drop_sources_unvalidated(&mut self, identifiers: Vec<GlobalId>);
 
     /// Append `updates` into the local input named `id` and advance its upper to `upper`.
     ///
@@ -288,10 +282,7 @@ pub trait StorageController: Debug + Send {
     /// The `StorageController` may include its own overrides on these policies.
     ///
     /// Identifiers not present in `policies` retain their existing read policies.
-    async fn set_read_policy(
-        &mut self,
-        policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>,
-    ) -> Result<(), StorageError>;
+    fn set_read_policy(&mut self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>);
 
     /// Ingests write frontier updates for collections that this controller
     /// maintains and potentially generates updates to read capabilities, which
@@ -315,16 +306,13 @@ pub trait StorageController: Debug + Send {
     /// [`ReadPolicy`]. Advancing the write frontier might change this implied
     /// capability, which in turn might change the overall `since` (a
     /// combination of all read capabilities) of a collection.
-    async fn update_write_frontiers(
-        &mut self,
-        updates: &[(GlobalId, Antichain<Self::Timestamp>)],
-    ) -> Result<(), StorageError>;
+    fn update_write_frontiers(&mut self, updates: &[(GlobalId, Antichain<Self::Timestamp>)]);
 
     /// Applies `updates` and sends any appropriate compaction command.
-    async fn update_read_capabilities(
+    fn update_read_capabilities(
         &mut self,
         updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
-    ) -> Result<(), StorageError>;
+    );
 
     /// Waits until the controller is ready to process a response.
     ///
@@ -1055,7 +1043,7 @@ where
             .ok_or(StorageError::IdentifierMissing(id))
     }
 
-    async fn prepare_export(
+    fn prepare_export(
         &mut self,
         id: GlobalId,
         from_id: GlobalId,
@@ -1073,10 +1061,7 @@ where
         Ok(CreateExportToken { id, from_id })
     }
 
-    async fn cancel_prepare_export(
-        &mut self,
-        CreateExportToken { id, from_id }: CreateExportToken,
-    ) {
+    fn cancel_prepare_export(&mut self, CreateExportToken { id, from_id }: CreateExportToken) {
         self.state
             .exported_collections
             .get_mut(&from_id)
@@ -1171,38 +1156,28 @@ where
         Ok(())
     }
 
-    async fn drop_sources(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError> {
+    fn drop_sources(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError> {
         self.validate_collection_ids(identifiers.iter().cloned())?;
-        let policies = identifiers
-            .into_iter()
-            .map(|id| (id, ReadPolicy::ValidFrom(Antichain::new())))
-            .collect();
-        self.set_read_policy(policies).await?;
+        self.drop_sources_unvalidated(identifiers);
         Ok(())
     }
 
-    async fn drop_sources_unvalidated(
-        &mut self,
-        identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError> {
+    fn drop_sources_unvalidated(&mut self, identifiers: Vec<GlobalId>) {
         let policies = identifiers
             .into_iter()
             .map(|id| (id, ReadPolicy::ValidFrom(Antichain::new())))
             .collect();
-        self.set_read_policy(policies).await?;
-        Ok(())
+        self.set_read_policy(policies);
     }
 
     /// Drops the read capability for the sinks and allows their resources to be reclaimed.
-    async fn drop_sinks(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError> {
+    fn drop_sinks(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError> {
         self.validate_export_ids(identifiers.iter().cloned())?;
-        self.drop_sinks_unvalidated(identifiers).await
+        self.drop_sinks_unvalidated(identifiers);
+        Ok(())
     }
 
-    async fn drop_sinks_unvalidated(
-        &mut self,
-        identifiers: Vec<GlobalId>,
-    ) -> Result<(), StorageError> {
+    fn drop_sinks_unvalidated(&mut self, identifiers: Vec<GlobalId>) {
         for id in identifiers {
             let export = match self.export(id) {
                 Ok(export) => export,
@@ -1218,11 +1193,9 @@ where
                 .retain(|from_export_id| *from_export_id != id);
 
             // Remove sink by removing its write frontier and arranging for deprovisioning.
-            self.update_write_frontiers(&[(id, Antichain::new())])
-                .await?;
+            self.update_write_frontiers(&[(id, Antichain::new())]);
             self.state.pending_host_deprovisions.insert(id);
         }
-        Ok(())
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -1289,10 +1262,7 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn set_read_policy(
-        &mut self,
-        policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>,
-    ) -> Result<(), StorageError> {
+    fn set_read_policy(&mut self, policies: Vec<(GlobalId, ReadPolicy<Self::Timestamp>)>) {
         let mut read_capability_changes = BTreeMap::default();
         for (id, policy) in policies.into_iter() {
             if let Ok(mut updates) =
@@ -1306,17 +1276,12 @@ where
             }
         }
         if !read_capability_changes.is_empty() {
-            self.update_read_capabilities(&mut read_capability_changes)
-                .await?;
+            self.update_read_capabilities(&mut read_capability_changes);
         }
-        Ok(())
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn update_write_frontiers(
-        &mut self,
-        updates: &[(GlobalId, Antichain<Self::Timestamp>)],
-    ) -> Result<(), StorageError> {
+    fn update_write_frontiers(&mut self, updates: &[(GlobalId, Antichain<Self::Timestamp>)]) {
         let mut read_capability_changes = BTreeMap::default();
         let mut collections = BTreeMap::new();
         let mut exports = vec![];
@@ -1354,17 +1319,15 @@ where
         }
 
         if !read_capability_changes.is_empty() {
-            self.update_read_capabilities(&mut read_capability_changes)
-                .await?;
+            self.update_read_capabilities(&mut read_capability_changes);
         }
-        Ok(())
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn update_read_capabilities(
+    fn update_read_capabilities(
         &mut self,
         updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
-    ) -> Result<(), StorageError> {
+    ) {
         // Location to record consequences that we need to act on.
         let mut storage_net = HashMap::new();
         // Repeatedly extract the maximum id, and updates for it.
@@ -1412,8 +1375,6 @@ where
                 }
             }
         }
-
-        Ok(())
     }
 
     async fn ready(&mut self) {
@@ -1440,7 +1401,7 @@ where
         match self.state.stashed_response.take() {
             None => (),
             Some(StorageResponse::FrontierUppers(updates)) => {
-                self.update_write_frontiers(&updates).await?;
+                self.update_write_frontiers(&updates);
             }
             Some(StorageResponse::DroppedIds(_ids)) => {
                 // TODO(petrosagg): It looks like the storage controller never cleans up GlobalIds


### PR DESCRIPTION
This PR moves the deprovisioning of storage hosts out of `update_read_capabilities` (and `drop_sinks_unvalidated`) into the `process` method. The main benefit of this is that `update_read_capabilities` becomes sync, which has a significant effect on the compute controller API: Basically the whole compute controller API becomes sync.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I've split the changes into commits as follows:
* The first commit only moves the deprovisioning of storage hosts into `StorageController::process`.
* The remaining three commits propagate the consequences of that change (i.e. methods becoming async and returning fewer errors) to storage, compute, and adapter.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
