### PR TITLE
remove required for discretionary issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/09-epic.yml
+++ b/.github/ISSUE_TEMPLATE/09-epic.yml
@@ -66,8 +66,6 @@ body:
         Please list all non-mandatory issues that complement, extend or enhance the product experience.
         When all required issues are complete we’ll either continue with the discretionary issues or
         move them back into the icebox or a follow on epic and mark this current epic as complete.
-    validations:
-      required: true
   - type: textarea
     id: blockers
     attributes:


### PR DESCRIPTION
The discretionary issues section of the epic template should not be required.  This removes the required validation.
