### PR TITLE
environmentd: set telemetry report interval to one hour

### DIFF
--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -37,7 +37,7 @@ use mz_ore::retry::Retry;
 use mz_ore::task;
 
 /// How frequently to send a summary to Segment.
-const REPORT_INTERVAL: Duration = Duration::from_secs(15);
+const REPORT_INTERVAL: Duration = Duration::from_secs(3600);
 
 /// Telemetry configuration.
 #[derive(Clone)]


### PR DESCRIPTION
Setting to 15s was accidentally left over from local debugging.


### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
