### PR TITLE
ci,zippy: Use a larger machine for the KafkaParallelInsert scenario

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -251,7 +251,7 @@ steps:
     label: "Zippy Kafka Parallel Insert"
     timeout_in_minutes: 120
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy


### PR DESCRIPTION
This scenario was already consuming almost 16Gb of memory, so needs to be moved to a larger AWS instance in order to prevent sporadic OOMs.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly Zippy KafkaParallelInsert was legitimately OOMing  on a 16Gb instance.