### PR TITLE
mz: add support for custom endpoints and versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,12 +3277,14 @@ dependencies = [
  "dirs",
  "indicatif",
  "mz-ore",
+ "once_cell",
  "open",
  "reqwest",
  "rpassword",
  "serde",
  "tokio",
  "toml",
+ "url",
  "uuid",
 ]
 

--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -29,4 +29,8 @@ for image in environmentd storaged computed; do
     docker push "$username/$image"
 done
 
-echo "Launch environment with materialized image ref \`$username/environmentd:latest\`"
+echo "Deploy this build to staging by running:"
+echo
+echo "    $ bin/mz --profile=staging login --endpoint=https://staging.cloud.materialize.com"
+echo "    $ bin/mz --profile=staging region enable aws/us-east-1 --version $username:latest"
+echo

--- a/bin/mz
+++ b/bin/mz
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mz -- build and run the Materialize CLI.
+
+exec cargo run --bin mz -- "$@"

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "3.2.20", features = [ "derive" ] }
 dirs = "4.0.0"
 indicatif = "0.17.2"
 mz-ore = { path = "../ore", features = ["async"] }
+once_cell = "1.16.0"
 open = "3.2.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rpassword = "7.2.0"
@@ -21,3 +22,4 @@ serde = { version = "1.0.147", features = ["derive"] }
 tokio = { version = "1.22.0", features = ["full"] }
 toml = "0.5.9"
 uuid = "1.2.2"
+url = "2.3.1"

--- a/src/mz/src/main.rs
+++ b/src/mz/src/main.rs
@@ -107,6 +107,8 @@ enum RegionCommand {
         cloud_provider_region: String,
         #[clap(long, hide = true)]
         version: Option<String>,
+        #[clap(long, hide = true)]
+        environmentd_extra_arg: Vec<String>,
     },
     /// Disable a region.
     #[clap(hide = true)]
@@ -240,6 +242,7 @@ async fn main() -> Result<()> {
                 RegionCommand::Enable {
                     cloud_provider_region,
                     version,
+                    environmentd_extra_arg,
                 } => {
                     let cloud_provider_region =
                         CloudProviderRegion::from_str(&cloud_provider_region)?;
@@ -260,6 +263,7 @@ async fn main() -> Result<()> {
                         &client,
                         &cloud_provider,
                         version,
+                        environmentd_extra_arg,
                         &valid_profile,
                     )
                     .await

--- a/src/mz/src/password.rs
+++ b/src/mz/src/password.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use crate::configuration::ValidProfile;
-use crate::{FronteggAppPassword, API_FRONTEGG_TOKEN_AUTH_URL};
+use crate::FronteggAppPassword;
 use anyhow::{Context, Result};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
@@ -33,7 +33,7 @@ pub(crate) async fn list_passwords(
     body.insert("description", &"App password for the CLI");
 
     client
-        .get(API_FRONTEGG_TOKEN_AUTH_URL)
+        .get(valid_profile.profile.endpoint().api_token_auth_url())
         .headers(headers)
         .json(&body)
         .send()

--- a/src/mz/src/region.rs
+++ b/src/mz/src/region.rs
@@ -117,6 +117,7 @@ pub(crate) async fn enable_region_environment(
     client: &Client,
     cloud_provider: &CloudProvider,
     version: Option<String>,
+    environmentd_extra_args: Vec<String>,
     valid_profile: &ValidProfile<'_>,
 ) -> Result<Region, reqwest::Error> {
     #[derive(Serialize)]
@@ -124,6 +125,8 @@ pub(crate) async fn enable_region_environment(
     struct Body {
         #[serde(skip_serializing_if = "Option::is_none")]
         environmentd_image_ref: Option<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        environmentd_extra_args: Vec<String>,
     }
 
     let authorization: String = format!("Bearer {}", valid_profile.frontegg_auth.access_token);


### PR DESCRIPTION
Teach mz to support custom API endpoints and versions. This makes it possible to use mz to deploy a custom build of Materialize to staging or a personal stack.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
