### PR TITLE
[sources] Remove sources from unsafe mode

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -550,13 +550,9 @@ impl<S: Append + 'static> Coordinator<S> {
         // This is disabled for the moment because it has unusual upper
         // advancement behavior.
         // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
-        let source_status_collection_id = if self.catalog.config().unsafe_mode {
-            Some(self.catalog.resolve_builtin_storage_collection(
-                &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
-            ))
-        } else {
-            None
-        };
+        let source_status_collection_id = Some(self.catalog.resolve_builtin_storage_collection(
+            &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
+        ));
 
         info!("coordinator init: installing existing objects in catalog");
         let mut privatelink_connections = HashMap::new();

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -519,13 +519,10 @@ impl<S: Append + 'static> Coordinator<S> {
         match self.catalog_transact(Some(session), ops).await {
             Ok(()) => {
                 for (source_id, source) in sources {
-                    let source_status_collection_id = if self.catalog.config().unsafe_mode {
+                    let source_status_collection_id =
                         Some(self.catalog.resolve_builtin_storage_collection(
                             &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
-                        ))
-                    } else {
-                        None
-                    };
+                        ));
 
                     let (data_source, status_collection_id) = match source.data_source {
                         DataSourceDesc::Ingestion(ingestion) => {


### PR DESCRIPTION
### Motivation

Part of the source errors epic: https://github.com/MaterializeInc/materialize/issues/12864

We originally guarded this behind unsafe mode to get some experience with this usage pattern in persist. Writes have been behaving well in CI, and we're now capturing enough source health info that this may be useful.

### Tips for reviewer

Changes we should probably merge before this one:
- https://github.com/MaterializeInc/materialize/pull/16333
- https://github.com/MaterializeInc/materialize/pull/16226

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

(Once this has merged, additional information will be available in `mz_internal`, which I don't think counts as a user-facing change in the usual way?)