### PR TITLE
[sources] Uncomment source error tests

### DIFF
--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -115,11 +115,10 @@ class Disruption:
                 > SELECT COUNT(*) FROM source1;
                 2
 
-                # TODO(bkirwi) https://github.com/MaterializeInc/materialize/issues/16065
-                #> SELECT status, error
-                #  FROM mz_internal.mz_source_status
-                #  WHERE name = 'source1'
-                #running <null>
+                > SELECT status, error
+                  FROM mz_internal.mz_source_status
+                  WHERE name = 'source1'
+                running <null>
 
                 #> SELECT status, error
                 #  FROM mz_internal.mz_sink_status

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -77,11 +77,6 @@ class Disruption:
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM
                   /* WITH ( REMOTE 'storaged:2100' ) REMOTE causes the status source to be empty */
-
-                # Wait for the source to start up
-                # TODO(bkirwi) - catch errors while blocked on client startup
-                > SELECT COUNT(*) FROM source1
-                1
                 """
             )
         )


### PR DESCRIPTION
### Motivation

Followup for: #16268 

### Tips for reviewer

I'll follow up later for the sink tests, but I wanted to get this in sooner to guard against any regressions.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
