### PR TITLE
adapter: Fix builtin schema migrations

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -45,6 +45,7 @@ pub const INFORMATION_SCHEMA: &str = "information_schema";
 
 pub static BUILTIN_PREFIXES: Lazy<Vec<&str>> = Lazy::new(|| vec!["mz_", "pg_"]);
 
+#[derive(Debug)]
 pub enum Builtin<T: 'static + TypeReference> {
     Log(&'static BuiltinLog),
     Table(&'static BuiltinTable),
@@ -100,7 +101,7 @@ pub struct BuiltinLog {
     pub schema: &'static str,
 }
 
-#[derive(Hash)]
+#[derive(Hash, Debug)]
 pub struct BuiltinTable {
     pub name: &'static str,
     pub schema: &'static str,
@@ -115,13 +116,14 @@ pub struct BuiltinSource {
     pub data_source: Option<IntrospectionType>,
 }
 
-#[derive(Hash)]
+#[derive(Hash, Debug)]
 pub struct BuiltinView {
     pub name: &'static str,
     pub schema: &'static str,
     pub sql: &'static str,
 }
 
+#[derive(Debug)]
 pub struct BuiltinType<T: TypeReference> {
     pub name: &'static str,
     pub schema: &'static str,
@@ -129,12 +131,14 @@ pub struct BuiltinType<T: TypeReference> {
     pub details: CatalogTypeDetails<T>,
 }
 
+#[derive(Debug)]
 pub struct BuiltinFunc {
     pub schema: &'static str,
     pub name: &'static str,
     pub inner: &'static mz_sql::func::Func,
 }
 
+#[derive(Debug)]
 pub struct BuiltinIndex {
     pub name: &'static str,
     pub schema: &'static str,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -615,7 +615,8 @@ def workflow_test_builtin_migration(c: Composition) -> None:
 
     c.down(destroy_volumes=True)
     with c.override(
-        # Random commit before pg_proc and mz_dataflow_operator_reachability were updated.
+        # Random commit before pg_proc, mz_dataflow_operator_reachability, mz_show_cluster_replicas, and
+        # mz_cluster_replica_statuses were updated.
         Materialized(
             image="materialize/materialized:devel-aa4128c9c485322f90ab0af2b9cb4d16e1c470c0",
             default_size=1,
@@ -642,6 +643,18 @@ def workflow_test_builtin_migration(c: Composition) -> None:
 
         > SELECT pg_typeof(address) FROM mz_internal.mz_dataflow_operator_reachability LIMIT 1;
         "bigint list"
+
+        > SELECT pg_typeof(process_id) FROM mz_internal.mz_cluster_replica_statuses LIMIT 1;
+        "bigint"
+
+        ! SELECT updated_at FROM mz_internal.mz_cluster_replica_statuses;
+        contains:column "updated_at" does not exist
+
+        > SELECT last_update FROM mz_internal.mz_cluster_replica_statuses LIMIT 0;
+
+        ! SELECT ready FROM mz_internal.mz_show_cluster_replicas LIMIT 0;
+        contains:column "ready" does not exist
+
     """
             )
         )
@@ -660,14 +673,25 @@ def workflow_test_builtin_migration(c: Composition) -> None:
         c.testdrive(
             input=dedent(
                 """
-       > SELECT * FROM v1;
-       5
-       # This column is new after the migration
-       > SELECT DISTINCT proowner FROM pg_proc;
-       <null>
+        > SELECT * FROM v1;
+        5
+        # This column is new after the migration
+        > SELECT DISTINCT proowner FROM pg_proc;
+        <null>
 
-       > SELECT pg_typeof(address) FROM mz_internal.mz_dataflow_operator_reachability LIMIT 1;
-       "uint8 list"
+        > SELECT pg_typeof(address) FROM mz_internal.mz_dataflow_operator_reachability LIMIT 1;
+        "uint8 list"
+
+        > SELECT pg_typeof(process_id) FROM mz_internal.mz_cluster_replica_statuses LIMIT 1;
+        "uint8"
+
+        ! SELECT last_update FROM mz_internal.mz_cluster_replica_statuses;
+        contains:column "last_update" does not exist
+
+        > SELECT updated_at FROM mz_internal.mz_cluster_replica_statuses LIMIT 0;
+
+        > SELECT ready FROM mz_internal.mz_show_cluster_replicas LIMIT 0;
+
     """
             )
         )
@@ -685,14 +709,25 @@ def workflow_test_builtin_migration(c: Composition) -> None:
         c.testdrive(
             input=dedent(
                 """
-       > SELECT * FROM v1;
-       5
-       # This column is new after the migration
-       > SELECT DISTINCT proowner FROM pg_proc;
-       <null>
+        > SELECT * FROM v1;
+        5
+        # This column is new after the migration
+        > SELECT DISTINCT proowner FROM pg_proc;
+        <null>
 
-       > SELECT pg_typeof(address) FROM mz_internal.mz_dataflow_operator_reachability LIMIT 1;
-       "uint8 list"
+        > SELECT pg_typeof(address) FROM mz_internal.mz_dataflow_operator_reachability LIMIT 1;
+        "uint8 list"
+
+        > SELECT pg_typeof(process_id) FROM mz_internal.mz_cluster_replica_statuses LIMIT 1;
+        "uint8"
+
+        ! SELECT last_update FROM mz_internal.mz_cluster_replica_statuses;
+        contains:column "last_update" does not exist
+
+        > SELECT updated_at FROM mz_internal.mz_cluster_replica_statuses LIMIT 0;
+
+        > SELECT ready FROM mz_internal.mz_show_cluster_replicas LIMIT 0;
+
     """
             )
         )

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -615,7 +615,7 @@ def workflow_test_builtin_migration(c: Composition) -> None:
 
     c.down(destroy_volumes=True)
     with c.override(
-        # Random commit before pg_proc and mz_dataflow_operator_reachability was updated.
+        # Random commit before pg_proc and mz_dataflow_operator_reachability were updated.
         Materialized(
             image="materialize/materialized:devel-aa4128c9c485322f90ab0af2b9cb4d16e1c470c0",
             default_size=1,
@@ -648,6 +648,31 @@ def workflow_test_builtin_migration(c: Composition) -> None:
 
         c.kill("materialized")
 
+    with c.override(
+        # This will stop working if we introduce a breaking change.
+        Materialized(),
+        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True),
+    ):
+        c.up("testdrive", persistent=True)
+        c.up("materialized")
+        c.wait_for_materialized()
+
+        c.testdrive(
+            input=dedent(
+                """
+       > SELECT * FROM v1;
+       5
+       # This column is new after the migration
+       > SELECT DISTINCT proowner FROM pg_proc;
+       <null>
+
+       > SELECT pg_typeof(address) FROM mz_internal.mz_dataflow_operator_reachability LIMIT 1;
+       "uint8 list"
+    """
+            )
+        )
+
+    # Restart materialize and test that everything still works to ensure that the migration was persisted correctly.
     with c.override(
         # This will stop working if we introduce a breaking change.
         Materialized(),


### PR DESCRIPTION
Previously, the adapter was only updating the persisted definition of system objects that were directly migrated. If a system object was migrated because it depended on an upstream system object that was migrated, then its persisted definition was not updated. In these scenarios, the migrated system object definition would be lost after a system restart, leading to an inconsistent stash.

This commit updates the builtin migration framework so that the persisted definitions of all system objects are updated.

Fixes #16396

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
