### PR TITLE
Add system table that contains the aws privatelink connection principals

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -77,6 +77,11 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             V1EnvVar(name="AWS_ACCESS_KEY_ID", value="minio"),
             V1EnvVar(name="AWS_SECRET_ACCESS_KEY", value="minio123"),
             V1EnvVar(name="MZ_ANNOUNCE_EGRESS_IP", value="1.2.3.4,88.77.66.55"),
+            V1EnvVar(name="MZ_AWS_ACCOUNT_ID", value="123456789000"),
+            V1EnvVar(
+                name="MZ_AWS_EXTERNAL_ID_PREFIX",
+                value="eb5cb59b-e2fe-41f3-87ca-d2176a495345",
+            ),
         ]
 
         for (k, v) in self.env.items():

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -81,7 +81,9 @@ use crate::catalog::builtin::{
     INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
-pub use crate::catalog::config::{ClusterReplicaSizeMap, Config, StorageHostSizeMap};
+pub use crate::catalog::config::{
+    AwsPrincipalContext, ClusterReplicaSizeMap, Config, StorageHostSizeMap,
+};
 pub use crate::catalog::error::{AmbiguousRename, Error, ErrorKind};
 use crate::catalog::storage::{BootstrapArgs, Transaction};
 use crate::client::ConnectionId;
@@ -189,6 +191,7 @@ pub struct CatalogState {
     availability_zones: Vec<String>,
     system_configuration: SystemVars,
     egress_ips: Vec<Ipv4Addr>,
+    aws_principal_context: Option<AwsPrincipalContext>,
 }
 
 impl CatalogState {
@@ -2101,6 +2104,7 @@ impl<S: Append> Catalog<S> {
                 availability_zones: config.availability_zones,
                 system_configuration: SystemVars::default(),
                 egress_ips: config.egress_ips,
+                aws_principal_context: config.aws_principal_context,
             },
             transient_revision: 0,
             storage: Arc::new(Mutex::new(config.storage)),
@@ -3043,6 +3047,7 @@ impl<S: Append> Catalog<S> {
             availability_zones: vec![],
             secrets_reader,
             egress_ips: vec![],
+            aws_principal_context: None,
         })
         .await?;
         Ok(catalog)

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1532,6 +1532,14 @@ pub static MZ_EGRESS_IPS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty().with_column("egress_ip", ScalarType::String.nullable(false)),
 });
 
+pub static MZ_AWS_PRIVATELINK_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_aws_privatelink_connections",
+    schema: MZ_CATALOG_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("principal", ScalarType::String.nullable(false)),
+});
+
 pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_metrics",
     // TODO[btv] - make this public once we work out whether and how to fuse it with
@@ -2774,6 +2782,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_AUDIT_EVENTS),
         Builtin::Table(&MZ_STORAGE_USAGE_BY_SHARD),
         Builtin::Table(&MZ_EGRESS_IPS),
+        Builtin::Table(&MZ_AWS_PRIVATELINK_CONNECTIONS),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_ARRANGEMENT_SHARING),

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -15,8 +15,10 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use mz_build_info::BuildInfo;
+use mz_cloud_resources::AwsExternalIdPrefix;
 use mz_compute_client::controller::ComputeReplicaAllocation;
 use mz_ore::metrics::MetricsRegistry;
+use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 use mz_storage_client::types::hosts::StorageHostResourceAllocation;
 
@@ -56,6 +58,8 @@ pub struct Config<'a, S> {
     pub secrets_reader: Arc<dyn SecretsReader>,
     /// IP Addresses which will be used for egress.
     pub egress_ips: Vec<Ipv4Addr>,
+    /// Context for generating an AWS Principal.
+    pub aws_principal_context: Option<AwsPrincipalContext>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -150,6 +154,25 @@ impl Default for StorageHostSizeMap {
                     )
                 })
                 .collect::<HashMap<_, _>>(),
+        )
+    }
+}
+
+/// Context used to generate an AWS Principal.
+///
+/// In the case of AWS PrivateLink connections, Materialize will connect as the
+/// AWS Principal generated via this context.
+#[derive(Debug, Clone)]
+pub struct AwsPrincipalContext {
+    pub aws_account_id: String,
+    pub aws_external_id_prefix: AwsExternalIdPrefix,
+}
+
+impl AwsPrincipalContext {
+    pub fn to_principal_string(&self, aws_external_id_suffix: GlobalId) -> String {
+        format!(
+            "arn:aws:iam::{}:role/mz_{}_{}",
+            self.aws_account_id, self.aws_external_id_prefix, aws_external_id_suffix
         )
     }
 }

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -160,8 +160,8 @@ impl Default for StorageHostSizeMap {
 
 /// Context used to generate an AWS Principal.
 ///
-/// In the case of AWS PrivateLink connections, Materialize will connect as the
-/// AWS Principal generated via this context.
+/// In the case of AWS PrivateLink connections, Materialize will connect to the
+/// VPC endpoint as the AWS Principal generated via this context.
 #[derive(Debug, Clone)]
 pub struct AwsPrincipalContext {
     pub aws_account_id: String,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -116,8 +116,9 @@ use mz_transform::Optimizer;
 
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
 use crate::catalog::{
-    self, storage, BuiltinMigrationMetadata, BuiltinTableUpdate, Catalog, CatalogItem,
-    ClusterReplicaSizeMap, DataSourceDesc, StorageHostSizeMap, StorageSinkConnectionState,
+    self, storage, AwsPrincipalContext, BuiltinMigrationMetadata, BuiltinTableUpdate, Catalog,
+    CatalogItem, ClusterReplicaSizeMap, DataSourceDesc, StorageHostSizeMap,
+    StorageSinkConnectionState,
 };
 use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
@@ -255,6 +256,7 @@ pub struct Config<S> {
     pub egress_ips: Vec<Ipv4Addr>,
     pub consolidations_tx: mpsc::UnboundedSender<Vec<mz_stash::Id>>,
     pub consolidations_rx: mpsc::UnboundedReceiver<Vec<mz_stash::Id>>,
+    pub aws_account_id: Option<String>,
 }
 
 /// Soft-state metadata about a compute replica
@@ -1035,6 +1037,7 @@ pub async fn serve<S: Append + 'static>(
         egress_ips,
         consolidations_tx,
         consolidations_rx,
+        aws_account_id,
     }: Config<S>,
 ) -> Result<(Handle, Client), AdapterError> {
     info!("coordinator init: beginning");
@@ -1057,6 +1060,16 @@ pub async fn serve<S: Append + 'static>(
     // Coordinator::sequence_create_compute_replica.
     availability_zones.shuffle(&mut rand::thread_rng());
 
+    let aws_principal_context =
+        if aws_account_id.is_some() && connection_context.aws_external_id_prefix.is_some() {
+            Some(AwsPrincipalContext {
+                aws_account_id: aws_account_id.unwrap(),
+                aws_external_id_prefix: connection_context.aws_external_id_prefix.clone().unwrap(),
+            })
+        } else {
+            None
+        };
+
     info!("coordinator init: opening catalog");
     let (mut catalog, builtin_migration_metadata, builtin_table_updates, _last_catalog_version) =
         Catalog::open(catalog::Config {
@@ -1075,6 +1088,7 @@ pub async fn serve<S: Append + 'static>(
             availability_zones,
             secrets_reader: secrets_controller.reader(),
             egress_ips,
+            aws_principal_context,
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -419,6 +419,10 @@ pub struct Args {
     )]
     announce_egress_ip: Vec<Ipv4Addr>,
 
+    /// The 12-digit AWS account id, which is used to generate an AWS Principal.
+    #[clap(long, env = "AWS_ACCOUNT_ID")]
+    aws_account_id: Option<String>,
+
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
@@ -768,6 +772,7 @@ max log level: {max_log_level}",
         storage_usage_collection_interval: args.storage_usage_collection_interval_sec,
         segment_api_key: args.segment_api_key,
         egress_ips: args.announce_egress_ip,
+        aws_account_id: args.aws_account_id,
     }))?;
 
     metrics.start_time_environmentd.set(

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -119,6 +119,8 @@ pub struct Config {
     pub segment_api_key: Option<String>,
     /// IP Addresses which will be used for egress.
     pub egress_ips: Vec<Ipv4Addr>,
+    /// 12-digit AWS account id, which will be used to generate an AWS Principal.
+    pub aws_account_id: Option<String>,
 
     // === Tracing options. ===
     /// The metrics registry to use.
@@ -307,6 +309,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         egress_ips: config.egress_ips,
         consolidations_tx,
         consolidations_rx,
+        aws_account_id: config.aws_account_id,
     })
     .await?;
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -249,6 +249,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         storage_usage_collection_interval: config.storage_usage_collection_interval,
         segment_api_key: None,
         egress_ips: vec![],
+        aws_account_id: None,
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -707,6 +707,7 @@ impl Runner {
             storage_usage_collection_interval: Duration::from_secs(3600),
             segment_api_key: None,
             egress_ips: vec![],
+            aws_account_id: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -339,6 +339,7 @@ impl Usage {
             availability_zones: vec![],
             secrets_reader,
             egress_ips: vec![],
+            aws_principal_context: None,
         })
         .await?;
 

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -83,8 +83,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
     )[0][0]
 
     assert principal == (
-        "arn:aws:iam::123456789000:role/mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_"
-        + aws_connection_id
+        f"arn:aws:iam::123456789000:role/mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_{aws_connection_id}"
     )
 
     mz.environmentd.sql(

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -78,6 +78,15 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
         0
     ][0]
 
+    principal = mz.environmentd.sql_query(
+        "SELECT principal FROM mz_aws_privatelink_connections"
+    )[0][0]
+
+    assert principal == (
+        "arn:aws:iam::123456789000:role/mz_eb5cb59b-e2fe-41f3-87ca-d2176a495345_"
+        + aws_connection_id
+    )
+
     mz.environmentd.sql(
         dedent(
             """\

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -50,6 +50,10 @@ mz_audit_events
 BASE TABLE
 materialize
 mz_catalog
+mz_aws_privatelink_connections
+BASE TABLE
+materialize
+mz_catalog
 mz_base_types
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -457,6 +457,7 @@ name
 -----------------------------
 mz_array_types
 mz_audit_events
+mz_aws_privatelink_connections
 mz_base_types
 mz_clusters
 mz_cluster_replicas
@@ -571,7 +572,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-33
+34
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
Addresses #16446 (as part of #16140).
Exposes AWS PrivateLink connection principal in SQL via new system table `mz_aws_privatelink_connections` with columns `id` and `principal`.
Generates the principal via
1) flags passed into evironmentd: `MZ_AWS_ACCOUNT_ID` (added in this PR) and `MZ_AWS_EXTERNAL_ID_PREFIX` (already added and used by storage)
2) global id of the connection

### Tips for reviewer
* I'd appreciate some suggestions for the comment describing the `MZ_AWS_ACCOUNT_ID` flag and `AwsPrincipalContext` object, from someone who has more knowledge on aws privatelink, principals, and accounts.
* How should I handle the error case in `src/adapter/src/catalog/builtin_table_updates.rs`? I currently throw a `tracing::error!` but I'm not sure if we want something more severe to happen.
* Is there any way to test this locally? It would be nice to do some thorough stress testing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
