### PR TITLE
persist: admin tool to manually compact a shard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.0.0"
+version = "0.34.0-dev"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -25,7 +25,7 @@ version=${1#v}
 
 sed -i.bak \
     "s/^version = .*/version = \"$version\"/" \
-    src/{compute,environmentd,storage}/Cargo.toml
+    src/{compute,environmentd,storage,persist-client}/Cargo.toml
 
 if ! [[ "$version" = *dev ]]; then
     sed -i.bak \
@@ -45,7 +45,7 @@ else
     done
 fi
 
-rm -f src/{compute,environmentd,storage}/Cargo.toml.bak LICENSE.bak
+rm -f src/{compute,environmentd,storage,persist-client}/Cargo.toml.bak LICENSE.bak
 
 cargo check
 

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.0.0"
+version = "0.34.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/persist-client/examples/admin.rs
+++ b/src/persist-client/examples/admin.rs
@@ -1,0 +1,104 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Commands for read-write administration of persist state
+
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
+use mz_persist_client::{PersistConfig, ShardId};
+
+use prometheus::proto::{MetricFamily, MetricType};
+use std::str::FromStr;
+use tracing::info;
+
+use crate::inspect::StateArgs;
+use crate::BUILD_INFO;
+
+/// Commands for read-write administration of persist state
+#[derive(Debug, clap::Args)]
+pub struct AdminArgs {
+    #[clap(subcommand)]
+    command: Command,
+
+    /// Whether to commit any modifications (defaults to dry run).
+    #[clap(long)]
+    pub(crate) commit: bool,
+}
+
+/// Individual subcommands of admin
+#[derive(Debug, clap::Subcommand)]
+pub(crate) enum Command {
+    /// Manually completes all fueled compactions in a shard.
+    ForceCompaction(ForceCompactionArgs),
+}
+
+/// Manually completes all fueled compactions in a shard.
+#[derive(Debug, clap::Parser)]
+pub(crate) struct ForceCompactionArgs {
+    #[clap(flatten)]
+    state: StateArgs,
+
+    /// An upper bound on compaction's memory consumption.
+    #[clap(long, default_value_t = 0)]
+    compaction_memory_bound_bytes: usize,
+}
+
+pub async fn run(command: AdminArgs) -> Result<(), anyhow::Error> {
+    match command.command {
+        Command::ForceCompaction(args) => {
+            let shard_id = ShardId::from_str(&args.state.shard_id).expect("invalid shard id");
+            let mut cfg = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
+            if args.compaction_memory_bound_bytes > 0 {
+                cfg.compaction_memory_bound_bytes = args.compaction_memory_bound_bytes;
+            }
+            let metrics_registry = MetricsRegistry::new();
+            let () = mz_persist_client::admin::force_compaction(
+                cfg,
+                &metrics_registry,
+                shard_id,
+                &args.state.consensus_uri,
+                &args.state.blob_uri,
+                command.commit,
+            )
+            .await?;
+            info_log_non_zero_metrics(&metrics_registry.gather());
+        }
+    }
+    Ok(())
+}
+
+fn info_log_non_zero_metrics(metric_families: &[MetricFamily]) {
+    for mf in metric_families {
+        for m in mf.get_metric() {
+            let val = match mf.get_field_type() {
+                MetricType::COUNTER => m.get_counter().get_value(),
+                MetricType::GAUGE => m.get_gauge().get_value(),
+                x => unimplemented!("unhandled metric type: {:?}", x),
+            };
+            if val == 0.0 {
+                continue;
+            }
+            let label_pairs = m.get_label();
+            let mut labels = String::new();
+            if !label_pairs.is_empty() {
+                labels.push_str("{");
+                for lb in label_pairs {
+                    if labels != "{" {
+                        labels.push_str(",");
+                    }
+                    labels.push_str(lb.get_name());
+                    labels.push_str(":");
+                    labels.push_str(lb.get_value());
+                }
+                labels.push_str("}");
+            }
+            info!("{}{} {}", mf.get_name(), labels, val);
+        }
+    }
+}

--- a/src/persist-client/examples/inspect.rs
+++ b/src/persist-client/examples/inspect.rs
@@ -7,14 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Persist command-line utilities
+//! Commands for read-only inspection of persist state
 
 use mz_persist_client::ShardId;
 
 use serde_json::json;
 use std::str::FromStr;
 
-/// Commands for inspecting current persist state
+/// Commands for read-only inspection of persist state
 #[derive(Debug, clap::Args)]
 pub struct InspectArgs {
     #[clap(subcommand)]
@@ -67,7 +67,7 @@ pub(crate) enum Command {
 pub struct StateArgs {
     /// Shard to view
     #[clap(long)]
-    shard_id: String,
+    pub(crate) shard_id: String,
 
     /// Consensus to use.
     ///
@@ -81,16 +81,16 @@ pub struct StateArgs {
     ///     &sslrootcert=/path/to/cockroach-cloud/certs/cluster-ca.crt
     ///     &options=--search_path=consensus
     ///
-    #[clap(long, verbatim_doc_comment)]
-    consensus_uri: String,
+    #[clap(long, verbatim_doc_comment, env = "CONSENSUS_URI")]
+    pub(crate) consensus_uri: String,
 
     /// Blob to use
     ///
     /// When connecting to a deployed environment's blob, the necessary connection glue must be in
     /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
     /// URI scoped to the environment's bucket prefix.
-    #[clap(long)]
-    blob_uri: String,
+    #[clap(long, env = "BLOB_URI")]
+    pub(crate) blob_uri: String,
 }
 
 /// Arguments for viewing the blobs of a given shard

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -16,7 +16,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::lattice::Lattice;
-use mz_build_info::DUMMY_BUILD_INFO;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::critical::SinceHandle;
@@ -38,6 +37,7 @@ use crate::maelstrom::api::{Body, ErrorCode, MaelstromError, NodeId, ReqTxnOp, R
 use crate::maelstrom::node::{Handle, Service};
 use crate::maelstrom::services::{CachingBlob, MaelstromBlob, MaelstromConsensus};
 use crate::maelstrom::Args;
+use crate::BUILD_INFO;
 
 pub fn run(args: Args) -> Result<(), anyhow::Error> {
     let read = std::io::stdin();
@@ -625,7 +625,7 @@ impl Service for TransactorService {
         let blob = CachingBlob::new(blob);
 
         // Construct requested Consensus.
-        let mut config = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        let mut config = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
         // to simplify some downstream logic (+ a bit more stress testing),
         // always downgrade the since of critical handles when asked
         config.critical_downgrade_interval = Duration::from_secs(0);

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::bail;
-use mz_build_info::DUMMY_BUILD_INFO;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
@@ -31,6 +30,7 @@ use mz_persist::workload::DataGenerator;
 use mz_persist_client::{Metrics, PersistConfig, PersistLocation, ShardId};
 
 use crate::open_loop::api::{BenchmarkReader, BenchmarkWriter};
+use crate::BUILD_INFO;
 
 /// Different benchmark configurations.
 #[derive(clap::ArgEnum, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -128,7 +128,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         consensus_uri: args.consensus_uri.clone(),
     };
     let persist = PersistClientCache::new(
-        PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
+        PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone()),
         &metrics_registry,
     )
     .open(location)

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::future::BoxFuture;
-use mz_build_info::DUMMY_BUILD_INFO;
 use mz_ore::metrics::MetricsRegistry;
 use mz_persist_client::async_runtime::CpuHeavyRuntime;
 use tracing::{error, trace};
@@ -37,6 +36,8 @@ use mz_ore::now::SYSTEM_TIME;
 use mz_persist::location::{Blob, Consensus, ExternalError, Indeterminate};
 use mz_persist::unreliable::{UnreliableBlob, UnreliableConsensus, UnreliableHandle};
 use mz_persist_client::{Metrics, PersistClient, PersistConfig, PersistLocation};
+
+use crate::BUILD_INFO;
 
 use self::impls::ConsensusTimestamper;
 use self::impls::PersistConsensus;
@@ -189,7 +190,7 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         blob_uri: args.blob_uri,
         consensus_uri: args.consensus_uri,
     };
-    let config = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+    let config = PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&config, &MetricsRegistry::new()));
     let (blob, consensus) = location.open_locations(&config, &metrics).await?;
     let unreliable = UnreliableHandle::default();

--- a/src/persist-client/src/admin.rs
+++ b/src/persist-client/src/admin.rs
@@ -1,0 +1,185 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! CLI introspection tools for persist
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::anyhow;
+use mz_ore::metrics::MetricsRegistry;
+use mz_persist::cfg::{BlobConfig, ConsensusConfig};
+use mz_persist::location::{Blob, Consensus};
+use tracing::info;
+
+use crate::async_runtime::CpuHeavyRuntime;
+use crate::internal::compact::{CompactReq, Compactor};
+use crate::internal::machine::Machine;
+use crate::internal::metrics::{MetricsBlob, MetricsConsensus};
+use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
+use crate::write::WriterId;
+use crate::{Metrics, PersistConfig, ShardId, StateVersions};
+
+/// Manually completes all fueled compactions in a shard.
+pub async fn force_compaction(
+    cfg: PersistConfig,
+    metrics_registry: &MetricsRegistry,
+    shard_id: ShardId,
+    consensus_uri: &str,
+    blob_uri: &str,
+    commit: bool,
+) -> Result<(), anyhow::Error> {
+    let metrics = Arc::new(Metrics::new(&cfg, metrics_registry));
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        Box::new(cfg.clone()),
+        metrics.postgres_consensus.clone(),
+    )?;
+    let consensus = consensus.clone().open().await?;
+    let consensus = Arc::new(MetricsConsensus::new(consensus, Arc::clone(&metrics)))
+        as Arc<dyn Consensus + Send + Sync>;
+    let blob = BlobConfig::try_from(blob_uri).await?;
+    let blob = blob.clone().open().await?;
+    let blob =
+        Arc::new(MetricsBlob::new(blob, Arc::clone(&metrics))) as Arc<dyn Blob + Send + Sync>;
+
+    let state_versions = Arc::new(StateVersions::new(
+        cfg.clone(),
+        consensus,
+        Arc::clone(&blob),
+        Arc::clone(&metrics),
+    ));
+
+    // Prime the K V codec magic
+    let versions = state_versions.fetch_live_diffs(&shard_id).await;
+    loop {
+        let state_res = state_versions
+            .fetch_current_state::<crate::inspect::K, crate::inspect::V, u64, i64>(
+                &shard_id,
+                versions.clone(),
+            )
+            .await;
+        let state = match state_res {
+            Ok(state) => state,
+            Err(codec) => {
+                let mut kvtd = crate::inspect::KVTD_CODECS.lock().expect("lockable");
+                *kvtd = codec.actual;
+                continue;
+            }
+        };
+        // This isn't the perfect place to put this check, the ideal would be in
+        // the apply_unbatched_cmd loop, but I don't want to pollute the prod
+        // code with this logic.
+        if cfg.build_version != state.applier_version {
+            // We could add a flag to override this check, if that comes up.
+            return Err(anyhow!("version of this tool {} does not match version of state {}. bailing so we don't corrupt anything", cfg.build_version, state.applier_version));
+        }
+        break;
+    }
+
+    let mut machine = Machine::<crate::inspect::K, crate::inspect::V, u64, i64>::new(
+        cfg.clone(),
+        shard_id,
+        Arc::clone(&metrics),
+        Arc::clone(&state_versions),
+    )
+    .await?;
+
+    let writer_id = WriterId::new();
+    info!("registering writer {}", writer_id);
+    // We don't bother expiring this writer in various error codepaths, instead
+    // letting it time out. /shrug
+    let _ = machine
+        .register_writer(
+            &writer_id,
+            "persistcli admin force-compaction",
+            cfg.writer_lease_duration,
+            (cfg.now)(),
+        )
+        .await;
+
+    let mut attempt = 0;
+    'outer: loop {
+        machine.fetch_and_update_state().await;
+        let reqs = machine.state().collections.trace.all_fueled_merge_reqs();
+        info!("attempt {}: got {} compaction reqs", attempt, reqs.len());
+        for (idx, req) in reqs.clone().into_iter().enumerate() {
+            let req = CompactReq {
+                shard_id,
+                desc: req.desc,
+                inputs: req.inputs,
+            };
+            let parts = req.inputs.iter().map(|x| x.parts.len()).sum::<usize>();
+            let bytes = req
+                .inputs
+                .iter()
+                .flat_map(|x| x.parts.iter().map(|x| x.encoded_size_bytes))
+                .sum::<usize>();
+            let start = Instant::now();
+            info!(
+                "attempt {} req {}: compacting {} batches {} in parts {} totaling bytes: lower={:?} upper={:?} since={:?}",
+                attempt,
+                idx,
+                req.inputs.len(),
+                parts,
+                bytes,
+                req.desc.lower().elements(),
+                req.desc.upper().elements(),
+                req.desc.since().elements(),
+            );
+            if !commit {
+                info!("skipping compaction because --commit is not set");
+                continue;
+            }
+            let res = Compactor::<crate::inspect::K, crate::inspect::V, u64, i64>::compact(
+                cfg.clone(),
+                Arc::clone(&blob),
+                Arc::clone(&metrics),
+                Arc::new(CpuHeavyRuntime::new()),
+                req,
+                writer_id.clone(),
+            )
+            .await?;
+            info!(
+                "attempt {} req {}: compacted into {} parts {} bytes in {:?}",
+                attempt,
+                idx,
+                res.output.parts.len(),
+                res.output
+                    .parts
+                    .iter()
+                    .map(|x| x.encoded_size_bytes)
+                    .sum::<usize>(),
+                start.elapsed(),
+            );
+            let apply_res = machine
+                .merge_res(&FueledMergeRes { output: res.output })
+                .await;
+            match apply_res {
+                ApplyMergeResult::AppliedExact | ApplyMergeResult::AppliedSubset => {
+                    info!("attempt {} req {}: {:?}", attempt, idx, apply_res);
+                }
+                ApplyMergeResult::NotAppliedInvalidSince
+                | ApplyMergeResult::NotAppliedNoMatch
+                | ApplyMergeResult::NotAppliedTooManyUpdates => {
+                    info!(
+                        "attempt {} req {}: {:?} trying again",
+                        attempt, idx, apply_res
+                    );
+                    attempt += 1;
+                    continue 'outer;
+                }
+            }
+        }
+        info!("attempt {}: did {} compactions", attempt, reqs.len());
+        let _ = machine.expire_writer(&writer_id).await;
+        info!("expired writer {}", writer_id);
+        return Ok(());
+    }
+}

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -348,15 +348,15 @@ pub async fn unreferenced_blobs(
 /// the type system and our safety checks that we really can read the data.
 
 #[derive(Debug)]
-struct K;
+pub(crate) struct K;
 #[derive(Debug)]
-struct V;
+pub(crate) struct V;
 #[derive(Debug)]
 struct T;
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 struct D(i64);
 
-static KVTD_CODECS: Mutex<(String, String, String, String)> =
+pub(crate) static KVTD_CODECS: Mutex<(String, String, String, String)> =
     Mutex::new((String::new(), String::new(), String::new(), String::new()));
 
 impl Codec for K {

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -124,6 +124,10 @@ where
         self.state.seqno()
     }
 
+    pub(crate) fn state(&self) -> &State<K, V, T, D> {
+        &self.state
+    }
+
     #[cfg(test)]
     pub fn seqno_since(&self) -> SeqNo {
         self.state.seqno_since()

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -235,6 +235,18 @@ impl<T: Timestamp + Lattice> Trace<T> {
         ApplyMergeResult::NotAppliedNoMatch
     }
 
+    pub(crate) fn all_fueled_merge_reqs(&self) -> Vec<FueledMergeReq<T>> {
+        let mut reqs = Vec::new();
+        self.spine.map_batches(|b| match b {
+            SpineBatch::Merged(_) => {} // No-op.
+            SpineBatch::Fueled { desc, parts, .. } => reqs.push(FueledMergeReq {
+                desc: desc.clone(),
+                inputs: parts.clone(),
+            }),
+        });
+        reqs
+    }
+
     // This is only called with the results of one `insert` and so the length of
     // `merge_reqs` is bounded by the number of levels in the spine (or possibly
     // some small constant multiple?). The number of levels is logarithmic in

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -47,6 +47,7 @@ use crate::internal::state_versions::StateVersions;
 use crate::read::{LeasedReaderId, ReadHandle};
 use crate::write::{WriteHandle, WriterId};
 
+pub mod admin;
 pub mod async_runtime;
 pub mod batch;
 pub mod cache;


### PR DESCRIPTION
Persist shards currently only perform compactions that they directly caused by inserting a batch. Any others are assumed to be done by someone else. Among other things, this doesn't backfill compactions when we change our selection criteria (such as when we started considering batch parts). This is one of the things we'll be revisiting in Persist Compaction 2.0, but until then add an admin tool we can use to manually fixup individual shards.

Touches #16161

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Left an open question about BuildInfo. Time to add persist to the list of things that get the version set?

Manually tested this against ./bin/environmentd, but we'll probably want to do a bit more testing on a staging cluster before we point it at anything real.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
