### PR TITLE
don't provide default features for mz_ore

### DIFF
--- a/ci/test/cargo-test-miri.sh
+++ b/ci/test/cargo-test-miri.sh
@@ -25,5 +25,5 @@ pkgs=(
 )
 
 for pkg in "${pkgs[@]}"; do
-    (cd src/"$pkg" && cargo miri test miri)
+    (cd src/"$pkg" && cargo miri test miri --all-features)
 done

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -28,7 +28,7 @@ mz-controller = { path = "../controller" }
 mz-expr = { path = "../expr" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["chrono", "async", "tracing_"] }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgcopy = { path = "../pgcopy" }

--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 clap = { version = "3.2.20", features = ["derive"] }
 hex = "0.4.3"
-mz-ore = { path = "../../src/ore", features = ["task"] }
+mz-ore = { path = "../../src/ore", features = ["cli", "async"] }
 mz-test-util = { path = "../../test/test-util" }
 prost = { version = "0.11.2", features = ["no-recursion-limit"] }
 prost-types = "0.11.2"

--- a/src/build-id/Cargo.toml
+++ b/src/build-id/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/MaterializeInc/materialize"
 [dependencies]
 anyhow = "1.0.66"
 libc = "0.2.137"
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["async"] }

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -18,7 +18,7 @@ url = { version = "2.3.1", features = ["serde"] }
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["server"] }
 once_cell = "1.16.0"
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["async"] }
 serde_json = "1.0.88"
 tokio = { version = "1.22.0", features = ["macros"] }
 tracing = "0.1.37"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -22,7 +22,7 @@ mz-compute-client = { path = "../compute-client" }
 mz-expr = { path = "../expr" }
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pid-file = { path = "../pid-file" }
 mz-prof = { path = "../prof" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -40,7 +40,7 @@ mz-orchestrator = { path = "../orchestrator" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-pgwire = { path = "../pgwire" }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.10.5"
 once_cell = "1.16.0"
 md-5 = "0.10.5"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["network"] }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
 mz-persist-types = { path = "../persist-types" }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -11,10 +11,10 @@ anyhow = "1.0.66"
 base64 = "0.13.1"
 derivative = "2.2.0"
 jsonwebtoken = "8.1.1"
-mz-ore = { path = "../ore" }
-reqwest = "0.11.13"
+mz-ore = { path = "../ore", features = ["network"] }
+reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.147", features = ["derive"] }
 thiserror = "1.0.37"
-tokio = "1.22.0"
+tokio = { version = "1.22.0", features = ["macros"] }
 tracing = "0.1.37"
-uuid = "1.2.2"
+uuid = { version = "1.2.2", features = ["serde"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -22,7 +22,7 @@ maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-avro-derive = { path = "../avro-derive" }
 mz-ccsr = { path = "../ccsr" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["network"] }
 mz-repr = { path = "../repr" }
 ordered-float = { version = "3.4.0", features = ["serde"] }
 prost = { version = "0.11.2", features = ["no-recursion-limit"] }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "3.2.20", features = ["derive"] }
 crossbeam = "0.8.2"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
-mz-ore = { path = "../ore", features = ["network", "task"] }
+mz-ore = { path = "../ore", features = ["cli", "network", "async"] }
 num_cpus = "1.14.0"
 prost = { version = "0.11.2", features = ["no-recursion-limit"] }
 rand = "0.8.5"

--- a/src/metabase/Cargo.toml
+++ b/src/metabase/Cargo.toml
@@ -7,5 +7,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-reqwest = "0.11.13"
+reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -13,7 +13,7 @@ axum = "0.5.17"
 clap = { version = "3.2.20", features = [ "derive" ] }
 dirs = "4.0.0"
 indicatif = "0.17.2"
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["async"] }
 open = "3.2.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rpassword = "7.2.0"

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.58"
-chrono = { version = "0.4.23", default_features = false }
+chrono = { version = "0.4.23", default_features = false, features = ["clock"] }
 futures = "0.3.25"
 itertools = "0.10.5"
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["async"] }
 mz-pid-file = { path = "../pid-file" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -14,7 +14,7 @@ futures-core = "0.3.21"
 http = "0.2.8"
 humantime = { version = "2.1.0", optional = true }
 mz-orchestrator = { path = "../orchestrator" }
-mz-ore = { path = "../ore", features = ["tracing_"] }
+mz-ore = { path = "../ore", features = ["tracing_", "cli"] }
 mz-repr = { path = "../repr", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"] }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -60,14 +60,15 @@ console-subscriber = { version = "0.1.8", optional = true }
 sentry-tracing = { version = "0.29.0", optional = true }
 
 [dev-dependencies]
+anyhow = { version = "1.0.66" }
 scopeguard = "1.1.0"
-tokio = { version = "1.22.0", features = ["macros"] }
+tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
-default = ["network", "chrono", "cli", "metrics", "stack", "test"]
-network = ["async-trait", "bytes", "futures", "openssl", "smallvec", "tokio-openssl", "tokio", "task"]
-task = ["tokio", "tokio/tracing"]
+async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio"]
+network = ["bytes", "smallvec"]
 tracing_ = [
+  "anyhow",
   "ansi_term",
   "atty",
   "tracing",
@@ -91,3 +92,7 @@ cli = ["clap"]
 stack = ["stacker"]
 test = ["anyhow", "ctor", "tracing-subscriber"]
 metrics = ["prometheus"]
+
+[[test]]
+name = "future"
+required-features = ["async"]

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -36,8 +36,8 @@ pub mod collections;
 pub mod display;
 pub mod env;
 pub mod fmt;
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "network")))]
-#[cfg(feature = "network")]
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
+#[cfg(feature = "async")]
 pub mod future;
 pub mod graph;
 pub mod hash;
@@ -59,16 +59,16 @@ pub mod permutations;
 pub mod process;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "process")))]
 pub mod result;
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "network")))]
-#[cfg(feature = "network")]
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
+#[cfg(feature = "async")]
 pub mod retry;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "stack")))]
 #[cfg(feature = "stack")]
 pub mod stack;
 pub mod stats;
 pub mod str;
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "task")))]
-#[cfg(feature = "task")]
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
+#[cfg(feature = "async")]
 pub mod task;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "test")))]
 #[cfg(feature = "test")]

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -88,6 +88,7 @@ pub static SYSTEM_TIME: Lazy<NowFn> = Lazy::new(|| NowFn::from(system_time));
 /// For use in tests.
 pub static NOW_ZERO: Lazy<NowFn> = Lazy::new(|| NowFn::from(now_zero));
 
+#[cfg(feature = "chrono")]
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;

--- a/src/ore/src/panic.rs
+++ b/src/ore/src/panic.rs
@@ -20,14 +20,14 @@ use std::cell::RefCell;
 use std::panic::{self, UnwindSafe};
 use std::process;
 
-#[cfg(feature = "task")]
+#[cfg(feature = "async")]
 use tokio::task_local;
 
 thread_local! {
     static CATCHING_UNWIND: RefCell<bool> = RefCell::new(false);
 }
 
-#[cfg(feature = "task")]
+#[cfg(feature = "async")]
 task_local! {
     pub(crate) static CATCHING_UNWIND_ASYNC: bool;
 }
@@ -56,9 +56,9 @@ pub fn set_abort_on_panic() {
     panic::set_hook(Box::new(move |panic_info| {
         old_hook(panic_info);
         let catching_unwind = CATCHING_UNWIND.with(|v| *v.borrow());
-        #[cfg(feature = "task")]
+        #[cfg(feature = "async")]
         let catching_unwind_async = CATCHING_UNWIND_ASYNC.try_with(|v| *v).unwrap_or(false);
-        #[cfg(not(feature = "task"))]
+        #[cfg(not(feature = "async"))]
         let catching_unwind_async = false;
         if !catching_unwind && !catching_unwind_async {
             process::abort();

--- a/src/ore/tests/future.rs
+++ b/src/ore/tests/future.rs
@@ -20,9 +20,9 @@ use scopeguard::defer;
 use mz_ore::future::OreFutureExt;
 use mz_ore::panic::set_abort_on_panic;
 
-// IMPORTANT!!! Do not add any tests to this file. This test sets and removes panic hooks
-// and can interfere with any concurrently running test. Therefore, it needs to be run
-// in isolation.
+// IMPORTANT!!! Do not add any additional tests to this file. This test sets and
+// removes panic hooks and can interfere with any concurrently running test.
+// Therefore, it needs to be run in isolation.
 
 #[tokio::test]
 async fn catch_panic_async() {

--- a/src/ore/tests/panic.rs
+++ b/src/ore/tests/panic.rs
@@ -19,9 +19,9 @@ use scopeguard::defer;
 
 use mz_ore::panic::{catch_unwind, set_abort_on_panic};
 
-// IMPORTANT!!! Do not add any tests to this file. This test sets and removes panic hooks
-// and can interfere with any concurrently running test. Therefore, it needs to be run
-// in isolation.
+// IMPORTANT!!! Do not add any additional tests to this file. This test sets and
+// removes panic hooks and can interfere with any concurrently running test.
+// Therefore, it needs to be run in isolation.
 
 #[test]
 fn catch_panic() {

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -66,7 +66,7 @@ datadriven = { version = "0.6.0", features = ["async"] }
 futures-task = "0.3.21"
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
-mz-ore = { path = "../ore", features = ["tracing_"] }
+mz-ore = { path = "../ore", features = ["network", "tracing_", "test"] }
 num_cpus = "1.14.0"
 num_enum = "0.5.7"
 serde_json = "1.0.88"

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -35,7 +35,7 @@ fail = { version = "0.5.1", features = ["failpoints"] }
 futures-util = "0.3.25"
 once_cell = "1.16.0"
 md-5 = "0.10.5"
-mz-ore = { path = "../ore", default-features = false, features = ["metrics", "task"] }
+mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async"] }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.42", features = ["vendored"] }

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -12,7 +12,7 @@ bytes = "1.2.1"
 clap = { version = "3.2.20", features = ["derive"] }
 datadriven = "0.6.0"
 fallible-iterator = "0.2.0"
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["cli"] }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.88"

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 mz-cloud-resources = { path = "../cloud-resources" }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["async"] }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ssh-util = { path = "../ssh-util" }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.10.5"
 once_cell = "1.16.0"
 mz-avro = { path = "../avro" }
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["bytes", "smallvec"] }
+mz-ore = { path = "../ore", features = ["bytes", "smallvec", "stack", "test"] }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 num-traits = "0.2.15"

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -14,7 +14,7 @@ bytefmt = "0.1.7"
 clap = { version = "3.2.20", features = ["derive"] }
 futures = "0.3.25"
 indicatif = "0.17.2"
-mz-ore = { path = "../ore" }
-tokio = { version = "1.22.0", features = ["macros", "net", "rt", "time"] }
+mz-ore = { path = "../ore", features = ["cli"] }
+tokio = { version = "1.22.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["async"] }
 segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
 serde_json = "1.0.88"
 tokio = { version = "1.22.0", features = ["sync"] }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -24,7 +24,7 @@ mz-compute-client = { path = "../compute-client" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["chrono", "async"] }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -20,7 +20,7 @@ md-5 = "0.10.5"
 mz-build-info = { path = "../build-info" }
 mz-controller = { path = "../controller" }
 mz-environmentd = { path = "../environmentd", default-features = false }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-orchestrator = { path = "../orchestrator" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-persist-client = { path = "../persist-client" }

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -14,7 +14,7 @@ harness = false
 async-trait = "0.1.58"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.25"
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["metrics", "network", "async", "test"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 prometheus = { version = "0.13.3", default-features = false }
 rand = "0.8.5"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -27,7 +27,7 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-orchestrator = { path = "../orchestrator" }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -37,7 +37,7 @@ mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-kinesis-util = { path = "../kinesis-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["async", "tracing_", "chrono"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-pgcopy = { path = "../pgcopy" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -41,7 +41,7 @@ mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-kinesis-util = { path = "../kinesis-util" }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["async"] }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -13,7 +13,7 @@ proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-fea
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.147", features = ["derive"] }
-mz-ore = { path = "../ore", features = ["tracing"] }
+mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"
 
 [dev-dependencies]

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 itertools = "0.10.5"
 mz-metabase = { path = "../../../src/metabase" }
-mz-ore = { path = "../../../src/ore", features = ["task"] }
-tokio = "1.22.0"
+mz-ore = { path = "../../../src/ore", features = ["network", "async", "test"] }
+tokio = { version = "1.22.0", features = ["macros"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "1.2.1"
 clap = { version = "3.2.20", features = ["derive"] }
 futures = "0.3.25"
 mz-kinesis-util = { path = "../../src/kinesis-util" }
-mz-ore = { path = "../../src/ore", features = ["task"] }
+mz-ore = { path = "../../src/ore", features = ["async"] }
 mz-test-util = { path = "../test-util" }
 rand = "0.8.5"
 tokio = "1.22.0"

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "std"] }
 mz-kafka-util = { path = "../../src/kafka-util" }
-mz-ore = { path = "../../src/ore", features = ["task"] }
+mz-ore = { path = "../../src/ore", features = ["async"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 tokio = "1.22.0"


### PR DESCRIPTION
### Motivation

very few places actually use them, and that adds to dependencies (especially on the cloud side, which is using very little in general)

in particular, this lets us drop 18 dependencies from our kubernetes controllers (due to transitive deps depending on plain `mz-ore` even though they don't actually use any of these default features).

### Tips for reviewer

we could also plausibly explicitly say `default-features = false` in more places, but given that as far as i can tell, no crate is actually using the full set of default features, this seems more annoying?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - i assume here that if it compiles, it works
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
