### PR TITLE
don't prevent the default link behaviour when the SVG is clicked.

### DIFF
--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -92,7 +92,7 @@ Apache License, Version 2.0. */}}
 
       // Add click handlers for all top-level items with children.
       const menus = $("nav[role=navigation] li.has-children");
-      menus.find("a:not([href]), svg").click((e) => {
+      menus.find("a:not([href])").click((e) => {
         $(e.target).parents("li").toggleClass("open");
         e.preventDefault();
         return false;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Thanks to @morsapaes for bringing this up. 

At the moment when the expand icon is clicked for a sidebar item that is a link with its own dedicated page it just expands the menu and does not take the user to the page resulting in the page being missed al together. 

![image](https://user-images.githubusercontent.com/46004116/203815125-4f46d98e-2b57-4667-af4c-b4105283c318.png) 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
