### PR TITLE
doc/user: remove duplicated clause from load gen source syntax diagram

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="667" height="747">
+<svg xmlns="http://www.w3.org/2000/svg" width="667" height="661">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -133,62 +133,54 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="607" y="487">)</text>
-   <rect x="153" y="611" width="58" height="32" rx="10"/>
-   <rect x="151"
+   <rect x="255" y="611" width="58" height="32" rx="10"/>
+   <rect x="253"
          y="609"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="161" y="629">WITH</text>
-   <rect x="231" y="611" width="26" height="32" rx="10"/>
-   <rect x="229"
+   <text class="terminal" x="263" y="629">WITH</text>
+   <rect x="333" y="611" width="26" height="32" rx="10"/>
+   <rect x="331"
          y="609"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="239" y="629">(</text>
-   <rect x="297" y="611" width="48" height="32"/>
-   <rect x="295" y="609" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="629">field</text>
-   <rect x="365" y="611" width="28" height="32" rx="10"/>
-   <rect x="363"
+   <text class="terminal" x="341" y="629">(</text>
+   <rect x="399" y="611" width="48" height="32"/>
+   <rect x="397" y="609" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="629">field</text>
+   <rect x="467" y="611" width="28" height="32" rx="10"/>
+   <rect x="465"
          y="609"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="373" y="629">=</text>
-   <rect x="413" y="611" width="38" height="32"/>
-   <rect x="411" y="609" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="421" y="629">val</text>
-   <rect x="297" y="567" width="24" height="32" rx="10"/>
-   <rect x="295"
+   <text class="terminal" x="475" y="629">=</text>
+   <rect x="515" y="611" width="38" height="32"/>
+   <rect x="513" y="609" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="523" y="629">val</text>
+   <rect x="399" y="567" width="24" height="32" rx="10"/>
+   <rect x="397"
          y="565"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="305" y="585">,</text>
-   <rect x="491" y="611" width="26" height="32" rx="10"/>
-   <rect x="489"
+   <text class="terminal" x="407" y="585">,</text>
+   <rect x="593" y="611" width="26" height="32" rx="10"/>
+   <rect x="591"
          y="609"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="499" y="629">)</text>
-   <rect x="481" y="713" width="138" height="32" rx="10"/>
-   <rect x="479"
-         y="711"
-         width="138"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="489" y="731">FOR ALL TABLES</text>
+   <text class="terminal" x="601" y="629">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-334 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m196 0 h10 m20 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m60 0 h10 m0 0 h28 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-385 198 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-523 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-556 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-120 70 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m23 -32 h-3"/>
-   <polygon points="657 695 665 691 665 699"/>
-   <polygon points="657 695 649 691 649 699"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-334 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m196 0 h10 m20 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m60 0 h10 m0 0 h28 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-385 198 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-523 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="657 625 665 621 665 629"/>
+   <polygon points="657 625 649 621 649 629"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -98,7 +98,6 @@ create_source_load_generator ::=
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
   ('FOR ALL TABLES' | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
-  'FOR ALL TABLES'?
 load_generator_option ::=
     'TICK INTERVAL' interval
     | 'SCALE FACTOR' scale_factor


### PR DESCRIPTION
### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
