### PR TITLE
test: Test source/sink status reporting

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -562,6 +562,17 @@ steps:
           composition: platform-checks
           args: [--scenario=RestartRedpanda]
 
+  - id: source-sink-errors
+    label: "Source/Sink Error Reporting"
+    artifact_paths: junit_mzcompose_*.xml
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: source-sink-errors
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build-x86_64

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -501,7 +501,7 @@ impl CatalogState {
         let plan = mz_sql::plan::plan(None, &session_catalog, stmt, &Params::empty())?;
         Ok(match plan {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let mut optimizer = Optimizer::logical_optimizer();
+                let optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
@@ -4996,7 +4996,7 @@ impl<S: Append> Catalog<S> {
                 })
             }
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let mut optimizer = Optimizer::logical_optimizer();
+                let optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
@@ -5010,7 +5010,7 @@ impl<S: Append> Catalog<S> {
             Plan::CreateMaterializedView(CreateMaterializedViewPlan {
                 materialized_view, ..
             }) => {
-                let mut optimizer = Optimizer::logical_optimizer();
+                let optimizer = Optimizer::logical_optimizer();
                 let optimized_expr = optimizer.optimize(materialized_view.expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), materialized_view.column_names);
                 CatalogItem::MaterializedView(MaterializedView {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -782,7 +782,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
 
         // Having installed all entries, creating all constraints, we can now relax read policies.
-        self.initialize_read_policies(policies_to_set, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS)
+        self.initialize_read_policies(&policies_to_set, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS)
             .await;
 
         info!("coordinator init: announcing completion of initialization to controller");

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -39,7 +39,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ///
     /// The timeline that `id_bundle` belongs to is also returned, if one exists.
     pub(crate) fn determine_timestamp(
-        &mut self,
+        &self,
         session: &Session,
         id_bundle: &CollectionIdBundle,
         when: &QueryWhen,
@@ -85,7 +85,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let timeline = timeline
                 .clone()
                 .expect("checked that timeline exists above");
-            let timestamp_oracle = self.get_timestamp_oracle_mut(&timeline);
+            let timestamp_oracle = self.get_timestamp_oracle(&timeline);
             oracle_read_ts = Some(timestamp_oracle.read_ts());
             candidate.join_assign(&oracle_read_ts.unwrap());
         } else if when.advance_to_upper() {

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -461,7 +461,7 @@ impl Optimizer {
         fields(path.segment = self.name)
     )]
     pub fn optimize(
-        &mut self,
+        &self,
         mut relation: MirRelationExpr,
     ) -> Result<mz_expr::OptimizedMirRelationExpr, TransformError> {
         let transform_result = self.transform(&mut relation, &EmptyIndexOracle);

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -312,7 +312,7 @@ mod tests {
         }
         let mut out = String::new();
         if test_type == TestType::Opt {
-            let mut optimizer = Optimizer::logical_optimizer();
+            let optimizer = Optimizer::logical_optimizer();
             dataflow = dataflow
                 .into_iter()
                 .map(|(id, rel)| (id, optimizer.optimize(rel).unwrap().into_inner()))
@@ -332,8 +332,8 @@ mod tests {
             _ => {}
         };
         if test_type == TestType::Opt {
-            let mut log_optimizer = Optimizer::logical_cleanup_pass();
-            let mut phys_optimizer = Optimizer::physical_optimizer();
+            let log_optimizer = Optimizer::logical_cleanup_pass();
+            let phys_optimizer = Optimizer::physical_optimizer();
             dataflow = dataflow
                 .into_iter()
                 .map(|(id, rel)| {

--- a/test/source-sink-errors/mzcompose
+++ b/test/source-sink-errors/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -1,0 +1,175 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from dataclasses import dataclass
+from textwrap import dedent
+from typing import Callable, Optional
+
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import Materialized, Redpanda, Storaged, Testdrive
+
+SERVICES = [Redpanda(), Materialized(), Testdrive(), Storaged()]
+
+
+@dataclass
+class Disruption:
+    name: str
+    breakage: Callable
+    expected_error: str
+    fixage: Optional[Callable]
+
+    def run_test(self, c: Composition) -> None:
+        print(f"+++ Running disruption scenario {self.name}")
+        seed = random.randint(0, 256**4)
+
+        c.down(destroy_volumes=True)
+        c.up("testdrive", persistent=True)
+        c.start_and_wait_for_tcp(services=["redpanda", "materialized", "storaged"])
+        c.wait_for_materialized()
+
+        with c.override(
+            Testdrive(
+                no_reset=True,
+                seed=seed,
+                entrypoint_extra=["--initial-backoff=1s", "--backoff-factor=0"],
+            )
+        ):
+            self.populate(c)
+            self.breakage(c, seed)
+            self.assert_error(c, self.expected_error)
+
+            if self.fixage:
+                self.fixage(c, seed)
+                self.assert_recovery(c)
+
+    def populate(self, c: Composition) -> None:
+        # Create a source and a sink
+        c.testdrive(
+            dedent(
+                """
+                > CREATE CONNECTION kafka_conn
+                  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+                > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+                  URL '${testdrive.schema-registry-url}'
+                  );
+
+                $ kafka-create-topic topic=source-topic
+
+                $ kafka-ingest topic=source-topic format=bytes
+                ABC
+
+                > CREATE SOURCE source1
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-source-topic-${testdrive.seed}')
+                  FORMAT BYTES
+                  ENVELOPE NONE
+                  /* TODO(bkirwi) WITH ( REMOTE 'storaged:2100' ) REMOTE causes the status source to be empty */
+
+                > CREATE SINK sink1 FROM source1
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-topic-${testdrive.seed}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
+                  /* WITH ( REMOTE 'storaged:2100' ) REMOTE causes the status source to be empty */
+
+                # Wait for the source to start up
+                # TODO(bkirwi) - catch errors while blocked on client startup
+                > SELECT COUNT(*) FROM source1
+                1
+                """
+            )
+        )
+
+    def assert_error(self, c: Composition, error: str) -> None:
+        # Validate that cluster2 continues to operate
+        c.testdrive(
+            dedent(
+                f"""
+                > SELECT status, error ~* '{error}'
+                  FROM mz_internal.mz_source_status
+                  WHERE name = 'source1'
+                stalled true
+
+                # TODO(bkirwi) https://github.com/MaterializeInc/materialize/pull/16232
+                #> SELECT status, error ~* '{error}'
+                #  FROM mz_internal.mz_sink_status
+                #  WHERE name = 'sink1'
+                # stalled true
+                """
+            )
+        )
+
+    def assert_recovery(self, c: Composition) -> None:
+        c.testdrive(
+            dedent(
+                """
+                $ kafka-ingest topic=source-topic format=bytes
+                ABC
+
+                > SELECT COUNT(*) FROM source1;
+                2
+
+                # TODO(bkirwi) https://github.com/MaterializeInc/materialize/issues/16065
+                #> SELECT status, error
+                #  FROM mz_internal.mz_source_status
+                #  WHERE name = 'source1'
+                #running <null>
+
+                #> SELECT status, error
+                #  FROM mz_internal.mz_sink_status
+                #  WHERE name = 'sink1'
+                #running <null>
+                """
+            )
+        )
+
+
+disruptions = [
+    Disruption(
+        name="delete-topic",
+        breakage=lambda c, seed: redpanda_topics(c, "delete", seed),
+        expected_error="UnknownTopicOrPartition",
+        fixage=None
+        # Re-creating the topic does not restart the source
+        # fixage=lambda c,seed: redpanda_topics(c, "create", seed),
+    ),
+    Disruption(
+        name="pause-redpanda",
+        breakage=lambda c, _: c.pause("redpanda"),
+        expected_error="OperationTimedOut",
+        fixage=lambda c, _: c.unpause("redpanda"),
+    ),
+    Disruption(
+        name="kill-redpanda",
+        breakage=lambda c, _: c.kill("redpanda"),
+        expected_error="BrokerTransportFailure|Resolve",
+        fixage=lambda c, _: c.up("redpanda"),
+    ),
+    # Can not be tested ATM due to REMOTE breaking things
+    # Disruption(
+    #     name="kill-redpanda-storaged",
+    #     breakage=lambda c, _: c.kill("redpanda", "storaged"),
+    #     expected_error="???",
+    #     fixage=lambda c, _: c.up("redpanda", "storaged"),
+    # ),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    """Test the detection and reporting of source/sink errors by
+    introducing a Disruption and then checking the mz_internal.mz_*_status tables
+    """
+
+    for id, disruption in enumerate(disruptions):
+        disruption.run_test(c)
+
+
+def redpanda_topics(c: Composition, action: str, seed: int) -> None:
+    for topic in ["source", "sink"]:
+        c.exec("redpanda", "rpk", "topic", action, f"testdrive-{topic}-topic-{seed}")

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -60,7 +60,6 @@ $ s3-create-bucket bucket=test-no-records
 
 $ s3-put-object bucket=test-no-records key=static-no-records.csv
 city,state,zip
-Rochester,NY,14618
 
 > CREATE SOURCE mismatched_column_names
   FROM S3 CONNECTION s3_conn


### PR DESCRIPTION
A mzcompose-based test that introduces disruptions against a source and a sink and confirms that the disruption is properly reflected in the mz_*_status tables. The disruption is then removed and the test checks that the status tables reflect resumed operation.

### Motivation

  * This PR adds a known-desirable feature.

Relates to #12864