### PR TITLE
Fuse `InlineLet` and `UpdateLet` into `RelationCSE`

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -363,10 +363,7 @@ impl Optimizer {
                     // Join fusion will clean this up to `Map{Input, Literal}`
                     Box::new(crate::literal_lifting::LiteralLifting::default()),
                     // Identifies common relation subexpressions.
-                    // Must be followed by let inlining, to keep under control.
-                    Box::new(crate::cse::relation_cse::RelationCSE),
-                    Box::new(crate::inline_let::InlineLet::new(false)),
-                    Box::new(crate::update_let::UpdateLet::default()),
+                    Box::new(crate::cse::relation_cse::RelationCSE::new(false)),
                     Box::new(crate::FuseAndCollapse::default()),
                 ],
             }),
@@ -401,10 +398,7 @@ impl Optimizer {
             }),
             Box::new(crate::canonicalize_mfp::CanonicalizeMfp),
             // Identifies common relation subexpressions.
-            // Must be followed by let inlining, to keep under control.
-            Box::new(crate::cse::relation_cse::RelationCSE),
-            Box::new(crate::inline_let::InlineLet::new(false)),
-            Box::new(crate::update_let::UpdateLet::default()),
+            Box::new(crate::cse::relation_cse::RelationCSE::new(false)),
             Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
             // Remove threshold operators which have no effect.
             // Must be done at the very end of the physical pass, because before
@@ -440,8 +434,7 @@ impl Optimizer {
                     // This goes after union fusion so we can cancel out
                     // more branches at a time.
                     Box::new(crate::union_cancel::UnionBranchCancellation),
-                    Box::new(crate::cse::relation_cse::RelationCSE),
-                    Box::new(crate::inline_let::InlineLet::new(true)),
+                    Box::new(crate::cse::relation_cse::RelationCSE::new(true)),
                     Box::new(crate::reduction::FoldConstants { limit: Some(10000) }),
                 ],
             }),

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -56,14 +56,23 @@ impl crate::Transform for UpdateLet {
         relation: &mut MirRelationExpr,
         args: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        *args.id_gen = IdGen::default(); // Get a fresh IdGen.
-        let result = self.action(relation, &mut HashMap::new(), args.id_gen);
+        let result = self.transform_without_trace(relation, args);
         mz_repr::explain_new::trace_plan(&*relation);
         result
     }
 }
 
 impl UpdateLet {
+    /// Performs the `UpdateLet` transformation without tracing the result.
+    pub fn transform_without_trace(
+        &self,
+        relation: &mut MirRelationExpr,
+        args: TransformArgs,
+    ) -> Result<(), crate::TransformError> {
+        *args.id_gen = IdGen::default(); // Get a fresh IdGen.
+        self.action(relation, &mut HashMap::new(), args.id_gen)
+    }
+
     /// Re-assign type information and identifier to each `Get`.
     pub fn action(
         &self,

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -263,7 +263,9 @@ mod tests {
             "RedundantJoin" => Ok(Box::new(
                 mz_transform::redundant_join::RedundantJoin::default(),
             )),
-            "RelationCSE" => Ok(Box::new(mz_transform::cse::relation_cse::RelationCSE)),
+            "RelationCSE" => Ok(Box::new(mz_transform::cse::relation_cse::RelationCSE::new(
+                false,
+            ))),
             "TopKFusion" => Ok(Box::new(mz_transform::fusion::top_k::TopK)),
             "ThresholdElision" => Ok(Box::new(mz_transform::threshold_elision::ThresholdElision)),
             "UnionBranchCancellation" => Ok(Box::new(

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -75,39 +75,7 @@ Applied Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtract
 | | keys = ((#0), (#1))
 
 ====
-No change: ThresholdElision, Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, NonNullable, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }], limit: 100 }, CanonicalizeMfp, Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }, CanonicalizeMfp
-====
-Applied RelationCSE:
-%0 = Let l0 =
-| Get x (u0)
-| | types = (Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-
-%1 = Let l1 =
-| Get %0 (l0)
-| | types = (Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-| Project (#0..=#2, #0..=#2)
-| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-
-%2 =
-| Get %1 (l1)
-| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-
-====
-Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
-%0 =
-| Get x (u0)
-| | types = (Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-| Project (#0..=#2, #0..=#2)
-| | types = (Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)
-| | keys = ((#0), (#1))
-
-====
-No change: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, ThresholdElision
+No change: ThresholdElision, Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, NonNullable, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE { inline_let: InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE { inline_let: InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FoldConstants { limit: Some(10000) }], limit: 100 }, CanonicalizeMfp, Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }, CanonicalizeMfp, RelationCSE { inline_let: InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FoldConstants { limit: Some(10000) }, ThresholdElision
 ====
 Final:
 %0 =

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -39,7 +39,7 @@ steps
 ====
 No change: TopKElision, NonNullRequirements { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Fixpoint { transforms: [FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ThresholdElision, Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, NonNullable, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }
 ====
-Applied Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
+Applied Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE { inline_let: InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }:
 %0 = Let l0 =
 | Get x (u0)
 | Filter #0
@@ -50,7 +50,7 @@ Applied Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceEl
 ====
 No change: ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map
 ====
-Applied Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }], limit: 100 }:
+Applied Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE { inline_let: InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FoldConstants { limit: Some(10000) }], limit: 100 }:
 %0 =
 | Get x (u0)
 | Filter #0
@@ -65,31 +65,7 @@ Applied Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursio
 ====
 No change: CanonicalizeMfp, Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }, CanonicalizeMfp
 ====
-Applied RelationCSE:
-%0 = Let l0 =
-| Get x (u0)
-
-%1 = Let l1 =
-| Get %0 (l0)
-| Filter #0
-
-%2 = Let l2 =
-| Union %1 %1
-
-%3 =
-| Get %2 (l2)
-
-====
-Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
-%0 = Let l1 =
-| Get x (u0)
-| Filter #0
-
-%1 =
-| Union %0 %0
-
-====
-Applied UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
+Applied RelationCSE { inline_let: InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }:
 %0 = Let l0 =
 | Get x (u0)
 | Filter #0
@@ -135,23 +111,13 @@ Applied Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGu
 (Join [(get u1) (get x)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] Unimplemented)
 
 ====
-No change: Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE, InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }], limit: 100 }, CanonicalizeMfp
+No change: Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE { inline_let: InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Negate, Filter, FlatMapToMap, Project, Join, TopK, InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Reduce, Union, UnionBranchCancellation, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Map, Fixpoint { transforms: [ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Project, Union, UnionBranchCancellation, RelationCSE { inline_let: InlineLet { inline_mfp: true, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FoldConstants { limit: Some(10000) }], limit: 100 }, CanonicalizeMfp
 ====
 Applied Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }:
 (Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 [(CallBinary AddInt64 #0 (1 Int64))]] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
 
 ====
-No change: CanonicalizeMfp
-====
-Applied RelationCSE:
-(let l0 (get u1) (let l1 (ArrangeBy (get l0) [[#0]]) (let l2 (get x) (let l3 (ArrangeBy (get l2) [[(CallBinary AddInt64 #0 (1 Int64))]]) (let l4 (Join [(get l1) (get l3)] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 [(CallBinary AddInt64 #0 (1 Int64))]] [[0 [#0] (false 1 true (false false false 0 false) 0)]])) (get l4))))))
-
-====
-Applied InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }:
-(Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 [(CallBinary AddInt64 #0 (1 Int64))]] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
-
-====
-No change: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, ThresholdElision
+No change: CanonicalizeMfp, RelationCSE { inline_let: InlineLet { inline_mfp: false, recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, update_let: UpdateLet { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } } }, FoldConstants { limit: Some(10000) }, ThresholdElision
 ====
 Final:
 (Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 [(CallBinary AddInt64 #0 (1 Int64))]] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))


### PR DESCRIPTION
Up to now, it used to be a rule that `RelationCSE` must always be followed by `InlineLet`. This commit makes `RelationCSE` automatically call `InlineLet`, which has several advantages:
 - It is impossible to forget calling `InlineLet` after `RelationCSE`.
 - It is impossible to accidentally insert something between them.
 - The optimizer trace is a bit cleaner: Before this change, `RelationCSE` almost always made a big, messy diff, and then `InlineLet` often reverted the plan to be the same or similar as before `RelationCSE`. Now we see the changes made by `RelationCSE` + `InlineLet` as just one diff. This is often an empty diff, and even when it is not an empty diff, it's a smaller diff than before.

I also fused `UpdateLet` into `RelationCSE`. Note that only 2 of the 3 instances of `RelationCSE` had `UpdateLet` after it. I'm not sure why the 3rd one (in `logical_cleanup_pass`) didn't have that. Now I also fused `UpdateLet` into `RelationCSE`, so all 3 instances of `RelationCSE` now involve `UpdateLet`. Is this ok, @frankmcsherry?

The random reviewer is @vmarcos.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  - [ ] The already existing tests cover it: There shouldn't be any explain plan changes. (The only test changes are those that show plans at different optimizer steps.)
  - [ ] I also ran the optimizer trace tool manually.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None