### PR TITLE
Add Differential join's start_keys to EXPLAIN

### DIFF
--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -254,7 +254,15 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                             None => format!("%{}", pos),
                         }
                     };
-                    let join_order = |head_idx: usize,
+                    let join_key_to_string = |key: &Vec<MirScalarExpr>| -> String {
+                        if key.is_empty() {
+                            "×".to_owned()
+                        } else {
+                            separated_text(", ", key.iter().map(Displayable::from)).to_string()
+                        }
+                    };
+                    let join_order = |start_idx: usize,
+                                      start_key: &Option<Vec<MirScalarExpr>>,
                                       tail: &Vec<(
                         usize,
                         Vec<MirScalarExpr>,
@@ -262,20 +270,19 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                     )>|
                      -> String {
                         format!(
-                            "{} » {}",
-                            input_name(head_idx),
+                            "{}{} » {}",
+                            input_name(start_idx),
+                            match start_key {
+                                None => "".to_owned(),
+                                Some(key) => format!("[{}]", join_key_to_string(key)),
+                            },
                             separated(
                                 " » ",
                                 tail.iter().map(|(pos, key, characteristics)| {
                                     format!(
                                         "{}[{}]{}",
                                         input_name(*pos),
-                                        if key.is_empty() {
-                                            "×".to_owned()
-                                        } else {
-                                            separated_text(", ", key.iter().map(Displayable::from))
-                                                .to_string()
-                                        },
+                                        join_key_to_string(key),
                                         characteristics
                                             .as_ref()
                                             .map(|c| c.explain())
@@ -287,12 +294,17 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                     };
                     ctx.indented(|ctx| {
                         match implementation {
-                            JoinImplementation::Differential((head_idx, _head_key), tail) => {
+                            JoinImplementation::Differential((start_idx, start_key), tail) => {
                                 soft_assert!(inputs.len() == tail.len() + 1);
 
                                 writeln!(f, "{}implementation", ctx.indent)?;
                                 ctx.indented(|ctx| {
-                                    writeln!(f, "{}{}", ctx.indent, join_order(*head_idx, tail))
+                                    writeln!(
+                                        f,
+                                        "{}{}",
+                                        ctx.indent,
+                                        join_order(*start_idx, start_key, tail)
+                                    )
                                 })?;
                             }
                             JoinImplementation::DeltaQuery(half_join_chains) => {
@@ -301,7 +313,12 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                                 writeln!(f, "{}implementation", ctx.indent)?;
                                 ctx.indented(|ctx| {
                                     for (pos, chain) in half_join_chains.iter().enumerate() {
-                                        writeln!(f, "{}{}", ctx.indent, join_order(pos, chain))?;
+                                        writeln!(
+                                            f,
+                                            "{}{}",
+                                            ctx.indent,
+                                            join_order(pos, &None, chain)
+                                        )?;
                                     }
                                     Ok(())
                                 })?;

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -197,7 +197,7 @@ Explained Query:
     Filter ((#4 = 24) OR ((#3 = 6) AND (#4 <= 4) AND (#4 >= 3))) // { arity: 25 }
       Join on=(#0 = #16) type=differential // { arity: 25 }
         implementation
-          %1:orders » %0:lineitem[#0]KAeif
+          %1:orders[#0] » %0:lineitem[#0]KAeif
         ArrangeBy keys=[[#0]] // { arity: 16 }
           Get materialize.public.lineitem // { arity: 16 }
         ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -414,7 +414,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:l1 » %1[#0]UKAif
+                    %0:l1[#1] » %1[#0]UKAif
                   ArrangeBy keys=[[#1]] // { arity: 2 }
                     Project (#4, #11) // { arity: 2 }
                       Get l1 // { arity: 16 }
@@ -435,7 +435,7 @@ Explained Query:
       Project (#0..=#4) // { arity: 5 }
         Join on=(#2 = #5) type=differential // { arity: 6 }
           implementation
-            %1:orders » %0:lineitem[#2]KA
+            %1:orders[#1] » %0:lineitem[#2]KA
           ArrangeBy keys=[[#2]] // { arity: 4 }
             Project (#0, #4, #11, #12) // { arity: 4 }
               Get materialize.public.lineitem // { arity: 16 }
@@ -480,7 +480,7 @@ Explained Query:
     Filter (#12 <= #5) AND ((#1 = 7) OR (#1 = 33) OR ((#1 = 17) AND (#13 <= "x") AND (#13 >= "s"))) // { arity: 14 }
       Join on=(#0 = #2) type=differential // { arity: 14 }
         implementation
-          %2:customer » %0:lineitem[×]Aef » %1:orders[#0]KAef
+          %2:customer[×] » %0:lineitem[×]Aef » %1:orders[#0]KAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Project (#0, #4) // { arity: 2 }
             Filter ((#4 = 7) OR (#4 = 17) OR (#4 = 33)) // { arity: 16 }
@@ -589,7 +589,7 @@ Explained Query:
         Filter (#1 < #6) AND (#16 > #5) AND (#16 >= #0) // { arity: 19 }
           Join on=(#3 = #11) type=differential // { arity: 19 }
             implementation
-              %2:customer » %1:orders[#1]KA » %0:lineitem[×]Af
+              %2:customer[#0] » %1:orders[#1]KA » %0:lineitem[×]Af
             ArrangeBy keys=[[]] // { arity: 2 }
               Project (#5, #10) // { arity: 2 }
                 Filter (#3 != 4) // { arity: 16 }
@@ -692,7 +692,7 @@ Explained Query:
       Filter (#10 <= 1994-03-17) AND (#0 >= 53) AND (#5 < #19) AND (#26 < #19) // { arity: 27 }
         Join on=(#0 = #16) type=differential // { arity: 27 }
           implementation
-            %1:orders » %0:lineitem[#0]KAiiiiif » %2:customer[×]Aiiiiif
+            %1:orders[#0] » %0:lineitem[#0]KAiiiiif » %2:customer[×]Aiiiiif
           ArrangeBy keys=[[#0]] // { arity: 16 }
             Get materialize.public.lineitem // { arity: 16 }
           ArrangeBy keys=[[#0]] // { arity: 9 }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -304,7 +304,7 @@ Explained Query:
       Project (#2, #3, #12, #0, #1, #4, #6, #7) // { arity: 8 }
         Join on=(eq(#0, #8, #15) AND #2 = #10 AND #5 = #11 AND #9 = #16 AND #13 = #14) type=differential // { arity: 17 }
           implementation
-            %2:stock » %5[#0, #1]UKKA » %0:item[#0]UKAlf » %1:supplier[#0]UKAlf » %3:nation[#0]UKAlf » %4:l0[#0]UKAlf
+            %2:stock[#0, #1] » %5[#0, #1]UKKA » %0:item[#0]UKAlf » %1:supplier[#0]UKAlf » %3:nation[#0]UKAlf » %4:l0[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Project (#0, #2) // { arity: 2 }
               Filter "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -326,7 +326,7 @@ Explained Query:
                 Project (#0, #2) // { arity: 2 }
                   Join on=(#17 = #18 AND #19 = #20 AND #21 = #22) type=differential // { arity: 23 }
                     implementation
-                      %0:stock » %1:supplier[#0]UKA » %2:nation[#0]UKA » %3:l0[#0]UKAlf
+                      %0:stock[#17] » %1:supplier[#0]UKA » %2:nation[#0]UKA » %3:l0[#0]UKAlf
                     ArrangeBy keys=[[#17]] // { arity: 18 }
                       Get materialize.public.stock // { arity: 18 }
                     ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -385,7 +385,7 @@ Explained Query:
         Project (#1..=#3, #10, #14) // { arity: 5 }
           Join on=(#0 = #9 AND eq(#1, #4, #7, #12) AND eq(#2, #5, #8, #13) AND eq(#3, #6, #11)) type=differential // { arity: 15 }
             implementation
-              %3:orderline » %2:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAlif » %1:neworder[#0, #1, #2]UKKKAlif
+              %3:orderline[#0, #1, #2] » %2:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAlif » %1:neworder[#0, #1, #2]UKKKAlif
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Filter "A%" ~~(padchar(#9)) // { arity: 22 }
@@ -432,7 +432,7 @@ Explained Query:
         Project (#4) // { arity: 1 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 9 }
             implementation
-              %1 » %0:l0[#0, #1, #2, #3]UKKKKAiif
+              %1[#0, #1, #2, #3] » %0:l0[#0, #1, #2, #3]UKKKKAiif
             ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 5 }
               Project (#0..=#2, #4, #6) // { arity: 5 }
                 Get l0 // { arity: 9 }
@@ -442,7 +442,7 @@ Explained Query:
                   Filter (#7 >= #3) // { arity: 8 }
                     Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 8 }
                       implementation
-                        %1:orderline » %0:l0[#0, #1, #2]UKKKAiif
+                        %1:orderline[#0, #1, #2] » %0:l0[#0, #1, #2]UKKKAiif
                       ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                         Project (#0..=#2, #4) // { arity: 4 }
                           Get l0 // { arity: 9 }
@@ -491,7 +491,7 @@ Explained Query:
       Project (#12, #19) // { arity: 2 }
         Join on=(#0 = #7 AND eq(#1, #5, #9) AND eq(#2, #6, #10, #14) AND eq(#3, #17, #18) AND #4 = #8 AND #11 = #13 AND #15 = #16 AND #20 = #21) type=differential // { arity: 22 }
           implementation
-            %2:orderline » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:stock[#0, #1]UKKAif » %4:supplier[#0, #1]UKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif
+            %2:orderline[#0, #1, #2] » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:stock[#0, #1]UKKAif » %4:supplier[#0, #1]UKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif
           ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
             Project (#0..=#2, #21) // { arity: 4 }
               Filter (#21) IS NOT NULL // { arity: 22 }
@@ -603,7 +603,7 @@ Explained Query:
           Filter (((#22 = "GERMANY") AND (#24 = "CAMBODIA")) OR ((#22 = "CAMBODIA") AND (#24 = "GERMANY"))) // { arity: 25 }
             Join on=(#0 = #4 AND #1 = #21 AND #2 = #8 AND #3 = #9 AND #5 = #11 AND eq(#6, #12, #17) AND eq(#7, #13, #18) AND #14 = #16 AND #20 = #23) type=differential // { arity: 25 }
               implementation
-                %2:orderline » %3:order[#0, #1, #2]UKKKAiif » %4:customer[#0, #1, #2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
+                %2:orderline[#0, #1, #2] » %3:order[#0, #1, #2]UKKKAiif » %4:customer[#0, #1, #2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
               ArrangeBy keys=[[#0]] // { arity: 2 }
                 Project (#0, #3) // { arity: 2 }
                   Get materialize.public.supplier // { arity: 7 }
@@ -678,7 +678,7 @@ Explained Query:
           Project (#11, #16, #24) // { arity: 3 }
             Join on=(eq(#0, #3, #9) AND #1 = #5 AND #2 = #23 AND #4 = #10 AND #6 = #12 AND eq(#7, #13, #18) AND eq(#8, #14, #19) AND #15 = #17 AND #20 = #21 AND #22 = #25) type=differential // { arity: 26 }
               implementation
-                %3:orderline » %4:order[#0, #1, #2]UKKKAiiif » %5:customer[#0, #1, #2]UKKKAiiif » %2:stock[#0, #1]UKKAiiiif » %0:item[#0]UKAliiiiif » %1:supplier[#0]UKAliiiiif » %6:nation[#0]UKAliiiiif » %8:region[#0]UKAeliiiiif » %7:nation[#0]UKAeliiiiif
+                %3:orderline[#0, #1, #2] » %4:order[#0, #1, #2]UKKKAiiif » %5:customer[#0, #1, #2]UKKKAiiif » %2:stock[#0, #1]UKKAiiiif » %0:item[#0]UKAliiiiif » %1:supplier[#0]UKAliiiiif » %6:nation[#0]UKAliiiiif » %8:region[#0]UKAeliiiiif » %7:nation[#0]UKAeliiiiif
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (#0 < 1000) AND "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -758,7 +758,7 @@ Explained Query:
       Project (#11, #15, #17) // { arity: 3 }
         Join on=(eq(#0, #1, #9) AND #2 = #10 AND #3 = #4 AND #5 = #16 AND #6 = #12 AND #7 = #13 AND #8 = #14) type=differential // { arity: 18 }
           implementation
-            %3:orderline » %4:order[#0, #1, #2]UKKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
+            %3:orderline[#0, #1, #2] » %4:order[#0, #1, #2]UKKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter "%BB" ~~(padchar(#4)) // { arity: 5 }
@@ -820,7 +820,7 @@ Explained Query:
           Filter (#11 <= #15) // { arity: 19 }
             Join on=(#0 = #10 AND eq(#1, #8, #13) AND eq(#2, #9, #14) AND #6 = #17 AND #7 = #12) type=differential // { arity: 19 }
               implementation
-                %2:orderline » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:nation[#0]UKAif
+                %2:orderline[#0, #1, #2] » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:nation[#0]UKAif
               ArrangeBy keys=[[#0, #1, #2]] // { arity: 7 }
                 Project (#0..=#2, #5, #8, #11, #21) // { arity: 7 }
                   Filter (#21) IS NOT NULL // { arity: 22 }
@@ -869,7 +869,7 @@ Explained Query:
         Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0 » %1[×]UA
+              %0[×] » %1[×]UA
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
                 Get l0 // { arity: 2 }
@@ -882,7 +882,7 @@ Explained Query:
         Project (#0, #14) // { arity: 2 }
           Join on=(#17 = #18 AND #19 = #20) type=differential // { arity: 21 }
             implementation
-              %0:stock » %1:supplier[#0]UKA » %2:nation[#0]UKAef
+              %0:stock[#17] » %1:supplier[#0]UKA » %2:nation[#0]UKAef
             ArrangeBy keys=[[#17]] // { arity: 18 }
               Get materialize.public.stock // { arity: 18 }
             ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -924,7 +924,7 @@ Explained Query:
         Filter (#3 <= #9) // { arity: 10 }
           Join on=(#0 = #6 AND #1 = #7 AND #2 = #8) type=differential // { arity: 10 }
             implementation
-              %1:orderline » %0:order[#0, #1, #2]UKKKAif
+              %1:orderline[#0, #1, #2] » %0:order[#0, #1, #2]UKKKAif
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
               Project (#0..=#2, #4..=#6) // { arity: 6 }
                 Get materialize.public.order // { arity: 8 }
@@ -978,7 +978,7 @@ Explained Query:
         Project (#0..=#22) // { arity: 23 }
           Join on=(#0 = #25 AND #1 = #23 AND #2 = #24) type=differential // { arity: 26 }
             implementation
-              %1:order » %0:customer[#0, #1, #2]UKKKAif
+              %1:order[#3, #1, #2] » %0:customer[#0, #1, #2]UKKKAif
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 22 }
               Get materialize.public.customer // { arity: 22 }
             ArrangeBy keys=[[#3, #1, #2]] // { arity: 4 }
@@ -1023,7 +1023,7 @@ Explained Query:
             Map (date_to_timestamp(#6)) // { arity: 13 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
-                  %0:orderline » %1:item[#0]UKAiif
+                  %0:orderline[#4] » %1:item[#0]UKAiif
                 ArrangeBy keys=[[#4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1077,7 +1077,7 @@ Explained Query:
       Project (#0..=#3, #5) // { arity: 5 }
         Join on=(#0 = #4 AND #5 = #6) type=differential // { arity: 7 }
           implementation
-            %1:l0 » %0:supplier[#0]UKA » %2[#0]UKA
+            %1:l0[#0] » %0:supplier[#0]UKA » %2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 4 }
             Project (#0..=#2, #4) // { arity: 4 }
               Get materialize.public.supplier // { arity: 7 }
@@ -1094,7 +1094,7 @@ Explained Query:
           Project (#2, #5) // { arity: 2 }
             Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 6 }
               implementation
-                %0:orderline » %1:stock[#0, #1]UKKAif
+                %0:orderline[#0, #1] » %1:stock[#0, #1]UKKAif
               ArrangeBy keys=[[#0, #1]] // { arity: 3 }
                 Project (#4, #5, #8) // { arity: 3 }
                   Filter (#4) IS NOT NULL AND (#5) IS NOT NULL AND (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 10 }
@@ -1134,7 +1134,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %1 » %0:l0[#0]KA
+              %1[#0] » %0:l0[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Get l0 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1143,7 +1143,7 @@ Explained Query:
                   Project (#0) // { arity: 1 }
                     Join on=(#0 = #1) type=differential // { arity: 2 }
                       implementation
-                        %1:supplier » %0:l1[#0]UKAlf
+                        %1:supplier[#0] » %0:l1[#0]UKAlf
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Get l1 // { arity: 1 }
                       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1160,7 +1160,7 @@ Explained Query:
         Project (#17, #19..=#21) // { arity: 4 }
           Join on=(#0 = #18) type=differential // { arity: 22 }
             implementation
-              %0:stock » %1:item[#0]UKAf
+              %0:stock[#0] » %1:item[#0]UKAf
             ArrangeBy keys=[[#0]] // { arity: 18 }
               Get materialize.public.stock // { arity: 18 }
             ArrangeBy keys=[[#0]] // { arity: 4 }
@@ -1215,14 +1215,14 @@ Explained Query:
           Filter (integer_to_double(#7) < (bigint_to_double(#11) / bigint_to_double(case when (#12 = 0) then null else #12 end))) // { arity: 13 }
             Join on=(#4 = #10) type=differential // { arity: 13 }
               implementation
-                %0:l0 » %1[#0]UKA
+                %0:l0[#4] » %1[#0]UKA
               Get l0 // { arity: 10 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Reduce group_by=[#0] aggregates=[sum(#1), count(#1)] // { arity: 3 }
                   Project (#0, #8) // { arity: 2 }
                     Join on=(#0 = #5) type=differential // { arity: 11 }
                       implementation
-                        %1:l0 » %0:item[#0]UKAlf
+                        %1:l0[#4] » %0:item[#0]UKAlf
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Filter "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -1265,7 +1265,7 @@ Explained Query:
           Project (#0..=#4, #8, #9, #13) // { arity: 8 }
             Join on=(#0 = #7 AND eq(#1, #5, #11) AND eq(#2, #6, #12) AND #4 = #10) type=differential // { arity: 14 }
               implementation
-                %2:orderline » %1:order[#0, #1, #2]UKKKA » %0:customer[#0, #1, #2]UKKKA
+                %2:orderline[#0, #1, #2] » %1:order[#0, #1, #2]UKKKA » %0:customer[#0, #1, #2]UKKKA
               ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                 Project (#0..=#2, #5) // { arity: 4 }
                   Get materialize.public.customer // { arity: 22 }
@@ -1331,7 +1331,7 @@ Explained Query:
             Map ((#2 = 1), (#2 = 2), (#2 = 3), (#2 = 4), (#2 = 5), padchar(#11)) // { arity: 18 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
-                  %0:orderline » %1:item[#0]UKAeliiiif
+                  %0:orderline[#4] » %1:item[#0]UKAeliiiif
                 ArrangeBy keys=[[#4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1375,7 +1375,7 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            %1 » %0:l0[#0]UKA
+            %1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1387,7 +1387,7 @@ Explained Query:
                       Filter (date_to_timestamp(#25) > 2010-05-23 12:00:00) // { arity: 30 }
                         Join on=(eq(#1, #23, #29)) type=differential // { arity: 30 }
                           implementation
-                            %2:orderline » %3:item[#0]UKAlif » %1:stock[#0]KAlif » %0:l0[×]Alif
+                            %2:orderline[#4] » %3:item[#0]UKAlif » %1:stock[#0]KAlif » %0:l0[×]Alif
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l0 // { arity: 3 }
@@ -1404,7 +1404,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#3 = #7) type=differential // { arity: 8 }
             implementation
-              %0:supplier » %1:nation[#0]UKAef
+              %0:supplier[#3] » %1:nation[#0]UKAef
             ArrangeBy keys=[[#3]] // { arity: 7 }
               Get materialize.public.supplier // { arity: 7 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1459,7 +1459,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
             implementation
-              %1 » %0:l0[#1, #2, #3, #4]KKKKA
+              %1[#0, #1, #2, #3] » %0:l0[#1, #2, #3, #4]KKKKA
             ArrangeBy keys=[[#1, #2, #3, #4]] // { arity: 5 }
               Get l0 // { arity: 5 }
             ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 4 }
@@ -1470,7 +1470,7 @@ Explained Query:
                       Filter (#10 > #3) // { arity: 14 }
                         Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
                           implementation
-                            %1:orderline » %0:l1[#2, #1, #0]KKKA
+                            %1:orderline[#2, #1, #0] » %0:l1[#2, #1, #0]KKKA
                           ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
                             Get l1 // { arity: 4 }
                           ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
@@ -1486,7 +1486,7 @@ Explained Query:
           Filter (#7 > #11) // { arity: 16 }
             Join on=(#0 = #14 AND #2 = #15 AND #3 = #8 AND #4 = #9 AND eq(#5, #10, #13) AND #6 = #12) type=differential // { arity: 16 }
               implementation
-                %1:orderline » %2:order[#0, #1, #2]UKKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
+                %1:orderline[#0, #1, #2] » %2:order[#0, #1, #2]UKKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Project (#0, #1, #3) // { arity: 3 }
                   Get materialize.public.supplier // { arity: 7 }
@@ -1544,7 +1544,7 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
-              %1 » %0:l1[#0, #1, #2]UKKKA
+              %1[#0, #1, #2] » %0:l1[#0, #1, #2]UKKKA
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
               Get l1 // { arity: 5 }
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
@@ -1553,7 +1553,7 @@ Explained Query:
                   Project (#0..=#2) // { arity: 3 }
                     Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                       implementation
-                        %1 » %0:l2[#0, #1, #2]UKKKA
+                        %1[#0, #1, #2] » %0:l2[#0, #1, #2]UKKKA
                       ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                         Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
@@ -1571,7 +1571,7 @@ Explained Query:
           Filter (numeric_to_double(#4) > (numeric_to_double(#5) / bigint_to_double(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
             CrossJoin type=differential // { arity: 7 }
               implementation
-                %0:l0 » %1[×]UAef
+                %0:l0[×] » %1[×]UAef
               ArrangeBy keys=[[]] // { arity: 5 }
                 Project (#0..=#2, #9, #16) // { arity: 5 }
                   Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -44,7 +44,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 , t2 WHERE t1.f1 = 123 AND t1.f
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[×]UAef
+      %1:t2[×] » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -80,7 +80,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1:t2 » %0:l0[×]UAef
+          %1:t2[×] » %0:l0[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 2 }
@@ -114,7 +114,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 3 }
         implementation
-          %1:t2 » %0:l0[×]UAef
+          %1:t2[×] » %0:l0[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 1 }
@@ -138,7 +138,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 ON (TRUE) WHERE t1
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[×]UAef
+      %1:t2[×] » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -192,7 +192,7 @@ Explained Query:
   Map (123) // { arity: 1 }
     CrossJoin type=differential // { arity: 0 }
       implementation
-        %1:t2 » %0:t1[×]UAef
+        %1:t2[×] » %0:t1[×]UAef
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
           Filter (#0 = 123) // { arity: 2 }
@@ -224,7 +224,7 @@ Explained Query:
   Return // { arity: 1 }
     CrossJoin type=differential // { arity: 1 }
       implementation
-        %1 » %0:l1[×]UAef
+        %1[×] » %0:l1[×]UAef
       Get l1 // { arity: 0 }
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
@@ -239,7 +239,7 @@ Explained Query:
     cte l2 =
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:t1 » %0:l1[×]UAef
+          %1:t1[×] » %0:l1[×]UAef
         Get l1 // { arity: 0 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
@@ -274,7 +274,7 @@ Explained Query:
       Map ((#0 = 123)) // { arity: 2 }
         CrossJoin type=differential // { arity: 1 }
           implementation
-            %1 » %0:t2[×]UAef
+            %1[×] » %0:t2[×]UAef
           ArrangeBy keys=[[]] // { arity: 0 }
             Project () // { arity: 0 }
               Filter (#0 = 123) // { arity: 2 }
@@ -318,7 +318,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (S
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1:t2 » %0:t1[×]UAef
+      %1:t2[×] » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -376,7 +376,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, (SELECT t2.f1 FROM t2) AS dt1 
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1:t2 » %0:t1[×]UAef
+      %1:t2[×] » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -400,7 +400,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE 123 = (SELECT t2.f1 FROM 
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1 » %0:t1[×]A
+      %1[×] » %0:t1[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[]] // { arity: 0 }
@@ -426,7 +426,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = (
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1 » %0:t1[×]UAef
+      %1[×] » %0:t1[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -541,7 +541,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, t2 WHERE t1.f1 = 123 AND t1.f1
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[×]UAeif
+      %1:t2[×] » %0:t1[×]UAeif
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -570,7 +570,7 @@ explain with(arity, join_impls) select * from int_table, double_table where int_
 Explained Query:
   Join on=(#1 = integer_to_double(#0)) type=differential // { arity: 2 }
     implementation
-      %1:double_table » %0:int_table[integer_to_double(#0)]KA
+      %1:double_table[#0] » %0:int_table[integer_to_double(#0)]KA
     ArrangeBy keys=[[integer_to_double(#0)]] // { arity: 1 }
       Get materialize.public.int_table // { arity: 1 }
     ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -585,7 +585,7 @@ Explained Query:
     Filter (#0) IS NOT NULL
       Join on=(#0 = #2 AND #1 = #5 AND #3 = #4) type=differential
         implementation
-          %1:u » %0:t[#0]KA » %2:v[#0, #1]KKA
+          %1:u[#0] » %0:t[#0]KA » %2:v[#0, #1]KKA
         ArrangeBy keys=[[#0]]
           Get materialize.public.t
         ArrangeBy keys=[[#0]]

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -247,7 +247,7 @@ Explained Query:
     Map (date_truncts(#0, #1)) // { arity: 3 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:date_trunc_timestamps » %0:date_trunc_fields[×]A
+          %1:date_trunc_timestamps[×] » %0:date_trunc_fields[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.date_trunc_fields // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -34,7 +34,7 @@ Explained Query:
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
-        %1 » %0:test1[×]A
+        %1[×] » %0:test1[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.test1 // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -20,7 +20,7 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        %0:t1 » %1[#0]UKA
+        %0:t1[#0] » %1[#0]UKA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -69,7 +69,7 @@ Explained Query:
     Project (#0, #2, #3, #1) // { arity: 4 }
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1 » %0:table_f1[×]A
+          %1[×] » %0:table_f1[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.table_f1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 3 }
@@ -78,7 +78,7 @@ Explained Query:
               Project (#0..=#2) // { arity: 3 }
                 Join on=(#0 = #3) type=differential // { arity: 4 }
                   implementation
-                    %1 » %0:l1[#0]KAf
+                    %1[#0] » %0:l1[#0]KAf
                   ArrangeBy keys=[[#0]] // { arity: 3 }
                     Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -97,7 +97,7 @@ Explained Query:
       Project (#0..=#2) // { arity: 3 }
         Join on=(#1 = #3) type=differential // { arity: 4 }
           implementation
-            %1:table_f5_f6 » %0:table_f4_f5_f6[#1]KAf
+            %1:table_f5_f6[#0] » %0:table_f4_f5_f6[#1]KAf
           ArrangeBy keys=[[#1]] // { arity: 3 }
             Filter (#1 = #2) // { arity: 3 }
               Get materialize.public.table_f4_f5_f6 // { arity: 3 }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -115,7 +115,7 @@ Explained Query:
     Project (#0, #2, #4) // { arity: 3 }
       Join on=(#1 = (#0 + 1) AND #3 = (#0 + #1)) type=differential // { arity: 5 }
         implementation
-          %1:l1 » %0:l0[(#0 + 1)]KA » %2:l1[#0]KA
+          %1:l1[#0] » %0:l0[(#0 + 1)]KA » %2:l1[#0]KA
         ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 2 }
@@ -158,7 +158,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %0:l » %1[#0]UKA
+          %0:l[#0] » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.l // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -186,7 +186,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:l0 » %0[×]A
+          %1:l0[×] » %0[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Distinct group_by=[#0] // { arity: 1 }
             Get l0 // { arity: 1 }
@@ -324,7 +324,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %0:l » %1[#0]UKA
+                  %0:l[#0] » %1[#0]UKA
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Get materialize.public.l // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -339,7 +339,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:r » %0:l[#0]KA
+            %1:r[#0] » %0:l[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -366,7 +366,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:r » %1[#0]UKA
+                    %0:r[#0] » %1[#0]UKA
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.r // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -381,7 +381,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:r » %0:l[#0]KA
+            %1:r[#0] » %0:l[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -408,7 +408,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:r » %1:l1[#0]UKA
+                    %0:r[#0] » %1:l1[#0]UKA
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.r // { arity: 2 }
                   Get l1 // { arity: 1 }
@@ -419,7 +419,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %0:l » %1:l1[#0]UKA
+                  %0:l[#0] » %1:l1[#0]UKA
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Get materialize.public.l // { arity: 2 }
                 Get l1 // { arity: 1 }
@@ -436,7 +436,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:r » %0:l[#0]KA
+            %1:r[#0] » %0:l[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -463,7 +463,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = m
 Explained Query:
   Join on=((#0 % 2) = (#2 % 2)) type=differential // { arity: 4 }
     implementation
-      %1:r » %0:l[(#0 % 2)]KA
+      %1:r[(#0 % 2)] » %0:l[(#0 % 2)]KA
     ArrangeBy keys=[[(#0 % 2)]] // { arity: 2 }
       Filter (#0) IS NOT NULL // { arity: 2 }
         Get materialize.public.l // { arity: 2 }
@@ -521,7 +521,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %1 » %0:t4362[#0]KA
+          %1[#0] » %0:t4362[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.t4362 // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -592,7 +592,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1:r3 » %0:l3[#0]KA
+        %1:r3[#0] » %0:l3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.l3 // { arity: 2 }
@@ -620,7 +620,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1:r3 » %0:l3[#0]KA
+        %1:r3[#0] » %0:l3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.l3 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -642,7 +642,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1:r3 » %0:l3[#0]KA
+        %1:r3[#0] » %0:l3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.l3 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -675,7 +675,7 @@ Explained Query:
     Filter (#0) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #3) type=differential // { arity: 6 }
         implementation
-          %1:t2 » %0:t1[#0]KAe
+          %1:t2[#0] » %0:t1[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
           ReadExistingIndex materialize.public.t1 lookup_values=[("l2"); ("l3")]
         ArrangeBy keys=[[#0]] // { arity: 3 }
@@ -710,7 +710,7 @@ Explained Query:
     Filter (#0) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #3) type=differential // { arity: 6 }
         implementation
-          %1:t2 » %0:t1[#0]KAe
+          %1:t2[#0] » %0:t1[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
           ReadExistingIndex materialize.public.t1 lookup_value=("l2")
         ArrangeBy keys=[[#0]] // { arity: 3 }
@@ -745,7 +745,7 @@ WHERE
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1:t2 » %0:t1[×]Ae
+      %1:t2[×] » %0:t1[×]Ae
     ArrangeBy keys=[[]] // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
         ReadExistingIndex materialize.public.t1 lookup_value=(2, "l2")

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -33,7 +33,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0 » %0:l0[×]A
+        %1:l0[×] » %0:l0[×]A
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -80,7 +80,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0 » %0:l0[×]Ae
+        %1:l0[×] » %0:l0[×]Ae
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -129,7 +129,7 @@ Explained Query:
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
-        %1:l0 » %0:l0[×]Ae
+        %1:l0[×] » %0:l0[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Get l0 // { arity: 3 }
@@ -157,7 +157,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
         implementation
-          %2:l0 » %0:t1[#1]KA » %1:l0[#0]KA
+          %2:l0[#0] » %0:t1[#1]KA » %1:l0[#0]KA
         ArrangeBy keys=[[#1]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -190,7 +190,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
         implementation
-          %2:l1 » %0:t1[#1]KA » %1:l1[#0]KA
+          %2:l1[#0] » %0:t1[#1]KA » %1:l1[#0]KA
         ArrangeBy keys=[[#1]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -223,7 +223,7 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        %1 » %0:t1[#0]KA
+        %1[#0] » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -302,7 +302,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0 » %0:l0[×]Ae
+        %1:l0[×] » %0:l0[×]Ae
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -327,7 +327,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0 » %0:l0[×]Aef
+        %1:l0[×] » %0:l0[×]Aef
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -354,7 +354,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0 » %0:l0[×]Aef
+        %1:l0[×] » %0:l0[×]Aef
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Filter (#1 = 2) // { arity: 3 }
@@ -429,7 +429,7 @@ Explained Query:
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0:t1[×]A
+          %1[×] » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t1 // { arity: 2 }
@@ -582,7 +582,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0:t1[×]A
+          %1[×] » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t1 // { arity: 2 }
@@ -642,7 +642,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1:l0 » %0:l0[×]A
+          %1:l0[×] » %0:l0[×]A
         Get l0 // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
@@ -675,7 +675,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %0:l0 » %1[#0]UKA
+                  %0:l0[#0] » %1[#0]UKA
                 Get l0 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
@@ -687,7 +687,7 @@ Explained Query:
         Filter (#0) IS NOT NULL // { arity: 4 }
           Join on=(#0 = #2) type=differential // { arity: 4 }
             implementation
-              %1:l0 » %0:l0[#0]KA
+              %1:l0[#0] » %0:l0[#0]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
     cte l0 =
@@ -710,7 +710,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l1 » %0:l1[×]Ae
+          %1:l1[×] » %0:l1[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l1 // { arity: 3 }
@@ -719,7 +719,7 @@ Explained Query:
             Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l2 » %0:l2[×]Ae
+          %1:l2[×] » %0:l2[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l2 // { arity: 3 }
@@ -887,7 +887,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1 » %1[×]UA
+          %0:t1[×] » %1[×]UA
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
@@ -916,7 +916,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1 » %0:l0[#0]KA
+            %1[#0] » %0:l0[#0]KA
           Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Union // { arity: 1 }
@@ -1134,7 +1134,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1 » %1[×]UA
+          %0:t1[×] » %1[×]UA
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
@@ -1168,7 +1168,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1 » %1[×]UA
+          %0:t1[×] » %1[×]UA
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
@@ -1192,13 +1192,13 @@ Explained Query:
     Union // { arity: 2 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1 » %1:l0[×]UA
+          %0:t1[×] » %1:l0[×]UA
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         Get l0 // { arity: 0 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t2 » %1:l0[×]UA
+          %0:t2[×] » %1:l0[×]UA
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t2 // { arity: 2 }
         Get l0 // { arity: 0 }
@@ -1223,7 +1223,7 @@ Explained Query:
   Return // { arity: 2 }
     CrossJoin type=differential // { arity: 2 }
       implementation
-        %1 » %0[×]A
+        %1[×] » %0[×]A
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
           Project (#0) // { arity: 1 }
@@ -1279,7 +1279,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:t1 » %0:t1[×]Ae
+        %1:t1[×] » %0:t1[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           ReadExistingIndex materialize.public.t1 lookup_value=(1)
@@ -1307,7 +1307,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l1 » %0:l1[×]Ae
+          %1:l1[×] » %0:l1[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l1 // { arity: 3 }
@@ -1316,7 +1316,7 @@ Explained Query:
             Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l2 » %0:l2[×]Ae
+          %1:l2[×] » %0:l2[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l2 // { arity: 3 }

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -53,7 +53,7 @@ Explained Query:
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1 » %0:t2[×]A
+          %1[×] » %0:t2[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t2 // { arity: 1 }
@@ -97,7 +97,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0:t2[#0]KA
+          %1[#0] » %0:t2[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -124,7 +124,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1 » %0:l0[#0]UKA
+            %1:t1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -159,7 +159,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0:t2[#0]KA
+          %1[#0] » %0:t2[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -186,13 +186,13 @@ Explained Query:
       Union // { arity: 2 }
         Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
           implementation
-            %1:l2 » %0:l1[(#0 + 1)]KA
+            %1:l2[#0] » %0:l1[(#0 + 1)]KA
           ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Get l2 // { arity: 1 }
         Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
           implementation
-            %1:l2 » %0:l1[(#0 + 2)]KA
+            %1:l2[#0] » %0:l1[(#0 + 2)]KA
           ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Get l2 // { arity: 1 }
@@ -262,7 +262,7 @@ Explained Query:
     cte l5 =
       Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
         implementation
-          %1:l2 » %0:l1[(#0 + 2)]KA
+          %1:l2[#0] » %0:l1[(#0 + 2)]KA
         ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
           Get l1 // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -278,7 +278,7 @@ Explained Query:
     cte l3 =
       Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
         implementation
-          %1:l2 » %0:l1[(#0 + 1)]KA
+          %1:l2[#0] » %0:l1[(#0 + 1)]KA
         ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
           Get l1 // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -363,7 +363,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1 » %0:l0[#0]UKA
+            %1:t1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -445,7 +445,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1 » %0:l0[#0]UKA
+            %1:t1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -479,7 +479,7 @@ Explained Query:
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0:t3[#0]KA
+          %1[#0] » %0:t3[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t3 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -506,7 +506,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0:l1[#0]KA
+            %1[#0] » %0:l1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l1 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -532,7 +532,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1 » %0:l2[#0]UKA
+            %1:t1[#0] » %0:l2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l2 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -545,7 +545,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:l0[#0]UKA
+            %1:t2[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -593,7 +593,7 @@ Explained Query:
         Project (#1, #3) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 4 }
             implementation
-              %1 » %0:l4[#0]KA
+              %1[#0] » %0:l4[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -619,7 +619,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:l1 » %0:l5[#0]UKA
+            %1:l1[#0] » %0:l5[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l5 // { arity: 1 }
           Get l1 // { arity: 1 }
@@ -631,7 +631,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0:t2[#0]KA
+            %1[#0] » %0:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.t2 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -657,7 +657,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:l1 » %0:l0[#0]UKA
+            %1:l1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Get l1 // { arity: 1 }
@@ -695,7 +695,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0:t3[#0]KA
+          %1[#0] » %0:t3[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t3 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -770,7 +770,7 @@ Explained Query:
     Project (#4, #4) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
         implementation
-          %1 » %0:l0[#0, #1]KKA
+          %1[#0, #1] » %0:l0[#0, #1]KKA
         ArrangeBy keys=[[#0, #1]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[#0, #1]] // { arity: 3 }
@@ -797,7 +797,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t1 » %0:l1[#0]UKAf
+            %1:t1[#0] » %0:l1[#0]UKAf
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0 = #1) // { arity: 2 }
               Get l1 // { arity: 2 }
@@ -810,7 +810,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:t3 » %0:t2[×]A
+          %1:t3[×] » %0:t2[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -249,7 +249,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 Explained Query:
   CrossJoin type=differential // { arity: 1 }
     implementation
-      %0:t1 » %1[×]UA
+      %0:t1[×] » %1[×]UA
     ArrangeBy keys=[[]] // { arity: 1 }
       Get materialize.public.t1 // { arity: 1 }
     ArrangeBy keys=[[]] // { arity: 0 }
@@ -270,7 +270,7 @@ Explained Query:
   Project (#0, #0, #2) // { arity: 3 }
     Join on=(#0 = #1) type=differential // { arity: 3 }
       implementation
-        %1:t3 » %2[×]UA » %0:t1[#0]KA
+        %1:t3[×] » %2[×]UA » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Get materialize.public.t1 // { arity: 1 }
       ArrangeBy keys=[[]] // { arity: 2 }
@@ -293,7 +293,7 @@ Explained Query:
   Project (#0, #0, #2) // { arity: 3 }
     Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 4 }
       implementation
-        %1:t3 » %2[#0]UKA » %0:t1[#0]KA
+        %1:t3[#1] » %2[#0]UKA » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Get materialize.public.t1 // { arity: 1 }
       ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -325,7 +325,7 @@ Explained Query:
     Map ((ascii(substr(replace(#1, "o", "i"), 2, 1)) * 2)) // { arity: 5 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1:age » %0:likes[#0]KA
+          %1:age[#0] » %0:likes[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL // { arity: 2 }
             Get materialize.public.likes // { arity: 2 }
@@ -448,7 +448,7 @@ Explained Query:
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1 » %0:y[#0]KA
+          %1[#0] » %0:y[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -465,7 +465,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0:l0[#0]UKA
+            %1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -486,7 +486,7 @@ Explained Query:
       Map (NOT(#2)) // { arity: 4 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0:y[#0]KA
+            %1[#0] » %0:y[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.y // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -503,7 +503,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1 » %0:l0[#0]UKA
+            %1[#0] » %0:l0[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -525,7 +525,7 @@ Explained Query:
       Map (NOT(#2)) // { arity: 4 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1 » %0:y[#0]KA
+            %1[#0] » %0:y[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.y // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -544,7 +544,7 @@ Explained Query:
           Filter (#0 <= #1) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
-                %1:x » %0:l0[×]A
+                %1:x[×] » %0:l0[×]A
               ArrangeBy keys=[[]] // { arity: 1 }
                 Get l0 // { arity: 1 }
               ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -206,7 +206,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM x, generate_series(1, 10)
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1 » %0:x[×]A
+      %1[×] » %0:x[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.x // { arity: 2 }
     Constant // { arity: 1 }
@@ -242,7 +242,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#1 = #3) type=differential // { arity: 4 }
             implementation
-              %1:l0 » %0:l0[#1]KA
+              %1:l0[#1] » %0:l0[#1]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
   With
@@ -266,7 +266,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#1 = #3) type=differential // { arity: 4 }
             implementation
-              %1:l0 » %0:l0[#1]KA
+              %1:l0[#1] » %0:l0[#1]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
   With
@@ -293,7 +293,7 @@ Explained Query:
           Project (#0..=#2) // { arity: 3 }
             Join on=(#1 = #3) type=differential // { arity: 4 }
               implementation
-                %1:l0 » %0:l0[#1]KA
+                %1:l0[#1] » %0:l0[#1]KA
               Get l0 // { arity: 2 }
               Get l0 // { arity: 2 }
   With

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -243,7 +243,7 @@ Explained Query:
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
         Join on=(#0 = #9 AND #7 = #10) type=differential // { arity: 11 }
           implementation
-            %0:l4 » %1[#0, #1]UKKA
+            %0:l4[#0, #7] » %1[#0, #1]UKKA
           ArrangeBy keys=[[#0, #7]] // { arity: 9 }
             Get l4 // { arity: 9 }
           ArrangeBy keys=[[#0, #1]] // { arity: 2 }
@@ -448,7 +448,7 @@ Explained Query:
         Filter (#40 = "ASIA") AND (#12 < 1995-01-01) AND (#12 >= 1994-01-01) // { arity: 42 }
           Join on=(#0 = #9 AND eq(#3, #34, #35) AND #8 = #17 AND #19 = #33 AND #37 = #39) type=differential // { arity: 42 }
             implementation
-              %5:region » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKAeiif
+              %5:region[#0] » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKAeiif
             ArrangeBy keys=[[#3]] // { arity: 8 }
               Get materialize.public.customer // { arity: 8 }
             ArrangeBy keys=[[#1]] // { arity: 9 }
@@ -869,7 +869,7 @@ Explained Query:
         Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0 » %1[×]UA
+              %0[×] » %1[×]UA
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum((#2 * integer_to_numeric(#1)))] // { arity: 2 }
                 Get l0 // { arity: 3 }
@@ -940,7 +940,7 @@ Explained Query:
         Filter (#21 >= 1994-01-01) AND (#19 < #20) AND (#20 < #21) AND (date_to_timestamp(#21) < 1995-01-01 00:00:00) AND ((#23 = "MAIL") OR (#23 = "SHIP")) // { arity: 25 }
           Join on=(#0 = #9) type=differential // { arity: 25 }
             implementation
-              %1:lineitem » %0:orders[#0]KAeiif
+              %1:lineitem[#0] » %0:orders[#0]KAeiif
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.orders // { arity: 9 }
             ArrangeBy keys=[[#0]] // { arity: 16 }
@@ -989,7 +989,7 @@ Explained Query:
                 Map (null) // { arity: 17 }
                   Join on=(#0 = #8 AND #1 = #9 AND #2 = #10 AND #3 = #11 AND #4 = #12 AND #5 = #13 AND #6 = #14 AND #7 = #15) type=differential // { arity: 16 }
                     implementation
-                      %1:customer » %0[#0, #1, #2, #3, #4, #5, #6, #7]KKKKKKKKA
+                      %1:customer[#0, #1, #2, #3, #4, #5, #6, #7] » %0[#0, #1, #2, #3, #4, #5, #6, #7]KKKKKKKKA
                     ArrangeBy keys=[[#0, #1, #2, #3, #4, #5, #6, #7]] // { arity: 8 }
                       Union // { arity: 8 }
                         Negate // { arity: 8 }
@@ -1006,7 +1006,7 @@ Explained Query:
           Filter NOT("%special%requests%" ~~(varchar_to_text(#16))) // { arity: 17 }
             Join on=(#0 = #9) type=differential // { arity: 17 }
               implementation
-                %1:orders » %0:customer[#0]KAf
+                %1:orders[#1] » %0:customer[#0]KAf
               ArrangeBy keys=[[#0]] // { arity: 8 }
                 Get materialize.public.customer // { arity: 8 }
               ArrangeBy keys=[[#1]] // { arity: 9 }
@@ -1055,7 +1055,7 @@ Explained Query:
           Filter (#10 >= 1995-09-01) AND (date_to_timestamp(#10) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1 = #16) type=differential // { arity: 25 }
               implementation
-                %1:part » %0:lineitem[#1]KAiif
+                %1:part[#0] » %0:lineitem[#1]KAiif
               ArrangeBy keys=[[#1]] // { arity: 16 }
                 Get materialize.public.lineitem // { arity: 16 }
               ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1109,7 +1109,7 @@ Explained Query:
       Project (#0..=#2, #4, #8) // { arity: 5 }
         Join on=(#0 = #7 AND #8 = #9) type=differential // { arity: 10 }
           implementation
-            %0:supplier » %1:l0[#0]UKA » %2[#0]UKA
+            %0:supplier[#0] » %1:l0[#0]UKA » %2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 7 }
             Get materialize.public.supplier // { arity: 7 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1175,7 +1175,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %1 » %0:l0[#0]KA
+              %1[#0] » %0:l0[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Get l0 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1186,7 +1186,7 @@ Explained Query:
                       Filter ((#1) IS NULL OR (#0 = #1)) // { arity: 2 }
                         CrossJoin type=differential // { arity: 2 }
                           implementation
-                            %1:supplier » %0:l1[×]Alf
+                            %1:supplier[×] » %0:l1[×]Alf
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Get l1 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 1 }
@@ -1204,7 +1204,7 @@ Explained Query:
           Filter (#8 != "Brand#45") AND NOT("MEDIUM POLISHED%" ~~(varchar_to_text(#9))) AND ((#10 = 3) OR (#10 = 9) OR (#10 = 14) OR (#10 = 19) OR (#10 = 23) OR (#10 = 36) OR (#10 = 45) OR (#10 = 49)) // { arity: 14 }
             Join on=(#0 = #5) type=differential // { arity: 14 }
               implementation
-                %1:part » %0:partsupp[#0]KAef
+                %1:part[#0] » %0:partsupp[#0]KAef
               ArrangeBy keys=[[#0]] // { arity: 5 }
                 Get materialize.public.partsupp // { arity: 5 }
               ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1258,7 +1258,7 @@ Explained Query:
           Filter (numeric_to_double(#1) < (0.2 * (numeric_to_double(#4) / bigint_to_double(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
             Join on=(#0 = #3) type=differential // { arity: 6 }
               implementation
-                %0:l1 » %1[#0]UKA
+                %0:l1[#0] » %1[#0]UKA
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
@@ -1266,7 +1266,7 @@ Explained Query:
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #2) type=differential // { arity: 17 }
                       implementation
-                        %1:l0 » %0[#0]UKA
+                        %1:l0[#1] » %0[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#0) // { arity: 1 }
@@ -1277,7 +1277,7 @@ Explained Query:
         Filter (#19 = "Brand#23") AND (#22 = "MED BOX") // { arity: 25 }
           Join on=(#1 = #16) type=differential // { arity: 25 }
             implementation
-              %1:part » %0:l0[#1]KAef
+              %1:part[#0] » %0:l0[#1]KAef
             Get l0 // { arity: 16 }
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.part // { arity: 9 }
@@ -1335,7 +1335,7 @@ Explained Query:
           Filter (#7 > 300) // { arity: 8 }
             Join on=(#2 = #6) type=differential // { arity: 8 }
               implementation
-                %0:l1 » %1[#0]UKAif
+                %0:l1[#2] » %1[#0]UKAif
               ArrangeBy keys=[[#2]] // { arity: 6 }
                 Get l1 // { arity: 6 }
               ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1343,7 +1343,7 @@ Explained Query:
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #1) type=differential // { arity: 17 }
                       implementation
-                        %1:l0 » %0[#0]UKA
+                        %1:l0[#0] » %0[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#2) // { arity: 1 }
@@ -1432,7 +1432,7 @@ Explained Query:
             Map ((#4 <= 20), (#4 >= 10), (#4 <= 30), (#4 >= 20), (#4 <= 11), (#4 >= 1), (#19 = "Brand#12"), (#21 <= 5), ((#22 = "SM BOX") OR (#22 = "SM PKG") OR (#22 = "SM CASE") OR (#22 = "SM PACK")), (#19 = "Brand#23"), (#21 <= 10), ((#22 = "MED BAG") OR (#22 = "MED BOX") OR (#22 = "MED PKG") OR (#22 = "MED PACK")), (#19 = "Brand#34"), (#21 <= 15), ((#22 = "LG BOX") OR (#22 = "LG PKG") OR (#22 = "LG CASE") OR (#22 = "LG PACK"))) // { arity: 40 }
               Join on=(#1 = #16) type=differential // { arity: 25 }
                 implementation
-                  %1:part » %0:lineitem[#1]KAeiiiiif
+                  %1:part[#0] » %0:lineitem[#1]KAeiiiiif
                 ArrangeBy keys=[[#1]] // { arity: 16 }
                   Get materialize.public.lineitem // { arity: 16 }
                 ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1491,7 +1491,7 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            %0:l0 » %1[#0]UKA
+            %0:l0[#0] » %1[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1500,7 +1500,7 @@ Explained Query:
                 Filter (integer_to_numeric(#2) > (0.5 * #5)) // { arity: 6 }
                   Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
                     implementation
-                      %0:l1 » %1[#0, #1]UKKAf
+                      %0:l1[#1, #0] » %1[#0, #1]UKKAf
                     ArrangeBy keys=[[#1, #0]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
                         Filter (#0 = #2) // { arity: 4 }
@@ -1511,7 +1511,7 @@ Explained Query:
                           Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
                             Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 18 }
                               implementation
-                                %1:lineitem » %0[#0, #1]UKKAiif
+                                %1:lineitem[#1, #2] » %0[#0, #1]UKKAiif
                               ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                                 Distinct group_by=[#0, #1] // { arity: 2 }
                                   Project (#1, #2) // { arity: 2 }
@@ -1523,7 +1523,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#1 = #6) type=differential // { arity: 7 }
             implementation
-              %1:partsupp » %2[#0]UKA » %0[×]A
+              %1:partsupp[#0] » %2[#0]UKA » %0[×]A
             ArrangeBy keys=[[]] // { arity: 1 }
               Distinct group_by=[#0] // { arity: 1 }
                 Project (#0) // { arity: 1 }
@@ -1540,7 +1540,7 @@ Explained Query:
           Filter (#8 = "CANADA") // { arity: 11 }
             Join on=(#3 = #7) type=differential // { arity: 11 }
               implementation
-                %1:nation » %0:supplier[#3]KAef
+                %1:nation[#0] » %0:supplier[#3]KAef
               ArrangeBy keys=[[#3]] // { arity: 7 }
                 Get materialize.public.supplier // { arity: 7 }
               ArrangeBy keys=[[#0]] // { arity: 4 }
@@ -1605,7 +1605,7 @@ Explained Query:
         Project (#1) // { arity: 1 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
-              %1 » %0:l2[#0, #2]KKA
+              %1[#1, #0] » %0:l2[#0, #2]KKA
             ArrangeBy keys=[[#0, #2]] // { arity: 3 }
               Get l2 // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 2 }
@@ -1616,7 +1616,7 @@ Explained Query:
                       Filter (#1 != #4) AND (#14 > #13) // { arity: 18 }
                         Join on=(#0 = #2) type=differential // { arity: 18 }
                           implementation
-                            %1:l1 » %0:l3[#0]KAf
+                            %1:l1[#0] » %0:l3[#0]KAf
                           ArrangeBy keys=[[#0]] // { arity: 2 }
                             Get l3 // { arity: 2 }
                           Get l1 // { arity: 16 }
@@ -1630,7 +1630,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
-              %0:l0 » %1[#0, #1]UKKA
+              %0:l0[#2, #0] » %1[#0, #1]UKKA
             ArrangeBy keys=[[#2, #0]] // { arity: 3 }
               Get l0 // { arity: 3 }
             ArrangeBy keys=[[#0, #1]] // { arity: 2 }
@@ -1639,7 +1639,7 @@ Explained Query:
                   Filter (#1 != #4) // { arity: 18 }
                     Join on=(#0 = #2) type=differential // { arity: 18 }
                       implementation
-                        %1:l1 » %0[#0]KA
+                        %1:l1[#0] » %0[#0]KA
                       ArrangeBy keys=[[#0]] // { arity: 2 }
                         Distinct group_by=[#1, #0] // { arity: 2 }
                           Project (#0, #2) // { arity: 2 }
@@ -1734,7 +1734,7 @@ Explained Query:
         Project (#1, #2) // { arity: 2 }
           Join on=(#0 = #3) type=differential // { arity: 4 }
             implementation
-              %1 » %0:l1[#0]KA
+              %1[#0] » %0:l1[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 3 }
               Get l1 // { arity: 3 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1743,7 +1743,7 @@ Explained Query:
                   Project (#0) // { arity: 1 }
                     Join on=(#0 = #1) type=differential // { arity: 2 }
                       implementation
-                        %1 » %0:l2[#0]UKA
+                        %1[#0] » %0:l2[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Get l2 // { arity: 1 }
                       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1761,7 +1761,7 @@ Explained Query:
           Filter (numeric_to_double(#2) > (numeric_to_double(#3) / bigint_to_double(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
-                %0:l0 » %1[×]UAef
+                %0:l0[×] » %1[×]UAef
               ArrangeBy keys=[[]] // { arity: 3 }
                 Project (#0, #4, #5) // { arity: 3 }
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -33,7 +33,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %0:l1 » %1[#0]UKA
+                      %0:l1[#0] » %1[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -50,7 +50,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -86,7 +86,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -125,7 +125,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:t1 » %1[#0]UKA
+                    %0:t1[#0] » %1[#0]UKA
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -140,7 +140,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -170,7 +170,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      %0:t1 » %1[#0]UKA
+                      %0:t1[#0] » %1[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -185,7 +185,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -215,7 +215,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      %0:t1 » %1[#0]UKA
+                      %0:t1[#0] » %1[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -230,7 +230,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -276,7 +276,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -307,7 +307,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -343,7 +343,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %0:l1 » %1[#0]UKA
+                      %0:l1[#0] » %1[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -361,7 +361,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -388,7 +388,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -416,7 +416,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -452,7 +452,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %0:l1 » %1[#0]UKA
+                      %0:l1[#0] » %1[#0]UKA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -469,7 +469,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -503,7 +503,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    %0:l1 » %1[#0]UKA
+                    %0:l1[#0] » %1[#0]UKA
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -520,7 +520,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -551,7 +551,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    %0:l1 » %1[#0]UKA
+                    %0:l1[#0] » %1[#0]UKA
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -568,7 +568,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -595,7 +595,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -623,7 +623,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2 » %0:t1[#0]KA
+            %1:t2[#0] » %0:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -680,7 +680,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:t1 » %1[#0]UKA
+                    %0:t1[#1] » %1[#0]UKA
                   ArrangeBy keys=[[#1]] // { arity: 2 }
                     Get materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -694,7 +694,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2 » %0:t1[#1]KA
+            %1:t2[#0] » %0:t1[#1]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -721,7 +721,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#1 = #2) type=differential // { arity: 3 }
                     implementation
-                      %0:t1 » %1[#0]UKA
+                      %0:t1[#1] » %1[#0]UKA
                     ArrangeBy keys=[[#1]] // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -735,7 +735,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2 » %0:t1[#1]KA
+            %1:t2[#0] » %0:t1[#1]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -758,7 +758,7 @@ Explained Query:
       Project (#0, #3) // { arity: 2 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2 » %0:t1[#1]KA
+            %1:t2[#0] » %0:t1[#1]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -855,7 +855,7 @@ Explained Query:
     Project (#1) // { arity: 1 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %0:t1 » %1[#1]UKA
+          %0:t1[#0] » %1[#1]UKA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Get materialize.public.t1 // { arity: 2 }
@@ -869,7 +869,7 @@ Explained Query:
                   Map (null) // { arity: 5 }
                     Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
                       implementation
-                        %1:t3 » %0[#0, #1]KKA
+                        %1:t3[#0, #1] » %0[#0, #1]KKA
                       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                         Union // { arity: 2 }
                           Map (6) // { arity: 2 }
@@ -885,7 +885,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:t3 » %0:t2[×]Aef
+          %1:t3[×] » %0:t2[×]Aef
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Get materialize.public.t2 // { arity: 2 }
@@ -942,7 +942,7 @@ Explained Query:
             Map (null) // { arity: 3 }
               Join on=(#0 = #1) type=differential // { arity: 2 }
                 implementation
-                  %1:t2 » %0[#0]KA
+                  %1:t2[#0] » %0[#0]KA
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
@@ -958,7 +958,7 @@ Explained Query:
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
           implementation
-            %1:t1 » %0:t2[×]A
+            %1:t1[×] » %0:t2[×]A
           ArrangeBy keys=[[]] // { arity: 1 }
             Get materialize.public.t2 // { arity: 1 }
           ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -75,7 +75,7 @@ explain with(arity, join_impls) select * from foo, bar where foo.a = abs(bar.a) 
 Explained Query:
   CrossJoin type=differential // { arity: 6 }
     implementation
-      %1:bar » %0:foo[×]Aef
+      %1:bar[×] » %0:foo[×]Aef
     ArrangeBy keys=[[]] // { arity: 3 }
       Filter (#0 = 3) // { arity: 3 }
         Get materialize.public.foo // { arity: 3 }

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -31,7 +31,7 @@ Explained Query:
   Project () // { arity: 0 }
     Join on=(#0 = (#1 + #2)) type=differential // { arity: 3 }
       implementation
-        %1:t2 » %0:t1[×]A
+        %1:t2[×] » %0:t1[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -55,7 +55,7 @@ Explained Query:
     Project () // { arity: 0 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         implementation
-          %0:l0 » %1[#0]UKA
+          %0:l0[#0] » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -35,7 +35,7 @@ Explained Query:
     Filter (#0 <= #2) // { arity: 6 }
       Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
         implementation
-          %2:t3 » %0:t1[#0]KAiif » %1:t2[#1]KAiif
+          %2:t3[#0] » %0:t1[#0]KAiif » %1:t2[#1]KAiif
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0 > 0) AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -116,7 +116,7 @@ Explained Query:
     Filter (#5 != #11) AND (#14 >= #10) // { arity: 15 }
       Join on=(#0 = #8 AND date_to_timestamp(#11) = (#5 - 9 months)) type=differential // { arity: 15 }
         implementation
-          %2:customer » %0:lineitem[×]A » %1:orders[#0, date_to_timestamp(#3)]KKA
+          %2:customer[×] » %0:lineitem[×]A » %1:orders[#0, date_to_timestamp(#3)]KKA
         ArrangeBy keys=[[]] // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }
         ArrangeBy keys=[[#0, date_to_timestamp(#3)]] // { arity: 4 }
@@ -158,7 +158,7 @@ Explained Query:
           Filter (#1 <= 195) AND (#1 >= 38) AND (1997-08-25 00:00:00 = date_to_timestamp(#4)) // { arity: 6 }
             Join on=(#0 = #3 AND #1 = #5) type=differential // { arity: 6 }
               implementation
-                %2 » %1:orders[#0]KAeiiiif » %0:lineitem[#0]KAeiiiif
+                %2[#0] » %1:orders[#0]KAeiiiif » %0:lineitem[#0]KAeiiiif
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Project (#4) // { arity: 1 }
                   Filter (#6 = 1997-01-25) // { arity: 8 }
@@ -196,7 +196,7 @@ Explained Query:
   Project (#1, #0, #1) // { arity: 3 }
     Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
       implementation
-        %2:customer » %1:orders[×]Aef » %0:lineitem[#2, #3]KKAef
+        %2:customer[×] » %1:orders[×]Aef » %0:lineitem[#2, #3]KKAef
       ArrangeBy keys=[[#2, #3]] // { arity: 4 }
         Project (#0, #1, #4, #6) // { arity: 4 }
           Filter (#4 = (#4 % 5)) // { arity: 8 }
@@ -228,7 +228,7 @@ Explained Query:
   Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
     Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 15 }
       implementation
-        %1:orders » %0:lineitem[#4, #5]KKAef » %2:customer[×]Aef
+        %1:orders[#2, #3] » %0:lineitem[#4, #5]KKAef » %2:customer[×]Aef
       ArrangeBy keys=[[#4, #5]] // { arity: 8 }
         Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -32,7 +32,7 @@ EXPLAIN WITH(arity, join_impls) select * from foo inner join bar on foo.a = bar.
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:bar » %0:foo[×]Aef
+      %1:bar[×] » %0:foo[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 1) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -62,7 +62,7 @@ EXPLAIN WITH(arity, join_impls) select * from foo inner join bar on foo.a = abs(
 Explained Query:
   Join on=(#0 = abs(#2)) type=differential // { arity: 4 }
     implementation
-      %1:bar » %0:foo[#0]KAef
+      %1:bar[abs(#0)] » %0:foo[#0]KAef
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Filter (1 = (#0 % 2)) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -97,7 +97,7 @@ EXPLAIN WITH(arity, join_impls) select * from (select * from foo where a = 1) fi
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:bar » %0:foo[×]Aef
+      %1:bar[×] » %0:foo[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 1) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -144,7 +144,7 @@ Explained Query:
   Project (#0, #5) // { arity: 2 }
     Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
       implementation
-        %1:bar » %2:baz[#0]UKA » %0:foo[#0]KA
+        %1:bar[#1] » %2:baz[#0]UKA » %0:foo[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -193,7 +193,7 @@ Explained Query:
     Filter (#0) IS NOT NULL AND (#3) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
         implementation
-          %1:bar » %0:foo[#0]KA » %2:baz[#0]KA
+          %1:bar[#0] » %0:foo[#0]KA » %2:baz[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -236,7 +236,7 @@ Explained Query:
     Filter (#2) IS NOT NULL AND (case when (#0 = 0) then null else #0 end) IS NOT NULL // { arity: 4 }
       Join on=(-(#2) = if (#0 = 0) then {null} else {#0}) type=differential // { arity: 4 }
         implementation
-          %1:bar » %0:foo[case when (#0 = 0) then null else #0 end]KA
+          %1:bar[-(#0)] » %0:foo[case when (#0 = 0) then null else #0 end]KA
         ArrangeBy keys=[[case when (#0 = 0) then null else #0 end]] // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
         ArrangeBy keys=[[-(#0)]] // { arity: 2 }
@@ -279,7 +279,7 @@ Explained Query:
     Filter (#0) IS NOT NULL AND (#4) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #4 = (#0 + 4)) type=differential // { arity: 6 }
         implementation
-          %2:baz » %0:bar[(#0 + 4)]KA » %1:foo[#0]KA
+          %2:baz[#0] » %0:bar[(#0 + 4)]KA » %1:foo[#0]KA
         ArrangeBy keys=[[(#0 + 4)]] // { arity: 2 }
           Get materialize.public.bar // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -316,7 +316,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(1 = (#0 / #2)) type=differential // { arity: 4 }
       implementation
-        %1:bar » %0:foo[×]A
+        %1:bar[×] » %0:foo[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
@@ -347,7 +347,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(eq(-1, (#3 - #1), (#0 / #2))) type=differential // { arity: 4 }
       implementation
-        %1:bar » %0:foo[×]A
+        %1:bar[×] » %0:foo[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
@@ -385,7 +385,7 @@ Explained Query:
   Project (#1, #3, #5) // { arity: 3 }
     Join on=(#0 = #2 AND #4 = (#0 + 4)) type=differential // { arity: 6 }
       implementation
-        %2:baz » %0:foo[(#0 + 4)]KA » %1:bar[#0]KA
+        %2:baz[#0] » %0:foo[(#0 + 4)]KA » %1:bar[#0]KA
       ArrangeBy keys=[[(#0 + 4)]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -113,7 +113,7 @@ Explained Query:
     Map (1) // { arity: 4 }
       CrossJoin type=differential // { arity: 3 }
         implementation
-          %1:t » %0:t[×]A
+          %1:t[×] » %0:t[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Map ((#0 + 1)) // { arity: 3 }
@@ -132,7 +132,7 @@ Explained Query:
     Map (2, 1) // { arity: 6 }
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1:t » %0:t[×]A
+          %1:t[×] » %0:t[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Project (#2, #3) // { arity: 2 }
             Map ((#1 + 1), (#0 + 1)) // { arity: 4 }
@@ -151,7 +151,7 @@ Explained Query:
     Map (3, 2, 1) // { arity: 8 }
       CrossJoin type=differential // { arity: 5 }
         implementation
-          %1:t » %0:t[×]A
+          %1:t[×] » %0:t[×]A
         ArrangeBy keys=[[]] // { arity: 3 }
           Project (#2..=#4) // { arity: 3 }
             Map ((#1 + 1), (#0 + 2), (#0 + 1)) // { arity: 5 }
@@ -201,7 +201,7 @@ Explained Query:
     Map ((1 + #0), 1) // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %0 » %1:t[×]A
+          %0[×] » %1:t[×]A
         Constant // { arity: 0 }
           - (() x 7)
         ArrangeBy keys=[[]] // { arity: 1 }
@@ -756,7 +756,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %1 » %0:t_pk[#0]UKAiif
+              %1[#0] » %0:t_pk[#0]UKAiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
@@ -806,7 +806,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %1 » %0:t[#0]KAiif
+              %1[#0] » %0:t[#0]KAiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -172,7 +172,7 @@ Explained Query:
   Project (#0, #1, #0, #1) // { arity: 4 }
     Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
       implementation
-        %1:t2 » %0:t1[#0, #1]KKA
+        %1:t2[#0, #1] » %0:t1[#0, #1]KKA
       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
         Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -195,7 +195,7 @@ select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and t2.f1 is null
 Explained Query:
   Join on=(#0 = (#2 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[#0]KA
+      %1:t2[(#0 + 1)] » %0:t1[#0]KA
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
@@ -210,7 +210,7 @@ select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 Explained Query:
   Join on=(#0 = (#2 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[#0]KA
+      %1:t2[(#0 + 1)] » %0:t1[#0]KA
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
@@ -225,7 +225,7 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 Explained Query:
   Join on=(#2 = (#0 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[(#0 + 1)]KA
+      %1:t2[#0] » %0:t1[(#0 + 1)]KA
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -240,7 +240,7 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and ((t2.f1 + 1) 
 Explained Query:
   Join on=(#2 = (#0 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2 » %0:t1[(#0 + 1)]KA
+      %1:t2[#0] » %0:t1[(#0 + 1)]KA
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -259,7 +259,7 @@ Explained Query:
     Filter (((#1 = 3) AND (#3 = 4)) OR ((#1 = 5) AND (#3 = 6))) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1:t2 » %0:t1[#0]KAef
+          %1:t2[#0] » %0:t1[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND ((#1 = 3) OR (#1 = 5)) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -283,7 +283,7 @@ Explained Query:
     Filter ((#1 = 5) OR ((#1 = 3) AND (#3 = 4))) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1:t2 » %0:t1[#0]KAef
+          %1:t2[#0] » %0:t1[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND ((#1 = 3) OR (#1 = 5)) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -307,7 +307,7 @@ Explained Query:
   Filter ((#1 = 27) OR ((#0 = #2) AND (#1 <= 1995))) // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:t2 » %0:t1[×]Aeiif
+        %1:t2[×] » %0:t1[×]Aeiif
       ArrangeBy keys=[[]] // { arity: 2 }
         Filter ((#1 = 27) OR (#1 <= 1995)) // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -397,7 +397,7 @@ Explained Query:
     Filter ((#4 = "materialized-view") OR ((#4 = "view") AND (#1 != "doesntmatter"))) // { arity: 5 }
       Join on=(#0 = #2) type=differential // { arity: 5 }
         implementation
-          %1 » %0:mz_schemas[#0]KAef
+          %1[#0] » %0:mz_schemas[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Project (#0, #3) // { arity: 2 }
             Get mz_catalog.mz_schemas // { arity: 4 }

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -142,7 +142,7 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              %0:t3 » %1[#0]UKA
+              %0:t3[#0] » %1[#0]UKA
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Get materialize.public.t3 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -156,7 +156,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2 » %0:t3[#0]KA
+            %1:t2[#0] » %0:t3[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t3 // { arity: 2 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -241,7 +241,7 @@ Explained Query:
     Project (#0) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         implementation
-          %0:l0 » %1[#0]UKA
+          %0:l0[#0] » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -253,7 +253,7 @@ Explained Query:
                     Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
                       CrossJoin type=differential // { arity: 3 }
                         implementation
-                          %1:t2 » %0[×]A
+                          %1:t2[×] » %0[×]A
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Distinct group_by=[#0] // { arity: 1 }
                             Get l0 // { arity: 1 }

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -31,7 +31,7 @@ count
 1
 
 > EXPLAIN WITH(join_impls) VIEW delta_join;
-"Explained Query:  Project (#0, #1, #0, #3)    Filter (#0) IS NOT NULL      Join on=(#0 = #2) type=differential        implementation          %1:t2 » %0:t1[#0]KA        ArrangeBy keys=[[#0]]          Get t1        ArrangeBy keys=[[#0]]          Get t2Used Indexes:  - i1  - i2"
+"Explained Query:  Project (#0, #1, #0, #3)    Filter (#0) IS NOT NULL      Join on=(#0 = #2) type=differential        implementation          %1:t2[#0] » %0:t1[#0]KA        ArrangeBy keys=[[#0]]          Get t1        ArrangeBy keys=[[#0]]          Get t2Used Indexes:  - i1  - i2"
 
 > SELECT count(*) AS count FROM delta_join;
 count


### PR DESCRIPTION
This is a follow-up from https://github.com/MaterializeInc/materialize/pull/16099. Before that PR, the `start_keys`/`start_arr` field (the `Option<Vec<MirScalarExpr>>`) of the `Differential` `JoinImplementation` was not used, and our EXPLAIN output was also not showing it. [Now it is used in the MIR->LIR lowering](https://github.com/MaterializeInc/materialize/blob/df343265f17c35654fbec59270e76e7c6a45b3d5/src/compute-client/src/plan/mod.rs#L1130), so this PR adds it also to the EXPLAIN output.

The random reviewer is @tokenrove.

### Motivation

  * This PR adds a feature that has not yet been specified: A minor tweak in `EXPLAIN WITH(join_impls)`.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - (Minor tweak in the join EXPLAIN output.)
