### PR TITLE
Localize expressions only once

### DIFF
--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -400,7 +400,7 @@ impl JoinInputMapper {
         index: usize,
     ) -> Option<MirScalarExpr> {
         if self.is_localized(expr, index) {
-            Some(expr.clone())
+            Some(self.map_expr_to_local(expr.clone()))
         } else {
             match expr {
                 MirScalarExpr::CallVariadic {
@@ -414,10 +414,10 @@ impl JoinInputMapper {
                             mz_ore::stack::maybe_grow(|| self.consequence_for_input(or_arg, index))
                         })
                         .collect::<Option<Vec<_>>>()?; // return None if any of them are None
-                    Some(self.map_expr_to_local(MirScalarExpr::CallVariadic {
+                    Some(MirScalarExpr::CallVariadic {
                         func: VariadicFunc::Or,
                         exprs: consequences_per_arg,
-                    }))
+                    })
                 }
                 MirScalarExpr::CallVariadic {
                     func: VariadicFunc::And,
@@ -435,10 +435,10 @@ impl JoinInputMapper {
                     if consequences_per_arg.is_empty() {
                         None
                     } else {
-                        Some(self.map_expr_to_local(MirScalarExpr::CallVariadic {
+                        Some(MirScalarExpr::CallVariadic {
                             func: VariadicFunc::And,
                             exprs: consequences_per_arg,
-                        }))
+                        })
                     }
                 }
                 _ => None,


### PR DESCRIPTION
While pushing down predicates, we unintentionally localize expressions more than once. The code would localize at each internal AST node, rather than at the leaves. For complex ASTs this would result in mis-planning. In particular, the @benesch reported query
```sql
SELECT
        s.name, r.name
FROM
        mz_schemas s,
        mz_relations r
WHERE
        r.schema_id = s.id AND (r.type = 'materialized-view' OR (r.type = 'view' AND s.name != 'doesntmatter'))
```
produces an incorrect plan and output. Deleting the `'doesntmatter'` clause prevents the error, which comes from the `OR ( AND )` structure (two internal AST nodes).

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

@philip-stoev you mentioned a grammar that tests lots of AND/OR combinations. I think a few things combine here. The query uses a view that is only inlined later, and it seems like this is part of what leaves a complex AST behind for the bug to manifest.

I haven't tested this with anything other than the supplied query, and we might want to do that and find a way to exercise the behavior of `main` on the erroneous query above.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
