### PR TITLE
compute,storage: install timely_util panic hook after sentry hook

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -96,7 +96,6 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    mz_timely_util::panic::halt_on_timely_communication_panic();
     let (tracing_target_callbacks, _sentry_guard) = mz_ore::tracing::configure(
         "computed",
         &args.tracing,
@@ -104,6 +103,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         (BUILD_INFO.version, BUILD_INFO.sha, BUILD_INFO.time),
     )
     .await?;
+
+    // Keep this _after_ the mz_ore::tracing::configure call so that its panic
+    // hook runs _before_ the one that sends things to sentry.
+    mz_timely_util::panic::halt_on_timely_communication_panic();
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {

--- a/src/storage/src/bin/storaged.rs
+++ b/src/storage/src/bin/storaged.rs
@@ -128,7 +128,6 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    mz_timely_util::panic::halt_on_timely_communication_panic();
     let (tracing_target_callbacks, _sentry_guard) = mz_ore::tracing::configure(
         "storaged",
         &args.tracing,
@@ -136,6 +135,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         (BUILD_INFO.version, BUILD_INFO.sha, BUILD_INFO.time),
     )
     .await?;
+
+    // Keep this _after_ the mz_ore::tracing::configure call so that its panic
+    // hook runs _before_ the one that sends things to sentry.
+    mz_timely_util::panic::halt_on_timely_communication_panic();
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {


### PR DESCRIPTION
So we don't send these "timely communication error" panics to Sentry.

https://sentry.io/organizations/materializeinc/issues/3732193399/
https://sentry.io/organizations/materializeinc/issues/3732193441/

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
