### PR TITLE
Reduce ON expression in JOIN lowering

### DIFF
--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -103,30 +103,27 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t
 Explained Query:
   Return // { arity: 3 }
     Union // { arity: 3 }
-      Get l0 // { arity: 3 }
       Map (null) // { arity: 3 }
         Union // { arity: 2 }
-          Project (#1, #0) // { arity: 2 }
-            Map (123) // { arity: 2 }
-              Negate // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 3 }
-          Project (#2, #1) // { arity: 2 }
-            Filter (#0 = 123) // { arity: 3 }
-              Map (123) // { arity: 3 }
-                Get materialize.public.t1 // { arity: 2 }
+          Negate // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l1 // { arity: 3 }
+          Get l0 // { arity: 2 }
+      Get l1 // { arity: 3 }
   With
-    cte l0 =
+    cte l1 =
       CrossJoin type=differential // { arity: 3 }
         implementation
-          %1:t2 » %0:t1[×]UAef
+          %1:t2 » %0:l0[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
-          Filter (#0 = 123) // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
+          Get l0 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Filter (#0 = 123) // { arity: 2 }
               Get materialize.public.t2 // { arity: 2 }
+    cte l0 =
+      Filter (#0 = 123) // { arity: 2 }
+        Get materialize.public.t1 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 = 123))
@@ -477,8 +474,19 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING (f1, f2) WHERE a1.f1 = 123 AND a1.f2 = 234;
 ----
 Explained Query:
-  Filter (#0 = 123) AND (#1 = 234) // { arity: 2 }
-    Get materialize.public.t4 // { arity: 2 }
+  Return // { arity: 2 }
+    Union // { arity: 2 }
+      Project (#1, #0) // { arity: 2 }
+        Map (234, 123) // { arity: 2 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
+      Get l0 // { arity: 2 }
+  With
+    cte l0 =
+      Filter (#0 = 123) AND (#1 = 234) // { arity: 2 }
+        Get materialize.public.t4 // { arity: 2 }
 
 Source materialize.public.t4
   filter=((#0 = 123) AND (#1 = 234))

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -74,39 +74,40 @@ Explained Query:
           Get materialize.public.table_f1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 3 }
           Union // { arity: 3 }
+            Negate // { arity: 3 }
+              Project (#0..=#2) // { arity: 3 }
+                Join on=(#0 = #3) type=differential // { arity: 4 }
+                  implementation
+                    %1 » %0:l1[#0]KAf
+                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                    Get l1 // { arity: 3 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Distinct group_by=[#1, #0] // { arity: 2 }
+                        Project (#1, #2) // { arity: 2 }
+                          Get l0 // { arity: 3 }
             Get l1 // { arity: 3 }
-            Project (#0..=#2) // { arity: 3 }
-              Join on=(#0 = #3) type=differential // { arity: 4 }
-                implementation
-                  %1:l0 » %0[#0]KAf
-                ArrangeBy keys=[[#0]] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Negate // { arity: 3 }
-                      Distinct group_by=[#0, #1, #2] // { arity: 3 }
-                        Get l1 // { arity: 3 }
-                    Distinct group_by=[#0, #1, #2] // { arity: 3 }
-                      Get l0 // { arity: 3 }
-                ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Get l0 // { arity: 3 }
+            Filter (#0 = #1) AND (#0 = #2) // { arity: 3 }
+              Get l0 // { arity: 3 }
   With
     cte l1 =
+      Filter (#0 = #1) AND (#0 = #2) AND (#1 = #2) // { arity: 3 }
+        Get materialize.public.table_f4_f5_f6 // { arity: 3 }
+    cte l0 =
       Project (#0..=#2) // { arity: 3 }
-        Join on=(#0 = #3) type=differential // { arity: 4 }
+        Join on=(#1 = #3) type=differential // { arity: 4 }
           implementation
-            %1:table_f5_f6 » %0:l0[#0]KAf
-          ArrangeBy keys=[[#0]] // { arity: 3 }
-            Get l0 // { arity: 3 }
+            %1:table_f5_f6 » %0:table_f4_f5_f6[#1]KAf
+          ArrangeBy keys=[[#1]] // { arity: 3 }
+            Filter (#1 = #2) // { arity: 3 }
+              Get materialize.public.table_f4_f5_f6 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0 = #1) // { arity: 2 }
                 Get materialize.public.table_f5_f6 // { arity: 2 }
-    cte l0 =
-      Filter (#0 = #1) AND (#0 = #2) AND (#1 = #2) // { arity: 3 }
-        Get materialize.public.table_f4_f5_f6 // { arity: 3 }
 
 Source materialize.public.table_f4_f5_f6
-  filter=((#0 = #1) AND (#0 = #2) AND (#1 = #2))
+  filter=((#1 = #2))
 Source materialize.public.table_f5_f6
   filter=((#0 = #1))
 

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -663,27 +663,25 @@ SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)
 Explained Query:
   Return // { arity: 3 }
     Union // { arity: 3 }
-      Get l1 // { arity: 3 }
       Get l2 // { arity: 3 }
       Get l1 // { arity: 3 }
       Get l2 // { arity: 3 }
+      Get l1 // { arity: 3 }
   With
     cte l2 =
-      Project (#0, #1, #4) // { arity: 3 }
-        Map (null) // { arity: 5 }
-          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-            implementation
-              %1:t1 » %0[#0, #1]KKA
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Distinct group_by=[#0, #1] // { arity: 2 }
-                    Project (#0, #1) // { arity: 2 }
+      Map (null) // { arity: 3 }
+        Union // { arity: 2 }
+          Negate // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Join on=(#0 = #2) type=differential // { arity: 3 }
+                implementation
+                  %0:l0 » %1[#0]UKA
+                Get l0 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
                       Get l1 // { arity: 3 }
-                Distinct group_by=[#0, #1] // { arity: 2 }
-                  Get materialize.public.t1 // { arity: 2 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Get materialize.public.t1 // { arity: 2 }
+          Get materialize.public.t1 // { arity: 2 }
     cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Filter (#0) IS NOT NULL // { arity: 4 }


### PR DESCRIPTION
This PR reduces the `on` expression used for attempting to lower outer joins, removing in the case of `USING` a vestigial `AND true`, and allowing the optimization to kick in. It may have other consequences, if someone has expressed a reducible `ON` condition (for example, written their own `AND true` into the condition).

Fixes #16211 

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

This does not yet have tests, but was confirmed to fix the issue in an interactive session. Up for collecting some tests from @philip-stoev 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
