### PR TITLE
dbt-materialize: remove PostgreSQL 63-character limitation on relation names

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Remove the 63-character limitation on relation names. Materialize does not
+  have this limitation, unlike PostgreSQL (see [dbt-core #2727](https://github.com/dbt-labs/dbt-core/pull/2727)).
+
 ## 1.3.2 - 2022-11-17
 
 * Add the `IN CLUSTER` clause to the custom seed materialization to ensure that

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -42,8 +42,8 @@ class MaterializeRelation(PostgresRelation):
 
     # Materialize does not have a 63-character limit for relation
     # names, unlike PostgreSQL (see dbt-core #2727)
-    def __post_init__(self):
-        pass
+    def relation_max_name_length(self):
+        return 16384
 
     @classproperty
     def get_relation_type(cls) -> Type[MaterializeRelationType]:

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -40,6 +40,11 @@ class MaterializeRelationType(StrEnum):
 class MaterializeRelation(PostgresRelation):
     type: Optional[MaterializeRelationType] = None
 
+    # Materialize does not have a 63-character limit for relation
+    # names, unlike PostgreSQL (see dbt-core #2727)
+    def __post_init__(self):
+        pass
+
     @classproperty
     def get_relation_type(cls) -> Type[MaterializeRelationType]:
         return MaterializeRelationType

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -117,3 +117,9 @@ expected_base_relation_types = {
     "table_model": "materializedview",
     "swappable": "materializedview",
 }
+
+test_relation_name_length = """
+{{ config(materialized='materializedview') }}
+
+    SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse'), (NULL, NULL)) _ (a, b)
+"""

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -20,6 +20,7 @@ from fixtures import (
     expected_indexes,
     test_materialized_view,
     test_materialized_view_index,
+    test_relation_name_length,
     test_sink,
     test_source,
     test_source_index,
@@ -44,6 +45,7 @@ class TestCustomMaterializations:
             "test_materialized_view.sql": test_materialized_view,
             "test_materialized_view_index.sql": test_materialized_view_index,
             "test_view_index.sql": test_view_index,
+            "test_relation_name_loooooooooooooooooonger_than_postgres_63_limit.sql": test_relation_name_length,
             "test_source.sql": test_source,
             "test_source_index.sql": test_source_index,
             "test_sink.sql": test_sink,
@@ -58,7 +60,7 @@ class TestCustomMaterializations:
         # run models
         results = run_dbt(["run"])
         # run result length
-        assert len(results) == 7
+        assert len(results) == 8
         # relations_equal
         check_relations_equal(
             project.adapter, ["test_materialized_view", "test_view_index"]


### PR DESCRIPTION
Fixes #15863.