### PR TITLE
persist: fix maelstrom flake

### DIFF
--- a/src/persist-client/examples/maelstrom/node.rs
+++ b/src/persist-client/examples/maelstrom/node.rs
@@ -219,6 +219,11 @@ pub struct Handle {
 }
 
 impl Handle {
+    /// Returns this handle's NodeId.
+    pub fn node_id(&self) -> NodeId {
+        self.node_id.clone()
+    }
+
     /// Send a response to Maelstrom.
     ///
     /// `dest` should be the `src` of the response. To make a service request,

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -239,10 +239,10 @@ impl StateVersions {
             }
             Err(live_diffs) => {
                 debug!(
-                    "apply_unbatched_cmd {} {} lost the CaS race, retrying: {} vs {:?}",
+                    "apply_unbatched_cmd {} {} lost the CaS race, retrying: {:?} vs {:?}",
                     new_state.shard_id(),
                     cmd_name,
-                    new_state.seqno(),
+                    expected,
                     live_diffs.last().map(|x| x.seqno)
                 );
                 Ok(Err(live_diffs))


### PR DESCRIPTION
This was just a brain fart when updating maelstrom to try to maximally exercise critical since handles in #15822. Before that PR, each copy of Transactor had a ReadHandle and thus its own since capability. This allowed it to know and assert that it could read at read_ts because it only ever updated the since capability itself to things that were less than read_ts. 15822 changed it so all Transactors shared a single CriticalReaderId and thus a single since capability, so it's possible for some other Transactor to move it past your read_ts. If we were able to proceed with this read_ts, we'd just find out in compare_and_append that it's out of date and we'd get a new read_ts that is above the since_ts.

To fix, give each node a unique token (specifically, the maelstrom node_id) for CaDS calls. When a CaDS detects that another node was the most recent to update the since, forward the local read_ts to the since_ts (i.e. set it to since_ts if the since_ts is larger).

Closes #16149

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
