### PR TITLE
testdrive: Fortify cvs-sources.td against #16048 (Part #3)

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -60,7 +60,6 @@ $ s3-create-bucket bucket=test-no-records
 
 $ s3-put-object bucket=test-no-records key=static-no-records.csv
 city,state,zip
-Rochester,NY,14618
 
 > CREATE SOURCE mismatched_column_names
   FROM S3 CONNECTION s3_conn


### PR DESCRIPTION
The "empty" CSV source that is required for certain parts of the test must in fact be empty, and it was not due to a mistake in the previous PR.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI continued to fail because I made a mistake in my previous attempt to fix the test.