### PR TITLE
adapter: split peek into mutable and immutable parts

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -501,7 +501,7 @@ impl CatalogState {
         let plan = mz_sql::plan::plan(None, &session_catalog, stmt, &Params::empty())?;
         Ok(match plan {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let mut optimizer = Optimizer::logical_optimizer();
+                let optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
@@ -4996,7 +4996,7 @@ impl<S: Append> Catalog<S> {
                 })
             }
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let mut optimizer = Optimizer::logical_optimizer();
+                let optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
@@ -5010,7 +5010,7 @@ impl<S: Append> Catalog<S> {
             Plan::CreateMaterializedView(CreateMaterializedViewPlan {
                 materialized_view, ..
             }) => {
-                let mut optimizer = Optimizer::logical_optimizer();
+                let optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(materialized_view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), materialized_view.column_names);
                 CatalogItem::MaterializedView(MaterializedView {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -782,7 +782,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
 
         // Having installed all entries, creating all constraints, we can now relax read policies.
-        self.initialize_read_policies(policies_to_set, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS)
+        self.initialize_read_policies(&policies_to_set, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS)
             .await;
 
         info!("coordinator init: announcing completion of initialization to controller");

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -39,7 +39,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ///
     /// The timeline that `id_bundle` belongs to is also returned, if one exists.
     pub(crate) fn determine_timestamp(
-        &mut self,
+        &self,
         session: &Session,
         id_bundle: &CollectionIdBundle,
         when: &QueryWhen,
@@ -85,7 +85,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let timeline = timeline
                 .clone()
                 .expect("checked that timeline exists above");
-            let timestamp_oracle = self.get_timestamp_oracle_mut(&timeline);
+            let timestamp_oracle = self.get_timestamp_oracle(&timeline);
             oracle_read_ts = Some(timestamp_oracle.read_ts());
             candidate.join_assign(&oracle_read_ts.unwrap());
         } else if when.advance_to_upper() {

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -461,7 +461,7 @@ impl Optimizer {
         fields(path.segment = self.name)
     )]
     pub fn optimize(
-        &mut self,
+        &self,
         mut relation: MirRelationExpr,
     ) -> Result<mz_expr::OptimizedMirRelationExpr, TransformError> {
         let transform_result = self.transform(&mut relation, &EmptyIndexOracle);

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -312,7 +312,7 @@ mod tests {
         }
         let mut out = String::new();
         if test_type == TestType::Opt {
-            let mut optimizer = Optimizer::logical_optimizer();
+            let optimizer = Optimizer::logical_optimizer();
             dataflow = dataflow
                 .into_iter()
                 .map(|(id, rel)| (id, optimizer.optimize(rel).unwrap().into_inner()))
@@ -332,8 +332,8 @@ mod tests {
             _ => {}
         };
         if test_type == TestType::Opt {
-            let mut log_optimizer = Optimizer::logical_cleanup_pass();
-            let mut phys_optimizer = Optimizer::physical_optimizer();
+            let log_optimizer = Optimizer::logical_cleanup_pass();
+            let phys_optimizer = Optimizer::physical_optimizer();
             dataflow = dataflow
                 .into_iter()
                 .map(|(id, rel)| {


### PR DESCRIPTION
This allows timestamp determination, planning, and optimizing to happen in immutable functions. This will allow us to:

- perform planning and optimization off of the main coord thread (#16217)
- safely re-plan on different clusters for index checks (#15427)

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a