### PR TITLE
test: Disable flaky pgwire test

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -36,6 +36,7 @@ use crate::util::PostgresErrorExt;
 pub mod util;
 
 #[test]
+#[ignore]
 fn test_bind_params() {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();


### PR DESCRIPTION

### Motivation
Disables a flaky test: https://github.com/MaterializeInc/materialize/issues/16294

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
