### PR TITLE
github: update Slack bug notification workflow

### DIFF
--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -40,11 +40,11 @@ jobs:
           color: red
           verbose: false
       - uses: actions-ecosystem/action-slack-notifier@v1
-        if: ${{ github.event.label.name == 'C-triage' }}
+        if: ${{ github.event.label.name == 'C-bug' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
             `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
-          channel: github-triage
+          channel: github-bugs
           color: red
           verbose: false


### PR DESCRIPTION
As discussed offline, we are deprecating the redundant `C-triage` label and sticking to the `C-bug` label. Accordingly, the internal Slack channel has been renamed to `github-bugs`.
