### PR TITLE
Remove `id_gen` field from `TransformArgs`

### DIFF
--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -35,7 +35,6 @@
 //! // .transform() will deduplicate any predicates
 //! use mz_transform::{Transform, TransformArgs};
 //! Filter.transform(&mut expr, TransformArgs {
-//!   id_gen: &mut Default::default(),
 //!   indexes: &mz_transform::EmptyIndexOracle,
 //! });
 //!

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -67,8 +67,6 @@ extern crate num_derive;
 /// Arguments that get threaded through all transforms.
 #[derive(Debug)]
 pub struct TransformArgs<'a> {
-    /// A shared instance of IdGen to allow constructing new Let expressions.
-    pub id_gen: &'a mut IdGen,
     /// The indexes accessible.
     pub indexes: &'a dyn IndexOracle,
 }
@@ -182,7 +180,6 @@ impl Transform for Fixpoint {
                         transform.transform(
                             relation,
                             TransformArgs {
-                                id_gen: args.id_gen,
                                 indexes: args.indexes,
                             },
                         )?;
@@ -206,7 +203,6 @@ impl Transform for Fixpoint {
             transform.transform(
                 relation,
                 TransformArgs {
-                    id_gen: args.id_gen,
                     indexes: args.indexes,
                 },
             )?;
@@ -289,7 +285,6 @@ impl Transform for FuseAndCollapse {
             transform.transform(
                 relation,
                 TransformArgs {
-                    id_gen: args.id_gen,
                     indexes: args.indexes,
                 },
             )?;
@@ -485,15 +480,8 @@ impl Optimizer {
         relation: &mut MirRelationExpr,
         indexes: &dyn IndexOracle,
     ) -> Result<(), TransformError> {
-        let mut id_gen = Default::default();
         for transform in self.transforms.iter() {
-            transform.transform(
-                relation,
-                TransformArgs {
-                    id_gen: &mut id_gen,
-                    indexes,
-                },
-            )?;
+            transform.transform(relation, TransformArgs { indexes })?;
         }
 
         Ok(())

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -59,7 +59,6 @@
 //!
 //! use mz_transform::{Transform, TransformArgs};
 //! PredicatePushdown::default().transform(&mut expr, TransformArgs {
-//!   id_gen: &mut Default::default(),
 //!   indexes: &mz_transform::EmptyIndexOracle,
 //! });
 //!

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -67,10 +67,10 @@ impl UpdateLet {
     pub fn transform_without_trace(
         &self,
         relation: &mut MirRelationExpr,
-        args: TransformArgs,
+        _args: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        *args.id_gen = IdGen::default(); // Get a fresh IdGen.
-        self.action(relation, &mut HashMap::new(), args.id_gen)
+        let mut id_gen = IdGen::default(); // Get a fresh IdGen.
+        self.action(relation, &mut HashMap::new(), &mut id_gen)
     }
 
     /// Re-assign type information and identifier to each `Get`.

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -123,12 +123,10 @@ mod tests {
         test_type: TestType,
     ) -> Result<String, Error> {
         let mut rel = parse_relation(s, cat, args)?;
-        let mut id_gen = Default::default();
         for t in args.get("apply").cloned().unwrap_or_else(Vec::new).iter() {
             get_transform(t)?.transform(
                 &mut rel,
                 TransformArgs {
-                    id_gen: &mut id_gen,
                     indexes: &EmptyIndexOracle,
                 },
             )?;
@@ -142,7 +140,6 @@ mod tests {
                     transform.transform(
                         &mut rel,
                         TransformArgs {
-                            id_gen: &mut id_gen,
                             indexes: &EmptyIndexOracle,
                         },
                     )?;
@@ -166,7 +163,6 @@ mod tests {
                         transform.transform(
                             &mut rel,
                             TransformArgs {
-                                id_gen: &mut id_gen,
                                 indexes: &EmptyIndexOracle,
                             },
                         )?;


### PR DESCRIPTION
No one uses this field, and the one transform that might have must intentionally avoid doing so. Presenting it seems to be a bit of a footgun, as it is unclear to implementors if it must be used and when it is we end up failing to reach an expression fixed point.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
