### PR TITLE
[sinks] Report client-wide errors even while retrying

### DIFF
--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -15,7 +15,6 @@ use anyhow::Context;
 use tokio::sync::Mutex;
 use tracing::trace;
 
-use mz_ore::halt;
 use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistClient, PersistLocation, ShardId};
@@ -67,20 +66,6 @@ impl Healthchecker {
             status_shard,
             now,
         })
-    }
-
-    /// Report a SinkStatus::Stalled and then halt with the same message.
-    pub async fn report_stall_and_halt<S>(hc: Option<&mut Self>, msg: S) -> !
-    where
-        S: ToString + std::fmt::Debug,
-    {
-        if let Some(healthchecker) = hc {
-            healthchecker
-                .update_status(SinkStatus::Stalled(msg.to_string()))
-                .await;
-        }
-
-        halt!("{msg:?}")
     }
 
     /// Process a [`SinkStatus`] emitted by a sink

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -215,7 +215,7 @@ impl KafkaSinkSendRetryManager {
 
 pub struct SinkProducerContext {
     metrics: Arc<SinkMetrics>,
-    healthchecker: mpsc::Sender<SinkStatus>,
+    status_tx: mpsc::Sender<SinkStatus>,
     retry_manager: Arc<Mutex<KafkaSinkSendRetryManager>>,
 }
 
@@ -227,7 +227,7 @@ impl ClientContext for SinkProducerContext {
     }
     fn error(&self, error: KafkaError, reason: &str) {
         let status = SinkStatus::Stalled(error.to_string());
-        let _ = self.healthchecker.try_send(status);
+        let _ = self.status_tx.try_send(status);
         MzClientContext.error(error, reason)
     }
 }
@@ -387,7 +387,7 @@ struct KafkaSinkState {
 
     progress_topic: String,
     progress_key: String,
-    progress_client: Arc<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>>,
+    progress_client: Arc<BaseConsumer<BrokerRewritingClientContext<SinkConsumerContext>>>,
 
     healthchecker: Arc<Mutex<Option<Healthchecker>>>,
     gate_ts: Rc<Cell<Option<Timestamp>>>,
@@ -405,6 +405,23 @@ struct KafkaSinkState {
     /// exactly-once guarantees.
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
 }
+
+struct SinkConsumerContext {
+    status_tx: mpsc::Sender<SinkStatus>,
+}
+
+impl ClientContext for SinkConsumerContext {
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        MzClientContext.log(level, fac, log_message)
+    }
+    fn error(&self, error: KafkaError, reason: &str) {
+        let status = SinkStatus::Stalled(error.to_string());
+        let _ = self.status_tx.try_send(status);
+        MzClientContext.error(error, reason)
+    }
+}
+
+impl ConsumerContext for SinkConsumerContext {}
 
 impl KafkaSinkState {
     fn new(
@@ -432,7 +449,7 @@ impl KafkaSinkState {
 
         let producer_context = SinkProducerContext {
             metrics: Arc::clone(&metrics),
-            healthchecker: status_tx,
+            status_tx: status_tx.clone(),
             retry_manager: Arc::clone(&retry_manager),
         };
 
@@ -489,7 +506,7 @@ impl KafkaSinkState {
         let progress_client = TokioHandle::current()
             .block_on(connection.connection.create_with_context(
                 connection_context,
-                MzClientContext,
+                SinkConsumerContext { status_tx },
                 &btreemap! {
                     "group.id" => format!("materialize-bootstrap-sink-{sink_id}"),
                     "isolation.level" => "read_committed".into(),

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -387,7 +387,7 @@ struct KafkaSinkState {
 
     progress_topic: String,
     progress_key: String,
-    progress_client: Arc<BaseConsumer<BrokerRewritingClientContext<SinkConsumerContext>>>,
+    progress_client: Option<Arc<BaseConsumer<BrokerRewritingClientContext<SinkConsumerContext>>>>,
 
     healthchecker: Arc<Mutex<Option<Healthchecker>>>,
     gate_ts: Rc<Cell<Option<Timestamp>>>,
@@ -527,7 +527,7 @@ impl KafkaSinkState {
             retry_manager,
             progress_topic: connection.progress.topic,
             progress_key: format!("mz-sink-{sink_id}"),
-            progress_client: Arc::new(progress_client),
+            progress_client: Some(Arc::new(progress_client)),
             healthchecker,
             gate_ts,
             latest_progress_ts: Timestamp::minimum(),
@@ -610,7 +610,9 @@ impl KafkaSinkState {
             .expect("Infinite retry cannot fail");
     }
 
-    async fn determine_latest_progress_record(&self) -> Result<Option<Timestamp>, anyhow::Error> {
+    async fn determine_latest_progress_record(
+        &mut self,
+    ) -> Result<Option<Timestamp>, anyhow::Error> {
         // Polls a message from a Kafka Source.  Blocking so should always be called on background
         // thread.
         fn get_next_message<C>(
@@ -737,13 +739,17 @@ impl KafkaSinkState {
             Ok(latest_ts)
         }
 
+        let progress_client = self
+            .progress_client
+            .take()
+            .expect("Claiming just-created progress client");
         // Only actually used for retriable errors.
         Retry::default()
             .clamp_backoff(Duration::from_secs(60 * 10))
             .retry_async(|_| async {
                 let progress_topic = self.progress_topic.clone();
                 let progress_key = self.progress_key.clone();
-                let progress_client = Arc::clone(&self.progress_client);
+                let progress_client = Arc::clone(&progress_client);
                 task::spawn_blocking(
                     || format!("get_latest_ts:{}", self.name),
                     move || {
@@ -1088,9 +1094,8 @@ where
         )
         .await;
 
-        let latest_ts = s
-            .halt_on_err(s.determine_latest_progress_record().await)
-            .await;
+        let latest_ts = s.determine_latest_progress_record().await;
+        let latest_ts = s.halt_on_err(latest_ts).await;
         info!(
             "{}: initial as_of: {:?}, latest progress record: {:?}",
             s.name, as_of.frontier, latest_ts

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -54,8 +54,14 @@ class Disruption:
         c.testdrive(
             dedent(
                 """
+                # We specify the progress topic explicitly so we can delete it in a test later,
+                # and confirm that the sink stalls. (Deleting the output topic is not enough if
+                # we're not actively publishing new messages to the sink.)
                 > CREATE CONNECTION kafka_conn
-                  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+                  TO KAFKA (
+                    BROKER '${testdrive.kafka-addr}',
+                    PROGRESS TOPIC 'testdrive-progress-topic-${testdrive.seed}'
+                  );
 
                 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
                   URL '${testdrive.schema-registry-url}'
@@ -82,7 +88,6 @@ class Disruption:
         )
 
     def assert_error(self, c: Composition, error: str) -> None:
-        # Validate that cluster2 continues to operate
         c.testdrive(
             dedent(
                 f"""
@@ -91,11 +96,15 @@ class Disruption:
                   WHERE name = 'source1'
                 stalled true
 
-                # TODO(bkirwi) https://github.com/MaterializeInc/materialize/pull/16232
-                #> SELECT status, error ~* '{error}'
-                #  FROM mz_internal.mz_sink_status
-                #  WHERE name = 'sink1'
-                # stalled true
+                # Sinks generally halt after receiving an error, which means that they may alternate
+                # between `stalled` and `starting`. Instead of relying on the current status, we
+                # check that the latest stall has the error we expect.
+                > SELECT status, error ~* '{error}'
+                  FROM mz_internal.mz_sink_status_history
+                  JOIN mz_sinks ON mz_sinks.id = sink_id
+                  WHERE name = 'sink1' and status = 'stalled'
+                  ORDER BY occurred_at DESC LIMIT 1
+                stalled true
                 """
             )
         )
@@ -115,10 +124,10 @@ class Disruption:
                   WHERE name = 'source1'
                 running <null>
 
-                #> SELECT status, error
-                #  FROM mz_internal.mz_sink_status
-                #  WHERE name = 'sink1'
-                #running <null>
+                > SELECT status, error
+                  FROM mz_internal.mz_sink_status
+                  WHERE name = 'sink1'
+                running <null>
                 """
             )
         )
@@ -128,7 +137,7 @@ disruptions = [
     Disruption(
         name="delete-topic",
         breakage=lambda c, seed: redpanda_topics(c, "delete", seed),
-        expected_error="UnknownTopicOrPartition",
+        expected_error="UnknownTopicOrPartition|Transaction",
         fixage=None
         # Re-creating the topic does not restart the source
         # fixage=lambda c,seed: redpanda_topics(c, "create", seed),
@@ -165,5 +174,5 @@ def workflow_default(c: Composition) -> None:
 
 
 def redpanda_topics(c: Composition, action: str, seed: int) -> None:
-    for topic in ["source", "sink"]:
+    for topic in ["source", "sink", "progress"]:
         c.exec("redpanda", "rpk", "topic", action, f"testdrive-{topic}-topic-{seed}")


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
