### PR TITLE
CREATE CONNECTION: add uppercase validation for kafka SASL MECHANISM

### DIFF
--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -319,6 +319,16 @@ contains:under-specified security configuration
   );
 contains:under-specified security configuration
 
+> CREATE SECRET s AS '...';
+
+! CREATE CONNECTION kafka_sasl_lowercase_mechanism TO KAFKA (
+    BROKER 'kafka:9092',
+    SASL MECHANISMS = 'plain',
+    SASL USERNAME = 'materialize',
+    SASL PASSWORD = SECRET s
+  );
+contains:invalid SASL MECHANISM "plain": must be uppercase
+
 ! CREATE CONNECTION multiple_brokers TO KAFKA (
     BROKER 'kafka:9092, kafka:9093'
   );
@@ -334,8 +344,6 @@ contains:cannot specify multiple Kafka broker addresses in one string
     USERNAME 'foo'
   );
 contains:must specify URL
-
-> CREATE SECRET s AS '...';
 
 ! CREATE CONNECTION missing_cert TO CONFLUENT SCHEMA REGISTRY (
     URL 'http://localhost',


### PR DESCRIPTION
Addresses #15564.

The field is an option value string, which is case sensitive, unlike identifiers which are only case-sensitive if double quoted. As such, we should error on lowercase inputs rather than automatically convert the string to uppercase.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
