### PR TITLE
Don't pick `arbitrary_arrangement` in IndexedFilter lowering.

### DIFF
--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -136,10 +136,12 @@ impl JoinImplementation {
                 // The first fundamental question is whether we should employ a delta query or not.
                 //
                 // Here we conservatively use the rule that if sufficient arrangements exist we will
-                // use a delta query. An arrangement is considered available
+                // use a delta query (except for 2-input joins).
+                // An arrangement is considered available for an input
                 // - if it is a global `Get` with columns present in `indexes`,
                 //   - or the same wrapped by an IndexedFilter,
-                // - if it is an `ArrangeBy` with the columns present,
+                // - if it is an `ArrangeBy` with the columns present (note that the ArrangeBy might
+                //   have been inserted by a previous run of JoinImplementation),
                 // - if it is a `Reduce` whose output is arranged the right way,
                 // - if it is a filter wrapped around either of these (see the mfp extraction).
                 //
@@ -549,7 +551,7 @@ mod differential {
             let mut start_keys = None;
             // Determine an appropriate arrangement to use for `start`.
             // It must line up with the arrangement of `order[1]`, or be set to `None` to avoid miscommunicating the validity.
-            // One way to do this is to take each of the keys of `order[1]`, globalize them, the attempt to find an equated
+            // One way to do this is to take each of the keys of `order[1]`, globalize them, then attempt to find an equated
             // expression that can be localized to order[0].0,
             if let Some((next_index, next_keys, _)) = order.get(1) {
                 // To populate with localized expressions equated to elements of `next_keys`.

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -135,6 +135,63 @@ WHERE a = 2 AND b = 'l2' OR a = 1 + 1 + 1 AND b = 'l3'
 ----
 2
 
+# Physical plan for the above. Should have an LIR ArrangeBy for the constant collection.
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR SELECT count(*) FROM t1
+WHERE a = 2 AND b = 'l2' OR a = 1 + 1 + 1 AND b = 'l3'
+----
+Explained Query:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+      Mfp
+        project=(#0)
+        map=(0)
+        Union
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0) }
+          Constant
+            - ()
+  Where
+    cte l0 =
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, count(true))
+        val_plan
+          project=(#0)
+          map=(true)
+        key_plan=id
+        Join::Linear
+          linear_stage[0]
+            closure
+              project=()
+            lookup={ relation=0, key=[#0, #1] }
+            stream={ key=[#0, #1], thinning=() }
+          source={ relation=1, key=[#0, #1] }
+          Get::PassArrangements materialize.public.t1
+            raw=false
+            arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+          ArrangeBy
+            raw=false
+            arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+            Constant
+              - (2, "l2")
+              - (3, "l3")
+
+Used Indexes:
+  - materialize.public.idx_t1_a_b
+
+EOF
+
 # Filter predicate occurring also as an output column
 
 query T multiline
@@ -940,7 +997,7 @@ WHERE a = 1000000;
 ----
 
 
-# In the following query, we would be able to detect literal constraints if we called `canonicalize_equivalences`
+# In the following query, we might be able to detect literal constraints if we called `canonicalize_equivalences`
 
 query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT a, b, c FROM t2 WHERE a IN (a + b, a + c, 1 + 5) AND a + b = 5 AND a + c = 4;
@@ -955,7 +1012,6 @@ Used Indexes:
   - materialize.public.idx_t2_a_b_c
 
 EOF
-
 
 # Regression test for https://github.com/MaterializeInc/materialize/issues/15696
 


### PR DESCRIPTION
This is a minor follow-up from https://github.com/MaterializeInc/materialize/pull/16036. That PR removed the problematic `arbitrary_arrangement` call from the `Differential` join case in the MIR -> LIR lowering. This PR does the same for the `IndexedFilter` case.

Note that currently there is no MIR `ArrangeBy` on the constant input of `IndexedFilter` (constant folding would remove the ArrangeBy anyway), so the `arbitrary_arrangement` call was always returning `None`.

This PR achieves two things:
- It future-proofs this lowering code against a situation where somehow some arrangements would appear on the constant input of `IndexedFilter`, and then `arbitrary_arrangement` could return a wrong one.
- It makes it explicit in the LIR plan that this input will be arranged, instead of relying on the [rendering code to arrange the starting input](https://github.com/MaterializeInc/materialize/blob/50bdf26fac2bb7cf3dacdcc6e85624b53fb6c60c/src/compute/src/render/join/linear_join.rs#L181). Generally, we want our arrangements to be explicit at least in the LIR plan, because this makes them have more visibility than when somewhere deep inside the rendering we introduce surprise arrangements.

@teskje is the random reviewer.

### Motivation

   * This PR refactors existing code. It came up here:
https://materializeinc.slack.com/archives/C02PPB50ZHS/p1668439495903279?thread_ts=1668431418.599719&cid=C02PPB50ZHS
(Note that in that Slack thread I mistakenly thought that we have an MIR `ArrangeBy` on the constant input of `IndexedFilter`, but this is not the case. Even if we were to put an ArrangeBy there, constant folding would remove it.)


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
