### PR TITLE
Project away columns of EXISTS subquery before lowering

### DIFF
--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1674,9 +1674,11 @@ fn apply_existential_subquery(
     outer: mz_expr::MirRelationExpr,
     col_map: &ColumnMap,
     cte_map: &mut CteMap,
-    subquery_expr: HirRelationExpr,
+    mut subquery_expr: HirRelationExpr,
     apply_requires_distinct_outer: bool,
 ) -> mz_expr::MirRelationExpr {
+    // Discard output columns, as they should not influence "existence".
+    subquery_expr = subquery_expr.project(Vec::new());
     branch(
         id_gen,
         outer,


### PR DESCRIPTION
More direct approach to ensuring that we decorrelate the easiest query we can.

Running to see if there are any `EXPLAIN` changes to speak of.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
