### PR TITLE
test: Panic in test instead of returning an error

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -41,37 +41,46 @@ impl<'a> FromSql<'a> for UInt8 {
 }
 
 #[test]
-fn test_persistence() -> Result<(), Box<dyn Error>> {
-    let data_dir = tempfile::tempdir()?;
+fn test_persistence() {
+    let data_dir = tempfile::tempdir().unwrap();
     let config = util::Config::default()
         .data_directory(data_dir.path())
         .unsafe_mode();
 
     {
-        let server = util::start_server(config.clone())?;
-        let mut client = server.connect(postgres::NoTls)?;
-        client.batch_execute(&format!(
-            "CREATE CONNECTION kafka_conn TO KAFKA (BROKER '{}')",
-            &*KAFKA_ADDRS,
-        ))?;
-        client.batch_execute(
-            "CREATE SOURCE src FROM KAFKA CONNECTION kafka_conn (TOPIC 'ignored') FORMAT BYTES",
-        )?;
-        client.batch_execute("CREATE VIEW constant AS SELECT 1")?;
+        let server = util::start_server(config.clone()).unwrap();
+        let mut client = server.connect(postgres::NoTls).unwrap();
+        client
+            .batch_execute(&format!(
+                "CREATE CONNECTION kafka_conn TO KAFKA (BROKER '{}')",
+                &*KAFKA_ADDRS,
+            ))
+            .unwrap();
+        client
+            .batch_execute(
+                "CREATE SOURCE src FROM KAFKA CONNECTION kafka_conn (TOPIC 'ignored') FORMAT BYTES",
+            )
+            .unwrap();
+        client
+            .batch_execute("CREATE VIEW constant AS SELECT 1")
+            .unwrap();
         client.batch_execute(
             "CREATE VIEW mat (a, a_data, c, c_data) AS SELECT 'a', data, 'c' AS c, data FROM src",
-        )?;
-        client.batch_execute("CREATE DEFAULT INDEX ON mat")?;
-        client.batch_execute("CREATE DATABASE d")?;
-        client.batch_execute("CREATE SCHEMA d.s")?;
-        client.batch_execute("CREATE VIEW d.s.v AS SELECT 1")?;
+        ).unwrap();
+        client.batch_execute("CREATE DEFAULT INDEX ON mat").unwrap();
+        client.batch_execute("CREATE DATABASE d").unwrap();
+        client.batch_execute("CREATE SCHEMA d.s").unwrap();
+        client
+            .batch_execute("CREATE VIEW d.s.v AS SELECT 1")
+            .unwrap();
     }
 
-    let server = util::start_server(config)?;
-    let mut client = server.connect(postgres::NoTls)?;
+    let server = util::start_server(config).unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
     assert_eq!(
         client
-            .query("SHOW VIEWS", &[])?
+            .query("SHOW VIEWS", &[])
+            .unwrap()
             .into_iter()
             .map(|row| row.get(0))
             .collect::<Vec<String>>(),
@@ -79,13 +88,15 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(
         client
-            .query_one("SHOW INDEXES ON mat", &[])?
+            .query_one("SHOW INDEXES ON mat", &[])
+            .unwrap()
             .get::<_, Vec<String>>("key"),
         &["a", "a_data", "c", "c_data"],
     );
     assert_eq!(
         client
-            .query("SHOW VIEWS FROM d.s", &[])?
+            .query("SHOW VIEWS FROM d.s", &[])
+            .unwrap()
             .into_iter()
             .map(|row| row.get(0))
             .collect::<Vec<String>>(),
@@ -98,22 +109,21 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
             .query(
                 "SELECT id FROM mz_objects WHERE id LIKE 'u%' ORDER BY 1",
                 &[]
-            )?
+            )
+            .unwrap()
             .into_iter()
             .map(|row| row.get(0))
             .collect::<Vec<String>>(),
         vec!["u1", "u2", "u3", "u4", "u5", "u6"]
     );
-
-    Ok(())
 }
 
 // Test that sources and sinks require an explicit `SIZE` parameter outside of
 // unsafe mode.
 #[test]
-fn test_source_sink_size_required() -> Result<(), Box<dyn Error>> {
-    let server = util::start_server(util::Config::default())?;
-    let mut client = server.connect(postgres::NoTls)?;
+fn test_source_sink_size_required() {
+    let server = util::start_server(util::Config::default()).unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Sources bail without an explicit size.
     let result = client.batch_execute("CREATE SOURCE lg FROM LOAD GENERATOR COUNTER");
@@ -123,7 +133,9 @@ fn test_source_sink_size_required() -> Result<(), Box<dyn Error>> {
     );
 
     // Sources work with an explicit size.
-    client.batch_execute("CREATE SOURCE lg FROM LOAD GENERATOR COUNTER WITH (SIZE '1')")?;
+    client
+        .batch_execute("CREATE SOURCE lg FROM LOAD GENERATOR COUNTER WITH (SIZE '1')")
+        .unwrap();
 
     // `ALTER SOURCE ... RESET SIZE` is banned.
     let result = client.batch_execute("ALTER SOURCE lg RESET (SIZE)");
@@ -132,10 +144,12 @@ fn test_source_sink_size_required() -> Result<(), Box<dyn Error>> {
         "size option is required"
     );
 
-    client.batch_execute(&format!(
-        "CREATE CONNECTION conn TO KAFKA (BROKER '{}')",
-        &*KAFKA_ADDRS,
-    ))?;
+    client
+        .batch_execute(&format!(
+            "CREATE CONNECTION conn TO KAFKA (BROKER '{}')",
+            &*KAFKA_ADDRS,
+        ))
+        .unwrap();
 
     // Sinks bail without an explicit size.
     let result = client.batch_execute("CREATE SINK snk FROM mz_sources INTO KAFKA CONNECTION conn (TOPIC 'foo') FORMAT JSON ENVELOPE DEBEZIUM");
@@ -153,18 +167,17 @@ fn test_source_sink_size_required() -> Result<(), Box<dyn Error>> {
         result.unwrap_err().unwrap_db_error().message(),
         "size option is required"
     );
-
-    Ok(())
 }
 
 // Test the /sql POST endpoint of the HTTP server.
 #[test]
-fn test_http_sql() -> Result<(), Box<dyn Error>> {
-    let server = util::start_server(util::Config::default())?;
+fn test_http_sql() {
+    let server = util::start_server(util::Config::default()).unwrap();
     let url = Url::parse(&format!(
         "http://{}/api/sql",
         server.inner.http_local_addr()
-    ))?;
+    ))
+    .unwrap();
 
     #[derive(Debug)]
     struct TestCaseSimple {
@@ -385,9 +398,10 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         let res = Client::new()
             .post(url.clone())
             .json(&json!({"query": tc.query}))
-            .send()?;
+            .send()
+            .unwrap();
         assert_eq!(res.status(), tc.status);
-        assert_eq!(res.text()?, tc.body);
+        assert_eq!(res.text().unwrap(), tc.body);
     }
 
     // Parameter-based queries
@@ -599,21 +613,19 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             }));
         }
         let req = json!({ "queries": queries });
-        let res = Client::new().post(url.clone()).json(&req).send()?;
+        let res = Client::new().post(url.clone()).json(&req).send().unwrap();
         assert_eq!(res.status(), tc.status, "{:?}: {:?}", req, res.text());
-        assert_eq!(res.text()?, tc.body, "{:?}", req);
+        assert_eq!(res.text().unwrap(), tc.body, "{:?}", req);
     }
-
-    Ok(())
 }
 
 // Test that the server properly handles cancellation requests.
 #[test]
-fn test_cancel_long_running_query() -> Result<(), Box<dyn Error>> {
+fn test_cancel_long_running_query() {
     let config = util::Config::default().unsafe_mode();
-    let server = util::start_server(config)?;
+    let server = util::start_server(config).unwrap();
 
-    let mut client = server.connect(postgres::NoTls)?;
+    let mut client = server.connect(postgres::NoTls).unwrap();
     let cancel_token = client.cancel_token();
 
     thread::spawn(move || {
@@ -622,7 +634,7 @@ fn test_cancel_long_running_query() -> Result<(), Box<dyn Error>> {
         let _ = cancel_token.cancel_query(postgres::NoTls);
     });
 
-    client.batch_execute("CREATE TABLE t (i INT)")?;
+    client.batch_execute("CREATE TABLE t (i INT)").unwrap();
 
     match client.simple_query("SELECT * FROM t AS OF 18446744073709551615") {
         Err(e) if e.code() == Some(&postgres::error::SqlState::QUERY_CANCELED) => {}
@@ -633,28 +645,27 @@ fn test_cancel_long_running_query() -> Result<(), Box<dyn Error>> {
     client
         .simple_query("SELECT 1")
         .expect("simple query succeeds after cancellation");
-
-    Ok(())
 }
 
 // Test that dataflow uninstalls cancelled peeks.
 #[test]
-fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
+fn test_cancel_dataflow_removal() {
     let config = util::Config::default().unsafe_mode();
-    let server = util::start_server(config)?;
+    let server = util::start_server(config).unwrap();
 
-    let mut client1 = server.connect(postgres::NoTls)?;
-    let mut client2 = server.connect(postgres::NoTls)?;
+    let mut client1 = server.connect(postgres::NoTls).unwrap();
+    let mut client2 = server.connect(postgres::NoTls).unwrap();
     let cancel_token = client1.cancel_token();
 
-    client1.batch_execute("CREATE TABLE t (i INT)")?;
+    client1.batch_execute("CREATE TABLE t (i INT)").unwrap();
     // No dataflows expected at startup.
     assert_eq!(
         client1
             .query_one(
                 "SELECT count(*) FROM mz_internal.mz_dataflow_operators",
                 &[]
-            )?
+            )
+            .unwrap()
             .get::<_, i64>(0),
         0
     );
@@ -668,7 +679,8 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
                         "SELECT count(*) FROM mz_internal.mz_dataflow_operators",
                         &[],
                     )
-                    .map_err(|_| ())?
+                    .map_err(|_| ())
+                    .unwrap()
                     .get(0);
                 if count == 0 {
                     Err(())
@@ -693,7 +705,8 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
                     "SELECT count(*) FROM mz_internal.mz_dataflow_operators",
                     &[],
                 )
-                .map_err(|_| ())?
+                .map_err(|_| ())
+                .unwrap()
                 .get(0);
             if count == 0 {
                 Ok(())
@@ -702,53 +715,54 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
             }
         })
         .unwrap();
-
-    Ok(())
 }
 
 #[test]
-fn test_storage_usage_collection_interval() -> Result<(), Box<dyn Error>> {
+fn test_storage_usage_collection_interval() {
     let config =
         util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(1));
-    let server = util::start_server(config)?;
-    let mut client = server.connect(postgres::NoTls)?;
+    let server = util::start_server(config).unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Retry because it may take some time for the initial snapshot to be taken.
-    let initial_storage: i64 = Retry::default().retry(|_| {
-        client
-            .query_one(
-                "SELECT SUM(size_bytes)::int8 FROM mz_catalog.mz_storage_usage;",
-                &[],
-            )
-            .map_err(|e| e.to_string())?
-            .try_get::<_, i64>(0)
-            .map_err(|e| e.to_string())
-    })?;
+    let initial_storage: i64 = Retry::default()
+        .retry(|_| {
+            client
+                .query_one(
+                    "SELECT SUM(size_bytes)::int8 FROM mz_catalog.mz_storage_usage;",
+                    &[],
+                )
+                .map_err(|e| e.to_string())
+                .unwrap()
+                .try_get::<_, i64>(0)
+                .map_err(|e| e.to_string())
+        })
+        .unwrap();
 
-    client.batch_execute("CREATE TABLE t (a INT)")?;
-    client.batch_execute("INSERT INTO t VALUES (1), (2)")?;
+    client.batch_execute("CREATE TABLE t (a INT)").unwrap();
+    client
+        .batch_execute("INSERT INTO t VALUES (1), (2)")
+        .unwrap();
 
     // Retry until storage usage is updated.
     Retry::default().max_duration(Duration::from_secs(5)).retry(|_| {
         let updated_storage = client
             .query_one("SELECT SUM(size_bytes)::int8 FROM mz_catalog.mz_storage_usage;", &[])
-            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string()).unwrap()
             .try_get::<_, i64>(0)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| e.to_string()).unwrap();
 
         if updated_storage > initial_storage {
             Ok(())
         } else {
             Err(format!("updated storage count {updated_storage} is not greater than initial storage {initial_storage}"))
         }
-    })?;
-
-    Ok(())
+    }).unwrap();
 }
 
 #[test]
-fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
-    let data_dir = tempfile::tempdir()?;
+fn test_storage_usage_updates_between_restarts() {
+    let data_dir = tempfile::tempdir().unwrap();
     let storage_usage_collection_interval = Duration::from_secs(3);
     let config = util::Config::default()
         .with_storage_usage_collection_interval(storage_usage_collection_interval)
@@ -756,8 +770,8 @@ fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
 
     // Wait for initial storage usage collection.
     let initial_timestamp: f64 = {
-        let server = util::start_server(config.clone())?;
-        let mut client = server.connect(postgres::NoTls)?;
+        let server = util::start_server(config.clone()).unwrap();
+        let mut client = server.connect(postgres::NoTls).unwrap();
         // Retry because it may take some time for the initial snapshot to be taken.
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
             client
@@ -765,41 +779,39 @@ fn test_storage_usage_updates_between_restarts() -> Result<(), Box<dyn Error>> {
                         "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_catalog.mz_storage_usage;",
                         &[],
                     )
-                    .map_err(|e| e.to_string())?
+                    .map_err(|e| e.to_string()).unwrap()
                     .try_get::<_, f64>(0)
                     .map_err(|e| e.to_string())
-        })?
+        }).unwrap()
     };
 
     std::thread::sleep(storage_usage_collection_interval);
 
     // Another storage usage collection should be scheduled immediately.
     {
-        let server = util::start_server(config)?;
-        let mut client = server.connect(postgres::NoTls)?;
+        let server = util::start_server(config).unwrap();
+        let mut client = server.connect(postgres::NoTls).unwrap();
 
         // Retry until storage usage is updated.
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
             let updated_timestamp = client
                 .query_one("SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_catalog.mz_storage_usage;", &[])
-                .map_err(|e| e.to_string())?
+                .map_err(|e| e.to_string()).unwrap()
                 .try_get::<_, f64>(0)
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| e.to_string()).unwrap();
 
             if updated_timestamp > initial_timestamp {
                 Ok(())
             } else {
                 Err(format!("updated storage collection timestamp {updated_timestamp} is not greater than initial timestamp {initial_timestamp}"))
             }
-        })?;
+        }).unwrap();
     }
-
-    Ok(())
 }
 
 #[test]
-fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Error>> {
-    let data_dir = tempfile::tempdir()?;
+fn test_storage_usage_doesnt_update_between_restarts() {
+    let data_dir = tempfile::tempdir().unwrap();
     let storage_usage_collection_interval = Duration::from_secs(60);
     let config = util::Config::default()
         .with_storage_usage_collection_interval(storage_usage_collection_interval)
@@ -807,8 +819,8 @@ fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Err
 
     // Wait for initial storage usage collection.
     let initial_timestamp: f64 = {
-        let server = util::start_server(config.clone())?;
-        let mut client = server.connect(postgres::NoTls)?;
+        let server = util::start_server(config.clone()).unwrap();
+        let mut client = server.connect(postgres::NoTls).unwrap();
         // Retry because it may take some time for the initial snapshot to be taken.
         Retry::default().max_duration(Duration::from_secs(60)).retry(|_| {
             client
@@ -816,37 +828,35 @@ fn test_storage_usage_doesnt_update_between_restarts() -> Result<(), Box<dyn Err
                         "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_catalog.mz_storage_usage;",
                         &[],
                     )
-                    .map_err(|e| e.to_string())?
+                    .map_err(|e| e.to_string()).unwrap()
                     .try_get::<_, f64>(0)
                     .map_err(|e| e.to_string())
-        })?
+        }).unwrap()
     };
 
     std::thread::sleep(Duration::from_secs(2));
 
     // Another storage usage collection should not be scheduled immediately.
     {
-        let server = util::start_server(config)?;
-        let mut client = server.connect(postgres::NoTls)?;
+        let server = util::start_server(config).unwrap();
+        let mut client = server.connect(postgres::NoTls).unwrap();
 
         let updated_timestamp = client
             .query_one(
                 "SELECT EXTRACT(EPOCH FROM MAX(collection_timestamp))::float8 FROM mz_catalog.mz_storage_usage;",
                 &[],
-            )?.get::<_, f64>(0);
+            ).unwrap().get::<_, f64>(0);
 
         assert_eq!(initial_timestamp, updated_timestamp);
     }
-
-    Ok(())
 }
 
 #[test]
-fn test_storage_usage_collection_interval_timestamps() -> Result<(), Box<dyn Error>> {
+fn test_storage_usage_collection_interval_timestamps() {
     let config =
         util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(30));
-    let server = util::start_server(config)?;
-    let mut client = server.connect(postgres::NoTls)?;
+    let server = util::start_server(config).unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Retry because it may take some time for the initial snapshot to be taken.
     Retry::default().max_duration(Duration::from_secs(10)).retry(|_| {
@@ -855,30 +865,29 @@ fn test_storage_usage_collection_interval_timestamps() -> Result<(), Box<dyn Err
                 "SELECT collection_timestamp, SUM(size_bytes)::int8 FROM mz_catalog.mz_storage_usage GROUP BY collection_timestamp ORDER BY collection_timestamp;",
                 &[],
             )
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| e.to_string()).unwrap();
         if rows.len() == 1 {
             Ok(())
         } else {
             Err(format!("expected a single timestamp, instead found {}", rows.len()))
         }
-    })?;
-
-    Ok(())
+    }).unwrap();
 }
 
 #[test]
-fn test_default_cluster_sizes() -> Result<(), Box<dyn Error>> {
+fn test_default_cluster_sizes() {
     let config = util::Config::default()
         .with_builtin_cluster_replica_size("1".to_string())
         .with_default_cluster_replica_size("2".to_string());
-    let server = util::start_server(config)?;
-    let mut client = server.connect(postgres::NoTls)?;
+    let server = util::start_server(config).unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
 
     let builtin_size: String = client
         .query(
             "SELECT size FROM (SHOW CLUSTER REPLICAS WHERE cluster LIKE 'mz_%')",
             &[],
-        )?
+        )
+        .unwrap()
         .get(0)
         .unwrap()
         .get(0);
@@ -888,11 +897,10 @@ fn test_default_cluster_sizes() -> Result<(), Box<dyn Error>> {
         .query(
             "SELECT size FROM (SHOW CLUSTER REPLICAS WHERE cluster = 'default')",
             &[],
-        )?
+        )
+        .unwrap()
         .get(0)
         .unwrap()
         .get(0);
     assert_eq!(builtin_size, "2");
-
-    Ok(())
 }


### PR DESCRIPTION
This commit modifies all the integration tests in mz-environmentd, so instead of returning an error they panic. When a test returns an error you lose the stack trace of where that error was returned from, which makes it extremely difficult to debug certain test failures. This is especially true of flaky tests in CI. Panics will print the full stack trace of where the test panicked from.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
