### PR TITLE
compute: error on peeks before the compaction frontier

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -746,6 +746,17 @@ impl PendingPeek {
         if upper.less_equal(&self.peek.timestamp) {
             return None;
         }
+
+        let read_frontier = self.trace_bundle.compaction_frontier();
+        if !read_frontier.less_equal(&self.peek.timestamp) {
+            let error = format!(
+                "Arrangement compaction frontier ({:?}) is beyond the time of the attempted read ({})",
+                read_frontier.elements(),
+                self.peek.timestamp,
+            );
+            return Some(PeekResponse::Error(error));
+        }
+
         let response = match self.collect_finished_data(max_result_size) {
             Ok(rows) => PeekResponse::Rows(rows),
             Err(text) => PeekResponse::Error(text),


### PR DESCRIPTION
This PR makes compute return a `PeekResponse::Error` when it is requested to fulfill a peek that is not beyond the target arrangement's compaction frontier. Previously, compute would read from the arrangement at the requested time regardless of compaction, which would most likely return empty or incomplete results.

### Motivation

   * This PR refactors existing code.

Closes https://github.com/MaterializeInc/materialize/issues/16238.

### Tips for reviewer

This doesn't cause any visible change of behavior in Materialize currently, because the compute controller always installs read holds to prevent compaction of indexes that have pending peeks.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
