### PR TITLE
adapter: Fix timedomain errors

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2174,52 +2174,6 @@ impl<S: Append + 'static> Coordinator<S> {
             self.txn_reads.insert(session.conn_id(), txn_reads);
         }
 
-        if in_immediate_multi_stmt_txn {
-            // Verify that the references and indexes for this query are in the
-            // current read transaction.
-            let allowed_id_bundle = &self
-                .txn_reads
-                .get(&session.conn_id())
-                .unwrap()
-                .read_holds
-                .id_bundle();
-            // Find the first reference or index (if any) that is not in the transaction. A
-            // reference could be caused by a user specifying an object in a different
-            // schema than the first query. An index could be caused by a CREATE INDEX
-            // after the transaction started.
-            let outside = peek_plan.id_bundle.difference(allowed_id_bundle);
-            if !outside.is_empty() {
-                let mut names: Vec<_> = allowed_id_bundle
-                    .iter()
-                    // This could filter out a view that has been replaced in another transaction.
-                    .filter_map(|id| self.catalog.try_get_entry(&id))
-                    .map(|item| item.name())
-                    .map(|name| {
-                        self.catalog
-                            .resolve_full_name(name, Some(session.conn_id()))
-                            .to_string()
-                    })
-                    .collect();
-                let mut outside: Vec<_> = outside
-                    .iter()
-                    .filter_map(|id| self.catalog.try_get_entry(&id))
-                    .map(|item| item.name())
-                    .map(|name| {
-                        self.catalog
-                            .resolve_full_name(name, Some(session.conn_id()))
-                            .to_string()
-                    })
-                    .collect();
-                // Sort so error messages are deterministic.
-                names.sort();
-                outside.sort();
-                return Err(AdapterError::RelationOutsideTimeDomain {
-                    relations: outside,
-                    names,
-                });
-            }
-        }
-
         // We only track the peeks in the session if the query doesn't use AS
         // OF or we're inside an explicit transaction. The latter case is
         // necessary to support PG's `BEGIN` semantics, whose behavior can
@@ -2314,6 +2268,51 @@ impl<S: Append + 'static> Coordinator<S> {
             self.determine_timestamp(session, &id_bundle, when, compute_instance, timeline)?
                 .timestamp
         };
+
+        if in_immediate_multi_stmt_txn {
+            if let Some(txn_reads) = self.txn_reads.get(&session.conn_id()) {
+                // Verify that the references and indexes for this query are in the
+                // current read transaction.
+                let allowed_id_bundle = txn_reads.read_holds.id_bundle();
+                if !allowed_id_bundle.is_empty() {
+                    // Find the first reference or index (if any) that is not in the transaction. A
+                    // reference could be caused by a user specifying an object in a different
+                    // schema than the first query. An index could be caused by a CREATE INDEX
+                    // after the transaction started.
+                    let outside = id_bundle.difference(&allowed_id_bundle);
+                    if !outside.is_empty() {
+                        let mut names: Vec<_> = allowed_id_bundle
+                            .iter()
+                            // This could filter out a view that has been replaced in another transaction.
+                            .filter_map(|id| self.catalog.try_get_entry(&id))
+                            .map(|item| item.name())
+                            .map(|name| {
+                                self.catalog
+                                    .resolve_full_name(name, Some(session.conn_id()))
+                                    .to_string()
+                            })
+                            .collect();
+                        let mut outside: Vec<_> = outside
+                            .iter()
+                            .filter_map(|id| self.catalog.try_get_entry(&id))
+                            .map(|item| item.name())
+                            .map(|name| {
+                                self.catalog
+                                    .resolve_full_name(name, Some(session.conn_id()))
+                                    .to_string()
+                            })
+                            .collect();
+                        // Sort so error messages are deterministic.
+                        names.sort();
+                        outside.sort();
+                        return Err(AdapterError::RelationOutsideTimeDomain {
+                            relations: outside,
+                            names,
+                        });
+                    }
+                }
+            }
+        }
 
         // before we have the corrected timestamp ^
         // TODO(guswynn&mjibson): partition `sequence_peek` by the response to

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2274,7 +2274,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // Verify that the references and indexes for this query are in the
                 // current read transaction.
                 let allowed_id_bundle = txn_reads.read_holds.id_bundle();
-                if !allowed_id_bundle.is_empty() {
+                if !allowed_id_bundle.is_empty() || !txn_reads.timestamp_independent {
                     // Find the first reference or index (if any) that is not in the transaction. A
                     // reference could be caused by a user specifying an object in a different
                     // schema than the first query. An index could be caused by a CREATE INDEX

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -585,3 +585,18 @@ SELECT INTERVAL '1 day'
 
 statement ok
 COMMIT
+
+# Time-domain error
+
+statement ok
+DELETE FROM t
+
+statement ok
+BEGIN;
+
+query I rowsort
+SELECT * FROM t
+----
+
+query error Transactions can only reference objects in the same timedomain.
+SELECT * FROM mz_views


### PR DESCRIPTION
The adapter recently re-ordered logic in sequence_peek so that creating the dataflow happens before the timedomain validation checks. However, creating a dataflow may panic if the dataflow is in a different timedomain than previous peeks in the same transaction.

This commit re-orders the timedomain validation to happen before creating the dataflow to avoid panics.

Fixes #16469


### Motivation
This PR fixes a recognized bug.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
