### PR TITLE
storage: add flow control to persist source

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -442,7 +442,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, collection);
+                persist_sink(scope, *id, meta, compute_state, collection);
             }
         }
         result

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -213,7 +213,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, collection);
+                persist_sink(scope, *id, meta, compute_state, collection);
             }
         }
         result

--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -18,6 +18,7 @@ use mz_storage_client::controller::CollectionMetadata;
 use crate::compute_state::ComputeState;
 
 pub(crate) fn persist_sink<G>(
+    scope: &G,
     target_id: GlobalId,
     target: &CollectionMetadata,
     compute_state: &mut ComputeState,
@@ -28,8 +29,14 @@ pub(crate) fn persist_sink<G>(
     let desired_collection = log_collection.map(Ok);
     let as_of = Antichain::from_elem(Timestamp::minimum());
 
-    let token =
-        crate::sink::persist_sink(target_id, target, desired_collection, as_of, compute_state);
+    let token = crate::sink::persist_sink(
+        scope,
+        target_id,
+        target,
+        desired_collection,
+        as_of,
+        compute_state,
+    );
 
     compute_state.sink_tokens.insert(
         target_id,

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -175,7 +175,7 @@ pub fn construct<A: Allocate>(
                         row_buf.clone()
                     },
                 );
-                persist_sink(*id, meta, compute_state, sinked);
+                persist_sink(scope, *id, meta, compute_state, sinked);
             }
 
             for variant in logs_active {

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -496,7 +496,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, collection);
+                persist_sink(scope, *id, meta, compute_state, collection);
             }
         }
         result

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -180,6 +180,8 @@ pub fn build_compute_dataflow<A: Allocate>(
                     dataflow.as_of.clone(),
                     dataflow.until.clone(),
                     mfp.as_mut(),
+                    // TODO: provide a more meaningful flow control input
+                    &timely::dataflow::operators::generic::operator::empty(region),
                     // Copy the logic in DeltaJoin/Get/Join to start.
                     |_timer, count| count > 1_000_000,
                 );
@@ -248,7 +250,7 @@ pub fn build_compute_dataflow<A: Allocate>(
 
             // Export declared sinks.
             for (sink_id, imports, sink) in sinks {
-                context.export_sink(compute_state, &mut tokens, imports, sink_id, &sink);
+                context.export_sink(region, compute_state, &mut tokens, imports, sink_id, &sink);
             }
         });
     })

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -32,6 +32,7 @@ where
     /// Export the sink described by `sink` from the rendering context.
     pub(crate) fn export_sink(
         &mut self,
+        scope: &G,
         compute_state: &mut crate::compute_state::ComputeState,
         tokens: &mut std::collections::BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
         import_ids: BTreeSet<GlobalId>,
@@ -71,6 +72,7 @@ where
         };
 
         let sink_token = sink_render.render_continuous_sink(
+            scope,
             compute_state,
             sink,
             sink_id,
@@ -99,6 +101,7 @@ where
 {
     fn render_continuous_sink(
         &self,
+        scope: &G,
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -50,6 +50,7 @@ where
 {
     fn render_continuous_sink(
         &self,
+        scope: &G,
         compute_state: &mut ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
@@ -62,6 +63,7 @@ where
         let desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
 
         persist_sink(
+            scope,
             sink_id,
             &self.storage_metadata,
             desired_collection,
@@ -72,6 +74,7 @@ where
 }
 
 pub(crate) fn persist_sink<G>(
+    scope: &G,
     sink_id: GlobalId,
     target: &CollectionMetadata,
     desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
@@ -94,6 +97,8 @@ where
         source_as_of,
         Antichain::new(), // we want all updates
         None,             // no MFP
+        // TODO: provide a more meaningful flow control input
+        &timely::dataflow::operators::generic::operator::empty(scope),
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -34,6 +34,7 @@ where
 {
     fn render_continuous_sink(
         &self,
+        _scope: &G,
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -62,6 +62,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
         Some(sink.as_of.frontier.clone()),
         timely::progress::Antichain::new(),
         None,
+        &timely::dataflow::operators::generic::operator::empty(scope),
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -342,6 +342,7 @@ where
                                     Some(as_of),
                                     Antichain::new(),
                                     None,
+                                    &timely::dataflow::operators::generic::operator::empty(scope),
                                     // Copy the logic in DeltaJoin/Get/Join to start.
                                     |_timer, count| count > 1_000_000,
                                 );
@@ -400,6 +401,7 @@ where
                                 Some(Antichain::from_elem(previous_as_of)),
                                 Antichain::new(),
                                 None,
+                                &timely::dataflow::operators::generic::operator::empty(scope),
                                 // Copy the logic in DeltaJoin/Get/Join to start.
                                 |_timer, count| count > 1_000_000,
                             );


### PR DESCRIPTION
### Motivation

This PR adds the ability to flow control the output of `persist_source`.

Users of `persist_source` have the ability to apply flow control to the output by providing a timely stream whose only purpose is to communicate the frontier until which data must be emitted. When the frontier of that flow control input is reached the source will stop producing data and it will wait for the frontier of the flow control input to advance. When the flow control frontier advances past the data frontier data emission resumes. This effectively limits the number of timestamps that can be in-flight at any given moment.

If no flow control is desired an empty stream whose frontier immediately advances to the empty antichain can be used. An easy easy of creating such stream is by using [`timely::dataflow::operators::generic::operator::empty`].

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
