### PR TITLE
sql-parser: permit EXPLAIN WITH ...

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5506,10 +5506,14 @@ impl<'a> Parser<'a> {
         };
 
         let config_flags = if self.parse_keyword(WITH) {
-            self.expect_token(&Token::LParen)?;
-            let config_flags = self.parse_comma_separated(Self::parse_identifier)?;
-            self.expect_token(&Token::RParen)?;
-            config_flags
+            if self.consume_token(&Token::LParen) {
+                let config_flags = self.parse_comma_separated(Self::parse_identifier)?;
+                self.expect_token(&Token::RParen)?;
+                config_flags
+            } else {
+                self.prev_token(); // push back WITH in case it's actually a CTE
+                vec![]
+            }
         } else {
             vec![]
         };

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -88,6 +88,14 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
 Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
 
+# regression test for #16029
+parse-statement
+EXPLAIN WITH a AS (SELECT 1) SELECT * FROM a
+----
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
+=>
+Explain(ExplainStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
 ----


### PR DESCRIPTION
EXPLAIN supports configuration of specific stages using WITH (...), which causes the parser to choke when you just want a plain EXPLAIN of an expression starting with a CTE.

It's sufficient to differentiate these uses of WITH by the opening parenthesis expected for configuration because the next token for a CTE must be an identifier, per with_clause as defined by Postgres (and <with clause> in the SQL standard).

Fixes #16029.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug: #16029.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Permit EXPLAIN on an expression beginning with a CTE, without needing extra parentheses to convince the parser.
