### PR TITLE
zippy: Increase the timeout of the KafkaSourcesLarge test to 48h

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -40,7 +40,8 @@ steps:
 
   - id: zippy-kafka-sources-large
     label: "Large Zippy Kafka Sources"
-    timeout_in_minutes: 1440
+    # 48h
+    timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
     plugins:


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

The Release Qualification pipeline was failing due to a low timeout.