### PR TITLE
ore: allow catching panics after set_abort_on_panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,7 @@ dependencies = [
  "paste",
  "pin-project",
  "prometheus",
+ "scopeguard",
  "sentry",
  "sentry-tracing",
  "serde",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,7 @@
 disallowed-methods = [
+    { path = "std::panic::catch_unwind", reason = "use mz_ore::panic::catch_unwind instead" },
+    { path = "futures::FutureExt::catch_unwind", reason = "use mz_ore::future::FutureExt::catch_unwind instead" },
+
     { path = "futures_executor::block_on", reason = "tokio::runtime::Handle::block_on instead" },
     { path = "futures::executor::block_on", reason = "tokio::runtime::Handle::block_on instead" },
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -60,6 +60,7 @@ console-subscriber = { version = "0.1.8", optional = true }
 sentry-tracing = { version = "0.29.0", optional = true }
 
 [dev-dependencies]
+scopeguard = "1.1.0"
 tokio = { version = "1.22.0", features = ["macros"] }
 
 [features]

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -15,8 +15,22 @@
 
 //! Panic utilities.
 
-use std::panic;
+use std::any::Any;
+use std::cell::RefCell;
+use std::panic::{self, UnwindSafe};
 use std::process;
+
+#[cfg(feature = "task")]
+use tokio::task_local;
+
+thread_local! {
+    static CATCHING_UNWIND: RefCell<bool> = RefCell::new(false);
+}
+
+#[cfg(feature = "task")]
+task_local! {
+    pub(crate) static CATCHING_UNWIND_ASYNC: bool;
+}
 
 /// Instructs the entire process to abort if any thread panics.
 ///
@@ -33,12 +47,64 @@ use std::process;
 /// forever will be more confusing to the end user than aborting the program
 /// entirely.
 ///
-/// Computations in which a panic is expected can still use
-/// [`panic::catch_unwind`] to recover.
+/// Computations in which a panic is expected can use the special
+/// [`catch_unwind`] function in this module to recover. Note that the
+/// `catch_unwind` function in the standard library is **not** compatible with
+/// this function.
 pub fn set_abort_on_panic() {
     let old_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
         old_hook(panic_info);
-        process::abort();
+        let catching_unwind = CATCHING_UNWIND.with(|v| *v.borrow());
+        #[cfg(feature = "task")]
+        let catching_unwind_async = CATCHING_UNWIND_ASYNC.try_with(|v| *v).unwrap_or(false);
+        #[cfg(not(feature = "task"))]
+        let catching_unwind_async = false;
+        if !catching_unwind && !catching_unwind_async {
+            process::abort();
+        }
     }))
+}
+
+/// Like [`std::panic::catch_unwind`], but can unwind panics even if
+/// [`set_abort_on_panic`] has been called.
+pub fn catch_unwind<F, R>(f: F) -> Result<R, Box<dyn Any + Send + 'static>>
+where
+    F: FnOnce() -> R + UnwindSafe,
+{
+    CATCHING_UNWIND.with(|catching_unwind| {
+        *catching_unwind.borrow_mut() = true;
+        #[allow(clippy::disallowed_methods)]
+        let res = panic::catch_unwind(f);
+        *catching_unwind.borrow_mut() = false;
+        res
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic;
+
+    use scopeguard::defer;
+
+    use super::*;
+
+    #[test]
+    fn catch_panic() {
+        let old_hook = panic::take_hook();
+        defer! {
+            panic::set_hook(old_hook);
+        }
+
+        set_abort_on_panic();
+
+        let result = catch_unwind(|| {
+            panic!("panicked");
+        })
+        .unwrap_err()
+        .downcast::<&str>()
+        .unwrap();
+
+        assert_eq!(*result, "panicked");
+    }
 }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -891,7 +891,7 @@ mod tests {
         // losing or misinterpreting something written out by a future version
         // of code.
         mz_ore::process::PANIC_ON_HALT.store(true, Ordering::SeqCst);
-        let v1_res = std::panic::catch_unwind(|| State::<(), (), u64, i64>::decode(&v1, &buf));
+        let v1_res = mz_ore::panic::catch_unwind(|| State::<(), (), u64, i64>::decode(&v1, &buf));
         assert!(v1_res.is_err());
     }
 
@@ -919,7 +919,7 @@ mod tests {
         // losing or misinterpreting something written out by a future version
         // of code.
         mz_ore::process::PANIC_ON_HALT.store(true, Ordering::SeqCst);
-        let v1_res = std::panic::catch_unwind(|| StateDiff::<u64>::decode(&v1, &buf));
+        let v1_res = mz_ore::panic::catch_unwind(|| StateDiff::<u64>::decode(&v1, &buf));
         assert!(v1_res.is_err());
     }
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -699,8 +699,8 @@ mod tests {
 
     use differential_dataflow::consolidation::consolidate_updates;
     use futures_task::noop_waker;
-    use futures_util::FutureExt;
     use mz_ore::cast::CastFrom;
+    use mz_ore::future::OreFutureExt;
     use mz_persist::indexed::encoding::BlobTraceBatchPart;
     use mz_persist::workload::DataGenerator;
     use mz_proto::protobuf_roundtrip;
@@ -1588,7 +1588,7 @@ mod tests {
             .perform(&read.machine.clone(), &read.gc.clone())
             .await;
         let expired_writer_heartbeat = AssertUnwindSafe(write.maybe_heartbeat_writer())
-            .catch_unwind()
+            .ore_catch_unwind()
             .await;
         assert!(matches!(expired_writer_heartbeat, Err(_)));
     }


### PR DESCRIPTION
Contrary to its documentation, ore's `set_abort_on_panic` function made it impossible to catch panics via `std::panic::catch_unwind`.

This commit introduces a new `mz_ore::panic::catch_unwind` function which *is* capable of catching panics, even after `set_abort_on_panic` has been called. It works by temporrily disabling the panic hook via a thread-local variable.

An analogous method is introduced for async code in the `OreFutureExt` trait, which mirrors the upstream implementation in the futures library on the `FutureExt` trait.

Fix #16236.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
