### PR TITLE
ore: fix typo of tracing feature

### DIFF
--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -74,13 +74,13 @@ pub mod task;
 #[cfg(feature = "test")]
 pub mod test;
 pub mod thread;
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing")))]
-#[cfg(feature = "tracing")]
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing_")))]
+#[cfg(feature = "tracing_")]
 pub mod tracing;
 pub mod vec;
 
 #[doc(hidden)]
 pub mod __private {
-    #[cfg(feature = "tracing")]
+    #[cfg(feature = "tracing_")]
     pub use tracing;
 }

--- a/src/ore/src/process.rs
+++ b/src/ore/src/process.rs
@@ -41,8 +41,8 @@ use std::sync::atomic::AtomicBool;
 ///
 /// If you need to write a Rust libtest test that asserts that a call to halt
 /// has occcurred, see [`PANIC_ON_HALT`].
-#[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing")))]
-#[cfg(feature = "tracing")]
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "tracing_")))]
+#[cfg(feature = "tracing_")]
 #[macro_export]
 macro_rules! halt {
     ($($arg:expr),* $(,)?) => {{


### PR DESCRIPTION
### Motivation

When the tracing feature was not enabled there were compilation errors in ore due to this.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->
