### PR TITLE
adapter: improve various metrics

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -921,7 +921,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // Watcher that listens for and reports compute service status changes.
         let mut compute_events = self.controller.compute.watch_services();
         let (idle_tx, mut idle_rx) = tokio::sync::mpsc::channel(1);
-        let idle_metric = self.metrics.queue_busy_time.with_label_values(&[]);
+        let idle_metric = self.metrics.queue_busy_seconds.with_label_values(&[]);
         spawn(|| "coord idle metric", async move {
             // Every 5 seconds, attempt to measure how long it takes for the
             // coord select loop to be empty, because this message is the last

--- a/src/adapter/src/coord/metrics.rs
+++ b/src/adapter/src/coord/metrics.rs
@@ -17,7 +17,7 @@ pub struct Metrics {
     pub query_total: IntCounterVec,
     pub active_sessions: IntGauge,
     pub active_subscribes: IntGauge,
-    pub queue_busy_time: HistogramVec,
+    pub queue_busy_seconds: HistogramVec,
     pub determine_timestamp: IntCounterVec,
 }
 
@@ -37,8 +37,8 @@ impl Metrics {
                 name: "mz_active_subscribes",
                 help: "The number of active SUBSCRIBE queries.",
             )),
-            queue_busy_time: registry.register(metric!(
-                name: "mz_coord_queue_busy_time",
+            queue_busy_seconds: registry.register(metric!(
+                name: "mz_coord_queue_busy_seconds",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
             )),
             determine_timestamp: registry.register(metric!(


### PR DESCRIPTION
- Specify seconds instead of time, as recommended by https://prometheus.io/docs/practices/naming/#metric-names
- Pre-populate some rare events with 0s so we can tell when they happened using promql's `rate` function.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a