### PR TITLE
Refactor show command logic in parser 

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1861,7 +1861,6 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
 }
 impl_display_t!(ShowObjectsStatement);
 
-
 /// `SHOW COLUMNS`
 ///
 /// Note: this is a MySQL-specific statement.
@@ -2754,7 +2753,6 @@ impl<T: AstInfo> AstDisplay for ShowStatement<T> {
             ShowStatement::ShowDatabases(stmt) => f.write_node(stmt),
             ShowStatement::ShowSchemas(stmt) => f.write_node(stmt),
             ShowStatement::ShowObjects(stmt) => f.write_node(stmt),
-            // ShowStatement::ShowIndexes(stmt) => f.write_node(stmt),
             ShowStatement::ShowColumns(stmt) => f.write_node(stmt),
             ShowStatement::ShowCreateView(stmt) => f.write_node(stmt),
             ShowStatement::ShowCreateMaterializedView(stmt) => f.write_node(stmt),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1774,6 +1774,27 @@ impl<T: AstInfo> AstDisplay for ShowSchemasStatement<T> {
 }
 impl_display_t!(ShowSchemasStatement);
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ShowObjectType<T: AstInfo> {
+    MaterializedView {
+        in_cluster: Option<T::ClusterName>,
+    },
+    Index {
+        in_cluster: Option<T::ClusterName>,
+        on_object: Option<T::ObjectName>,
+    },
+    Table,
+    View,
+    Source,
+    Sink,
+    Type,
+    Role,
+    Cluster,
+    ClusterReplica,
+    Object,
+    Secret,
+    Connection,
+}
 /// `SHOW <object>S`
 ///
 /// ```sql
@@ -1784,9 +1805,8 @@ impl_display_t!(ShowSchemasStatement);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowObjectsStatement<T: AstInfo> {
-    pub object_type: ObjectType,
+    pub object_type: ShowObjectType<T>,
     pub from: Option<T::SchemaName>,
-    pub in_cluster: Option<T::ClusterName>,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
@@ -1795,27 +1815,43 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
         f.write_str("SHOW");
         f.write_str(" ");
         f.write_str(match &self.object_type {
-            ObjectType::Table => "TABLES",
-            ObjectType::View => "VIEWS",
-            ObjectType::MaterializedView => "MATERIALIZED VIEWS",
-            ObjectType::Source => "SOURCES",
-            ObjectType::Sink => "SINKS",
-            ObjectType::Type => "TYPES",
-            ObjectType::Role => "ROLES",
-            ObjectType::Cluster => "CLUSTERS",
-            ObjectType::ClusterReplica => "CLUSTER REPLICAS",
-            ObjectType::Object => "OBJECTS",
-            ObjectType::Secret => "SECRETS",
-            ObjectType::Connection => "CONNECTIONS",
-            ObjectType::Index => unreachable!(),
+            ShowObjectType::Table => "TABLES",
+            ShowObjectType::View => "VIEWS",
+            ShowObjectType::Source => "SOURCES",
+            ShowObjectType::Sink => "SINKS",
+            ShowObjectType::Type => "TYPES",
+            ShowObjectType::Role => "ROLES",
+            ShowObjectType::Cluster => "CLUSTERS",
+            ShowObjectType::ClusterReplica => "CLUSTER REPLICAS",
+            ShowObjectType::Object => "OBJECTS",
+            ShowObjectType::Secret => "SECRETS",
+            ShowObjectType::Connection => "CONNECTIONS",
+            ShowObjectType::MaterializedView { .. } => "MATERIALIZED VIEWS",
+            ShowObjectType::Index { .. } => "INDEXES",
         });
+
+        if let ShowObjectType::Index { on_object, .. } = &self.object_type {
+            if let Some(on_object) = on_object {
+                f.write_str(" ON ");
+                f.write_node(on_object);
+            }
+        }
+
         if let Some(from) = &self.from {
             f.write_str(" FROM ");
             f.write_node(from);
         }
-        if let Some(cluster) = &self.in_cluster {
-            f.write_str(" IN CLUSTER ");
-            f.write_node(cluster);
+
+        // append IN CLUSTER clause
+        match &self.object_type {
+            ShowObjectType::MaterializedView { in_cluster }
+            | ShowObjectType::Index { in_cluster, .. } => {
+                if let Some(cluster) = in_cluster {
+                    f.write_str(" IN CLUSTER ");
+                    f.write_node(cluster);
+                }
+            }
+            _ => (),
         }
         if let Some(filter) = &self.filter {
             f.write_str(" ");
@@ -1825,38 +1861,6 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
 }
 impl_display_t!(ShowObjectsStatement);
 
-/// `SHOW INDEX|INDEXES|KEYS`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ShowIndexesStatement<T: AstInfo> {
-    pub on_object: Option<T::ObjectName>,
-    pub from_schema: Option<T::SchemaName>,
-    pub in_cluster: Option<T::ClusterName>,
-    pub filter: Option<ShowStatementFilter<T>>,
-}
-
-impl<T: AstInfo> AstDisplay for ShowIndexesStatement<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        f.write_str("SHOW ");
-        f.write_str("INDEXES");
-        if let Some(on_object) = &self.on_object {
-            f.write_str(" ON ");
-            f.write_node(on_object);
-        }
-        if let Some(from_schema) = &self.from_schema {
-            f.write_str(" FROM ");
-            f.write_node(from_schema);
-        }
-        if let Some(in_cluster) = &self.in_cluster {
-            f.write_str(" IN CLUSTER ");
-            f.write_node(in_cluster);
-        }
-        if let Some(filter) = &self.filter {
-            f.write_str(" ");
-            f.write_node(filter);
-        }
-    }
-}
-impl_display_t!(ShowIndexesStatement);
 
 /// `SHOW COLUMNS`
 ///
@@ -2733,7 +2737,6 @@ pub enum ShowStatement<T: AstInfo> {
     ShowDatabases(ShowDatabasesStatement<T>),
     ShowSchemas(ShowSchemasStatement<T>),
     ShowObjects(ShowObjectsStatement<T>),
-    ShowIndexes(ShowIndexesStatement<T>),
     ShowColumns(ShowColumnsStatement<T>),
     ShowCreateView(ShowCreateViewStatement<T>),
     ShowCreateMaterializedView(ShowCreateMaterializedViewStatement<T>),
@@ -2751,7 +2754,7 @@ impl<T: AstInfo> AstDisplay for ShowStatement<T> {
             ShowStatement::ShowDatabases(stmt) => f.write_node(stmt),
             ShowStatement::ShowSchemas(stmt) => f.write_node(stmt),
             ShowStatement::ShowObjects(stmt) => f.write_node(stmt),
-            ShowStatement::ShowIndexes(stmt) => f.write_node(stmt),
+            // ShowStatement::ShowIndexes(stmt) => f.write_node(stmt),
             ShowStatement::ShowColumns(stmt) => f.write_node(stmt),
             ShowStatement::ShowCreateView(stmt) => f.write_node(stmt),
             ShowStatement::ShowCreateMaterializedView(stmt) => f.write_node(stmt),

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1188,7 +1188,7 @@ SHOW SECRETS
 ----
 SHOW SECRETS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Secret, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Secret, from: None, filter: None }))
 
 parse-statement
 ALTER SECRET secret RENAME TO secret2

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1284,7 +1284,7 @@ SELECT * FROM (SHOW TABLES)
 ----
 SELECT * FROM (SHOW TABLES)
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: None })), order_by: [], limit: None, offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, filter: None })), order_by: [], limit: None, offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT NULLIF(x, '')

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -37,21 +37,21 @@ SHOW ROLES
 ----
 SHOW ROLES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, filter: None }))
 
 parse-statement
 SHOW CLUSTERS
 ----
 SHOW CLUSTERS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, filter: None }))
 
 parse-statement
 SHOW USERS
 ----
 SHOW ROLES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, filter: None }))
 
 parse-statement
 SHOW SCHEMAS
@@ -72,70 +72,70 @@ SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, filter: None }))
 
 parse-statement
 SHOW SOURCES FROM foo.bar
 ----
 SHOW SOURCES FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), filter: None }))
 
 parse-statement
 SHOW VIEWS
 ----
 SHOW VIEWS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: View, from: None, filter: None }))
 
 parse-statement
 SHOW VIEWS FROM foo.bar
 ----
 SHOW VIEWS FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS
 ----
 SHOW MATERIALIZED VIEWS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView { in_cluster: None }, from: None, filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS FROM foo.bar
 ----
 SHOW MATERIALIZED VIEWS FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView { in_cluster: None }, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS FROM foo.bar IN CLUSTER baz
 ----
 SHOW MATERIALIZED VIEWS FROM foo.bar IN CLUSTER baz
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView { in_cluster: Some(Unresolved(Ident("baz"))) }, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS IN CLUSTER baz
 ----
 SHOW MATERIALIZED VIEWS IN CLUSTER baz
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: None, in_cluster: Some(Unresolved(Ident("baz"))), filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView { in_cluster: Some(Unresolved(Ident("baz"))) }, from: None, filter: None }))
 
 parse-statement
 SHOW TABLES
 ----
 SHOW TABLES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, filter: None }))
 
 parse-statement
 SHOW TABLES FROM foo.bar
 ----
 SHOW TABLES FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), filter: None }))
 
 parse-statement
 SHOW TABLES IN CLUSTER baz
@@ -149,14 +149,14 @@ SHOW SINKS
 ----
 SHOW SINKS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, filter: None }))
 
 parse-statement
 SHOW SINKS FROM foo.bar
 ----
 SHOW SINKS FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), filter: None }))
 
 parse-statement
 SHOW SINKS FROM foo.bar IN CLUSTER baz
@@ -170,77 +170,70 @@ SHOW TABLES LIKE '%foo%'
 ----
 SHOW TABLES LIKE '%foo%'
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: Some(Like("%foo%")) }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, filter: Some(Like("%foo%")) }))
 
 parse-statement
 SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, filter: None }))
 
 parse-statement
 SHOW VIEWS FROM foo LIKE '%foo%'
 ----
 SHOW VIEWS FROM foo LIKE '%foo%'
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo")])), in_cluster: None, filter: Some(Like("%foo%")) }))
+Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo")])), filter: Some(Like("%foo%")) }))
 
 parse-statement
 SHOW INDEXES ON foo
 ----
 SHOW INDEXES ON foo
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: Some(Name(UnresolvedObjectName([Ident("foo")]))), from_schema: None, in_cluster: None, filter: None }))
-
-parse-statement
-SHOW INDEXES ON foo
-----
-SHOW INDEXES ON foo
-=>
-Show(ShowIndexes(ShowIndexesStatement { on_object: Some(Name(UnresolvedObjectName([Ident("foo")]))), from_schema: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: None, on_object: Some(Name(UnresolvedObjectName([Ident("foo")]))) }, from: None, filter: None }))
 
 parse-statement
 SHOW INDEXES
 ----
 SHOW INDEXES
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: None, on_object: None }, from: None, filter: None }))
 
 parse-statement
 SHOW INDEXES IN CLUSTER c
 ----
 SHOW INDEXES IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: None, in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: Some(Unresolved(Ident("c"))), on_object: None }, from: None, filter: None }))
 
 parse-statement
 SHOW INDEXES ON t IN CLUSTER c
 ----
 SHOW INDEXES ON t IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: Some(Name(UnresolvedObjectName([Ident("t")]))), from_schema: None, in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: Some(Unresolved(Ident("c"))), on_object: Some(Name(UnresolvedObjectName([Ident("t")]))) }, from: None, filter: None }))
 
 parse-statement
 SHOW INDEXES FROM s
 ----
 SHOW INDEXES FROM s
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: Some(UnresolvedSchemaName([Ident("s")])), in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: None, on_object: None }, from: Some(UnresolvedSchemaName([Ident("s")])), filter: None }))
 
 parse-statement
 SHOW INDEXES FROM s IN CLUSTER c
 ----
 SHOW INDEXES FROM s IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: Some(UnresolvedSchemaName([Ident("s")])), in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: Some(Unresolved(Ident("c"))), on_object: None }, from: Some(UnresolvedSchemaName([Ident("s")])), filter: None }))
 
 parse-statement
 SHOW INDEXES LIKE 'pattern'
 ----
 SHOW INDEXES LIKE 'pattern'
 =>
-Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: None, in_cluster: None, filter: Some(Like("pattern")) }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Index { in_cluster: None, on_object: None }, from: None, filter: Some(Like("pattern")) }))
 
 parse-statement
 SHOW INDEXES FROM s ON t
@@ -338,7 +331,7 @@ SHOW CLUSTERS
 ----
 SHOW CLUSTERS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, filter: None }))
 
 # TODO(justin): "all" here should be its own token so that it doesn't get
 # downcased.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1326,9 +1326,6 @@ fn plan_set_expr(
                 ShowStatement::ShowDatabases(stmt) => {
                     show::show_databases(qcx.scx, stmt)?.plan_hir(qcx)
                 }
-                ShowStatement::ShowIndexes(stmt) => {
-                    show::show_indexes(qcx.scx, stmt)?.plan_hir(qcx)
-                }
                 ShowStatement::ShowObjects(stmt) => {
                     show::show_objects(qcx.scx, stmt)?.plan_hir(qcx)
                 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -169,9 +169,6 @@ pub fn describe(
         Statement::Show(ShowStatement::ShowDatabases(stmt)) => {
             show::show_databases(&scx, stmt)?.describe()?
         }
-        Statement::Show(ShowStatement::ShowIndexes(stmt)) => {
-            show::show_indexes(&scx, stmt)?.describe()?
-        }
         Statement::Show(ShowStatement::ShowObjects(stmt)) => {
             show::show_objects(&scx, stmt)?.describe()?
         }
@@ -317,7 +314,6 @@ pub fn plan(
         Statement::Show(ShowStatement::ShowDatabases(stmt)) => {
             show::show_databases(scx, stmt)?.plan()
         }
-        Statement::Show(ShowStatement::ShowIndexes(stmt)) => show::show_indexes(scx, stmt)?.plan(),
         Statement::Show(ShowStatement::ShowObjects(stmt)) => show::show_objects(scx, stmt)?.plan(),
         Statement::Show(ShowStatement::ShowSchemas(stmt)) => show::show_schemas(scx, stmt)?.plan(),
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -25,10 +25,10 @@ use query::QueryContext;
 
 use crate::ast::visit_mut::VisitMut;
 use crate::ast::{
-    SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
-    ShowCreateSinkStatement, ShowCreateSourceStatement, ShowCreateTableStatement,
-    ShowCreateViewStatement, ShowDatabasesStatement, ShowObjectsStatement, ShowSchemasStatement,
-    ShowStatementFilter, Statement, Value,
+    SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement, ShowCreateSinkStatement,
+    ShowCreateSourceStatement, ShowCreateTableStatement, ShowCreateViewStatement,
+    ShowDatabasesStatement, ShowObjectsStatement, ShowSchemasStatement, ShowStatementFilter,
+    Statement, Value,
 };
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::names::{

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -18,19 +18,22 @@ use std::fmt::Write;
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Datum, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
-use mz_sql_parser::ast::{ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement};
+use mz_sql_parser::ast::{
+    ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement, ShowObjectType,
+};
 use query::QueryContext;
 
 use crate::ast::visit_mut::VisitMut;
 use crate::ast::{
-    ObjectType, SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
+    SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
     ShowCreateSinkStatement, ShowCreateSourceStatement, ShowCreateTableStatement,
-    ShowCreateViewStatement, ShowDatabasesStatement, ShowIndexesStatement, ShowObjectsStatement,
-    ShowSchemasStatement, ShowStatementFilter, Statement, Value,
+    ShowCreateViewStatement, ShowDatabasesStatement, ShowObjectsStatement, ShowSchemasStatement,
+    ShowStatementFilter, Statement, Value,
 };
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::names::{
-    self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedSchemaName,
+    self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedObjectName,
+    ResolvedSchemaName,
 };
 use crate::parse;
 use crate::plan::scope::Scope;
@@ -299,24 +302,28 @@ pub fn show_objects<'a>(
     ShowObjectsStatement {
         object_type,
         from,
-        in_cluster,
         filter,
     }: ShowObjectsStatement<Aug>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     match object_type {
-        ObjectType::Table => show_tables(scx, from, filter),
-        ObjectType::Source => show_sources(scx, from, filter),
-        ObjectType::View => show_views(scx, from, filter),
-        ObjectType::MaterializedView => show_materialized_views(scx, from, in_cluster, filter),
-        ObjectType::Sink => show_sinks(scx, from, filter),
-        ObjectType::Type => show_types(scx, from, filter),
-        ObjectType::Object => show_all_objects(scx, from, filter),
-        ObjectType::Role => bail_unsupported!("SHOW ROLES"),
-        ObjectType::Cluster => show_clusters(scx, filter),
-        ObjectType::ClusterReplica => show_cluster_replicas(scx, filter),
-        ObjectType::Secret => show_secrets(scx, from, filter),
-        ObjectType::Index => unreachable!("SHOW INDEX handled separately"),
-        ObjectType::Connection => show_connections(scx, from, filter),
+        ShowObjectType::Table => show_tables(scx, from, filter),
+        ShowObjectType::Source => show_sources(scx, from, filter),
+        ShowObjectType::View => show_views(scx, from, filter),
+        ShowObjectType::Sink => show_sinks(scx, from, filter),
+        ShowObjectType::Type => show_types(scx, from, filter),
+        ShowObjectType::Object => show_all_objects(scx, from, filter),
+        ShowObjectType::Role => bail_unsupported!("SHOW ROLES"),
+        ShowObjectType::Cluster => show_clusters(scx, filter),
+        ShowObjectType::ClusterReplica => show_cluster_replicas(scx, filter),
+        ShowObjectType::Secret => show_secrets(scx, from, filter),
+        ShowObjectType::Connection => show_connections(scx, from, filter),
+        ShowObjectType::MaterializedView { in_cluster } => {
+            show_materialized_views(scx, from, in_cluster, filter)
+        }
+        ShowObjectType::Index {
+            in_cluster,
+            on_object,
+        } => show_indexes(scx, from, on_object, in_cluster, filter),
     }
 }
 
@@ -447,12 +454,10 @@ fn show_all_objects<'a>(
 
 pub fn show_indexes<'a>(
     scx: &'a StatementContext<'a>,
-    ShowIndexesStatement {
-        in_cluster,
-        on_object,
-        from_schema,
-        filter,
-    }: ShowIndexesStatement<Aug>,
+    from_schema: Option<ResolvedSchemaName>,
+    on_object: Option<ResolvedObjectName>,
+    in_cluster: Option<ResolvedClusterName>,
+    filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let mut query_filter = Vec::new();
 
@@ -462,8 +467,8 @@ pub fn show_indexes<'a>(
         query_filter.push(format!("schema_id = {}", schema_spec));
     }
 
-    if let Some(on_object) = on_object {
-        let on_item = scx.get_item_by_resolved_name(&on_object)?;
+    if let Some(on_object) = &on_object {
+        let on_item = scx.get_item_by_resolved_name(on_object)?;
         if on_item.item_type() != CatalogItemType::View
             && on_item.item_type() != CatalogItemType::MaterializedView
             && on_item.item_type() != CatalogItemType::Source

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -919,7 +919,7 @@ impl Runner {
         match statement {
             Statement::CreateView { .. }
             | Statement::Select { .. }
-            | Statement::Show(ShowStatement::ShowIndexes { .. }) => (),
+            | Statement::Show(ShowStatement::ShowObjects(..)) => (),
             _ => {
                 if output.is_err() {
                     // We're not interested in testing our hacky handling of INSERT etc


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->
This PR refactors existing code, and the motivation is described in the https://github.com/MaterializeInc/materialize/issues/15479.

### Tips for reviewer

This PR introduces a new AST type for show statement -- `ShowObjectType`.
 
With the new type, the following refactorization work has been done

1. associated the `in_cluster` field to materialized views and indexes only.
2. remove `ShowIndexesStatement` and move `on_object` to the `ShowObjectType::Index`
3. change the planner to understand the new AST.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
