### PR TITLE
environmentd: periodically report environment summaries to Segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,6 +3617,7 @@ dependencies = [
  "mz-prof",
  "mz-repr",
  "mz-secrets",
+ "mz-segment",
  "mz-service",
  "mz-sql",
  "mz-stash",

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -160,11 +160,14 @@ impl<S: Append + 'static> Coordinator<S> {
                 // We use an `if let` here because the peek could have been canceled already.
                 // We can also potentially receive multiple `Complete` responses, followed by
                 // a `Dropped` response.
-                if let Some(pending_subscribes) = self.pending_subscribes.get_mut(&sink_id) {
-                    let remove = pending_subscribes.process_response(response);
+                if let Some(pending_subscribe) = self.pending_subscribes.get_mut(&sink_id) {
+                    let remove = pending_subscribe.process_response(response);
                     if remove {
+                        self.metrics
+                            .active_subscribes
+                            .with_label_values(&[pending_subscribe.session_type])
+                            .dec();
                         self.pending_subscribes.remove(&sink_id);
-                        self.metrics.active_subscribes.dec();
                     }
                 }
             }

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -43,6 +43,7 @@ mod util;
 pub mod catalog;
 pub mod client;
 pub mod config;
+pub mod metrics;
 pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -137,6 +137,11 @@ impl<T: TimestampManipulation> Session<T> {
         &self.transaction().inner().unwrap().pcx
     }
 
+    /// Reports whether the session is a system session.
+    pub fn is_system(&self) -> bool {
+        crate::catalog::is_reserved_name(&self.user().name)
+    }
+
     /// Starts an explicit transaction, or changes an implicit to an explicit
     /// transaction.
     pub fn start_transaction(

--- a/src/adapter/src/subscribe.rs
+++ b/src/adapter/src/subscribe.rs
@@ -18,34 +18,20 @@ use mz_repr::{Datum, Row};
 use crate::coord::peek::PeekResponseUnary;
 
 /// A description of a pending subscribe from coord's perspective
-pub(crate) struct PendingSubscribe {
+pub struct PendingSubscribe {
+    /// The type of the session that created the subscribe.
+    pub session_type: &'static str,
     /// Channel to send responses to the client
     ///
     /// The responses have the form `PeekResponseUnary` but should perhaps become `TailResponse`.
-    channel: mpsc::UnboundedSender<PeekResponseUnary>,
+    pub channel: mpsc::UnboundedSender<PeekResponseUnary>,
     /// Whether progress information should be emitted
-    emit_progress: bool,
+    pub emit_progress: bool,
     /// Number of columns in the output
-    arity: usize,
+    pub arity: usize,
 }
 
 impl PendingSubscribe {
-    /// Create a new [PendingSubscribe].
-    /// * The `channel` receives batches of finalized PeekResponses.
-    /// * If `emit_progress` is true, the finalized rows are either data or progress updates
-    /// * `arity` is the arity of the sink relation.
-    pub(crate) fn new(
-        channel: mpsc::UnboundedSender<PeekResponseUnary>,
-        emit_progress: bool,
-        arity: usize,
-    ) -> Self {
-        Self {
-            channel,
-            emit_progress,
-            arity,
-        }
-    }
-
     /// Process a subscribe response
     ///
     /// Returns `true` if the sink should be removed.

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -48,6 +48,7 @@ mz-postgres-util = { path = "../postgres-util" }
 mz-prof = { path = "../prof" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
+mz-segment = { path = "../segment" }
 mz-service = { path = "../service" }
 mz-sql = { path = "../sql" }
 mz-stash = { path = "../stash" }

--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -1,0 +1,160 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Telemetry collection.
+
+// To test this module, you'll need to run environmentd with the following
+// flags.
+//
+//   --tls-mode=disable
+//   --segment-api-key=<REDACTED>
+//   --frontegg-tenant=<REDACTED>
+//   --frontegg-jwk=<REDACTED>
+//   --frontegg-api-token-url=<REDACTED>
+//   --frontegg-password-prefix=mzp_
+//
+// Use values from a personal Materialize Cloud stack for the values that
+// are listed as <REDACTED>.
+//
+// You can then use the Segment debugger to watch the events emitted by your
+// environment in real time:
+// https://app.segment.com/materializeinc/sources/cloud_dev/debugger.
+
+use serde::Serialize;
+use serde_json::json;
+use tokio::time::{self, Duration};
+use tracing::warn;
+use uuid::Uuid;
+
+use mz_ore::collections::CollectionExt;
+use mz_ore::retry::Retry;
+use mz_ore::task;
+
+/// How frequently to send a summary to Segment.
+const REPORT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Telemetry configuration.
+#[derive(Clone)]
+pub struct Config {
+    /// The Segment client to report telemetry events to.
+    pub segment_client: mz_segment::Client,
+    /// A client to the adapter to introspect.
+    pub adapter_client: mz_adapter::Client,
+    /// The ID of the organization for which to report data.
+    pub organization_id: Uuid,
+}
+
+/// Starts reporting telemetry events to Segment.
+pub fn start_reporting(config: Config) {
+    task::spawn(|| "telemetry_rollup", report_rollup_loop(config.clone()));
+    task::spawn(|| "telemetry_traits", report_traits_loop(config));
+}
+
+async fn report_rollup_loop(
+    Config {
+        segment_client,
+        adapter_client,
+        organization_id,
+    }: Config,
+) {
+    #[derive(Default)]
+    struct Rollup {
+        selects: u64,
+        subscribes: u64,
+    }
+
+    let mut interval = time::interval(REPORT_INTERVAL);
+
+    // The first tick always completes immediately. Ignore it.
+    interval.tick().await;
+
+    let mut last_rollup = Rollup::default();
+    loop {
+        interval.tick().await;
+
+        let query_total = &adapter_client.metrics().query_total;
+        let current_rollup = Rollup {
+            selects: query_total.with_label_values(&["user", "select"]).get(),
+            subscribes: query_total.with_label_values(&["user", "subscribe"]).get(),
+        };
+
+        segment_client.track(
+            // We use the organization ID as the user ID for events
+            // that are not associated with a particular user.
+            organization_id,
+            "Environment Rolled Up",
+            json!({
+                "event_source": "environmentd",
+                "selects": current_rollup.selects - last_rollup.selects,
+                "subscribes": current_rollup.subscribes - last_rollup.subscribes,
+            }),
+            Some(json!({
+                "groupId": organization_id,
+            })),
+        );
+
+        last_rollup = current_rollup;
+    }
+}
+
+async fn report_traits_loop(
+    Config {
+        segment_client,
+        adapter_client,
+        organization_id,
+    }: Config,
+) {
+    const QUERY: &str = "SELECT
+    (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%') AS active_sources,
+    (SELECT count(*) FROM mz_sinks WHERE id LIKE 'u%') AS active_sinks";
+
+    #[derive(Debug, Serialize)]
+    struct Traits {
+        active_sources: i64,
+        active_sinks: i64,
+        active_subscribes: i64,
+    }
+
+    let mut interval = time::interval(REPORT_INTERVAL);
+    loop {
+        interval.tick().await;
+
+        let traits = Retry::default()
+            .initial_backoff(Duration::from_secs(1))
+            .max_tries(5)
+            .retry_async(|_state| async {
+                let rows = adapter_client.introspection_execute_one(QUERY).await?;
+                let row = rows.into_element();
+                let mut row = row.iter();
+                Ok::<_, anyhow::Error>(serde_json::to_value(Traits {
+                    active_sources: row.next().unwrap().unwrap_int64(),
+                    active_sinks: row.next().unwrap().unwrap_int64(),
+                    active_subscribes: adapter_client
+                        .metrics()
+                        .active_subscribes
+                        .with_label_values(&["user"])
+                        .get(),
+                })?)
+            })
+            .await;
+
+        match traits {
+            Ok(traits) => {
+                segment_client.group(
+                    // We use the organization ID as the user ID for events
+                    // that are not associated with a particular user.
+                    organization_id,
+                    organization_id,
+                    traits,
+                );
+            }
+            Err(e) => warn!("unable to collect telemetry traits: {e}"),
+        }
+    }
+}

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -259,6 +259,10 @@ impl FronteggAuthentication {
             }
         }))
     }
+
+    pub fn tenant_id(&self) -> Uuid {
+        self.tenant_id
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
This commit adds a telemetry loop, similar to what we had in the old binary days, to environmentd.

Every hour, we report:

  * the current active sources, sinks, and subscribes as properties of the organization to Segment, via a group call.

  * the number of SELECT and SUBSCRIBE statements made in the last hour, as a "Environment Rolled Up" track event.

The idea is that tools that want the most up-to-date description of an environment can look at the rolled up state in the `accounts` table, while tools that want an hour-by-hour accounting of how active an environment is can watch for "Environment Rolled Up" events.

Fix MaterializeInc/cloud#4734.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
