### PR TITLE
adapter: add `launchdarkly-server-sdk` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,10 +839,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f346b6890a0dfa7266974910e7df2d5088120dd54721b9b0e5aae1ae5e05715"
+dependencies = [
+ "cargo-lock",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+
+[[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytefmt"
@@ -894,6 +915,49 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "camino"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
+dependencies = [
+ "semver",
+ "serde",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cast"
@@ -1210,12 +1274,11 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44919ecaf6f99e8e737bc239408931c9a01e9a6c74814fee8242dd2506b65390"
+checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
 dependencies = [
  "cfg-if",
- "glob",
 ]
 
 [[package]]
@@ -1320,13 +1383,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
@@ -1486,6 +1549,12 @@ dependencies = [
  "num_cpus",
  "parking_lot",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "datadriven"
@@ -1854,10 +1923,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eac3c0b9fa6eb75255ebb42c0ba3e2210d102a66d2795afef6fed668f373311"
+
+[[package]]
+name = "eventsource-client"
+version = "0.11.0"
+source = "git+https://github.com/MaterializeInc/rust-eventsource-client#7189b690cbfa7ff5be2e943fbce83b8a8b67b928"
+dependencies = [
+ "futures",
+ "hyper",
+ "hyper-timeout",
+ "hyper-tls",
+ "log",
+ "pin-project",
+ "rand",
+ "tokio",
+]
 
 [[package]]
 name = "fail"
@@ -2750,6 +2843,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "launchdarkly-server-sdk"
+version = "1.0.0-beta.4"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk#4d02461c887ce754304b4c76a7faeb5395af47f4"
+dependencies = [
+ "built",
+ "chrono",
+ "crossbeam-channel",
+ "data-encoding",
+ "eventsource-client",
+ "futures",
+ "launchdarkly-server-sdk-evaluation",
+ "lazy_static",
+ "log",
+ "lru",
+ "moka",
+ "parking_lot",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "threadpool",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+]
+
+[[package]]
+name = "launchdarkly-server-sdk-evaluation"
+version = "1.0.0-beta.5"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk-evaluation#c085b34eba2bb48269152f2641ee128af2d71732"
+dependencies = [
+ "base16ct",
+ "chrono",
+ "lazy_static",
+ "log",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -3032,6 +3169,28 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "moka"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b49a05f67020456541f4f29cbaa812016a266a86ec76f96d3873d459c68fe5e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "rustc_version",
+ "scheduled-thread-pool",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid",
 ]
 
 [[package]]
@@ -3144,6 +3303,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools",
+ "launchdarkly-server-sdk",
  "maplit",
  "mz-audit-log",
  "mz-build-info",
@@ -4662,16 +4822,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -5356,8 +5516,8 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.10.0"
-source = "git+https://github.com/MaterializeInc/pprof-rs.git#01621bfd418799f5a285dcf8a7fd3123363f6894"
+version = "0.11.0"
+source = "git+https://github.com/MaterializeInc/pprof-rs.git#d0c984a4d7181078dcd45bc8fe441d8d5a9efa46"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -5639,6 +5799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -5997,6 +6168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6095,6 +6275,9 @@ name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "sentry"
@@ -6387,6 +6570,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6521,9 +6719,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symbolic-common"
-version = "9.0.0"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea2ab8b85d27d49d184438b4b77fbd521b385cc9c5c802f60e784f2df25a03d"
+checksum = "c5d7c8cd6663e22c348c74cf0b2c77d196fd252c7efe5594ae05edb07d0475da"
 dependencies = [
  "debugid",
  "memmap2",
@@ -6533,9 +6731,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "9.0.0"
+version = "10.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7939b15a1c62633d1fce17f8a7b668312eaa2d3b117bf4ced5e6e77870c43b6a"
+checksum = "86dc78e43163d342e72c0175113cf0c6ffc6b2540163c8680c4ed91c992af9e2"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -6598,6 +6796,12 @@ dependencies = [
  "rayon",
  "winapi",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -6685,6 +6889,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -6966,6 +7179,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7203,6 +7417,12 @@ name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
 
 [[package]]
 name = "try-lock"

--- a/deny.toml
+++ b/deny.toml
@@ -36,9 +36,13 @@ name = "log"
 wrappers = [
     "deadpool-postgres",
     "env_logger",
+    "eventsource-client",
     "fail",
     "globset",
+    "hyper-rustls",
     "jsonpath_lib",
+    "launchdarkly-server-sdk",
+    "launchdarkly-server-sdk-evaluation",
     "mio",
     "native-tls",
     "opentls",
@@ -82,6 +86,8 @@ wrappers = [
   "fail",
   "findshlibs",
   "indicatif",
+  "launchdarkly-server-sdk",
+  "launchdarkly-server-sdk-evaluation",
   "mysql_async",
   "mysql_common",
   "native-tls",
@@ -106,7 +112,10 @@ wrappers = [
 # actively maintained.
 [[bans.deny]]
 name = "unicase"
-wrappers = ["mime_guess"]
+wrappers = [
+    "mime_guess",
+    "pulldown-cmark",
+]
 
 [licenses]
 allow = [
@@ -150,7 +159,7 @@ allow-git = [
     # v0.18 of opentelemetry.
     "https://github.com/MaterializeInc/tracing.git",
 
-    # Waiting on https://github.com/tikv/pprof-rs/pull/158 to make it into a
+    # Waiting on https://github.com/tikv/pprof-rs/pull/181 to make it into a
     # release.
     "https://github.com/MaterializeInc/pprof-rs.git",
 
@@ -179,9 +188,6 @@ allow-git = [
     # into a release.
     "https://github.com/jorgecarleitao/arrow2.git",
 
-    # Waiting on https://github.com/Byron/open-rs/pull/59.
-    "https://github.com/Byron/open-rs.git",
-
     # Waiting for hashlink, indexmap, and lru to upgrade to hashbrown v0.13,
     # which depends on ahash v0.8 instead of v0.7. In the meantime we've
     # backported the ahash v0.8 bump into hashbrown v0.12.
@@ -192,4 +198,17 @@ allow-git = [
     "https://github.com/frankmcsherry/columnation",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
+
+    # Waiting on https://github.com/launchdarkly/rust-eventsource-client/pull/43
+    # to make it into a release.
+    "https://github.com/MaterializeInc/rust-eventsource-client.git",
+
+    # Waiting on
+    # https://github.com/launchdarkly/rust-server-sdk-evaluation/pull/1 to make
+    # it into a release.
+    "https://github.com/MaterializeInc/rust-server-sdk-evaluation",
+
+    # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
+    # it into a release.
+    "https://github.com/MaterializeInc/rust-server-sdk",
 ]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,6 +19,7 @@ fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 itertools = "0.10.5"
 once_cell = "1.16.0"
+launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk", default_features = false, features = ["hypertls"]}
 maplit = "1.0.2"
 mz-audit-log = { path = "../audit-log" }
 mz-build-info = { path = "../build-info" }

--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -1,0 +1,8 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -42,6 +42,7 @@ mod util;
 
 pub mod catalog;
 pub mod client;
+pub mod config;
 pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};

--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive"] }
 hex = "0.4.3"
 mz-ore = { path = "../../src/ore", features = ["task"] }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.58"
 bytesize = "1.1.0"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.25"
 mz-build-info = { path = "../build-info" }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 mz-build-info = { path = "../build-info" }
 mz-compute-client = { path = "../compute-client" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -52,7 +52,7 @@ mz-service = { path = "../service" }
 mz-sql = { path = "../sql" }
 mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
-nix = "0.25.0"
+nix = "0.26.1"
 num_cpus = "1.14.0"
 openssl = { version = "0.10.42", features = ["vendored"] }
 openssl-sys = { version = "0.9.78", features = ["vendored"] }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -15,7 +15,7 @@ aho-corasick = "0.7.20"
 anyhow = "1.0.66"
 bytes = "1.2.1"
 bytesize = "1.1.0"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 csv = "1.1.6"
 dec = "0.4.8"
 derivative = "2.2.0"

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive"] }
 crossbeam = "0.8.2"
 mz-avro = { path = "../avro" }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 aws-arn = "0.3.1"
 aws-sdk-sts = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 enum-kinds = "0.5.1"
 globset = "0.4.9"
 hex = "0.4.3"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 bytes = "1.2.1"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.20", features = ["derive"] }
 fallible-iterator = "0.2.0"
 futures = "0.3.25"

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 mz-kafka-util = { path = "../../src/kafka-util" }
 mz-ore = { path = "../../src/ore", features = ["task"] }
 rand = "0.8.5"


### PR DESCRIPTION
Splits the first commit of #16089 [as agreed in the main PR](https://github.com/MaterializeInc/materialize/pull/16089#issuecomment-1331364625).

### Motivation

  * This PR adds a known-desirable feature.

This pulls the first commit of #16089 as its own PR in order to reduce the line diff and minimize `Cargo.lock` friction when rebasing #16089. The idea is to merge this fast and rebase #16089 after that.

### Tips for reviewer

The single commit here:

- Adds `launchdarkly-server-sdk` to the `Cargo.toml` in the `mz_adapter` crate.
- Creates `mz_adapter::config` module to host the implementation of the LD synchronization task.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
