### PR TITLE
ci: Run the Release Qualification Test with the right queue

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -42,7 +42,7 @@ steps:
     label: "Large Zippy Kafka Sources"
     timeout_in_minutes: 1440
     agents:
-      queue: builder-linux-x86_64
+      queue: linux-x86_64-large
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy


### PR DESCRIPTION
The "linux-x86_64-large" has been given extra EBS storage so that the Release Qualification Test can complete successfully.


### Motivation

  * This PR fixes a previously unreported bug.
The Release Qualification Test was running out of disk space at the 250Gb Buildkite default.