### PR TITLE
environmentd: Have environmentd panic on child crashes during testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3927,6 +3927,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools",
+ "libc",
  "mz-orchestrator",
  "mz-ore",
  "mz-pid-file",

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -57,6 +57,7 @@ class Materialized(Service):
         depends_on: Optional[List[str]] = None,
         allow_host_ports: bool = False,
         environment_id: Optional[str] = None,
+        propagate_crashes: bool = True,
     ) -> None:
         if persist_blob_url is None:
             persist_blob_url = f"file://{data_directory}/persist/blob"
@@ -94,6 +95,9 @@ class Materialized(Service):
 
         if environment_id:
             environment += [f"MZ_ENVIRONMENT_ID={environment_id}"]
+
+        if propagate_crashes:
+            environment += ["MZ_ORCHESTRATOR_PROCESS_PROPAGATE_CRASHES=1"]
 
         self.default_storage_size = default_size
         self.default_replica_size = (

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -30,7 +30,6 @@ from materialize.zippy.replica_actions import (
     CreateReplica,
     DropDefaultReplica,
     DropReplica,
-    KillReplica,
 )
 from materialize.zippy.sink_actions import CreateSinkParameterized
 from materialize.zippy.source_actions import CreateSourceParameterized
@@ -129,7 +128,6 @@ class ClusterReplicas(Scenario):
             KillStoraged: 10,
             KillComputed: 10,
             CreateReplica: 30,
-            KillReplica: 10,
             DropReplica: 10,
             CreateTopicParameterized(): 10,
             CreateSourceParameterized(): 10,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -299,6 +299,10 @@ pub struct Args {
         required_if_eq("orchestrator", "process")
     )]
     orchestrator_process_secrets_directory: Option<PathBuf>,
+    /// Whether the process orchestrator should handle crashes in child
+    /// processes by crashing the parent process.
+    #[clap(long, env = "ORCHESTRATOR_PROCESS_PROPAGATE_CRASHES")]
+    orchestrator_process_propagate_crashes: bool,
 
     /// The init container to use for computed and storaged when using the
     /// kubernetes orchestrator.
@@ -600,6 +604,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                         command_wrapper: args
                             .orchestrator_process_wrapper
                             .map_or(Ok(vec![]), |s| shell_words::split(&s))?,
+                        propagate_crashes: args.orchestrator_process_propagate_crashes,
                     }))
                     .context("creating process orchestrator")?,
             );

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1104,7 +1104,7 @@ source materialize.public.t1 (u1, storage):
 // of cancelled (sends a pgwire cancel request on a new connection).
 #[test]
 fn test_github_12546() {
-    let config = util::Config::default();
+    let config = util::Config::default().with_propagate_crashes(false);
     let server = util::start_server(config).unwrap();
 
     server

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -59,6 +59,7 @@ pub struct Config {
     storage_usage_collection_interval: Duration,
     default_cluster_replica_size: String,
     builtin_cluster_replica_size: String,
+    propagate_crashes: bool,
 }
 
 impl Default for Config {
@@ -74,6 +75,7 @@ impl Default for Config {
             storage_usage_collection_interval: Duration::from_secs(3600),
             default_cluster_replica_size: "1".to_string(),
             builtin_cluster_replica_size: "1".to_string(),
+            propagate_crashes: false,
         }
     }
 }
@@ -141,6 +143,11 @@ impl Config {
         self.builtin_cluster_replica_size = builtin_cluster_replica_size;
         self
     }
+
+    pub fn with_propagate_crashes(mut self, propagate_crashes: bool) -> Self {
+        self.propagate_crashes = propagate_crashes;
+        self
+    }
 }
 
 pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
@@ -186,6 +193,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             environment_id: environment_id.clone(),
             secrets_dir: data_directory.join("secrets"),
             command_wrapper: vec![],
+            propagate_crashes: config.propagate_crashes,
         }))?,
     );
     // Messing with the clock causes persist to expire leases, causing hangs and

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4.23", default_features = false, features = ["clock"] }
 futures = "0.3.25"
 hex = "0.4.3"
 itertools = "0.10.5"
+libc = "0.2.137"
 mz-orchestrator = { path = "../orchestrator" }
 mz-ore = { path = "../ore", features = ["async"] }
 mz-pid-file = { path = "../pid-file" }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -649,6 +649,7 @@ impl Runner {
                 environment_id: environment_id.clone(),
                 secrets_dir: temp_dir.path().join("secrets"),
                 command_wrapper: vec![],
+                propagate_crashes: true,
             })
             .await?,
         );

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -24,7 +24,8 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Materialized(),
+    # We use mz_panic() in some test scenarios, so environmentd must stay up.
+    Materialized(propagate_crashes=False),
     Testdrive(volumes=["mzdata:/mzdata"]),
 ]
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -37,7 +37,8 @@ SERVICES = [
     Computed(name="computed_2"),
     Computed(name="computed_3"),
     Computed(name="computed_4"),
-    Materialized(),
+    # We use mz_panic() in some test scenarios, so environmentd must stay up.
+    Materialized(propagate_crashes=False),
     Redpanda(),
     Testdrive(
         volumes=[


### PR DESCRIPTION
By default, the process orchestrator will restart any computed and storageds that it manages. During testing, this will unfortunately mask panics that should have caused the test to fail instead.

- Add a new environmentd-command line option that will cause environmentd to panic if any of its children exit with an exit code that implies a crash or a panic happened on the child.
- Make sure the new behavior is in effect for sqllogictests, cargo unit tests and mzcompose-based tests
- do not panic environmentd in mzcompose workflows that explicitly use mz_panic() to panic a computed
- Remove the KillReplica Action from Zippy, that was using mz_panic() internally. The original idea of this Action was to panic a single replica, but in practice mz_panic() is evaluated by all replicas and they all panic together.
### Motivation

  * This PR fixes a previously unreported bug.

The fact that the process orchestrator is restarting panicked children masks bugs that should have been exposed during testing.