### PR TITLE
Sql: add hint on MzTimestampOutOfRange error around required format

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2427,6 +2427,12 @@ impl EvalError {
             EvalError::LikeEscapeTooLong => {
                 Some("Escape string must be empty or one character.".into())
             }
+            EvalError::MzTimestampOutOfRange => Some(
+                "Integer, numeric, and text casts to mz_timestamp must be in the form of whole \
+                milliseconds since the Unix epoch. Values with fractional parts cannot be \
+                converted to mz_timestamp."
+                    .into(),
+            ),
             _ => None,
         }
     }


### PR DESCRIPTION
Per #16023, add the valid cast copy from the [docs](https://materialize.com/docs/sql/types/mz_timestamp/#valid-casts) for MzTimestampOutOfRange errors.

Updated message:
```
materialize=> SELECT EXTRACT('epoch' from now())::mz_timestamp;
ERROR:  mz_timestamp out of range
HINT:  Integer, numeric, and text casts to mz_timestamp must be in the form of milliseconds since the Unix epoch.
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
