### PR TITLE
advance persist shard `since` and `upper` to `[]` when source is dropped

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -551,10 +551,14 @@ impl<S: Append + 'static> Coordinator<S> {
         // Migrate builtin objects.
         self.controller
             .storage
-            .drop_sources_unvalidated(builtin_migration_metadata.previous_materialized_view_ids);
+            .drop_sources_unvalidated(builtin_migration_metadata.previous_materialized_view_ids)
+            .await
+            .unwrap();
         self.controller
             .storage
-            .drop_sources_unvalidated(builtin_migration_metadata.previous_source_ids);
+            .drop_sources_unvalidated(builtin_migration_metadata.previous_source_ids)
+            .await
+            .unwrap();
         self.controller
             .storage
             .drop_sinks_unvalidated(builtin_migration_metadata.previous_sink_ids);

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -79,6 +79,7 @@ use derivative::Derivative;
 use futures::StreamExt;
 use itertools::Itertools;
 use rand::seq::SliceRandom;
+use timely::progress::Antichain;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
@@ -912,7 +913,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let appends = entries
             .iter()
             .filter(|entry| entry.is_table())
-            .map(|entry| (entry.id(), Vec::new(), advance_to))
+            .map(|entry| (entry.id(), Vec::new(), Antichain::from_elem(advance_to)))
             .collect();
         self.controller
             .storage

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use derivative::Derivative;
+use timely::progress::Antichain;
 use tokio::sync::OwnedMutexGuard;
 use tracing::warn;
 
@@ -294,7 +295,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         timestamp,
                     })
                     .collect();
-                (id, updates, advance_to)
+                (id, updates, Antichain::from_elem(advance_to))
             })
             .collect();
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1155,7 +1155,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // Advance the new table to a timestamp higher than the current read timestamp so
                 // that the table is immediately readable.
                 let upper = since_ts.step_forward();
-                let appends = vec![(table_id, Vec::new(), upper)];
+                let appends = vec![(table_id, Vec::new(), Antichain::from_elem(upper))];
                 self.controller
                     .storage
                     .append(appends)

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1219,11 +1219,10 @@ where
     }
 
     fn drop_sources_unvalidated(&mut self, identifiers: Vec<GlobalId>) {
-        let policies = identifiers
-            .into_iter()
-            .map(|id| (id, ReadPolicy::ValidFrom(Antichain::new())))
-            .collect();
-        self.set_read_policy(policies);
+        for id in identifiers {
+            self.update_write_frontiers(&[(id, Antichain::new())]);
+            self.set_read_policy(vec![(id.clone(), ReadPolicy::ValidFrom(Antichain::new()))]);
+        }
     }
 
     /// Drops the read capability for the sinks and allows their resources to be reclaimed.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Necessary so we can drop write handles to closed shards to prevent mem / resource leaks: https://github.com/MaterializeInc/materialize/issues/15828#issuecomment-1328847150 / https://materializeinc.slack.com/archives/C01CFKM1QRF/p1669663344660499
Necessary for shard clean up: https://github.com/MaterializeInc/materialize/pull/14704 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

I'm very unfamiliar with the storage controller, send help 🙏 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
