### PR TITLE
Don't spam the console with errors on local builds due to querying metrics from the process orchestrator

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -145,7 +145,10 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
         &self,
         _id: &str,
     ) -> Result<Vec<ServiceProcessMetrics>, anyhow::Error> {
-        anyhow::bail!("metrics are not supported on the process orchestrator");
+        // Metrics are not currently supported on the process orchestrator
+        loop {
+            tokio::time::sleep(Duration::MAX).await;
+        }
     }
 
     async fn ensure_service(


### PR DESCRIPTION
See title. Blocking forever shouldn't cause any problems here, it will just make it so the metrics stream never returns anything to the controller stack.

### Motivation

  * This PR fixes a recognized bug.

    Reported by @teskje on Slack


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None unless the user is running on-prem which is unsupported
