### PR TITLE
persist: routinely reconnect to postgres/crdb to rebalance load

### DIFF
--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -628,9 +628,7 @@ impl Service for TransactorService {
             Some(consensus_uri) => {
                 ConsensusConfig::try_from(
                     consensus_uri,
-                    config.consensus_connection_pool_max_size,
-                    config.consensus_connection_pool_ttl,
-                    config.consensus_connection_pool_ttl_stagger,
+                    Box::new(config.clone()),
                     metrics.postgres_consensus.clone(),
                 )?
                 .open()

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -629,6 +629,8 @@ impl Service for TransactorService {
                 ConsensusConfig::try_from(
                     consensus_uri,
                     config.consensus_connection_pool_max_size,
+                    config.consensus_connection_pool_ttl,
+                    config.consensus_connection_pool_ttl_stagger,
                     metrics.postgres_consensus.clone(),
                 )?
                 .open()

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -81,9 +81,7 @@ impl PersistClientCache {
                 // concurrency.
                 let consensus = ConsensusConfig::try_from(
                     x.key(),
-                    self.cfg.consensus_connection_pool_max_size,
-                    self.cfg.consensus_connection_pool_ttl,
-                    self.cfg.consensus_connection_pool_ttl_stagger,
+                    Box::new(self.cfg.clone()),
                     self.metrics.postgres_consensus.clone(),
                 )?;
                 let consensus =

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -82,6 +82,8 @@ impl PersistClientCache {
                 let consensus = ConsensusConfig::try_from(
                     x.key(),
                     self.cfg.consensus_connection_pool_max_size,
+                    self.cfg.consensus_connection_pool_ttl,
+                    self.cfg.consensus_connection_pool_ttl_stagger,
                     self.metrics.postgres_consensus.clone(),
                 )?;
                 let consensus =

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -11,7 +11,6 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use anyhow::anyhow;
 use bytes::BufMut;
@@ -48,9 +47,7 @@ pub async fn fetch_latest_state(
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let consensus = ConsensusConfig::try_from(
         consensus_uri,
-        1,
-        Duration::MAX,
-        Duration::MAX,
+        Box::new(cfg.clone()),
         metrics.postgres_consensus.clone(),
     )?;
     let consensus = consensus.clone().open().await?;
@@ -91,9 +88,7 @@ pub async fn fetch_latest_state_rollup(
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let consensus = ConsensusConfig::try_from(
         consensus_uri,
-        1,
-        Duration::MAX,
-        Duration::MAX,
+        Box::new(cfg.clone()),
         metrics.postgres_consensus.clone(),
     )?;
     let consensus = consensus.clone().open().await?;
@@ -125,9 +120,7 @@ pub async fn fetch_state_rollups(
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let consensus = ConsensusConfig::try_from(
         consensus_uri,
-        1,
-        Duration::MAX,
-        Duration::MAX,
+        Box::new(cfg.clone()),
         metrics.postgres_consensus.clone(),
     )?;
     let consensus = consensus.clone().open().await?;
@@ -187,9 +180,7 @@ pub async fn fetch_state_diffs(
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let consensus = ConsensusConfig::try_from(
         consensus_uri,
-        1,
-        Duration::MAX,
-        Duration::MAX,
+        Box::new(cfg.clone()),
         metrics.postgres_consensus.clone(),
     )?;
     let consensus = consensus.clone().open().await?;
@@ -275,9 +266,7 @@ pub async fn unreferenced_blobs(
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
     let consensus = ConsensusConfig::try_from(
         consensus_uri,
-        1,
-        Duration::MAX,
-        Duration::MAX,
+        Box::new(cfg.clone()),
         metrics.postgres_consensus.clone(),
     )?;
     let consensus = consensus.clone().open().await?;

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -11,6 +11,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::anyhow;
 use bytes::BufMut;
@@ -45,8 +46,13 @@ pub async fn fetch_latest_state(
 ) -> Result<impl serde::Serialize, anyhow::Error> {
     let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let consensus =
-        ConsensusConfig::try_from(consensus_uri, 1, metrics.postgres_consensus.clone())?;
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        1,
+        Duration::MAX,
+        Duration::MAX,
+        metrics.postgres_consensus.clone(),
+    )?;
     let consensus = consensus.clone().open().await?;
     let blob = BlobConfig::try_from(blob_uri).await?;
     let blob = blob.clone().open().await?;
@@ -83,8 +89,13 @@ pub async fn fetch_latest_state_rollup(
 ) -> Result<impl serde::Serialize, anyhow::Error> {
     let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let consensus =
-        ConsensusConfig::try_from(consensus_uri, 1, metrics.postgres_consensus.clone())?;
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        1,
+        Duration::MAX,
+        Duration::MAX,
+        metrics.postgres_consensus.clone(),
+    )?;
     let consensus = consensus.clone().open().await?;
     let blob = BlobConfig::try_from(blob_uri).await?;
     let blob = blob.clone().open().await?;
@@ -112,8 +123,13 @@ pub async fn fetch_state_rollups(
 ) -> Result<impl serde::Serialize, anyhow::Error> {
     let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let consensus =
-        ConsensusConfig::try_from(consensus_uri, 1, metrics.postgres_consensus.clone())?;
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        1,
+        Duration::MAX,
+        Duration::MAX,
+        metrics.postgres_consensus.clone(),
+    )?;
     let consensus = consensus.clone().open().await?;
     let blob = BlobConfig::try_from(blob_uri).await?;
     let blob = blob.clone().open().await?;
@@ -169,8 +185,13 @@ pub async fn fetch_state_diffs(
 ) -> Result<Vec<impl serde::Serialize>, anyhow::Error> {
     let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let consensus =
-        ConsensusConfig::try_from(consensus_uri, 1, metrics.postgres_consensus.clone())?;
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        1,
+        Duration::MAX,
+        Duration::MAX,
+        metrics.postgres_consensus.clone(),
+    )?;
     let consensus = consensus.clone().open().await?;
     let blob = BlobConfig::try_from(blob_uri).await?;
     let blob = blob.clone().open().await?;
@@ -252,8 +273,13 @@ pub async fn unreferenced_blobs(
 ) -> Result<impl serde::Serialize, anyhow::Error> {
     let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
     let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
-    let consensus =
-        ConsensusConfig::try_from(consensus_uri, 1, metrics.postgres_consensus.clone())?;
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        1,
+        Duration::MAX,
+        Duration::MAX,
+        metrics.postgres_consensus.clone(),
+    )?;
     let consensus = consensus.clone().open().await?;
     let blob = BlobConfig::try_from(blob_uri).await?;
     let blob = blob.clone().open().await?;

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -128,6 +128,18 @@ pub enum ConsensusConfig {
     Mem,
 }
 
+/// Configuration knobs for [Consensus].
+pub trait ConsensusKnobs: std::fmt::Debug + Send + Sync {
+    /// Maximum number of connections allowed in a pool.
+    fn connection_pool_max_size(&self) -> usize;
+    /// Minimum TTL of a connection. It is expected that connections are
+    /// routinely culled to balance load to the backing store of [Consensus].
+    fn connection_pool_ttl(&self) -> Duration;
+    /// Minimum time between TTLing connections. Helps stagger reconnections
+    /// to avoid stampeding the backing store of [Consensus].
+    fn connection_pool_ttl_stagger(&self) -> Duration;
+}
+
 impl ConsensusConfig {
     /// Opens the associated implementation of [Consensus].
     pub async fn open(self) -> Result<Arc<dyn Consensus + Send + Sync>, ExternalError> {
@@ -144,9 +156,7 @@ impl ConsensusConfig {
     /// Parses a [Consensus] config from a uri string.
     pub fn try_from(
         value: &str,
-        connection_pool_max_size: usize,
-        connection_pool_ttl: Duration,
-        connection_pool_ttl_stagger: Duration,
+        knobs: Box<dyn ConsensusKnobs>,
         metrics: PostgresConsensusMetrics,
     ) -> Result<Self, ExternalError> {
         let url = Url::parse(value).map_err(|err| {
@@ -158,15 +168,9 @@ impl ConsensusConfig {
         })?;
 
         let config = match url.scheme() {
-            "postgres" | "postgresql" => {
-                Ok(ConsensusConfig::Postgres(PostgresConsensusConfig::new(
-                    value,
-                    connection_pool_max_size,
-                    connection_pool_ttl,
-                    connection_pool_ttl_stagger,
-                    metrics,
-                )?))
-            }
+            "postgres" | "postgresql" => Ok(ConsensusConfig::Postgres(
+                PostgresConsensusConfig::new(value, knobs, metrics)?,
+            )),
             "mem" => {
                 if !cfg!(debug_assertions) {
                     warn!("persist unexpectedly using in-mem consensus in a release binary");

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -18,6 +18,7 @@ pub struct PostgresConsensusMetrics {
     pub(crate) connpool_size: UIntGauge,
     pub(crate) connpool_acquires: IntCounter,
     pub(crate) connpool_acquire_seconds: Counter,
+    pub(crate) connpool_ttl_reconnections: Counter,
 }
 
 impl PostgresConsensusMetrics {
@@ -35,6 +36,10 @@ impl PostgresConsensusMetrics {
             connpool_acquire_seconds: registry.register(metric!(
                 name: "mz_persist_postgres_connpool_acquire_seconds",
                 help: "time spent acquiring connections from pool",
+            )),
+            connpool_ttl_reconnections: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_ttl_reconnections",
+                help: "times a connection was recycled due to ttl",
             )),
         }
     }

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -18,6 +18,7 @@ pub struct PostgresConsensusMetrics {
     pub(crate) connpool_size: UIntGauge,
     pub(crate) connpool_acquires: IntCounter,
     pub(crate) connpool_acquire_seconds: Counter,
+    pub(crate) connpool_connections_created: Counter,
     pub(crate) connpool_ttl_reconnections: Counter,
 }
 
@@ -36,6 +37,10 @@ impl PostgresConsensusMetrics {
             connpool_acquire_seconds: registry.register(metric!(
                 name: "mz_persist_postgres_connpool_acquire_seconds",
                 help: "time spent acquiring connections from pool",
+            )),
+            connpool_connections_created: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_connections_created",
+                help: "times a connection was created",
             )),
             connpool_ttl_reconnections: registry.register(metric!(
                 name: "mz_persist_postgres_connpool_ttl_reconnections",

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -169,10 +169,12 @@ impl PostgresConsensus {
         );
 
         let last_ttl_connection = AtomicU64::new(0);
+        let connections_created = config.metrics.connpool_connections_created.clone();
         let ttl_reconnections = config.metrics.connpool_ttl_reconnections.clone();
         let pool = Pool::builder(manager)
             .max_size(config.connection_pool_max_size)
-            .post_create(Hook::async_fn(|client, _| {
+            .post_create(Hook::async_fn(move |client, _| {
+                connections_created.inc();
                 Box::pin(async move {
                     debug!("opened new consensus postgres connection");
                     client.batch_execute(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

When CRDB rolls their nodes, we can wind up with heavy connection skew that can push undue load onto individual nodes. This PR forces periodic reconnections to CRDB from `persist`, smoothing out the reconnects over time to avoid stampedes. A reconnection is triggered with a `deadpool` pre-recycle hook, where we choose not to recycle a connection if it is past a given TTL && enough time has passed since the last TTLed connection.

Testing that this solves the rebalance problem is a little tricky. For now, I've verified that running locally we can see the `connpool_ttl_reconnections` and `connpool_connections_created` counters tick up at the expected intervals.

### Motivation

  * This PR fixes a recognized bug.

Addresses one of the Storage items in https://github.com/MaterializeInc/cloud/issues/4288 / one of the follow-ups to incident 5

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
