### PR TITLE
docs: Add style guide for cargo tests

### DIFF
--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -247,6 +247,13 @@ They are named different as to avoid clashing with inherent methods.
 These functions require a closure that produces a _name_ for the task, to improve the use of
 [`tokio-console`]
 
+### Test-specific
+
+You should prefer to panic in tests rather than returning an error. Tests that return errors
+do not produce useful backtraces and instead just point to the line in libtest that assert
+that the test didn't return an error. Panics will produce useful backtraces that include
+the line where the panic occurred. This is especially useful for debugging flaky tests in CI.
+
 [Clippy]: https://github.com/rust-lang/rust-clippy
 [rustfmt]: https://github.com/rust-lang/rustfmt
 [rust-api]: https://rust-lang.github.io/api-guidelines/

--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -250,7 +250,7 @@ These functions require a closure that produces a _name_ for the task, to improv
 ### Test-specific
 
 You should prefer to panic in tests rather than returning an error. Tests that return errors
-do not produce useful backtraces and instead just point to the line in libtest that assert
+do not produce useful backtraces and instead just point to the line in libtest that asserts
 that the test didn't return an error. Panics will produce useful backtraces that include
 the line where the panic occurred. This is especially useful for debugging flaky tests in CI.
 


### PR DESCRIPTION
This commit adds a section to the style guide for cargo tests.

### Motivation
Adds docs.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
