### PR TITLE
adapter: print COUNT(*) when EXPLAIN'ing COUNT(*)

### DIFF
--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -379,14 +379,18 @@ impl<'a> DisplayText for Displayable<'a, HirScalarExpr> {
 
 impl<'a> DisplayText for Displayable<'a, AggregateExpr> {
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut ()) -> fmt::Result {
-        let func = self.0.func.clone().into_expr();
-        if self.0.distinct {
-            write!(f, "{}(distinct ", func)?;
-            Displayable::from(self.0.expr.as_ref()).fmt_text(f, ctx)?;
-        } else {
-            write!(f, "{}(", func)?;
-            Displayable::from(self.0.expr.as_ref()).fmt_text(f, ctx)?;
+        if self.0.is_count_asterisk() {
+            return write!(f, "count(*)");
         }
+
+        write!(
+            f,
+            "{}({}",
+            self.0.func.clone().into_expr(),
+            if self.0.distinct { "distinct " } else { "" }
+        )?;
+
+        Displayable::from(self.0.expr.as_ref()).fmt_text(f, ctx)?;
         write!(f, ")")
     }
 }

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -81,7 +81,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                             )
                         })?;
                     } else {
-                        write!(f, "{}Constant <empty>", ctx.indent)?;
+                        writeln!(f, "{}Constant <empty>", ctx.indent)?;
                     }
                 }
                 Err(err) => {

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -670,14 +670,18 @@ impl<'a> DisplayText for Displayable<'a, MirScalarExpr> {
 
 impl<'a> DisplayText for Displayable<'a, AggregateExpr> {
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut ()) -> fmt::Result {
-        let func = self.0.func.clone();
-        if self.0.distinct {
-            write!(f, "{}(distinct ", func)?;
-            Displayable::from(&self.0.expr).fmt_text(f, ctx)?;
-        } else {
-            write!(f, "{}(", func)?;
-            Displayable::from(&self.0.expr).fmt_text(f, ctx)?;
+        if self.0.is_count_asterisk() {
+            return write!(f, "count(*)");
         }
+
+        write!(
+            f,
+            "{}({}",
+            self.0.func.clone(),
+            if self.0.distinct { "distinct " } else { "" }
+        )?;
+
+        Displayable::from(&self.0.expr).fmt_text(f, ctx)?;
         write!(f, ")")
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -2853,4 +2853,22 @@ impl AggregateExpr {
     ) -> ColumnType {
         self.func.output_type(self.expr.typ(outers, inner, params))
     }
+
+    pub fn is_count_asterisk(&self) -> bool {
+        // This could be much less cumbersome if box/deref pattern
+        // syntax were stable: <https://github.com/rust-lang/rust/issues/29641>
+        if self.func != AggregateFunc::Count {
+            return false;
+        }
+        match &*self.expr {
+            HirScalarExpr::Literal(
+                row,
+                mz_repr::ColumnType {
+                    scalar_type: mz_repr::ScalarType::Bool,
+                    nullable: false,
+                },
+            ) => row.unpack_first() == mz_repr::Datum::True,
+            _ => false,
+        }
+    }
 }

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -144,7 +144,7 @@ Explained Query:
                 Get l0 // { arity: 2 }
             Project (#0) // { arity: 1 }
               Filter error("more than one record produced in subquery") AND (#1 > 1) // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                   Project (#0) // { arity: 1 }
                     Get l0 // { arity: 2 }
   With

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -121,7 +121,7 @@ Explained Query:
       Negate // { types: "(boolean?, bigint)" }
         TopK limit=1 monotonic=false // { types: "(boolean?, bigint)" }
           Project (#1, #2) // { types: "(boolean?, bigint)" }
-            Reduce group_by=[#0] aggregates=[min(#1), count(true)] // { types: "(double precision, boolean?, bigint)" }
+            Reduce group_by=[#0] aggregates=[min(#1), count(*)] // { types: "(double precision, boolean?, bigint)" }
               Project (#0, #1) // { types: "(double precision, boolean?)" }
                 Join on=(#0 = #2) type=differential // { types: "(double precision, boolean?, double precision)" }
                   ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
@@ -136,7 +136,7 @@ Explained Query:
                       Map (error("more than one record produced in subquery")) // { types: "(double precision)" }
                         Project () // { types: "()" }
                           Filter error("more than one record produced in subquery") AND (#0 > 1) // { types: "(bigint)" }
-                            Reduce aggregates=[count(true)] // { types: "(bigint)" }
+                            Reduce aggregates=[count(*)] // { types: "(bigint)" }
                               Project () // { types: "()" }
                                 Get materialize.public.u // { types: "(integer?)" }
       Constant // { types: "(boolean?, bigint)" }

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -161,7 +161,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { keys: "([])" }
           Project () // { keys: "([])" }
             Filter (#0 > 1) // { keys: "([])" }
-              Reduce aggregates=[count(true)] // { keys: "([])" }
+              Reduce aggregates=[count(*)] // { keys: "([])" }
                 Project () // { keys: "()" }
                   Get l0 // { keys: "()" }
     cte l0 =

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -298,7 +298,7 @@ GROUP BY 1,
 ----
 Explained Query:
   Project (#0..=#4, #3) // { arity: 6 }
-    Reduce group_by=[#1, #2] aggregates=[count(true), min(#2), min(#0)] // { arity: 5 }
+    Reduce group_by=[#1, #2] aggregates=[count(*), min(#2), min(#0)] // { arity: 5 }
       Project (#0, #1, #28) // { arity: 3 }
         Filter (#10 <= 1995-11-14) AND (#30 <= 12907776) AND (#10 >= 1995-04-19) AND (#30 >= #5) // { arity: 33 }
           Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
@@ -527,7 +527,7 @@ WHERE l_receiptDATE BETWEEN '1992-06-21' AND '1992-11-22'
 GROUP BY 1
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[count(true), count(distinct #1)] // { arity: 3 }
+  Reduce group_by=[#0] aggregates=[count(*), count(distinct #1)] // { arity: 3 }
     Project (#0, #17) // { arity: 2 }
       Filter (#4 <= 30) AND (#12 <= 1998-11-27) AND (#12 <= 1992-11-22) AND (#4 >= 1) AND (#12 >= 1992-06-21) AND (#12 >= 1992-07-13) // { arity: 33 }
         Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
@@ -584,7 +584,7 @@ GROUP BY 1,
 ----
 Explained Query:
   Project (#0, #0..=#2) // { arity: 4 }
-    Reduce group_by=[#1] aggregates=[min(#0), count(true)] // { arity: 3 }
+    Reduce group_by=[#1] aggregates=[min(#0), count(*)] // { arity: 3 }
       Project (#2, #3) // { arity: 2 }
         Filter (#1 < #6) AND (#16 > #5) AND (#16 >= #0) // { arity: 19 }
           Join on=(#3 = #11) type=differential // { arity: 19 }
@@ -687,7 +687,7 @@ WHERE l_extendedprice < o_totalprice
 GROUP BY 1
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[count(true), count(distinct #0)] // { arity: 3 }
+  Reduce group_by=[#0] aggregates=[count(*), count(distinct #0)] // { arity: 3 }
     Project (#25) // { arity: 1 }
       Filter (#10 <= 1994-03-17) AND (#0 >= 53) AND (#5 < #19) AND (#26 < #19) // { arity: 27 }
         Join on=(#0 = #16) type=differential // { arity: 27 }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -261,7 +261,7 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#5]
     Project (#0..=#2, #6, #7, #5) // { arity: 6 }
       Map ((bigint_to_double(#1) / bigint_to_double(case when (#3 = 0) then null else #3 end)), (numeric_to_double(#2) / bigint_to_double(case when (#4 = 0) then null else #4 end))) // { arity: 8 }
-        Reduce group_by=[#0] aggregates=[sum(#1), sum(#2), count(#1), count(#2), count(true)] // { arity: 6 }
+        Reduce group_by=[#0] aggregates=[sum(#1), sum(#2), count(#1), count(#2), count(*)] // { arity: 6 }
           Project (#3, #7, #8) // { arity: 3 }
             Filter (date_to_timestamp(#6) > 2007-01-02 00:00:00) // { arity: 10 }
               Get materialize.public.orderline // { arity: 10 }
@@ -424,7 +424,7 @@ ORDER BY o_ol_cnt
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#4) // { arity: 1 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 9 }
             implementation
@@ -946,7 +946,7 @@ ORDER BY custdist DESC, c_count DESC
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
             Union // { arity: 2 }
@@ -1432,7 +1432,7 @@ ORDER BY numwait DESC, su_name
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#0) // { arity: 1 }
           Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
             implementation
@@ -1517,7 +1517,7 @@ ORDER BY substr(c_state, 1, 1)
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[substr(char_to_text(#0), 1, 1)] aggregates=[count(true), sum(#1)] // { arity: 3 }
+      Reduce group_by=[substr(char_to_text(#0), 1, 1)] aggregates=[count(*), sum(#1)] // { arity: 3 }
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
@@ -1554,7 +1554,7 @@ Explained Query:
                   Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                     Get l0 // { arity: 23 }
               ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(true)] // { arity: 2 }
+                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
                   Project (#16) // { arity: 1 }
                     Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                       Get l0 // { arity: 23 }

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -290,7 +290,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get materialize.public.t1 // { arity: 2 }
 
@@ -389,7 +389,7 @@ Explained Query:
             Get materialize.public.t2 // { arity: 2 }
         Project () // { arity: 0 }
           Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-            Reduce aggregates=[count(true)] // { arity: 1 }
+            Reduce aggregates=[count(*)] // { arity: 1 }
               Project () // { arity: 0 }
                 Get materialize.public.t2 // { arity: 2 }
 
@@ -412,7 +412,7 @@ Explained Query:
             Get materialize.public.t2 // { arity: 2 }
         Project () // { arity: 0 }
           Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-            Reduce aggregates=[count(true)] // { arity: 1 }
+            Reduce aggregates=[count(*)] // { arity: 1 }
               Project () // { arity: 0 }
                 Get materialize.public.t2 // { arity: 2 }
 

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -188,7 +188,7 @@ With
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
               Get l8 // { arity: 2 }
   cte l8 =
     Project (#0, #2) // { arity: 2 }
@@ -363,7 +363,7 @@ With
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
               Get l8 // { arity: 2 }
   cte l8 =
     Project (#0, #2) // { arity: 2 }
@@ -478,7 +478,7 @@ With
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
               Get l9 // { arity: 2 }
   cte l9 =
     Project (#0, #2) // { arity: 2 }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -421,7 +421,7 @@ With
       Map (error("more than one record produced in subquery"))
         Project (#0)
           Filter (#1 > 1)
-            Reduce group_by=[#0] aggregates=[count(true)]
+            Reduce group_by=[#0] aggregates=[count(*)]
               Get l8
   cte l8 =
     Project (#0, #1)
@@ -442,7 +442,7 @@ With
       Map (error("more than one record produced in subquery"))
         Project (#0)
           Filter (#1 > 1)
-            Reduce group_by=[#0] aggregates=[count(true)]
+            Reduce group_by=[#0] aggregates=[count(*)]
               Get l4
   cte l4 =
     Project (#0, #1)

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -908,3 +908,31 @@ With
       - ()
 
 EOF
+
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR SELECT COUNT(*);
+----
+Return
+  Union
+    Get l1
+    CrossJoin
+      Project ()
+        CrossJoin
+          Union
+            Negate
+              Distinct
+                Get l1
+            Distinct
+              Get l0
+          Get l0
+      Constant
+        - (0)
+With
+  cte l1 =
+    Reduce aggregates=[count(*)]
+      Get l0
+  cte l0 =
+    Constant
+      - ()
+
+EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -396,3 +396,12 @@ CrossJoin
         Get materialize.public.t
 
 EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR SELECT COUNT(*);
+----
+Reduce aggregates=[count(*)]
+  Constant
+    - ()
+
+EOF

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -55,12 +55,12 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get l0 // { arity: 1 }
     cte l0 =
       Project (#2) // { arity: 1 }
-        Reduce group_by=[#0, #1] aggregates=[count(true)] // { arity: 3 }
+        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
           Filter (#0 = #0) AND (#1 = #1) // { arity: 2 }
             Get materialize.public.test2 // { arity: 2 }
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -531,7 +531,7 @@ Explained Query:
             Map (error("more than one record produced in subquery")) // { arity: 1 }
               Project () // { arity: 0 }
                 Filter (#0 > 1) // { arity: 1 }
-                  Reduce aggregates=[count(true)] // { arity: 1 }
+                  Reduce aggregates=[count(*)] // { arity: 1 }
                     Project () // { arity: 0 }
                       Get l0 // { arity: 2 }
   With

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -120,7 +120,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[count(true)] // { arity: 1 }
+      Reduce aggregates=[count(*)] // { arity: 1 }
         Project () // { arity: 0 }
           ReadExistingIndex materialize.public.t1 lookup_values=[(2, "l2"); (3, "l3")]
 
@@ -165,7 +165,7 @@ Explained Query:
   Where
     cte l0 =
       Reduce::Accumulable
-        simple_aggrs[0]=(0, 0, count(true))
+        simple_aggrs[0]=(0, 0, count(*))
         val_plan
           project=(#0)
           map=(true)

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -262,7 +262,7 @@ Explained Query:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[min(#0), max(#0), sum(#0), count(true), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0)), list_agg(row(list[#0]))] // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+      Reduce aggregates=[min(#0), max(#0), sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0)), list_agg(row(list[#0]))] // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
         Project (#1) // { types: "(integer)" }
           Get materialize.public.int_table // { types: "(integer?, integer)" }
 
@@ -288,7 +288,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[count(true), count(distinct #0)] // { types: "(bigint, bigint)" }
+      Reduce aggregates=[count(*), count(distinct #0)] // { types: "(bigint, bigint)" }
         Project (#1) // { types: "(integer)" }
           Get materialize.public.int_table // { types: "(integer?, integer)" }
 
@@ -717,7 +717,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { types: "(integer)" }
           Project () // { types: "()" }
             Filter (#0 > 1) // { types: "(bigint)" }
-              Reduce aggregates=[count(true)] // { types: "(bigint)" }
+              Reduce aggregates=[count(*)] // { types: "(bigint)" }
                 Get l0 // { types: "()" }
     cte l0 =
       Project () // { types: "()" }

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -223,7 +223,7 @@ Explained Query:
             - ()
   With
     cte l1 =
-      Reduce aggregates=[count(true)]
+      Reduce aggregates=[count(*)]
         Project ()
           Union
             Map (null)

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -173,7 +173,7 @@ Explained Query:
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
               Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                Reduce aggregates=[count(true)] // { arity: 1 }
+                Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
                     Get materialize.public.t1 // { arity: 2 }
 
@@ -205,7 +205,7 @@ Explained Query:
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
               Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                Reduce aggregates=[count(true)] // { arity: 1 }
+                Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
                     Get l0 // { arity: 3 }
     cte l0 =
@@ -234,7 +234,7 @@ Explained Query:
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
               Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                Reduce aggregates=[count(true)] // { arity: 1 }
+                Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
                     Get materialize.public.t1 // { arity: 2 }
 
@@ -279,7 +279,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get materialize.public.t1 // { arity: 2 }
 
@@ -452,7 +452,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get l0 // { arity: 3 }
     cte l0 =
@@ -509,7 +509,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get l0 // { arity: 3 }
     cte l0 =
@@ -559,7 +559,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Get l1 // { arity: 0 }
     cte l1 =
       Project () // { arity: 0 }
@@ -605,7 +605,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get l0 // { arity: 3 }
     cte l1 =
@@ -925,7 +925,7 @@ Explained Query:
               Map (error("more than one record produced in subquery")) // { arity: 1 }
                 Project () // { arity: 0 }
                   Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                    Reduce aggregates=[count(true)] // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
                       Project () // { arity: 0 }
                         Get l1 // { arity: 3 }
     cte l1 =
@@ -1036,7 +1036,7 @@ Explained Query:
       Get l0 // { arity: 2 }
   With
     cte l0 =
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#0) // { arity: 1 }
           Get materialize.public.t1 // { arity: 2 }
 

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -75,7 +75,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 1 }
           Project () // { arity: 0 }
             Filter (#0 > 1) // { arity: 1 }
-              Reduce aggregates=[count(true)] // { arity: 1 }
+              Reduce aggregates=[count(*)] // { arity: 1 }
                 Project () // { arity: 0 }
                   Get materialize.public.t1 // { arity: 1 }
 
@@ -114,7 +114,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
@@ -175,7 +175,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Project (#0) // { arity: 1 }
                   Get l3 // { arity: 2 }
     cte l3 =
@@ -252,7 +252,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Project (#0) // { arity: 1 }
                   Get l5 // { arity: 2 }
     cte l5 =
@@ -268,7 +268,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Project (#0) // { arity: 1 }
                   Get l3 // { arity: 2 }
     cte l3 =
@@ -353,7 +353,7 @@ Explained Query:
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
               Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
@@ -495,7 +495,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Project (#0) // { arity: 1 }
                   Get l5 // { arity: 2 }
     cte l5 =
@@ -522,7 +522,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Get l3 // { arity: 1 }
     cte l3 =
       Project (#0) // { arity: 1 }
@@ -609,7 +609,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Get l6 // { arity: 1 }
     cte l6 =
       Project (#0) // { arity: 1 }
@@ -647,7 +647,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Get l2 // { arity: 1 }
     cte l2 =
       Project (#0) // { arity: 1 }
@@ -712,7 +712,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 2 }
           Project (#0) // { arity: 1 }
             Filter (#1 > 1) // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                 Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
@@ -787,7 +787,7 @@ Explained Query:
         Map (error("more than one record produced in subquery")) // { arity: 3 }
           Project (#0, #1) // { arity: 2 }
             Filter (#2 > 1) // { arity: 3 }
-              Reduce group_by=[#0, #1] aggregates=[count(true)] // { arity: 3 }
+              Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
                 Get l2 // { arity: 2 }
     cte l2 =
       Project (#0, #1) // { arity: 2 }
@@ -878,7 +878,7 @@ With
       Map (error("more than one record produced in subquery")) // { arity: 1, types: "(integer)" }
         Project () // { arity: 0, types: "()" }
           Filter (#0 > 1) // { arity: 1, types: "(bigint)" }
-            Reduce aggregates=[count(true)] // { arity: 1, types: "(bigint)" }
+            Reduce aggregates=[count(*)] // { arity: 1, types: "(bigint)" }
               Get l2 // { arity: 1, types: "(integer)" }
   cte l2 =
     Project (#0) // { arity: 1, types: "(integer)" }

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -189,7 +189,7 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#9]
     Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
       Map (bigint_to_double(case when (#6 = 0) then null else #6 end), (numeric_to_double(#2) / #8), (numeric_to_double(#3) / #8), (numeric_to_double(#7) / #8)) // { arity: 12 }
-        Reduce group_by=[#4, #5] aggregates=[sum(#0), sum(#1), sum((#1 * (1 - #2))), sum(((#1 * (1 - #2)) * (1 + #3))), count(true), sum(#2)] // { arity: 8 }
+        Reduce group_by=[#4, #5] aggregates=[sum(#0), sum(#1), sum((#1 * (1 - #2))), sum(((#1 * (1 - #2)) * (1 + #3))), count(*), sum(#2)] // { arity: 8 }
           Project (#4..=#9) // { arity: 6 }
             Filter (date_to_timestamp(#10) <= 1998-10-02 00:00:00) // { arity: 16 }
               Get materialize.public.lineitem // { arity: 16 }
@@ -386,7 +386,7 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
-    Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
       Project (#5) // { arity: 1 }
         Filter (#4 >= 1993-07-01) AND (date_to_timestamp(#4) < 1993-10-01 00:00:00) // { arity: 11 }
           Join on=(eq(#0, #9, #10)) type=delta // { arity: 11 }
@@ -979,7 +979,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
             Union // { arity: 2 }
@@ -1262,7 +1262,7 @@ Explained Query:
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[sum(#1), count(true)] // { arity: 3 }
+                Reduce group_by=[#0] aggregates=[sum(#1), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #2) type=differential // { arity: 17 }
                       implementation
@@ -1601,7 +1601,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
@@ -1730,7 +1730,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[substr(char_to_text(#0), 1, 2)] aggregates=[count(true), sum(#1)] // { arity: 3 }
+      Reduce group_by=[substr(char_to_text(#0), 1, 2)] aggregates=[count(*), sum(#1)] // { arity: 3 }
         Project (#1, #2) // { arity: 2 }
           Join on=(#0 = #3) type=differential // { arity: 4 }
             implementation
@@ -1767,7 +1767,7 @@ Explained Query:
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
               ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(true)] // { arity: 2 }
+                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
                   Project (#5) // { arity: 1 }
                     Filter (#5 > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                       Get l0 // { arity: 9 }

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -816,7 +816,7 @@ Explained Query:
             Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[#1]] // { arity: 2 }
           Filter (#1) IS NOT NULL // { arity: 2 }
-            Reduce aggregates=[count(true), max(#0)] // { arity: 2 }
+            Reduce aggregates=[count(*), max(#0)] // { arity: 2 }
               Union // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 2 }

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -34,7 +34,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[count(true)] // { arity: 1 }
+      Reduce aggregates=[count(*)] // { arity: 1 }
         Constant // { arity: 0 }
           - (() x 1000000000)
 

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -72,7 +72,7 @@ Explained Query:
                     Get l1 // { arity: 1 }
   With
     cte l2 =
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
           Filter (#2 > #0) // { arity: 3 }
             CrossJoin type=delta // { arity: 3 }

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -172,7 +172,7 @@ Explained Query:
                   Map (error("more than one record produced in subquery")) // { arity: 1 }
                     Project () // { arity: 0 }
                       Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                        Reduce aggregates=[count(true)] // { arity: 1 }
+                        Reduce aggregates=[count(*)] // { arity: 1 }
                           Project () // { arity: 0 }
                             Get l0 // { arity: 9 }
     cte l0 =

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -539,7 +539,7 @@ select a, b, max(2), count(*) from t where b = 1 group by a, b;
 Explained Query:
   Project (#0, #2, #3, #1) // { arity: 4 }
     Map (1, 2) // { arity: 4 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 = 1) // { arity: 2 }
             Get materialize.public.t // { arity: 2 }
@@ -556,7 +556,7 @@ select a, b, count(*), max(2) from t where b = 1 group by a, b;
 Explained Query:
   Project (#0, #2, #1, #3) // { arity: 4 }
     Map (1, 2) // { arity: 4 }
-      Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 = 1) // { arity: 2 }
             Get materialize.public.t // { arity: 2 }
@@ -659,7 +659,7 @@ Explained Query:
                 Map (error("more than one record produced in subquery")) // { arity: 1 }
                   Project () // { arity: 0 }
                     Filter (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(true)] // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
                         Project () // { arity: 0 }
                           Get l0 // { arity: 2 }
     cte l0 =
@@ -705,7 +705,7 @@ Explained Query:
                 Map (error("more than one record produced in subquery")) // { arity: 1 }
                   Project () // { arity: 0 }
                     Filter (#0 > 1) // { arity: 1 }
-                      Reduce aggregates=[count(true)] // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
                         Project () // { arity: 0 }
                           Get l0 // { arity: 2 }
     cte l0 =
@@ -768,7 +768,7 @@ Explained Query:
     ArrangeBy keys=[[]] // { arity: 0 }
       Project () // { arity: 0 }
         Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-          Reduce aggregates=[count(true)] // { arity: 1 }
+          Reduce aggregates=[count(*)] // { arity: 1 }
             Project () // { arity: 0 }
               Get materialize.public.t1 // { arity: 2 }
 

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -288,7 +288,7 @@ Explained Query:
           Get l0
   With
     cte l0 =
-      Reduce group_by=[extract_year_d(#0)] aggregates=[count(true)]
+      Reduce group_by=[extract_year_d(#0)] aggregates=[count(*)]
         Project (#2)
           Get materialize.public.people
 


### PR DESCRIPTION
Not super happy with this, thanks to the duplication of is_count_asterisk and its general cumbersomeness.  Suggestions appreciated.  See also my comment on #15939.

I'd also like to document in the code _why_ we do this, but it's not clear whether to put that in one comment and a pointer from the other, or just to duplicate it, as well.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug, #15939.

### Tips for reviewer

Is there a way to avoid the duplication of is_count_asterisk that isn't itself as long as the duplication?  I did try to associate this with mz_expr::AggregateFunc, but it's a pain matching out the Literal from the expr and passing that on.  I'm also not sold on this in general, compared to giving a distinct representation to `COUNT(*)`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
