### PR TITLE
cloudtest: Improve the debuggability of cloudtest

### DIFF
--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -13,7 +13,19 @@ set -xeu
 
 echo "~~~ Cleaning up after cloudtest" >&2
 
-bin/ci-builder run stable kubectl --context kind-kind get pods -o name | grep -v -E 'kubernetes|minio|postgres|redpanda' | xargs -L 1 bin/ci-builder run stable kubectl --context kind-kind logs --prefix=true > services.log || true
-buildkite-agent artifact upload services.log
+bin/ci-builder run stable kubectl --context kind-kind get pods -o name | grep -v -E 'kubernetes|minio|postgres|redpanda' | xargs -L 1 bin/ci-builder run stable kubectl --context kind-kind logs --prefix=true > kubectl-get-logs.log || true
+buildkite-agent artifact upload kubectl-get-logs.log
+
+bin/ci-builder run stable kubectl --context kind-kind get pods -o name | grep -v -E 'kubernetes|minio|postgres|redpanda' | xargs -L 1 bin/ci-builder run stable kubectl --context kind-kind logs --previous --prefix=true > kubectl-get-logs-previous.log || true
+buildkite-agent artifact upload kubectl-get-logs-previous.log
+
+bin/ci-builder run stable kubectl --context kind-kind get events > kubectl-get-events.log || true
+buildkite-agent artifact upload kubectl-get-events.log
+
+bin/ci-builder run stable kubectl --context kind-kind get all > kubectl-get-all.log || true
+buildkite-agent artifact upload kubectl-get-all.log
+
+bin/ci-builder run stable kubectl --context kind-kind describe all > kubectl-describe-all.log || true
+buildkite-agent artifact upload kubectl-describe-all.log
 
 bin/ci-builder run stable kubectl --context kind-kind delete all --all

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -548,7 +548,7 @@ steps:
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
-          args: [-m, "not long", --aws-region=us-east-2, test/cloudtest/]
+          args: [--exitfirst, -m, "not long", --aws-region=us-east-2, test/cloudtest/]
 
   - id: checks-restart-redpanda
     label: "Checks + restart Redpanda"


### PR DESCRIPTION
- fail the entire CI job after the first test failure, so that the relevant logs are collected
- preserve the output from kubectl get all , describe all , get events

Fixes: #16269

### Motivation

  * This PR fixes a previously unreported bug.
Debugging cloudtest failures is difficult.