### PR TITLE
[sources] Expect to see the running state in the status history table

### DIFF
--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -36,9 +36,10 @@ SELECT id FROM mz_sources WHERE name = 'kafka_source'
 
 > select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
 "<TIMESTAMP> UTC" ${source_id} starting <null> <null>
+"<TIMESTAMP> UTC" ${source_id} running <null> <null>
 
 > select * from mz_internal.mz_source_status where id = '${source_id}';
-"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" starting <null> <null>
+"${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
 
 $ set-from-sql var=sink_id
 SELECT id FROM mz_sinks WHERE name = 'kafka_sink'


### PR DESCRIPTION
Recently we've made sources able to report health earlier, which made this test racy... sometimes it will change to running status before testdrive gets around to making the check. Let's look for that running status directly.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Reported bug: https://github.com/MaterializeInc/materialize/issues/16363

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
