### PR TITLE
[sinks] Move sink status writes out of unsafe mode

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -448,15 +448,10 @@ impl<S: Append + 'static> Coordinator<S> {
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.collection(sink.from)?;
 
-        // This is in unsafe mode for the moment because we want to attempt to roll out the change slowly as we're
-        // stressing persist in a new way.
-        let status_id = if self.catalog.config().unsafe_mode {
+        let status_id =
             Some(self.catalog.resolve_builtin_storage_collection(
                 &crate::catalog::builtin::MZ_SINK_STATUS_HISTORY,
-            ))
-        } else {
-            None
-        };
+            ));
 
         // The AsOf is used to determine at what time to snapshot reading from the persist collection.  This is
         // primarily relevant when we do _not_ want to include the snapshot in the sink.  Choosing now will mean


### PR DESCRIPTION
### Motivation

We kept sink writes behind unsafe mode a little longer than expected, to handle a few more cases where we weren't promptly reporting errors up. Should be good to go now, though.

Closes https://github.com/MaterializeInc/materialize/issues/16426. Undoes #15744.

### Tips for reviewer

Blocked behind #16431.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Writes status events, including errors, to the `mz_sink_status_history` collection. (Which populates the `mz_sink_status` view.)
