### PR TITLE
coord: Initialize new tables uppers

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1142,6 +1142,18 @@ impl<S: Append + 'static> Coordinator<S> {
                     DEFAULT_LOGICAL_COMPACTION_WINDOW_MS,
                 )
                 .await;
+
+                // Advance the new table to a timestamp higher than the current read timestamp so
+                // that the table is immediately readable.
+                let upper = self.get_local_read_ts().step_forward();
+                let appends = vec![(table_id, Vec::new(), upper)];
+                self.controller
+                    .storage
+                    .append(appends)
+                    .expect("invalid table upper initialization")
+                    .await
+                    .expect("One-shot dropped while waiting synchronously")
+                    .unwrap();
                 Ok(ExecuteResponse::CreatedTable)
             }
             Err(AdapterError::Catalog(catalog::Error {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1145,7 +1145,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
                 // Advance the new table to a timestamp higher than the current read timestamp so
                 // that the table is immediately readable.
-                let upper = self.get_local_read_ts().step_forward();
+                let upper = since_ts.step_forward();
                 let appends = vec![(table_id, Vec::new(), upper)];
                 self.controller
                     .storage


### PR DESCRIPTION
When creating a new collection, the upper is initialized to the minimum timestamp value. The collection is not readable until the upper is advanced.

Previously, when creating a table we don't immediately advance it's upper. As a consequence the table doesn't become readable until the next periodic table advancement.

This commit updates the create table DDL logic, so that the table's upper is immediately advanced, and therefore immediately readable.

Fixes #16115

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
