### PR TITLE
[sources] Use metadata poll to detect consumer errors in the Kafka source

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -69,7 +69,6 @@ use mz_timely_util::order::Partitioned;
 
 use crate::healthcheck::write_to_persist;
 use crate::source::antichain::{MutableOffsetAntichain, OffsetAntichain};
-use crate::source::healthcheck::{SourceStatus, SourceStatusUpdate};
 
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::{ReclockBatch, ReclockError, ReclockFollower, ReclockOperator};
@@ -381,16 +380,7 @@ where
                                     untimestamped_messages.entry(pid).or_default().push(((message, ts, diff), offset));
                                 }
                                 SourceMessageType::SourceStatus(update) => {
-                                    let update = match update {
-                                        SourceStatusUpdate { status: SourceStatus::Starting, ..} => Some(HealthStatus::Starting),
-                                        SourceStatusUpdate { status: SourceStatus::Running, ..} => Some(HealthStatus::Running),
-                                        SourceStatusUpdate { status: SourceStatus::Stalled, error: Some(e)} => Some(HealthStatus::StalledWithError(e)),
-                                        other => {
-                                            warn!("Received currently-unhandled source status update: {other:?}");
-                                            None
-                                        },
-                                    };
-                                    status_update = update.or(status_update);
+                                    status_update = Some(update);
                                 }
                             }
                         }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -35,8 +35,8 @@ use mz_storage_client::types::errors::{DecodeError, SourceErrorDetails};
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
 use mz_storage_client::types::sources::MzOffset;
 
-use crate::source::healthcheck::SourceStatusUpdate;
 use crate::source::metrics::SourceBaseMetrics;
+use crate::source::source_reader_pipeline::HealthStatus;
 
 /// Extension trait to the SourceConnection trait that defines how to intantiate a particular
 /// connetion into a reader and offset committer
@@ -186,7 +186,7 @@ pub enum SourceMessageType<Key, Value, Diff> {
         Diff,
     ),
     /// Information about the source status
-    SourceStatus(SourceStatusUpdate),
+    SourceStatus(HealthStatus),
     /// Signals that this [`SourceReader`] instance will never emit
     /// messages/updates for a given partition anymore. This is similar enough
     /// to a timely operator dropping a capability, hence the naming.


### PR DESCRIPTION
Previously, we were capturing all errors reported to the error handler in the consumer. This was an improvement over before we did that, but had some issues:
- It's hard to tell whether an error is transient or permanent; they look the same to the error logger.
- All of the workers will see the connection errors, but only workers that get messages would observe the recovery. Since there are sometimes more workers than partitions, we could get into a state where some worker would report ill health forever, even when the system was fine.

This switches us to detecting connection issues via the background poll of the metadata check.

### Motivation

Known-desirable feature: https://github.com/MaterializeInc/materialize/issues/16065
As observed in https://github.com/MaterializeInc/materialize/pull/16268

### Tips for reviewer

For context, once this is in, we can [uncomment some additional testing in #16268](https://github.com/MaterializeInc/materialize/pull/16268#discussion_r1032714767):

```diff
-                #> SELECT status, error
-                #  FROM mz_internal.mz_source_status
-                #  WHERE name = 'source1'
-                #running <null>
+                > SELECT status, error
+                  FROM mz_internal.mz_source_status
+                  WHERE name = 'source1'
+                running <null>
 ```

To improve the latency of noticing errors, I've reduced the polling interval from five minutes to fifteen seconds. I think this is fine - should be at most a few ~inexpensive requests per second - but please tell me if you disagree.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
