### PR TITLE
test: Clean up envd integration tests

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -497,8 +497,6 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
     // is done by starting a web server that awaits the refresh request, which the
     // test waits for.
 
-    mz_ore::test::init_logging();
-
     let ca = Ca::new_root("test ca")?;
     let (server_cert, server_key) =
         ca.request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])?;
@@ -600,8 +598,6 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
 #[allow(clippy::unit_arg)]
 #[test]
 fn test_auth() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let ca = Ca::new_root("test ca")?;
     let (server_cert, server_key) =
         ca.request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])?;

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -37,8 +37,6 @@ pub mod util;
 
 #[test]
 fn test_bind_params() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config)?;
     let mut client = server.connect(postgres::NoTls)?;
@@ -100,8 +98,6 @@ fn test_bind_params() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_partial_read() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
     let query = "VALUES ('1'), ('2'), ('3'), ('4'), ('5'), ('6'), ('7')";
@@ -130,8 +126,6 @@ fn test_partial_read() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_read_many_rows() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
     let query = "VALUES (1), (2), (3)";
@@ -148,8 +142,6 @@ fn test_read_many_rows() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_conn_startup() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
 
@@ -279,8 +271,6 @@ fn test_conn_startup() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_conn_user() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
 
@@ -309,8 +299,6 @@ fn test_conn_user() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_simple_query_no_hang() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
     assert!(client.simple_query("asdfjkl;").is_err());
@@ -322,8 +310,6 @@ fn test_simple_query_no_hang() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_copy() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
 
@@ -365,8 +351,6 @@ fn test_copy() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_arrays() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default().unsafe_mode())?;
     let mut client = server.connect(postgres::NoTls)?;
 
@@ -412,8 +396,6 @@ fn test_arrays() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_record_types() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
 
@@ -476,8 +458,6 @@ fn pg_test_inner(dir: PathBuf) -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_pgtest() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let dir: PathBuf = ["..", "..", "test", "pgtest"].iter().collect();
     pg_test_inner(dir)
 }
@@ -485,8 +465,6 @@ fn test_pgtest() -> Result<(), Box<dyn Error>> {
 #[test]
 // Materialize's differences from Postgres' responses.
 fn test_pgtest_mz() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let dir: PathBuf = ["..", "..", "test", "pgtest-mz"].iter().collect();
     pg_test_inner(dir)
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -42,8 +42,6 @@ impl<'a> FromSql<'a> for UInt8 {
 
 #[test]
 fn test_persistence() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let data_dir = tempfile::tempdir()?;
     let config = util::Config::default()
         .data_directory(data_dir.path())
@@ -114,8 +112,6 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
 // unsafe mode.
 #[test]
 fn test_source_sink_size_required() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let server = util::start_server(util::Config::default())?;
     let mut client = server.connect(postgres::NoTls)?;
 
@@ -164,7 +160,6 @@ fn test_source_sink_size_required() -> Result<(), Box<dyn Error>> {
 // Test the /sql POST endpoint of the HTTP server.
 #[test]
 fn test_http_sql() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
     let server = util::start_server(util::Config::default())?;
     let url = Url::parse(&format!(
         "http://{}/api/sql",
@@ -645,8 +640,6 @@ fn test_cancel_long_running_query() -> Result<(), Box<dyn Error>> {
 // Test that dataflow uninstalls cancelled peeks.
 #[test]
 fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config)?;
 
@@ -715,8 +708,6 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_storage_usage_collection_interval() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let config =
         util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(1));
     let server = util::start_server(config)?;
@@ -757,8 +748,6 @@ fn test_storage_usage_collection_interval() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let data_dir = tempfile::tempdir()?;
     let storage_usage_collection_interval = Duration::from_secs(3);
     let config = util::Config::default()
@@ -810,8 +799,6 @@ fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let data_dir = tempfile::tempdir()?;
     let storage_usage_collection_interval = Duration::from_secs(60);
     let config = util::Config::default()
@@ -856,8 +843,6 @@ fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Err
 
 #[test]
 fn test_storage_usage_collection_interval_timestamps() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let config =
         util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(30));
     let server = util::start_server(config)?;
@@ -883,8 +868,6 @@ fn test_storage_usage_collection_interval_timestamps() -> Result<(), Box<dyn Err
 
 #[test]
 fn test_default_cluster_sizes() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-
     let config = util::Config::default()
         .with_builtin_cluster_replica_size("1".to_string())
         .with_default_cluster_replica_size("2".to_string());


### PR DESCRIPTION
This commit cleans up the environmentd integration tests by doing the following:
  - Remove logging from all the tests. The logging has gotten extremely noisy and is not helpful for debugging test failures. However it is useful for production debugging, so we cannot remove them completely.
  - Move utility methods from the sql module to the util module.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
