### PR TITLE
Developer documentation: Fix tokio-console documentation

### DIFF
--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -10,13 +10,13 @@ First, install `tokio-console`:
 cargo install tokio-console
 ```
 
-Then run `materialized` with the `console-subscriber` on:
+Then run `environmentd`:
 
 ```
-RUSTFLAGS="--cfg tokio_unstable" cargo run --features tokio-console -- --dev --tokio-console
+./bin/environmentd --tokio-console
 ```
 
-(note that this may slow down `materialized` a lot, as it increases the amount of tracing by a lot,
+(note that this may slow down `environmentd` a lot, as it increases the amount of tracing by a lot,
 and may inadvertently turn on debug logging for `rdkafka`)
 
 Then, in a different tmux pane/terminal, run:


### PR DESCRIPTION
Tokio console support is back and simple to access with a `./bin/environmentd` flag, but the developer docs are  outdated.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): None