### PR TITLE
adapter: restore and improve replica not ready notices

### DIFF
--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -69,6 +69,7 @@ impl AdapterNotice {
             AdapterNotice::ClusterDoesNotExist { name: _ } => Some("Create the cluster with CREATE CLUSTER or pick an extant cluster with SET CLUSTER = name. List available clusters with SHOW CLUSTERS.".into()),
             AdapterNotice::DroppedActiveDatabase { name: _ } => Some("Choose a new active database by executing SET DATABASE = <name>.".into()),
             AdapterNotice::DroppedActiveCluster { name: _ } => Some("Choose a new active cluster by executing SET CLUSTER = <name>.".into()),
+            AdapterNotice::ClusterReplicaStatusChanged { .. } => Some("The cluster replica may be restarting or going offline.".into()),
             _ => None
         }
     }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -368,16 +368,6 @@ impl<T: TimestampManipulation> Session<T> {
                 return None;
             }
         }
-        // Suppress replica NotReady notices until they don't occur on
-        // create/drop replica, as that leads to user confusion.
-        //
-        // TODO: Removing this variant completely, since it's the only call
-        // to broadcast_notice, causes Rust to warn about various unused
-        // functions. If we don't find another usage of notices, consider
-        // removing the entire notice system.
-        if matches!(notice, AdapterNotice::ClusterReplicaStatusChanged { .. }) {
-            return None;
-        }
         match self.prev_notice.as_ref() {
             // De-duplicate ClusterReplicaStatusChanged notices.
             Some(prev_notice @ AdapterNotice::ClusterReplicaStatusChanged { .. }) => {

--- a/test/cloudtest/test_replica_restart.py
+++ b/test/cloudtest/test_replica_restart.py
@@ -11,7 +11,6 @@ import threading
 import time
 from io import StringIO
 
-import pytest
 from pg8000 import Connection
 
 from materialize.cloudtest.application import MaterializeApplication
@@ -48,7 +47,6 @@ def assert_notice(conn: Connection, contains: bytes) -> None:
 
 # Test that a crashed (and restarted) computed replica generates expected notice
 # events.
-@pytest.mark.skip(reason="https://github.com/MaterializeInc/materialize/issues/16002")
 def test_crash_computed(mz: MaterializeApplication) -> None:
     mz.environmentd.sql("DROP TABLE IF EXISTS t1 CASCADE")
     mz.environmentd.sql("CREATE TABLE t1 (f1 TEXT)")


### PR DESCRIPTION
Fix the bug that was not correctly suppressing these notices, and add a hint. This should resolve the user unfriendliness.

See https://github.com/MaterializeInc/materialize/issues/16159#issuecomment-1321497066

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a