### PR TITLE
Add a commandline flag --stderr-log-format for optional json logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7172,6 +7172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7181,12 +7191,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -40,7 +40,7 @@ tokio-openssl = { version = "0.6.3", optional = true }
 # log lines we care about.
 # Note that this feature is distinct from `tracing`'s `log` feature, which has `tracing` macros emit `log` records if
 # there is no global `tracing` subscriber.
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt", "tracing-log"], optional = true }
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt", "json", "tracing-log"], optional = true }
 
 
 # For the `tracing` feature


### PR DESCRIPTION
This adds the ability to configure our tracing-subscriber setup to log either pretty text, or structured json - one is great for humans, the other is good in infrastructure with a structured log aggregation setup.

@guswynn and I also believe that the restructured dynamic filter also prevents a bug or another when it comes to changing the log levels.

### Motivation

  * This PR adds a feature that has not yet been specified.

We'd love to have more structured logs in the cloud, and this is a stepping stone to that.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  * The option `--stderr-log-format=json` is now available for writing structured log messages in JSON.