### PR TITLE
test: Fix mz-ore test flake

### DIFF
--- a/src/ore/src/future.rs
+++ b/src/ore/src/future.rs
@@ -262,33 +262,3 @@ impl<T, E> Sink<T> for DevNull<T, E> {
         Poll::Ready(Ok(()))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::panic;
-
-    use scopeguard::defer;
-
-    use super::OreFutureExt;
-
-    #[tokio::test]
-    async fn catch_panic_async() {
-        let old_hook = panic::take_hook();
-        defer! {
-            panic::set_hook(old_hook);
-        }
-
-        crate::panic::set_abort_on_panic();
-
-        let result = async {
-            panic!("panicked");
-        }
-        .ore_catch_unwind()
-        .await
-        .unwrap_err()
-        .downcast::<&str>()
-        .unwrap();
-
-        assert_eq!(*result, "panicked");
-    }
-}

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -80,31 +80,3 @@ where
         res
     })
 }
-
-#[cfg(test)]
-mod tests {
-    use std::panic;
-
-    use scopeguard::defer;
-
-    use super::*;
-
-    #[test]
-    fn catch_panic() {
-        let old_hook = panic::take_hook();
-        defer! {
-            panic::set_hook(old_hook);
-        }
-
-        set_abort_on_panic();
-
-        let result = catch_unwind(|| {
-            panic!("panicked");
-        })
-        .unwrap_err()
-        .downcast::<&str>()
-        .unwrap();
-
-        assert_eq!(*result, "panicked");
-    }
-}

--- a/src/ore/tests/future.rs
+++ b/src/ore/tests/future.rs
@@ -1,0 +1,46 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic;
+
+use scopeguard::defer;
+
+use mz_ore::future::OreFutureExt;
+use mz_ore::panic::set_abort_on_panic;
+
+// IMPORTANT!!! Do not add any tests to this file. This test sets and removes panic hooks
+// and can interfere with any concurrently running test. Therefore, it needs to be run
+// in isolation.
+
+#[tokio::test]
+async fn catch_panic_async() {
+    let old_hook = panic::take_hook();
+    defer! {
+        panic::set_hook(old_hook);
+    }
+
+    set_abort_on_panic();
+
+    let result = async {
+        panic!("panicked");
+    }
+    .ore_catch_unwind()
+    .await
+    .unwrap_err()
+    .downcast::<&str>()
+    .unwrap();
+
+    assert_eq!(*result, "panicked");
+}

--- a/src/ore/tests/panic.rs
+++ b/src/ore/tests/panic.rs
@@ -1,0 +1,43 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic;
+
+use scopeguard::defer;
+
+use mz_ore::panic::{catch_unwind, set_abort_on_panic};
+
+// IMPORTANT!!! Do not add any tests to this file. This test sets and removes panic hooks
+// and can interfere with any concurrently running test. Therefore, it needs to be run
+// in isolation.
+
+#[test]
+fn catch_panic() {
+    let old_hook = panic::take_hook();
+    defer! {
+        panic::set_hook(old_hook);
+    }
+
+    set_abort_on_panic();
+
+    let result = catch_unwind(|| {
+        panic!("panicked");
+    })
+    .unwrap_err()
+    .downcast::<&str>()
+    .unwrap();
+
+    assert_eq!(*result, "panicked");
+}


### PR DESCRIPTION
Some tests in mz-ore were setting and removing panic hooks. This had the potential of interfering with concurrently running tests. This commit moves these tests to their own files so that they aren't run concurrently with any other test.

Fixes #16337

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
