### PR TITLE
adapter: Add size of system tables to boot logs

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -876,7 +876,11 @@ impl<S: Append + 'static> Coordinator<S> {
                 .snapshot(system_table.id(), read_ts)
                 .await
                 .unwrap();
-            info!("coordinator init: table size {}", current_contents.len());
+            info!(
+                "coordinator init: table size {} elements, {} bytes",
+                current_contents.len(),
+                std::mem::size_of_val(&*current_contents),
+            );
             let retractions = current_contents
                 .into_iter()
                 .map(|(row, diff)| BuiltinTableUpdate {


### PR DESCRIPTION


### Motivation
Add logs


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
