### PR TITLE
testdrive: Adjust fix-replica-targeted-select.td for cloudtest

### DIFF
--- a/test/testdrive/replica-targeted-select.td
+++ b/test/testdrive/replica-targeted-select.td
@@ -22,8 +22,7 @@
 > CREATE CLUSTER test REPLICAS (
       r1 (SIZE '1'),
       r2 (SIZE '2'),
-      r4 (SIZE '4'),
-      r8 (SIZE '8')
+      r4 (SIZE '4')
   )
 
 > SET cluster = test
@@ -52,20 +51,6 @@
 1
 2
 3
-
-> SET cluster_replica = r8
-
-> SELECT DISTINCT worker_id
-  FROM mz_internal.mz_worker_compute_frontiers
-  ORDER BY worker_id
-0
-1
-2
-3
-4
-5
-6
-7
 
 # Clean up.
 > DROP CLUSTER test


### PR DESCRIPTION
cloudtest uses a 3-node KinD K8s cluster, and therefore one can not sucessfully create 4-replica clusters. The fourth replica will fail to start due to anti-affinity rules.

Adjust the test to use 3 replicas, as that is sufficient to prove the point the test is designed to make.

### Motivation

Nightly testdrive-in-cloudtest was failing.