### PR TITLE
storage: report native frontier when tracing

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1399,7 +1399,7 @@ where
                                 reclock.source_frontier: {:?}",
                                 untimestamped_batch.batch_upper,
                                 untimestamped_batch.batch_lower,
-                                OffsetAntichain::from(timestamper.source_upper())
+                                timestamper.source_upper()
                             );
                             // We keep batches in the order they arrive from the
                             // source. And we assume that the source frontier never


### PR DESCRIPTION
### Motivation

This PR fixes a bug where if tracing is enabled and the reclocking operator is not initialized we might attempt to log its current upper as an OffsetAntichain. However during initialization the source upper is the empty antichain which cannot be represented as an OffsetAntichain.

In other words this code tried to be helpful by logging a trace and instead panicked the process.

The bug only triggers when tracing is enabled which is how this got through CI and extensive testing.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
