### PR TITLE
test: Fix flaky startup test

### DIFF
--- a/ci/test/cargo-test/image/Dockerfile
+++ b/ci/test/cargo-test/image/Dockerfile
@@ -22,5 +22,7 @@ COPY run-tests /usr/local/bin
 COPY protobuf-install /usr/local/
 ENV PROTOC /usr/local/bin/protoc
 
+# Ensure any Rust binaries that crash print a backtrace.
+ENV RUST_BACKTRACE=1
 
 WORKDIR /workdir

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1961,7 +1961,7 @@ fn test_coord_startup_blocking() -> Result<(), Box<dyn Error>> {
     let now = Arc::new(Mutex::new(initial_time));
     let now_fn = {
         let timestamp = Arc::clone(&now);
-        NowFn::from(move || *timestamp.lock().unwrap())
+        NowFn::from(move || *timestamp.lock().expect("lock poisoned"))
     };
     let data_dir = tempfile::tempdir()?;
     let config = util::Config::default()
@@ -1990,21 +1990,27 @@ fn test_coord_startup_blocking() -> Result<(), Box<dyn Error>> {
 
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let server = util::start_server(config.clone()).unwrap();
-        let mut client = server.connect(postgres::NoTls).unwrap();
+        let server =
+            util::start_server(config.clone()).expect("unable to start server asynchronously");
+        let mut client = server
+            .connect(postgres::NoTls)
+            .expect("unable to start client asynchronously");
 
-        client.query("SELECT 1", &[]).unwrap();
-        tx.send(()).unwrap();
+        client
+            .query("SELECT 1", &[])
+            .expect("unable to query server asynchronously");
+        tx.send(())
+            .expect("receiver waiting for server startup has hung up");
     });
 
     let server_started = Retry::default()
-        .max_duration(Duration::from_secs(1))
+        .max_duration(Duration::from_secs(3))
         .retry(|_| rx.try_recv());
     assert!(server_started.is_err(), "server should be blocked");
 
     *now.lock().expect("lock poisoned") = initial_time + 5_000;
     Retry::default()
-        .max_duration(Duration::from_secs(5))
+        .max_duration(Duration::from_secs(30))
         .retry(|_| rx.try_recv())?;
 
     Ok(())


### PR DESCRIPTION
The test mz-environmentd::sql::test_coord_startup_blocking had become
flaky, so it was ignored in a previous commit. This commit increases
the timeout to wait for the server to start up. This removes the
flakiness.

Fixes #16210

### Motivation
 This PR fixes a recognized bug.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): NA
