### PR TITLE
Fix compute persist_sink shutdown

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -373,6 +373,10 @@ where
                         }
                     }
                 }
+                else => {
+                    // All inputs are exhausted, so we can shut down.
+                    return;
+                }
             };
 
             if !active_worker {
@@ -666,6 +670,10 @@ where
                             persist_frontier = frontier;
                         }
                     }
+                }
+                else => {
+                    // All inputs are exhausted, so we can shut down.
+                    return;
                 }
             }
 
@@ -981,6 +989,10 @@ where
                             batches_frontier = frontier;
                         }
                     }
+                }
+                else => {
+                    // All inputs are exhausted, so we can shut down.
+                    return;
                 }
             };
 

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -1,0 +1,103 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test confirms that dataflow operators are cleaned up when they are not
+# needed anymore.
+#
+# This test relies on testdrive's automatic retries, since it queries
+# introspection sources that take a while to update.
+
+# Create a clean replica to inspect dataflow state on.
+
+> CREATE CLUSTER test REPLICAS (r1 (SIZE '1', INTROSPECTION INTERVAL '10ms'))
+> SET cluster = test
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+
+# Verify that an index dataflow is cleaned up when the index is dropped.
+
+> CREATE TABLE t (a int)
+> CREATE INDEX test_index ON t (a)
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+true
+> DROP INDEX test_index
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+
+# Verify that an index dataflow is cleaned up when its input advances to the
+# empty frontier.
+# To make sure that we don't query mz_dataflow_operators before the dataflow
+# was created, we query the index once and then wait for a bit as well.
+
+> CREATE VIEW constant_view AS SELECT generate_series(1, 1000) AS a
+> CREATE INDEX test_index ON constant_view (a)
+> SELECT count(*) FROM constant_view
+1000
+> SELECT mz_internal.mz_sleep(1)
+<null>
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+> DROP INDEX test_index
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+
+# Verify that an MV dataflow is cleaned up when the MV is dropped.
+
+> CREATE MATERIALIZED VIEW test_mv AS SELECT a FROM t
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+true
+> DROP MATERIALIZED VIEW test_mv
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+
+# Verify that an MV dataflow is cleaned up when its input advances to the
+# empty frontier.
+# To make sure that we don't query mz_dataflow_operators before the dataflow
+# was created, we query the MV once and then wait for a bit as well.
+
+> CREATE MATERIALIZED VIEW test_mv AS SELECT generate_series(1, 1000)
+> SELECT count(*) FROM test_mv
+1000
+> SELECT mz_internal.mz_sleep(1)
+<null>
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+> DROP MATERIALIZED VIEW test_mv
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/16326
+
+> CREATE SOURCE lgtpch FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.1) FOR ALL TABLES WITH (SIZE = '1');
+> CREATE MATERIALIZED VIEW q14 AS
+  SELECT
+    100.00 * sum(case
+      when p_type like 'PROMO%'
+        then l_extendedprice * (1 - l_discount)
+      else 0
+    end) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+  FROM
+    lineitem,
+    part
+  WHERE
+    l_partkey = p_partkey
+    AND l_shipdate >= DATE '1995-09-01'
+    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month
+> SELECT count(*) > 0 FROM q14
+true
+> SELECT mz_internal.mz_sleep(1)
+<null>
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+> DROP MATERIALIZED VIEW q14
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
+
+# Clean up.
+> DROP CLUSTER test CASCADE


### PR DESCRIPTION
This PR makes persist_sink shut itself done correctly, both when the shutdown token is dropped, and when the inputs have advanced to the empty frontier.

The PR is split into 5 commits:

* The first commit makes a couple minor cleanups to the persist_sink. Those are not required but make the later changes slightly simpler.
* The second commit makes the persist_sink use the "state-of-the-art" approach to async timely operators. See [this Slack thread](https://materializeinc.slack.com/archives/CMNT2QSBZ/p1669653900369139) for context. The main difference is that we get rid of the `scheduler` and instead can write code that looks like a regular (non-timely) async function.
* The third commit adds logic to shut down the persist sink operators once all their inputs have stopped producing data.
* The fourth commit removes the persist writer heartbeating, which was broken by the second commit and is not needed anymore.
* The fifth commit adds a test that confirms dataflow cleanup is working as intended.

Apart from the dataflow operator shutdown, I also verified that with these changes there are no stray tokio tasks left behind either. So this is a potential fix for the seqno leak we are still seeing in production.

### Example

Materialized view dataflows get cleaned up as soon as the inputs have advanced to the empty frontier:

```sql
materialize=> create materialized view test as select generate_series(1, 1000);
CREATE MATERIALIZED VIEW
materialize=> select * from mz_internal.mz_dataflow_operators;
 id | worker_id | name
----+-----------+------
(0 rows)

materialize=> select count(*) from test;
 count
-------
  1000
(1 row)

materialize=> drop materialized view test;
DROP MATERIALIZED VIEW
```

Materialized view dataflows with inputs that don't advance to the empty frontier get cleaned up when they are dropped:

```sql
materialize=> create materialized view test as select * from mz_views;
CREATE MATERIALIZED VIEW
materialize=> select * from mz_internal.mz_dataflow_operators;
 id  | worker_id |                     name
-----+-----------+----------------------------------------------
 326 | 0         | Map
 328 | 0         | Map
 340 | 0         | Map
 342 | 0         | Map
 358 | 0         | Map
 322 | 0         | OkErr
 338 | 0         | OkErr
 354 | 0         | FlatMap
 347 | 0         | Feedback
 356 | 0         | Exchange
 330 | 0         | Concatenate
 344 | 0         | Concatenate
 324 | 0         | InspectBatch
 351 | 0         | InspectBatch
 363 | 0         | InspectBatch
 316 | 0         | Dataflow: 1.3.test
 370 | 0         | Dataflow: 1.3.test
 353 | 0         | persist_sink u2 write_batches
 365 | 0         | persist_sink u2 append_batches
 334 | 0         | persist_source u2: part fetcher
 318 | 0         | persist_source s275: part fetcher
 333 | 0         | persist_source u2: part distribution
 317 | 0         | persist_source s275: part distribution
 348 | 0         | persist_sink u2 mint_batch_descriptions
 336 | 0         | persist_source u2: consumed part collector
 320 | 0         | persist_source s275: consumed part collector

materialize=> drop materialized view test;
DROP MATERIALIZED VIEW
materialize=> select * from mz_internal.mz_dataflow_operators;
 id | worker_id | name
----+-----------+------
(0 rows)
```

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/16326.
May help with https://github.com/MaterializeInc/materialize/issues/15937.

### Tips for reviewer

Look at the commits and their messages separately!

For the second commit, I suggest you view the diff with "Hide whitespace" enabled. That makes it less painful, but still not great unfortunately.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
