### PR TITLE
Improve outer join lowering

### DIFF
--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -5893,35 +5893,44 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                 "input": {
                                   "Project": {
                                     "input": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 3
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
+                                      "Map": {
+                                        "input": {
+                                          "Get": {
+                                            "id": {
+                                              "Local": 3
                                             },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": false
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": true
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": false
+                                            "typ": {
+                                              "column_types": [
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": false
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": true
+                                                },
+                                                {
+                                                  "scalar_type": "Int32",
+                                                  "nullable": false
+                                                }
+                                              ],
+                                              "keys": []
                                             }
-                                          ],
-                                          "keys": []
-                                        }
+                                          }
+                                        },
+                                        "scalars": [
+                                          {
+                                            "Column": 1
+                                          }
+                                        ]
                                       }
                                     },
                                     "outputs": [
-                                      1
+                                      4
                                     ]
                                   }
                                 },
@@ -5949,23 +5958,32 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                   "Join": {
                                                     "inputs": [
                                                       {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 1
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
+                                                        "Map": {
+                                                          "input": {
+                                                            "Get": {
+                                                              "id": {
+                                                                "Local": 1
                                                               },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
+                                                              "typ": {
+                                                                "column_types": [
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  },
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  }
+                                                                ],
+                                                                "keys": []
                                                               }
-                                                            ],
-                                                            "keys": []
-                                                          }
+                                                            }
+                                                          },
+                                                          "scalars": [
+                                                            {
+                                                              "Column": 1
+                                                            }
+                                                          ]
                                                         }
                                                       },
                                                       {
@@ -5992,10 +6010,10 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                     "equivalences": [
                                                       [
                                                         {
-                                                          "Column": 1
+                                                          "Column": 2
                                                         },
                                                         {
-                                                          "Column": 2
+                                                          "Column": 3
                                                         }
                                                       ]
                                                     ],
@@ -6250,43 +6268,52 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                             "input": {
                               "Project": {
                                 "input": {
-                                  "Get": {
-                                    "id": {
-                                      "Local": 7
-                                    },
-                                    "typ": {
-                                      "column_types": [
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
+                                  "Map": {
+                                    "input": {
+                                      "Get": {
+                                        "id": {
+                                          "Local": 7
                                         },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": true
-                                        },
-                                        {
-                                          "scalar_type": "Int32",
-                                          "nullable": false
+                                        "typ": {
+                                          "column_types": [
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": false
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": true
+                                            },
+                                            {
+                                              "scalar_type": "Int32",
+                                              "nullable": false
+                                            }
+                                          ],
+                                          "keys": []
                                         }
-                                      ],
-                                      "keys": []
-                                    }
+                                      }
+                                    },
+                                    "scalars": [
+                                      {
+                                        "Column": 3
+                                      }
+                                    ]
                                   }
                                 },
                                 "outputs": [
-                                  3
+                                  6
                                 ]
                               }
                             },
@@ -6316,23 +6343,32 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                   "Join": {
                                                     "inputs": [
                                                       {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 6
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
+                                                        "Map": {
+                                                          "input": {
+                                                            "Get": {
+                                                              "id": {
+                                                                "Local": 6
                                                               },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
+                                                              "typ": {
+                                                                "column_types": [
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  },
+                                                                  {
+                                                                    "scalar_type": "Int32",
+                                                                    "nullable": true
+                                                                  }
+                                                                ],
+                                                                "keys": []
                                                               }
-                                                            ],
-                                                            "keys": []
-                                                          }
+                                                            }
+                                                          },
+                                                          "scalars": [
+                                                            {
+                                                              "Column": 1
+                                                            }
+                                                          ]
                                                         }
                                                       },
                                                       {
@@ -6359,10 +6395,10 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                     "equivalences": [
                                                       [
                                                         {
-                                                          "Column": 1
+                                                          "Column": 2
                                                         },
                                                         {
-                                                          "Column": 2
+                                                          "Column": 3
                                                         }
                                                       ]
                                                     ],

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -632,16 +632,18 @@ Return
           Union
             Negate
               Project (#0, #1)
-                Join on=(#1 = #2)
-                  Get l6
+                Join on=(#2 = #3)
+                  Map (#1)
+                    Get l6
                   Get l8
             Get l6
       Get l7
 With
   cte l8 =
     Distinct group_by=[#0]
-      Project (#3)
-        Get l7
+      Project (#6)
+        Map (#3)
+          Get l7
   cte l7 =
     Filter (#3 = #5)
       Project (#0..=#5)
@@ -658,15 +660,17 @@ With
         Union
           Negate
             Project (#0, #1)
-              Join on=(#1 = #2)
-                Get l1
+              Join on=(#2 = #3)
+                Map (#1)
+                  Get l1
                 Get l4
           Get l1
       Get l3
   cte l4 =
     Distinct group_by=[#0]
-      Project (#1)
-        Get l3
+      Project (#4)
+        Map (#1)
+          Get l3
   cte l3 =
     Filter (#1 = #3)
       Project (#0..=#3)

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -863,41 +863,42 @@ Explained Query:
           Filter (#1) IS NOT NULL // { arity: 2 }
             Reduce aggregates=[count(true), max(#0)] // { arity: 2 }
               Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Project (#4) // { arity: 1 }
-                  Map (null) // { arity: 5 }
-                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                      implementation
-                        %1:t3[#0, #1] » %0[#0, #1]KKA
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Union // { arity: 2 }
-                          Map (6) // { arity: 2 }
-                            Negate // { arity: 1 }
-                              Distinct group_by=[#0] // { arity: 1 }
-                                Project (#1) // { arity: 1 }
-                                  Get l0 // { arity: 2 }
-                          Distinct group_by=[#0, #1] // { arity: 2 }
-                            Get materialize.public.t3 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Get materialize.public.t3 // { arity: 2 }
+                Map (null) // { arity: 1 }
+                  Union // { arity: 0 }
+                    Negate // { arity: 0 }
+                      CrossJoin type=differential // { arity: 0 }
+                        implementation
+                          %0:l0[×] » %1[×]UAef
+                        Get l0 // { arity: 0 }
+                        ArrangeBy keys=[[]] // { arity: 0 }
+                          Distinct // { arity: 0 }
+                            Project () // { arity: 0 }
+                              Get l1 // { arity: 1 }
+                    Project () // { arity: 0 }
+                      Get materialize.public.t3 // { arity: 2 }
+                Get l1 // { arity: 1 }
   With
-    cte l0 =
-      CrossJoin type=differential // { arity: 2 }
+    cte l1 =
+      CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:t3[×] » %0:t2[×]Aef
+          %1:l0[×] » %0:t2[×]Aef
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Get materialize.public.t2 // { arity: 2 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#1 = 6) // { arity: 2 }
-              Get materialize.public.t3 // { arity: 2 }
+        Get l0 // { arity: 0 }
+    cte l0 =
+      ArrangeBy keys=[[]] // { arity: 0 }
+        Project () // { arity: 0 }
+          Filter (#1 = 6) // { arity: 2 }
+            Get materialize.public.t3 // { arity: 2 }
 
 Source materialize.public.t1
   project=(#2, #1)
   map=(dummy)
 Source materialize.public.t2
+  project=(#2, #1)
+  map=(dummy)
+Source materialize.public.t3
   project=(#2, #1)
   map=(dummy)
 


### PR DESCRIPTION
This PR improves the "optimistic" outer join lowering from applying only to exact column equality to equalities of expressions supported by the two inputs. This is most clearly seen on outer joins that appear to be column equality but are in fact type conversions. For example, 
```sql
create table foo (a int8, u text);
create table bar (b int4, v text);
explain select * from foo left join bar on (a = b);
```
On `main` this plans as
```
materialize=> explain select * from foo left join bar on (a = b);
                        Optimized Plan                        
--------------------------------------------------------------
 Explained Query:                                            +
   Return                                                    +
     Union                                                   +
       Get l0                                                +
       Project (#0, #1, #4, #5)                              +
         Map (null, null)                                    +
           Join on=(#0 = #2 AND #1 = #3) type=differential   +
             ArrangeBy keys=[[#0, #1]]                       +
               Union                                         +
                 Negate                                      +
                   Distinct group_by=[#0, #1]                +
                     Project (#0, #1)                        +
                       Get l0                                +
                 Distinct group_by=[#0, #1]                  +
                   Get materialize.public.foo                +
             ArrangeBy keys=[[#0, #1]]                       +
               Get materialize.public.foo                    +
   With                                                      +
     cte l0 =                                                +
       Join on=(#0 = integer_to_bigint(#2)) type=differential+
         ArrangeBy keys=[[#0]]                               +
           Filter (#0) IS NOT NULL                           +
             Get materialize.public.foo                      +
         ArrangeBy keys=[[integer_to_bigint(#0)]]            +
           Filter (#0) IS NOT NULL                           +
             Get materialize.public.bar                      +
```
and in this PR plans as
```
materialize=> explain select * from foo left join bar on (a = b);
                        Optimized Plan                        
--------------------------------------------------------------
 Explained Query:                                            +
   Return                                                    +
     Union                                                   +
       Map (null, null)                                      +
         Union                                               +
           Negate                                            +
             Project (#0, #1)                                +
               Join on=(#0 = #2) type=differential           +
                 ArrangeBy keys=[[#0]]                       +
                   Get materialize.public.foo                +
                 ArrangeBy keys=[[#0]]                       +
                   Distinct group_by=[#0]                    +
                     Project (#0)                            +
                       Get l0                                +
           Get materialize.public.foo                        +
       Get l0                                                +
   With                                                      +
     cte l0 =                                                +
       Join on=(#0 = integer_to_bigint(#2)) type=differential+
         ArrangeBy keys=[[#0]]                               +
           Filter (#0) IS NOT NULL                           +
             Get materialize.public.foo                      +
         ArrangeBy keys=[[integer_to_bigint(#0)]]            +
           Filter (#0) IS NOT NULL                           +
             Get materialize.public.bar                      +
```

The two CTEs are identical, but in the `main` case there is a `Distinct` on multiple columns of `foo`, rather than just on the key column. The `main` plan generally will keep full copies of all columns of `foo`, rather than just the distinct keys.

### Motivation

  * This PR adds a feature that has not yet been specified.

Outer join lowering was limited in scope to exact column equalities. In many cases there can be conversions of types, truncation of values, or other transformations that foil the existing lowering but are not incorrect to perform.

### Tips for reviewer

This has not been exercised on exotic outer joins such as those that do not just equate simple transformations of columns. It still appears correct, under the premise that it finds outer joins that could have been column equality if each input had been subjected to `map(keys)`. Tagging in @philip-stoev as a review to point several unpleasant forms of outer joins at this PR.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
