### PR TITLE
feature-benchmark: Use a unique environment_id on retries

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -56,6 +56,7 @@ class Materialized(Service):
         volumes_extra: Optional[List[str]] = None,
         depends_on: Optional[List[str]] = None,
         allow_host_ports: bool = False,
+        environment_id: Optional[str] = None,
     ) -> None:
         if persist_blob_url is None:
             persist_blob_url = f"file://{data_directory}/persist/blob"
@@ -86,6 +87,9 @@ class Materialized(Service):
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_SESSION_TOKEN",
             ]
+
+        if environment_id:
+            environment += [f"MZ_ENVIRONMENT_ID={environment_id}"]
 
         self.default_storage_size = default_size
         self.default_replica_size = (

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -116,6 +116,8 @@ def run_one_scenario(
         mz = Materialized(
             image=f"materialize/materialized:{tag}" if tag else None,
             default_size=size,
+            # Avoid clashes with the Kafka sink progress topic across restarts
+            environment_id=str(time.time()),
         )
 
         with c.override(mz):


### PR DESCRIPTION
Mz needs to be started with a unique environment_id, otherwise it will panic due to a clash in the sink progress topic.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly feature benchmark was failing with a panic in the product.