### PR TITLE
adapter: don't panic in EXPLAIN if the expected stage is mising

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2673,7 +2673,12 @@ impl<S: Append + 'static> Coordinator<S> {
                     .into_iter()
                     .find(|entry| entry.path == stage.path())
                     .map(|entry| Row::pack_slice(&[Datum::from(entry.plan.as_str())]))
-                    .unwrap_or_else(|| panic!("plan at {}", stage.path()));
+                    .ok_or_else(|| {
+                        AdapterError::Internal(format!(
+                            "a plan at stage {} does not exist in the collected optimizer trace",
+                            stage.path(),
+                        ))
+                    })?;
                 vec![row]
             }
         };


### PR DESCRIPTION
This should help us to troubleshoot the quite unexpected behavior observed in #16294.

### Motivation


* This PR adds a feature that has not yet been specified.

The errors observed in #16294 are unexpected, as every trace should contain the stages that can be specifically selected (`RAW`, `DECORRELATED`, `OPTIMIZED`, `PHYSICAL`). In order to debug this further, it will be better if we throw an internal error and keep the process alive.

### Tips for reviewer

This is just a minor changes so the tests in #16294 don't fail with a panic. I hope this will allow us to identify the root cause faster.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.