### PR TITLE
github: drop C-triage from bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -11,7 +11,7 @@ name: Bug
 description: >
   A defect in an existing feature. For example, "consistency is violated if
   Kafka Connect restarts."
-labels: [C-bug, C-triage]
+labels: [C-bug]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
As discussed, we consider `C-triage` to be redundant with the updated bug triage process.
