### PR TITLE
storage: log information about pg wal peeks and keepalives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,6 +4558,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "axum",
+ "bytesize",
  "chrono",
  "clap",
  "crossbeam-channel",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["n
 aws-sdk-s3 = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 aws-sdk-sqs = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 axum = "0.5.17"
+bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive", "env"] }
 crossbeam-channel = { version = "0.5.6" }


### PR DESCRIPTION
This is add extra logging so we can better intuit what is happening when we hit this retry in production

More information here: https://github.com/MaterializeInc/materialize/issues/16484