### PR TITLE
interchange: don't crash on invalid Avro field/record names

### DIFF
--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -20,6 +20,7 @@ digest = "0.10.6"
 enum-kinds = "0.5.1"
 flate2 = "1.0.24"
 itertools = "0.10.5"
+once_cell = "1.16.0"
 rand = "0.8.5"
 regex = "1.7.0"
 serde = { version = "1.0.147", features = ["derive"] }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -165,7 +165,7 @@ mod tests {
         ];
         for (typ, datum, expected) in valid_pairings {
             let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
-            let schema_generator = AvroSchemaGenerator::new(None, None, None, desc, false);
+            let schema_generator = AvroSchemaGenerator::new(None, None, None, desc, false).unwrap();
             let avro_value =
                 encode_datums_as_avro(std::iter::once(datum), schema_generator.value_columns());
             assert_eq!(

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -282,7 +282,8 @@ mod tests {
             &crate::encode::column_names_and_types(desc),
             "data",
             &HashMap::new(),
-        );
+        )
+        .unwrap();
         let schema = build_schema(row_schema);
 
         let values = vec![

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2072,7 +2072,7 @@ fn kafka_sink_builder(
                     .map(|(desc, _indices)| desc.clone()),
                 value_desc.clone(),
                 matches!(envelope, SinkEnvelope::Debezium),
-            );
+            )?;
             let value_schema = schema_generator.value_writer_schema().to_string();
             let key_schema = schema_generator
                 .key_writer_schema()

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -926,7 +926,8 @@ where
                 key_desc,
                 value_desc,
                 matches!(envelope, Some(SinkEnvelope::Debezium)),
-            );
+            )
+            .expect("avro schema validated");
             let encoder = AvroEncoder::new(schema_generator, key_schema_id, value_schema_id);
             encode_stream(
                 stream,

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -164,7 +164,34 @@ $ schema-registry-verify schema-type=avro subject=testdrive-namespace-key-value-
 $ kafka-verify-data format=avro sink=materialize.public.namespace_key_value_sink sort-messages=true
 {"b": 2} {"before": null, "after": {"row": {"a": 1, "b": 2}}}
 
+# Test a sink over a view whose column names are not directly usable as
+# Avro schema names.
+
+> CREATE MATERIALIZED VIEW tricky_names AS SELECT 1 AS "tricky-name", 1 AS "tricky!name", 1 AS "tricky@name", 1 AS "666";
+
+> CREATE SINK tricky_sink FROM tricky_names
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-tricky-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ schema-registry-verify schema-type=avro subject=testdrive-tricky-sink-${testdrive.seed}-value
+{"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"tricky_name","type":"int"},{"name":"tricky_name1","type":"int"},{"name":"tricky_name2","type":"int"},{"name":"_666","type":"int"}]}]},{"name":"after","type":["null","row"]}]}
+
 # Bad Sinks
+
+! CREATE SINK bad_sink FROM namespace_key_value_data
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bad-sink-${testdrive.seed}')
+  KEY (b)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'bad-name', AVRO VALUE FULLNAME = 'goodname')
+  ENVELOPE DEBEZIUM
+contains:Invalid name. Must start with [A-Za-z_] and subsequently only contain [A-Za-z0-9_]. Found: bad-name
+
+! CREATE SINK bad_sink FROM namespace_key_value_data
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bad-sink-${testdrive.seed}')
+  KEY (b)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'goodname', AVRO VALUE FULLNAME = 'bad-name')
+  ENVELOPE DEBEZIUM
+contains:Invalid name. Must start with [A-Za-z_] and subsequently only contain [A-Za-z0-9_]. Found: bad-name
 
 > CREATE MATERIALIZED VIEW input (a, b) AS SELECT * FROM (VALUES (1, 2))
 


### PR DESCRIPTION
Not super sure who owns this code right now, so requested review from @umanwizard (because Avro) and @bkirwi (because sinks).

----

When creating an Avro schema for a Kafka sink, we were using user-supplied field and record names, but not validating that they were actually valid for use as a name in an Avro schema, resulting in a panic.

This commit makes two changes:

  * Column names that are not directly usable as field names in an Avro record are munged to be valid. Leading numbers are prefixed with an underscore, and any other invalid characters are replaced with an underscore. If this results in duplicate names, the names are suffixed with an incrementing number, as in "foo", "foo1", "foo2".

  * The AVRO KEY FULLNAME and AVRO VALUE FULLNAME options are gracefully rejected if they are not directly valid as Avro names.

Fix #16372.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Gracefully return an error rather than crashing if the value of the `AVRO KEY FULLNAME` or `AVRO VALUE FULLNAME` option in an Avro-formatted Kafka sink is not a valid Avro name.
