### PR TITLE
feature-benchmark: Re-enable for the Platform era

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -30,8 +30,7 @@ steps:
           - { value: testdrive-size-1}
           - { value: testdrive-size-8}
           - { value: testdrive-in-cloudtest}
-#          - { value: feature-benchmark-single-node }
-#          - { value: feature-benchmark-cluster }
+          - { value: feature-benchmark }
           - { value: zippy-kafka-sources }
           - { value: zippy-kafka-parallel-insert }
           - { value: zippy-user-tables }
@@ -80,40 +79,17 @@ steps:
 
   - wait: ~
 
-# Disabled until we formulate a general performance strategy
-#  - id: feature-benchmark-single-node
-#    label: "Feature benchmark (single node)"
-#    timeout_in_minutes: 360
-#    agents:
-#      queue: linux-x86_64
-#    plugins:
-#      - ./ci/plugins/mzcompose:
-#          composition: feature-benchmark
-#          args:
-#            - --this-nodes
-#            - 1
-#            - --this-workers
-#            - 4
-#            - --other-tag
-#            - latest
-#            - --other-options
-#            - --workers 4
-
-#  - id: feature-benchmark-cluster
-#    label: "Feature benchmark (cluster)"
-#    timeout_in_minutes: 360
-#    agents:
-#      queue: linux-x86_64
-#    plugins:
-#      - ./ci/plugins/mzcompose:
-#          composition: feature-benchmark
-#          args:
-#            - --this-nodes
-#            - 4
-#            - --other-tag
-#            - latest
-#            - --other-options
-#            - --workers 4
+  - id: feature-benchmark
+    label: "Feature benchmark against 'latest'"
+    timeout_in_minutes: 360
+    agents:
+      queue: linux-x86_64-large
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: feature-benchmark
+          args:
+             - --other-tag
+             - latest
 
   - id: coverage
     label: Code coverage

--- a/doc/developer/feature-benchmark.md
+++ b/doc/developer/feature-benchmark.md
@@ -32,12 +32,6 @@ To run one benchmark scenario or a named subset:
 ./mzcompose run default --root-scenario=FastPath
 ```
 
-To use specific Mz command-line options:
-
-```
- ./mzcompose run default --this-options "--workers 16" --other-options "--workers 1"
-```
-
 To compare specific Mz versions:
 
 ```
@@ -49,10 +43,9 @@ To compare specific Mz git revisions:
 ./mzcompose run default --this-tag unstable-42ad7432657d3e5c1a3492fa76985cd6b79fcab6 ...
 ```
 
-To start a 2-node computed cluster for `THIS`:
-
+To use a specific SIZE for sources, sinks and dataflows:
 ```
-./mzcompose run default --this-nodes 2 ...
+./mzcompose run default --this-size 2 --other-size 4 ...
 ```
 
 # Output
@@ -132,6 +125,15 @@ Currently, the `Min` strategy is used, that is, the minimum value measured is us
 The framework will report failure in case a particular measurement indicates a performance regression between the two Mz instances that exceeds a particular threshold. Otherwise the number will
 be reported.
 
+## Retry policy
+
+Any suspected performance regressions will be retried up to `--max-retries` times (default is 3). Only regressions that are
+repeatedly reproducible will cause the benchmark to exit with a nonzero exit code. The bottom of the Buildkite log will show
+the retry attempts.
+
+Reported performance improvements are not retried to establish reprodicibility, so should be considered flukes if seen in the CI
+output until reliably reproduced locally.
+
 # Troubleshooting
 
 ## Benchmark terminated prematurely
@@ -146,8 +148,7 @@ of the `feature-benchmark_testdrive_*` container that exited most recently and t
 
 ## Dealing with false positives
 
-The feature benchmark will retry any regressed scenarios up to `--max-cycles=3` times in order to weed out false positives. mzcompose.py will exit with a non-zero
-exit code only if there are scenarios that reported a regression every time they were tried.
+The feature benchmark will retry any regressed scenarios up to `--max-cycles=3` times in order to weed out false positives.
 
 # Writing benchmark scenarios
 

--- a/test/feature-benchmark/scenarios_concurrency.py
+++ b/test/feature-benchmark/scenarios_concurrency.py
@@ -48,14 +48,14 @@ $ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-sc
             [
                 f"""
 > CREATE CONNECTION IF NOT EXISTS csr_conn
-FOR CONFLUENT SCHEMA REGISTRY
-URL '${{testdrive.schema-registry-url}}';
+  FOR CONFLUENT SCHEMA REGISTRY
+  URL '${{testdrive.schema-registry-url}}';
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
 
 > CREATE SOURCE s{s}
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-parallel-ingestion-${{testdrive.seed}}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 """
                 for s in sources
             ]


### PR DESCRIPTION
    feature-benchmark: Re-enable for the Platform era
    
    - remove ability to run against the stand-alone binary
    - remove the ability to specify environmentd options
    - replace --workers and --nodes with a unified --size option that
      affects the SIZE used for sources, sinks and dataflows
    - fix SQL rot in various scenarios
    - re-enable scenarios that were disabled for various reasons
    - remove the KafkaRaw scenario altogether as it is relying on
      kafka statistics counters that are no longer available from within SQL
    - fix a bug affecting all restarting scenarios where they were not restarting
      Mz with the version and parameters it was originally started with
    - re enable the Nightly CI job
    - fix the DeltaJoin scenario to actually use delta joins -- after recent
      Optimizer changes the query had reverted to a differential join plan


### Motivation

  * This PR fixes a previously unreported bug.

The Feature Benchmark was removed from Nightly due to constant SQL syntax breakages.