### PR TITLE
persist: write debugging info into state

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -302,7 +302,10 @@ where
                 .expect("could not open persist client");
 
             let mut write = persist_client
-                .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
+                .open_writer::<SourceData, (), Timestamp, Diff>(
+                    shard_id,
+                    &format!("persist_sink::mint_batch_descriptions {}", sink_id),
+                )
                 .await
                 .expect("could not open persist shard");
 
@@ -602,7 +605,10 @@ where
                 .expect("could not open persist client");
 
             let mut write = persist_client
-                .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
+                .open_writer::<SourceData, (), Timestamp, Diff>(
+                    shard_id,
+                    &format!("persist_sink::write_batches {}", sink_id),
+                )
                 .await
                 .expect("could not open persist shard");
 
@@ -918,7 +924,10 @@ where
                 .expect("could not open persist client");
 
             let mut write = persist_client
-                .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
+                .open_writer::<SourceData, (), Timestamp, Diff>(
+                    shard_id,
+                    &format!("persist_sink::append_batches {}", sink_id),
+                )
                 .await
                 .expect("could not open persist shard");
 

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -59,7 +59,7 @@ async fn bench_writes_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let mut write = client
-        .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new())
+        .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new(), "bench")
         .await?;
 
     // Write the data as fast as we can while keeping each batch in its own
@@ -104,7 +104,7 @@ async fn bench_write_to_listen_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let (mut write, read) = client
-        .open::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new())
+        .open::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new(), "bench")
         .await?;
 
     // Start the listener in a task before the write so it can't "cheat" by
@@ -191,7 +191,7 @@ pub fn bench_snapshot(
         let shard_id = ShardId::new();
         let (_, as_of) = runtime.block_on(async {
             let mut write = client
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(shard_id)
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(shard_id, "bench")
                 .await
                 .expect("failed to open shard");
             load(&mut write, data).await
@@ -211,7 +211,7 @@ async fn bench_snapshot_one_iter(
     as_of: &Antichain<u64>,
 ) -> Result<(), anyhow::Error> {
     let mut read = client
-        .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64>(*shard_id)
+        .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64>(*shard_id, "bench")
         .await?;
 
     let x = read

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -132,11 +132,15 @@ impl Transactor {
             .parse::<u64>()
             .expect("maelstrom node_id should be n followed by an integer");
 
-        let (mut write, mut read) = client.open(shard_id).await?;
+        let (mut write, mut read) = client.open(shard_id, "maelstrom long-lived").await?;
         // Use the CONTROLLER_CRITICAL_SINCE id for all nodes so we get coverage
         // of contending traffic.
         let since = client
-            .open_critical_since(shard_id, PersistClient::CONTROLLER_CRITICAL_SINCE)
+            .open_critical_since(
+                shard_id,
+                PersistClient::CONTROLLER_CRITICAL_SINCE,
+                "maelstrom since",
+            )
             .await?;
         let read_ts = Self::maybe_init_shard(&mut write).await?;
 
@@ -267,7 +271,7 @@ impl Transactor {
             // state and exercise some more code paths.
             let mut read = self
                 .client
-                .open_leased_reader(self.shard_id)
+                .open_leased_reader(self.shard_id, "maelstrom short-lived")
                 .await
                 .expect("codecs should match");
 
@@ -298,6 +302,7 @@ impl Transactor {
                         .open_critical_since(
                             self.shard_id,
                             PersistClient::CONTROLLER_CRITICAL_SINCE,
+                            "maelstrom since",
                         )
                         .await?;
                     continue;
@@ -331,6 +336,7 @@ impl Transactor {
                         .open_critical_since(
                             self.shard_id,
                             PersistClient::CONTROLLER_CRITICAL_SINCE,
+                            "maelstrom since",
                         )
                         .await?;
                     continue;

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -502,7 +502,9 @@ mod raw_persist_benchmark {
 
         let mut readers = vec![];
         for _ in 0..num_readers {
-            let (_writer, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
+            let (_writer, reader) = persist
+                .open::<Vec<u8>, Vec<u8>, u64, i64>(id, "open loop")
+                .await?;
 
             let listen = reader
                 .listen(Antichain::from_elem(0))
@@ -531,7 +533,7 @@ mod raw_persist_benchmark {
             let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel(10);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id)
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id, "open loop")
                 .await?;
 
             // Intentionally create the span outside the task to set the parent.
@@ -575,7 +577,7 @@ mod raw_persist_benchmark {
             handles.push(handle);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id)
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id, "open loop")
                 .await?;
 
             // Intentionally create the span outside the task to set the parent.

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -102,13 +102,13 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         .parse()
         .map_err(anyhow::Error::msg)?;
 
-    let (bindings_write, bindings_read) = persist.open(bindings_id).await?;
+    let (bindings_write, bindings_read) = persist.open(bindings_id, "source example").await?;
 
     let consensus = PersistConsensus::new(bindings_write, bindings_read);
     let timestamper =
         ConsensusTimestamper::new(now_fn.clone(), timestamp_interval.clone(), consensus).await;
 
-    let (data_write, data_read) = persist.open(data_id).await?;
+    let (data_write, data_read) = persist.open(data_id, "source example").await?;
 
     // First, render one instance of the source.
     let source1 = source.clone();
@@ -130,7 +130,9 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     for i in 0..num_readers {
         let reader_name = format!("reader-{}", i);
         let reader_name_clone = reader_name.clone();
-        let (_write, data_read) = persist.open::<String, (), Timestamp, _>(data_id).await?;
+        let (_write, data_read) = persist
+            .open::<String, (), Timestamp, _>(data_id, "source example")
+            .await?;
         let pipeline = mz_ore::task::spawn(|| &reader_name_clone, async move {
             let as_of = data_read.since().clone();
             if let Err(e) = reader::spawn_reader_pipeline(reader_name, data_read, as_of).await {
@@ -150,12 +152,12 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     // timestamper.
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    let (bindings_write, bindings_read) = persist.open(bindings_id).await?;
+    let (bindings_write, bindings_read) = persist.open(bindings_id, "source example").await?;
     let consensus = PersistConsensus::new(bindings_write, bindings_read);
     let timestamper =
         ConsensusTimestamper::new(now_fn.clone(), timestamp_interval.clone(), consensus).await;
 
-    let data_write = persist.open_writer(data_id).await?;
+    let data_write = persist.open_writer(data_id, "source example").await?;
 
     let source2 = source.clone();
     let source_pipeline2 = mz_ore::task::spawn(|| "source-2", async move {
@@ -1383,7 +1385,7 @@ mod reader {
                 }
             }
             let mut listen = read
-                .clone()
+                .clone("source example")
                 .await
                 .listen(as_of.clone())
                 .await

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -57,11 +57,7 @@ impl PersistClientCache {
     /// metrics.
     #[cfg(test)]
     pub fn new_no_metrics() -> Self {
-        use mz_build_info::DUMMY_BUILD_INFO;
-        use mz_ore::now::SYSTEM_TIME;
-
-        let cfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
-        Self::new(cfg, &MetricsRegistry::new())
+        Self::new(PersistConfig::new_for_tests(), &MetricsRegistry::new())
     }
 
     /// Returns a new [PersistClient] for interfacing with persist shards made

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -350,7 +350,7 @@ mod tests {
         let shard_id = crate::ShardId::new();
 
         let mut since = client
-            .open_critical_since::<(), (), u64, i64, i64>(shard_id, CriticalReaderId::new())
+            .open_critical_since::<(), (), u64, i64, i64>(shard_id, CriticalReaderId::new(), "")
             .await
             .expect("codec mismatch");
 
@@ -379,6 +379,7 @@ mod tests {
             .open_critical_since::<(), (), u64, i64, i64>(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
+                "",
             )
             .await
             .expect("codec mismatch");
@@ -398,6 +399,7 @@ mod tests {
             .open_critical_since::<(), (), u64, i64, i64>(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
+                "",
             )
             .await
             .expect("codec mismatch");

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -776,12 +776,14 @@ impl RustType<ProtoHandleDebugState> for HandleDebugState {
     fn into_proto(&self) -> ProtoHandleDebugState {
         ProtoHandleDebugState {
             hostname: self.hostname.into_proto(),
+            purpose: self.purpose.into_proto(),
         }
     }
 
     fn from_proto(proto: ProtoHandleDebugState) -> Result<Self, TryFromProtoError> {
         Ok(HandleDebugState {
             hostname: proto.hostname,
+            purpose: proto.purpose,
         })
     }
 }
@@ -1009,6 +1011,7 @@ mod tests {
             last_heartbeat_timestamp_ms: 3,
             debug: HandleDebugState {
                 hostname: "host".to_owned(),
+                purpose: "purpose".to_owned(),
             },
             // Old ProtoReaderState had no lease_duration_ms field
             lease_duration_ms: 0,
@@ -1033,6 +1036,7 @@ mod tests {
             most_recent_write_upper: None,
             debug: Some(ProtoHandleDebugState {
                 hostname: "host".to_owned(),
+                purpose: "purpose".to_owned(),
             }),
         };
         let expected = WriterState {
@@ -1042,6 +1046,7 @@ mod tests {
             most_recent_write_upper: Antichain::from_elem(0),
             debug: HandleDebugState {
                 hostname: "host".to_owned(),
+                purpose: "purpose".to_owned(),
             },
         };
         assert_eq!(<WriterState<u64>>::from_proto(proto).unwrap(), expected);

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -67,7 +67,10 @@ impl<K, V, T: Clone, D> Clone for Machine<K, V, T, D> {
             metrics: Arc::clone(&self.metrics),
             shard_metrics: Arc::clone(&self.shard_metrics),
             state_versions: Arc::clone(&self.state_versions),
-            state: self.state.clone(self.cfg.build_version.clone()),
+            state: self.state.clone(
+                self.state.applier_version.clone(),
+                self.state.hostname.clone(),
+            ),
         }
     }
 }
@@ -155,7 +158,7 @@ where
         let mut applied_ever_true = false;
         let metrics = Arc::clone(&self.metrics);
         let (_seqno, _applied, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.add_and_remove_rollups, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.add_and_remove_rollups, |_, _, state| {
                 let ret = state.add_and_remove_rollups(add_rollup, remove_rollups);
                 if let Continue(applied) = ret {
                     applied_ever_true = applied_ever_true || applied;
@@ -174,8 +177,9 @@ where
     ) -> (Upper<T>, LeasedReaderState<T>) {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, (shard_upper, read_cap), _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |seqno, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |seqno, cfg, state| {
                 state.register_leased_reader(
+                    &cfg.hostname,
                     reader_id,
                     seqno,
                     lease_duration,
@@ -193,8 +197,8 @@ where
     ) -> CriticalReaderState<T> {
         let metrics = Arc::clone(&self.metrics);
         let (_seqno, state, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |_seqno, state| {
-                state.register_critical_reader::<O>(reader_id)
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |_seqno, cfg, state| {
+                state.register_critical_reader::<O>(&cfg.hostname, reader_id)
             })
             .await;
         state
@@ -208,8 +212,13 @@ where
     ) -> (Upper<T>, WriterState<T>) {
         let metrics = Arc::clone(&self.metrics);
         let (_seqno, (shard_upper, writer_state), _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |_seqno, state| {
-                state.register_writer(writer_id, lease_duration, heartbeat_timestamp_ms)
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |_seqno, cfg, state| {
+                state.register_writer(
+                    &cfg.hostname,
+                    writer_id,
+                    lease_duration,
+                    heartbeat_timestamp_ms,
+                )
             })
             .await;
         (shard_upper, writer_state)
@@ -223,8 +232,14 @@ where
     ) -> LeasedReaderState<T> {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, read_cap, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.clone_reader, |seqno, state| {
-                state.clone_reader(new_reader_id, seqno, lease_duration, heartbeat_timestamp_ms)
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.clone_reader, |seqno, cfg, state| {
+                state.clone_reader(
+                    &cfg.hostname,
+                    new_reader_id,
+                    seqno,
+                    lease_duration,
+                    heartbeat_timestamp_ms,
+                )
             })
             .await;
         debug_assert_eq!(seqno, read_cap.seqno);
@@ -374,7 +389,7 @@ where
             .stream(Retry::persist_defaults(SystemTime::now()).into_retry_stream());
         loop {
             let cmd_res = self
-                .apply_unbatched_cmd(&metrics.cmds.compare_and_append, |_, state| {
+                .apply_unbatched_cmd(&metrics.cmds.compare_and_append, |_, _, state| {
                     state.compare_and_append(
                         batch,
                         writer_id,
@@ -515,7 +530,7 @@ where
         // crashes.
         let mut merge_result_ever_applied = ApplyMergeResult::NotAppliedNoMatch;
         let (_seqno, _apply_merge_result, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.merge_res, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.merge_res, |_, _, state| {
                 let ret = state.apply_merge_res(res);
                 if let Continue(result) = ret {
                     // record if we've ever applied the merge
@@ -543,7 +558,7 @@ where
         heartbeat_timestamp_ms: u64,
     ) -> (SeqNo, Since<T>, RoutineMaintenance) {
         let metrics = Arc::clone(&self.metrics);
-        self.apply_unbatched_idempotent_cmd(&metrics.cmds.downgrade_since, |seqno, state| {
+        self.apply_unbatched_idempotent_cmd(&metrics.cmds.downgrade_since, |seqno, _cfg, state| {
             state.downgrade_since(
                 reader_id,
                 seqno,
@@ -565,7 +580,7 @@ where
         let (_seqno, res, maintenance) = self
             .apply_unbatched_idempotent_cmd(
                 &metrics.cmds.compare_and_downgrade_since,
-                |_seqno, state| {
+                |_seqno, _cfg, state| {
                     state.compare_and_downgrade_since::<O>(
                         reader_id,
                         expected_opaque,
@@ -588,7 +603,7 @@ where
     ) -> (SeqNo, bool, RoutineMaintenance) {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, existed, maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.heartbeat_reader, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.heartbeat_reader, |_, _, state| {
                 state.heartbeat_leased_reader(reader_id, heartbeat_timestamp_ms)
             })
             .await;
@@ -642,7 +657,7 @@ where
     ) -> (SeqNo, bool, RoutineMaintenance) {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, existed, maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.heartbeat_writer, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.heartbeat_writer, |_, _, state| {
                 state.heartbeat_writer(writer_id, heartbeat_timestamp_ms)
             })
             .await;
@@ -692,7 +707,7 @@ where
     pub async fn expire_leased_reader(&mut self, reader_id: &LeasedReaderId) -> SeqNo {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, _existed, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, _, state| {
                 state.expire_leased_reader(reader_id)
             })
             .await;
@@ -702,7 +717,7 @@ where
     pub async fn expire_critical_reader(&mut self, reader_id: &CriticalReaderId) -> SeqNo {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, _existed, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, _, state| {
                 state.expire_critical_reader(reader_id)
             })
             .await;
@@ -712,7 +727,7 @@ where
     pub async fn expire_writer(&mut self, writer_id: &WriterId) -> SeqNo {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, _existed, _maintenance) = self
-            .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_writer, |_, state| {
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_writer, |_, _, state| {
                 state.expire_writer(writer_id)
             })
             .await;
@@ -791,7 +806,7 @@ where
 
     async fn apply_unbatched_idempotent_cmd<
         R,
-        WorkFn: FnMut(SeqNo, &mut StateCollections<T>) -> ControlFlow<Infallible, R>,
+        WorkFn: FnMut(SeqNo, &PersistConfig, &mut StateCollections<T>) -> ControlFlow<Infallible, R>,
     >(
         &mut self,
         cmd: &CmdMetrics,
@@ -824,7 +839,7 @@ where
     async fn apply_unbatched_cmd<
         R,
         E,
-        WorkFn: FnMut(SeqNo, &mut StateCollections<T>) -> ControlFlow<E, R>,
+        WorkFn: FnMut(SeqNo, &PersistConfig, &mut StateCollections<T>) -> ControlFlow<E, R>,
     >(
         &mut self,
         cmd: &CmdMetrics,
@@ -837,7 +852,7 @@ where
             loop {
                 let (work_ret, mut new_state) = match self
                     .state
-                    .clone_apply(&self.cfg.build_version, &mut work_fn)
+                    .clone_apply(&self.cfg, &mut work_fn)
                 {
                     Continue(x) => x,
                     Break(err) => {

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -45,12 +45,14 @@ message ProtoLeasedReaderState {
     uint64 seqno = 2;
     uint64 last_heartbeat_timestamp_ms = 3;
     uint64 lease_duration_ms = 4;
+    ProtoHandleDebugState debug = 5;
 }
 
 message ProtoCriticalReaderState {
     ProtoU64Antichain since = 1;
     int64 opaque = 2;
     string opaque_codec = 3;
+    ProtoHandleDebugState debug = 4;
 }
 
 message ProtoWriterState {
@@ -58,6 +60,11 @@ message ProtoWriterState {
     uint64 lease_duration_ms = 2;
     string most_recent_write_token = 3;
     ProtoU64Antichain most_recent_write_upper = 4;
+    ProtoHandleDebugState debug = 5;
+}
+
+message ProtoHandleDebugState {
+    string hostname = 1;
 }
 
 message ProtoStateRollup {
@@ -69,6 +76,7 @@ message ProtoStateRollup {
     string ts_codec = 4;
     string diff_codec = 5;
     uint64 seqno = 6;
+    string hostname = 14;
     uint64 last_gc_req = 10;
     map<uint64, string> rollups = 12;
 
@@ -80,6 +88,7 @@ message ProtoStateRollup {
 
 enum ProtoStateField {
     ROLLUPS = 0;
+    HOSTNAME = 7;
     LAST_GC_REQ = 1;
     LEASED_READERS = 2;
     CRITICAL_READERS = 6;

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -65,6 +65,7 @@ message ProtoWriterState {
 
 message ProtoHandleDebugState {
     string hostname = 1;
+    string purpose = 2;
 }
 
 message ProtoStateRollup {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -75,13 +75,17 @@ impl IdempotencyToken {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LeasedReaderState<T> {
+    /// The seqno capability of this reader.
     pub seqno: SeqNo,
+    /// The since capability of this reader.
     pub since: Antichain<T>,
     /// UNIX_EPOCH timestamp (in millis) of this reader's most recent heartbeat
     pub last_heartbeat_timestamp_ms: u64,
     /// Duration (in millis) allowed after [Self::last_heartbeat_timestamp_ms]
     /// after which this reader may be expired
     pub lease_duration_ms: u64,
+    /// For debugging.
+    pub debug: HandleDebugState,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -89,9 +93,14 @@ pub struct OpaqueState(pub [u8; 8]);
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CriticalReaderState<T> {
+    /// The since capability of this reader.
     pub since: Antichain<T>,
+    /// An opaque token matched on by compare_and_downgrade_since.
     pub opaque: OpaqueState,
+    /// The [Codec64] used to encode [Self::opaque].
     pub opaque_codec: String,
+    /// For debugging.
+    pub debug: HandleDebugState,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -107,6 +116,16 @@ pub struct WriterState<T> {
     /// The upper of the most recent successful compare_and_append by this
     /// writer.
     pub most_recent_write_upper: Antichain<T>,
+    /// For debugging.
+    pub debug: HandleDebugState,
+}
+
+/// Debugging info for a reader or writer.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HandleDebugState {
+    /// Hostname of the persist user that registered this writer or reader. For
+    /// critical readers, this is the _most recent_ registration.
+    pub hostname: String,
 }
 
 /// A subset of a [HollowBatch] corresponding 1:1 to a blob.
@@ -244,6 +263,7 @@ where
 
     pub fn register_leased_reader(
         &mut self,
+        hostname: &str,
         reader_id: &LeasedReaderId,
         seqno: SeqNo,
         lease_duration: Duration,
@@ -252,6 +272,9 @@ where
         // TODO: Handle if the reader or writer already exist (probably with a
         // retry).
         let read_cap = LeasedReaderState {
+            debug: HandleDebugState {
+                hostname: hostname.to_owned(),
+            },
             seqno,
             since: self.trace.since().clone(),
             last_heartbeat_timestamp_ms: heartbeat_timestamp_ms,
@@ -265,12 +288,16 @@ where
 
     pub fn register_critical_reader<O: Opaque + Codec64>(
         &mut self,
+        hostname: &str,
         reader_id: &CriticalReaderId,
     ) -> ControlFlow<Infallible, CriticalReaderState<T>> {
         let state = match self.critical_readers.get(reader_id) {
             Some(state) => state.clone(),
             None => {
                 let state = CriticalReaderState {
+                    debug: HandleDebugState {
+                        hostname: hostname.to_owned(),
+                    },
                     since: self.trace.since().clone(),
                     opaque: OpaqueState(Codec64::encode(&O::initial())),
                     opaque_codec: O::codec_name(),
@@ -285,11 +312,15 @@ where
 
     pub fn register_writer(
         &mut self,
+        hostname: &str,
         writer_id: &WriterId,
         lease_duration: Duration,
         heartbeat_timestamp_ms: u64,
     ) -> ControlFlow<Infallible, (Upper<T>, WriterState<T>)> {
         let writer_state = WriterState {
+            debug: HandleDebugState {
+                hostname: hostname.to_owned(),
+            },
             last_heartbeat_timestamp_ms: heartbeat_timestamp_ms,
             lease_duration_ms: u64::try_from(lease_duration.as_millis())
                 .expect("lease duration as millis must fit within u64"),
@@ -302,6 +333,7 @@ where
 
     pub fn clone_reader(
         &mut self,
+        hostname: &str,
         new_reader_id: &LeasedReaderId,
         seqno: SeqNo,
         lease_duration: Duration,
@@ -309,6 +341,9 @@ where
     ) -> ControlFlow<Infallible, LeasedReaderState<T>> {
         // TODO: Handle if the reader already exists (probably with a retry).
         let read_cap = LeasedReaderState {
+            debug: HandleDebugState {
+                hostname: hostname.to_owned(),
+            },
             seqno,
             since: self.trace.since().clone(),
             last_heartbeat_timestamp_ms: heartbeat_timestamp_ms,
@@ -639,6 +674,9 @@ pub struct State<K, V, T, D> {
     pub(crate) shard_id: ShardId,
 
     pub(crate) seqno: SeqNo,
+    /// Hostname of the persist user that created this version of state. For
+    /// debugging.
+    pub(crate) hostname: String,
     pub(crate) collections: StateCollections<T>,
 
     // According to the docs, PhantomData is to "mark things that act like they
@@ -652,11 +690,12 @@ pub struct State<K, V, T, D> {
 }
 
 impl<K, V, T: Clone, D> State<K, V, T, D> {
-    pub(crate) fn clone(&self, applier_version: Version) -> Self {
+    pub(crate) fn clone(&self, applier_version: Version, hostname: String) -> Self {
         Self {
             applier_version,
             shard_id: self.shard_id.clone(),
             seqno: self.seqno.clone(),
+            hostname,
             collections: self.collections.clone(),
             _phantom: self._phantom.clone(),
         }
@@ -671,6 +710,7 @@ impl<K, V, T: Debug, D> Debug for State<K, V, T, D> {
             applier_version,
             shard_id,
             seqno,
+            hostname,
             collections,
             _phantom,
         } = self;
@@ -678,6 +718,7 @@ impl<K, V, T: Debug, D> Debug for State<K, V, T, D> {
             .field("applier_version", applier_version)
             .field("shard_id", shard_id)
             .field("seqno", seqno)
+            .field("hostname", hostname)
             .field("collections", collections)
             .field("_phantom", _phantom)
             .finish()
@@ -694,6 +735,7 @@ impl<K, V, T: PartialEq, D> PartialEq for State<K, V, T, D> {
             applier_version: self_applier_version,
             shard_id: self_shard_id,
             seqno: self_seqno,
+            hostname: self_hostname,
             collections: self_collections,
             _phantom: _,
         } = self;
@@ -701,12 +743,14 @@ impl<K, V, T: PartialEq, D> PartialEq for State<K, V, T, D> {
             applier_version: other_applier_version,
             shard_id: other_shard_id,
             seqno: other_seqno,
+            hostname: other_hostname,
             collections: other_collections,
             _phantom: _,
         } = other;
         self_applier_version == other_applier_version
             && self_shard_id == other_shard_id
             && self_seqno == other_seqno
+            && self_hostname == other_hostname
             && self_collections == other_collections
     }
 }
@@ -771,11 +815,12 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Codec64,
 {
-    pub fn new(applier_version: Version, shard_id: ShardId) -> Self {
+    pub fn new(applier_version: Version, hostname: String, shard_id: ShardId) -> Self {
         State {
             applier_version,
             shard_id,
             seqno: SeqNo::minimum(),
+            hostname,
             collections: StateCollections {
                 last_gc_req: SeqNo::minimum(),
                 rollups: BTreeMap::new(),
@@ -833,20 +878,21 @@ where
 
     pub fn clone_apply<R, E, WorkFn>(
         &self,
-        build_version: &Version,
+        cfg: &PersistConfig,
         work_fn: &mut WorkFn,
     ) -> ControlFlow<E, (R, Self)>
     where
-        WorkFn: FnMut(SeqNo, &mut StateCollections<T>) -> ControlFlow<E, R>,
+        WorkFn: FnMut(SeqNo, &PersistConfig, &mut StateCollections<T>) -> ControlFlow<E, R>,
     {
         let mut new_state = State {
-            applier_version: build_version.clone(),
+            applier_version: cfg.build_version.clone(),
             shard_id: self.shard_id,
             seqno: self.seqno.next(),
+            hostname: cfg.hostname.clone(),
             collections: self.collections.clone(),
             _phantom: PhantomData,
         };
-        let work_ret = work_fn(new_state.seqno, &mut new_state.collections)?;
+        let work_ret = work_fn(new_state.seqno, cfg, &mut new_state.collections)?;
         Continue((work_ret, new_state))
     }
 
@@ -988,12 +1034,16 @@ mod tests {
 
     #[test]
     fn downgrade_since() {
-        let mut state =
-            State::<(), (), u64, i64>::new(DUMMY_BUILD_INFO.semver_version(), ShardId::new());
+        let mut state = State::<(), (), u64, i64>::new(
+            DUMMY_BUILD_INFO.semver_version(),
+            "".to_owned(),
+            ShardId::new(),
+        );
         let reader = LeasedReaderId::new();
         let seqno = SeqNo::minimum();
         let now = SYSTEM_TIME.clone();
         let _ = state.collections.register_leased_reader(
+            "",
             &reader,
             seqno,
             Duration::from_secs(10),
@@ -1043,6 +1093,7 @@ mod tests {
         // Create a second reader.
         let reader2 = LeasedReaderId::new();
         let _ = state.collections.register_leased_reader(
+            "",
             &reader2,
             seqno,
             Duration::from_secs(10),
@@ -1084,6 +1135,7 @@ mod tests {
         // Create a third reader.
         let reader3 = LeasedReaderId::new();
         let _ = state.collections.register_leased_reader(
+            "",
             &reader3,
             seqno,
             Duration::from_secs(10),
@@ -1131,12 +1183,13 @@ mod tests {
         mz_ore::test::init_logging();
         let mut state = State::<String, String, u64, i64>::new(
             DUMMY_BUILD_INFO.semver_version(),
+            "".to_owned(),
             ShardId::new(),
         )
         .collections;
 
         let writer_id = WriterId::new();
-        let _ = state.register_writer(&writer_id, Duration::from_secs(10), 0);
+        let _ = state.register_writer("", &writer_id, Duration::from_secs(10), 0);
         let now = SYSTEM_TIME.clone();
 
         // State is initially empty.
@@ -1217,6 +1270,7 @@ mod tests {
 
         let mut state = State::<String, String, u64, i64>::new(
             DUMMY_BUILD_INFO.semver_version(),
+            "".to_owned(),
             ShardId::new(),
         );
         // Cannot take a snapshot with as_of == shard upper.
@@ -1234,7 +1288,7 @@ mod tests {
         let writer_id = WriterId::new();
         let _ = state
             .collections
-            .register_writer(&writer_id, Duration::from_secs(10), 0);
+            .register_writer("", &writer_id, Duration::from_secs(10), 0);
 
         // Advance upper to 5.
         assert!(state
@@ -1272,6 +1326,7 @@ mod tests {
         let reader = LeasedReaderId::new();
         // Advance the since to 2.
         let _ = state.collections.register_leased_reader(
+            "",
             &reader,
             SeqNo::minimum(),
             Duration::from_secs(10),
@@ -1361,6 +1416,7 @@ mod tests {
 
         let mut state = State::<String, String, u64, i64>::new(
             DUMMY_BUILD_INFO.semver_version(),
+            "".to_owned(),
             ShardId::new(),
         );
 
@@ -1372,7 +1428,7 @@ mod tests {
         let writer_id = WriterId::new();
         let _ = state
             .collections
-            .register_writer(&writer_id, Duration::from_secs(10), 0);
+            .register_writer("", &writer_id, Duration::from_secs(10), 0);
         let now = SYSTEM_TIME.clone();
 
         // Add two batches of data, one from [0, 5) and then another from [5, 10).
@@ -1425,6 +1481,7 @@ mod tests {
 
         let mut state = State::<String, String, u64, i64>::new(
             DUMMY_BUILD_INFO.semver_version(),
+            "".to_owned(),
             ShardId::new(),
         );
         let now = SYSTEM_TIME.clone();
@@ -1446,13 +1503,13 @@ mod tests {
 
         assert!(state
             .collections
-            .register_writer(&writer_id_one, Duration::from_secs(10), 0)
+            .register_writer("", &writer_id_one, Duration::from_secs(10), 0)
             .is_continue());
 
         let writer_id_two = WriterId::new();
         assert!(state
             .collections
-            .register_writer(&writer_id_two, Duration::from_secs(10), 0)
+            .register_writer("", &writer_id_two, Duration::from_secs(10), 0)
             .is_continue());
 
         // Writer is registered and is now eligible to write
@@ -1501,6 +1558,7 @@ mod tests {
         mz_ore::test::init_logging();
         let mut state = State::<String, String, u64, i64>::new(
             DUMMY_BUILD_INFO.semver_version(),
+            "".to_owned(),
             ShardId::new(),
         );
 
@@ -1517,7 +1575,7 @@ mod tests {
         let writer_id = WriterId::new();
         let _ = state
             .collections
-            .register_writer(&writer_id, Duration::from_secs(10), 0);
+            .register_writer("", &writer_id, Duration::from_secs(10), 0);
         assert_eq!(state.maybe_gc(false), None);
 
         // A write will gc though.

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -459,11 +459,15 @@ impl StateVersions {
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64,
     {
-        let empty_state = State::new(self.cfg.build_version.clone(), shard_metrics.shard_id);
+        let empty_state = State::new(
+            self.cfg.build_version.clone(),
+            self.cfg.hostname.clone(),
+            shard_metrics.shard_id,
+        );
         let rollup_seqno = empty_state.seqno.next();
         let rollup_key = PartialRollupKey::new(rollup_seqno, &RollupId::new());
         let (applied, initial_state) = match empty_state
-            .clone_apply(&self.cfg.build_version, &mut |_, state| {
+            .clone_apply(&self.cfg, &mut |_, _, state| {
                 state.add_and_remove_rollups((rollup_seqno, &rollup_key), &[])
             }) {
             Continue(x) => x,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -886,8 +886,9 @@ where
                 .await
                 .unwrap();
 
+            let purpose = format!("controller data {}", id);
             let write = persist_client
-                .open_writer(metadata.data_shard)
+                .open_writer(metadata.data_shard, &purpose)
                 .await
                 .expect("invalid persist usage");
 
@@ -897,6 +898,7 @@ where
                     .open_critical_since(
                         metadata.data_shard,
                         PersistClient::CONTROLLER_CRITICAL_SINCE,
+                        &purpose,
                     )
                     .await
                     .expect("invalid persist usage");
@@ -1240,7 +1242,10 @@ where
         // heartbeat continously. The assumption is that calls to snapshot are rare and therefore
         // worth it to always create a new handle.
         let mut read_handle = persist_client
-            .open_leased_reader::<SourceData, (), _, _>(metadata.data_shard)
+            .open_leased_reader::<SourceData, (), _, _>(
+                metadata.data_shard,
+                &format!("snapshot {}", id),
+            )
             .await
             .expect("invalid persist usage");
 

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -209,6 +209,7 @@ where
             let from_read_handle = persist_client
                 .open_leased_reader::<SourceData, (), T, Diff>(
                     export.description.from_storage_metadata.data_shard,
+                    "rehydration since",
                 )
                 .await
                 .expect("from collection disappeared");

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -181,7 +181,10 @@ where
 
         let read = read
             .expect("could not open persist client")
-            .open_leased_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(data_shard)
+            .open_leased_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(
+                data_shard,
+                &format!("persist_source data {}", source_id),
+            )
             .await;
 
         // This is a moment where we may have dropped our source if our token

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -51,7 +51,7 @@ pub async fn write_to_persist(
         Row::pack_slice(&[timestamp, collection_id, status, error, metadata])
     };
 
-    let mut handle = client.open_writer(status_shard).await.expect(
+    let mut handle = client.open_writer(status_shard, &format!("healthcheck::write_to_persist {}", collection_id)).await.expect(
         "Invalid usage of the persist client for collection {collection_id} status history shard",
     );
 

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -115,7 +115,10 @@ pub fn render<G>(
                 .open(metadata.persist_location)
                 .await
                 .expect("could not open persist client")
-                .open_writer::<SourceData, (), Timestamp, Diff>(metadata.data_shard)
+                .open_writer::<SourceData, (), Timestamp, Diff>(
+                    metadata.data_shard,
+                    &format!("persist_sink::storage {}", src_id),
+                )
                 .await
                 .expect("could not open persist shard");
 

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -481,7 +481,10 @@ mod tests {
             .await
             .unwrap();
 
-        let (write_handle, mut read_handle) = persist_client.open(shard_id).await.unwrap();
+        let (write_handle, mut read_handle) = persist_client
+            .open(shard_id, "tests::dump_storage_collection")
+            .await
+            .unwrap();
 
         let upper = write_handle.upper();
         let readable_upper = Antichain::from_elem(upper.elements()[0] - 1);

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -1326,7 +1326,7 @@ mod tests {
         drop(persist_clients);
 
         let read_handle = persist_client
-            .open_leased_reader::<SourceData, (), Timestamp, Diff>(binding_shard)
+            .open_leased_reader::<SourceData, (), Timestamp, Diff>(binding_shard, "test_since_hold")
             .await
             .expect("error opening persist shard");
 

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -130,7 +130,7 @@ impl PersistHandle {
         drop(persist_clients);
 
         let (write_handle, read_handle) = persist_client
-            .open(metadata.remap_shard)
+            .open(metadata.remap_shard, &format!("reclock {}", id))
             .await
             .context("error opening persist shard")?;
 
@@ -151,7 +151,7 @@ impl PersistHandle {
         );
 
         let listener = read_handle
-            .clone()
+            .clone(&format!("reclock::listener {}", id))
             .await
             .listen(as_of.clone())
             .await

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -117,6 +117,7 @@ pub struct SinkHandle {
 impl SinkHandle {
     /// A new handle.
     pub fn new(
+        sink_id: GlobalId,
         persist_location: PersistLocation,
         shard_id: ShardId,
         persist_clients: Arc<Mutex<PersistClientCache>>,
@@ -132,7 +133,7 @@ impl SinkHandle {
                 .expect("opening persist client");
 
             let mut read_handle: ReadHandle<SourceData, (), Timestamp, Diff> = client
-                .open_leased_reader(shard_id)
+                .open_leased_reader(shard_id, &format!("sink::since {}", sink_id))
                 .await
                 .expect("opening reader for shard");
 
@@ -299,6 +300,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     self.storage_state.sink_handles.insert(
                         export.id,
                         SinkHandle::new(
+                            export.id,
                             export
                                 .description
                                 .from_storage_metadata

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -217,7 +217,10 @@ where
                 (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
                     loop {
                         let (mut data_write_handle, data_read_handle) = persist_client
-                            .open::<SourceData, (), Timestamp, Diff>(data_shard.clone())
+                            .open::<SourceData, (), Timestamp, Diff>(
+                                data_shard.clone(),
+                                "tests::check_loop",
+                            )
                             .await
                             .unwrap();
                         if let Some(values) = until(


### PR DESCRIPTION
See individual commits for details.

Closes #16091

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I'm looking for a better name than "description" for the second commit (already means something in dd and persist).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
