### PR TITLE
Add a regression test for #16128

### DIFF
--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -9,6 +9,8 @@
 
 # This file contains tests for the PredicatePushdown transform.
 
+mode cockroach
+
 statement ok
 CREATE TABLE x (a int not null, u int, b bool)
 
@@ -422,24 +424,40 @@ Source mz_catalog.mz_materialized_views
 
 EOF
 
-DROP SCHEMA public CASCADE ;
- CREATE SCHEMA public ;
- CREATE TABLE table_f2_f3 ( f2 INTEGER , f3 INTEGER  ) ;
- CREATE TABLE table_f3_f4_f5 ( f3 INTEGER , f4 INTEGER , f5 INTEGER  ) ;
- CREATE TABLE table_f4_f5_f6 ( f4 INTEGER , f5 INTEGER , f6 INTEGER  ) ;
- INSERT INTO table_f2_f3 VALUES ( 0 , 0 ) ;
- INSERT INTO table_f2_f3 VALUES ( 0 , 1 ) ;
- INSERT INTO table_f2_f3 VALUES ( NULL , 0 ) ;
- INSERT INTO table_f3_f4_f5 VALUES ( 0 , 1 , NULL ) ;
- INSERT INTO table_f3_f4_f5 VALUES ( 1 , 1 , 0 ) ;
- INSERT INTO table_f3_f4_f5 VALUES ( 1 , NULL , 0 ) ;
- INSERT INTO table_f4_f5_f6 VALUES ( 0 , 0 , 1 ) ;
- INSERT INTO table_f4_f5_f6 VALUES ( 1 , 0 , 0 ) ;
- INSERT INTO table_f4_f5_f6 VALUES ( NULL , 0 , 1 ) ;
- INSERT INTO table_f4_f5_f6 VALUES ( NULL , 1 , 0 ) ;
- INSERT INTO table_f4_f5_f6 VALUES ( NULL , 1 , 0 ) ;
+# One more for https://github.com/MaterializeInc/materialize/issues/16128
+# https://github.com/MaterializeInc/materialize/pull/16147#issuecomment-1322042176
 
-query IIIIII
+statement ok
+DROP SCHEMA public CASCADE ;
+
+statement ok
+CREATE SCHEMA public ;
+
+statement ok
+CREATE TABLE table_f2_f3 ( f2 INTEGER , f3 INTEGER  ) ;
+
+statement ok
+CREATE TABLE table_f3_f4_f5 ( f3 INTEGER , f4 INTEGER , f5 INTEGER  ) ;
+
+statement ok
+CREATE TABLE table_f4_f5_f6 ( f4 INTEGER , f5 INTEGER , f6 INTEGER  ) ;
+
+statement ok
+INSERT INTO table_f2_f3 VALUES ( 0 , 0 ), ( 0 , 1 ), ( NULL , 0 );
+
+statement ok
+INSERT INTO table_f3_f4_f5 VALUES ( 0 , 1 , NULL ), ( 1 , 1 , 0 ), ( 1 , NULL , 0 );
+
+statement ok
+INSERT INTO table_f4_f5_f6 VALUES ( 0 , 0 , 1 ), ( 1 , 0 , 0 ), ( NULL , 0 , 1 ), ( NULL , 1 , 0 ), ( NULL , 1 , 0 );
+
+query IIIIII rowsort
 SELECT * FROM table_f2_f3  JOIN ( table_f3_f4_f5  JOIN table_f4_f5_f6  USING ( f5  )  )  USING ( f3  )
  WHERE f6  IS  NULL  OR f3  >= f6  AND f6  <=  10000   ;
 ----
+1  0  0  1  0  1
+1  0  0  1  1  0
+1  0  0  1  NULL  1
+1  0  0  NULL  0  1
+1  0  0  NULL  1  0
+1  0  0  NULL  NULL  1

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -356,7 +356,7 @@ Used Indexes:
 
 EOF
 
-# Regression test for https://github.com/MaterializeInc/materialize/issues/16128
+# Regression tests for https://github.com/MaterializeInc/materialize/issues/16128
 
 statement ok
 CREATE TABLE tt1 (f1 DOUBLE PRECISION, f2 DOUBLE PRECISION NOT NULL);
@@ -380,8 +380,6 @@ Explained Query (fast path):
   Constant <empty>
 
 EOF
-
-# Another test for https://github.com/MaterializeInc/materialize/issues/16128
 
 query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT
@@ -423,3 +421,25 @@ Source mz_catalog.mz_materialized_views
   map=(dummy, dummy, dummy, dummy)
 
 EOF
+
+DROP SCHEMA public CASCADE ;
+ CREATE SCHEMA public ;
+ CREATE TABLE table_f2_f3 ( f2 INTEGER , f3 INTEGER  ) ;
+ CREATE TABLE table_f3_f4_f5 ( f3 INTEGER , f4 INTEGER , f5 INTEGER  ) ;
+ CREATE TABLE table_f4_f5_f6 ( f4 INTEGER , f5 INTEGER , f6 INTEGER  ) ;
+ INSERT INTO table_f2_f3 VALUES ( 0 , 0 ) ;
+ INSERT INTO table_f2_f3 VALUES ( 0 , 1 ) ;
+ INSERT INTO table_f2_f3 VALUES ( NULL , 0 ) ;
+ INSERT INTO table_f3_f4_f5 VALUES ( 0 , 1 , NULL ) ;
+ INSERT INTO table_f3_f4_f5 VALUES ( 1 , 1 , 0 ) ;
+ INSERT INTO table_f3_f4_f5 VALUES ( 1 , NULL , 0 ) ;
+ INSERT INTO table_f4_f5_f6 VALUES ( 0 , 0 , 1 ) ;
+ INSERT INTO table_f4_f5_f6 VALUES ( 1 , 0 , 0 ) ;
+ INSERT INTO table_f4_f5_f6 VALUES ( NULL , 0 , 1 ) ;
+ INSERT INTO table_f4_f5_f6 VALUES ( NULL , 1 , 0 ) ;
+ INSERT INTO table_f4_f5_f6 VALUES ( NULL , 1 , 0 ) ;
+
+query IIIIII
+SELECT * FROM table_f2_f3  JOIN ( table_f3_f4_f5  JOIN table_f4_f5_f6  USING ( f5  )  )  USING ( f3  )
+ WHERE f6  IS  NULL  OR f3  >= f6  AND f6  <=  10000   ;
+----


### PR DESCRIPTION
This is just a trivial follow-up from https://github.com/MaterializeInc/materialize/pull/16147#issuecomment-1322042176. We wanted to merge that PR quickly, because it was marked as a release-blocker, so we merged it without this test. This PR now adds the test.

Closes https://github.com/MaterializeInc/materialize/issues/16198

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
