### PR TITLE
platform checks: Restart Debezium and Redpanda together

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -366,15 +366,15 @@ steps:
           composition: platform-checks
           args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
 
-  - id: checks-oneatatime-restart-redpanda
-    label: "Checks oneatatime + restart Redpanda"
+  - id: checks-oneatatime-restart-redpanda-debezium
+    label: "Checks oneatatime + restart Redpanda & Debezium"
     timeout_in_minutes: 300
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartRedpanda, --execution-mode=oneatatime]
+          args: [--scenario=RestartRedpandaDebezium, --execution-mode=oneatatime]
 
   - id: checks-parallel-drop-create-default-replica
     label: "Checks parallel + DROP/CREATE replica"
@@ -437,14 +437,14 @@ steps:
           args: [--scenario=RestartPostgresBackend, --execution-mode=parallel]
 
   - id: checks-parallel-restart-redpanda
-    label: "Checks parallel + restart Redpanda"
+    label: "Checks parallel + restart Redpanda & Debezium"
     timeout_in_minutes: 300
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartRedpanda, --execution-mode=parallel]
+          args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel]
 
   - id: checks-upgrade-entire-mz
     label: "Platform checks upgrade, whole-Mz restart"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -551,7 +551,7 @@ steps:
           args: [--exitfirst, -m, "not long", --aws-region=us-east-2, test/cloudtest/]
 
   - id: checks-restart-redpanda
-    label: "Checks + restart Redpanda"
+    label: "Checks + restart Redpanda & Debezium"
     depends_on: build-x86_64
     inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
@@ -560,7 +560,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartRedpanda]
+          args: [--scenario=RestartRedpandaDebezium]
 
   - id: lang-csharp
     label: ":csharp: tests"

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -112,12 +112,15 @@ class StartComputed(MzcomposeAction):
             c.up("computed_1")
 
 
-class RestartRedpanda(MzcomposeAction):
+class RestartRedpandaDebezium(MzcomposeAction):
+    """Restarts Redpanda and Debezium. Debezium is unable to survive Redpanda restarts so the two go together."""
+
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
 
-        c.kill("redpanda")
-        c.start_and_wait_for_tcp(services=["redpanda"])
+        for service in ["redpanda", "debezium"]:
+            c.kill(service)
+            c.start_and_wait_for_tcp(services=[service])
 
 
 class RestartPostgresBackend(MzcomposeAction):

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -29,7 +29,7 @@ from materialize.checks.mzcompose_actions import (
     RestartPostgresBackend as RestartPostgresBackendAction,
 )
 from materialize.checks.mzcompose_actions import (
-    RestartRedpanda as RestartRedpandaAction,
+    RestartRedpandaDebezium as RestartRedpandaDebeziumAction,
 )
 from materialize.checks.mzcompose_actions import (
     RestartSourcePostgres as RestartSourcePostgresAction,
@@ -176,15 +176,15 @@ class RestartSourcePostgres(Scenario):
         ]
 
 
-class RestartRedpanda(Scenario):
+class RestartRedpandaDebezium(Scenario):
     def actions(self) -> List[Action]:
         return [
             StartMz(),
             Initialize(self.checks),
-            RestartRedpandaAction(),
+            RestartRedpandaDebeziumAction(),
             Manipulate(self.checks, phase=1),
-            RestartRedpandaAction(),
+            RestartRedpandaDebeziumAction(),
             Manipulate(self.checks, phase=2),
-            RestartRedpandaAction(),
+            RestartRedpandaDebeziumAction(),
             Validate(self.checks),
         ]


### PR DESCRIPTION
Debezium is very sensitive to Redpanda downtime and no amount of configuration seems to fix. Therefore, both need to be restarted together. Therefore, RestartRedpanda scenario is being renamed to RestartRedpandaDebezium and will do as it says.

### Motivation
  * This PR fixes a previously unreported bug.
There were some sporadic CI failures