### PR TITLE
Rename some metrics columns

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -368,8 +368,8 @@ Field         | Type       | Meaning
 --------------|------------|--------
 `replica_id`  | [`bigint`] | The ID of a cluster replica.
 `process_id`  | [`bigint`] | An identifier of a compute process within a replica.
-`nano_cpus`   | [`bigint`] | Approximate CPU usage, in billionths of a vCPU core.
-`bytes_memory`| [`bigint`] | Approximate RAM usage, in bytes.
+`cpu_nano_cores`   | [`bigint`] | Approximate CPU usage, in billionths of a vCPU core.
+`memory_bytes`| [`bigint`] | Approximate RAM usage, in bytes.
 
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1540,8 +1540,8 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::UInt64.nullable(false))
         .with_column("process_id", ScalarType::UInt64.nullable(false))
-        .with_column("nano_cpus", ScalarType::UInt64.nullable(true))
-        .with_column("bytes_memory", ScalarType::UInt64.nullable(true)),
+        .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(true))
+        .with_column("memory_bytes", ScalarType::UInt64.nullable(true)),
 });
 
 pub static MZ_STORAGE_HOST_METRICS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1551,8 +1551,8 @@ pub static MZ_STORAGE_HOST_METRICS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTab
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("nano_cpus", ScalarType::UInt64.nullable(true))
-        .with_column("bytes_memory", ScalarType::UInt64.nullable(true)),
+        .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(true))
+        .with_column("memory_bytes", ScalarType::UInt64.nullable(true)),
 });
 
 pub static MZ_STORAGE_SHARDS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -845,15 +845,15 @@ impl CatalogState {
             |(
                 process_id,
                 ServiceProcessMetrics {
-                    nano_cpus,
-                    bytes_memory,
+                    cpu_nano_cores,
+                    memory_bytes,
                 },
             )| {
                 Row::pack_slice(&[
                     replica_id.into(),
                     u64::cast_from(process_id).into(),
-                    (*nano_cpus).into(),
-                    (*bytes_memory).into(),
+                    (*cpu_nano_cores).into(),
+                    (*memory_bytes).into(),
                 ])
             },
         );

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -412,8 +412,8 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             };
 
             ServiceProcessMetrics {
-                nano_cpus: cpu,
-                bytes_memory: memory,
+                cpu_nano_cores: cpu,
+                memory_bytes: memory,
             }
         }
         let ret = futures::future::join_all((0..scale.get()).map(|i| get_metrics(self, id, i)));

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -111,8 +111,8 @@ pub trait Service: fmt::Debug + Send + Sync {
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ServiceProcessMetrics {
-    pub nano_cpus: Option<u64>,
-    pub bytes_memory: Option<u64>,
+    pub cpu_nano_cores: Option<u64>,
+    pub memory_bytes: Option<u64>,
 }
 
 /// A simple language for describing assertions about a label's existence and value.

--- a/test/cloudtest/test_metrics.py
+++ b/test/cloudtest/test_metrics.py
@@ -18,7 +18,7 @@ def test_replica_metrics(mz: MaterializeApplication) -> None:
             """
             > CREATE CLUSTER my_cluster REPLICAS (my_replica (SIZE '4-4'))
 
-            > SELECT COUNT(*) FROM mz_internal.mz_cluster_replica_metrics m JOIN mz_cluster_replicas cr ON m.replica_id = cr.id WHERE cr.name = 'my_replica' AND m.nano_cpus IS NOT NULL AND m.bytes_memory IS NOT NULL
+            > SELECT COUNT(*) FROM mz_internal.mz_cluster_replica_metrics m JOIN mz_cluster_replicas cr ON m.replica_id = cr.id WHERE cr.name = 'my_replica' AND m.cpu_nano_cores IS NOT NULL AND m.memory_bytes IS NOT NULL
             4
 
             > DROP CLUSTER my_cluster


### PR DESCRIPTION
`nano_cpus` -> `cpu_nano_cores`; `bytes_memory` -> `memory_bytes`

### Motivation

Match the style we use elsewhere of \<quantity>_\<unit>


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Rename `nano_cpus` to `cpu_nano_cores` and `bytes_memory` to `memory_bytes` in `mz_cluster_replica_metrics`.
