### PR TITLE
[source] Percolate up a few more Kafka errors

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -77,6 +77,8 @@ pub struct KafkaSourceReader {
     partition_metrics: KafkaPartitionMetrics,
     /// Whether or not to unpack and allocate headers and pass them through in the `SourceMessage`
     include_headers: bool,
+    /// The latest error reported to the consumer context.
+    recent_error: Arc<Mutex<Option<KafkaError>>>,
 }
 
 pub struct KafkaOffsetCommiter {
@@ -111,12 +113,14 @@ impl SourceConnectionBuilder for KafkaSourceConnection {
             ..
         } = self;
         let (stats_tx, stats_rx) = crossbeam_channel::unbounded();
+        let recent_error = Arc::new(Mutex::new(None));
         let consumer: BaseConsumer<_> =
             TokioHandle::current().block_on(connection.create_with_context(
                 &connection_context,
                 GlueConsumerContext {
                     activator: consumer_activator,
                     stats_tx,
+                    recent_error: Arc::clone(&recent_error),
                 },
                 &btreemap! {
                     // Default to disabling Kafka auto commit. This can be
@@ -249,6 +253,7 @@ impl SourceConnectionBuilder for KafkaSourceConnection {
                     topic.clone(),
                     source_id,
                 ),
+                recent_error,
             },
             KafkaOffsetCommiter {
                 source_id,
@@ -358,6 +363,24 @@ impl SourceReader for KafkaSourceReader {
                 Ok(None) => {
                     // no message in this queue; keep looping
                 }
+            }
+        }
+        if let Some(err) = self
+            .recent_error
+            .lock()
+            .expect("locking error mutex")
+            .take()
+        {
+            // If we're blocking _and_ kafka is reporting an error, pass it on.
+            // Otherwise, discard it. It's possible for us to experience an error while there
+            // are more messages in the queue; in that case, we'll rely on the client reporting that
+            // error again in the future if the error condition persists.
+            if let NextMessage::Pending = next_message {
+                next_message =
+                    NextMessage::Ready(SourceMessageType::SourceStatus(SourceStatusUpdate {
+                        status: SourceStatus::Stalled,
+                        error: Some(err.to_string()),
+                    }))
             }
         }
 
@@ -741,6 +764,7 @@ impl PartitionConsumer {
 struct GlueConsumerContext {
     activator: SyncActivator,
     stats_tx: crossbeam_channel::Sender<Jsonb>,
+    recent_error: Arc<Mutex<Option<KafkaError>>>,
 }
 
 impl ClientContext for GlueConsumerContext {
@@ -762,6 +786,8 @@ impl ClientContext for GlueConsumerContext {
         MzClientContext.log(level, fac, log_message)
     }
     fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
+        let mut recent_error = self.recent_error.lock().expect("recording error");
+        *recent_error = Some(error.clone());
         MzClientContext.error(error, reason)
     }
 }


### PR DESCRIPTION
This captures a few more error cases in the Kafka source:
- The errors that get returned from `poll`. I have not observed these, but they should be possible.
- Errors reported to the context. These are previously only logged, but there seems to be error information that isn't otherwise available in there: like "all the brokers are down", where otherwise the consumer will just sit around and wait indefinitely.

### Motivation

[#15633 ](https://github.com/MaterializeInc/materialize/issues/16065)

### Tips for reviewer

Some idiosyncrasies:
- If there are messages buffered when we hit some error condition, that error won't be reported. In general it's impossible to distinguish between "we had an error and now we have messages" and "we got some messages before this error" via the rdkafka API. The downstream status handling will clear any error states when it sees new messages, so we maintain the same behaviour here.
- If the error condition clears, but we don't have any data coming in, we'll continue to report "stalled". I have not found any way to detect "everything's healthy, and we just have no messages" via rdkafka yet, so this seems unavoidable. Better to have the stalled state persist too long than clear it too early, I think!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
