### PR TITLE
Remove `skip(1)` from `differential::plan`

### DIFF
--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1206,7 +1206,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                         );
                         (JoinPlan::Linear(ljp), missing)
                     }
-                    Differential((start, start_arr), order) => {
+                    Differential((start, start_arr, _start_characteristic), order) => {
                         let source_arrangement = start_arr.as_ref().and_then(|key| {
                             input_keys[*start]
                                 .arranged

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -439,6 +439,7 @@ impl MirRelationExpr {
                     };
                     let join_order = |start_idx: usize,
                                       start_key: &Option<Vec<MirScalarExpr>>,
+                                      start_characteristics: &Option<JoinInputCharacteristics>,
                                       tail: &Vec<(
                         usize,
                         Vec<MirScalarExpr>,
@@ -446,12 +447,16 @@ impl MirRelationExpr {
                     )>|
                      -> String {
                         format!(
-                            "{}{} » {}",
+                            "{}{}{} » {}",
                             input_name(start_idx),
                             match start_key {
                                 None => "".to_owned(),
                                 Some(key) => format!("[{}]", join_key_to_string(key)),
                             },
+                            start_characteristics
+                                .as_ref()
+                                .map(|c| c.explain())
+                                .unwrap_or_else(|| "".to_string()),
                             separated(
                                 " » ",
                                 tail.iter().map(|(pos, key, characteristics)| {
@@ -470,7 +475,10 @@ impl MirRelationExpr {
                     };
                     ctx.indented(|ctx| {
                         match implementation {
-                            JoinImplementation::Differential((start_idx, start_key), tail) => {
+                            JoinImplementation::Differential(
+                                (start_idx, start_key, start_characteristics),
+                                tail,
+                            ) => {
                                 soft_assert!(inputs.len() == tail.len() + 1);
 
                                 writeln!(f, "{}implementation", ctx.indent)?;
@@ -479,7 +487,12 @@ impl MirRelationExpr {
                                         f,
                                         "{}{}",
                                         ctx.indent,
-                                        join_order(*start_idx, start_key, tail)
+                                        join_order(
+                                            *start_idx,
+                                            start_key,
+                                            start_characteristics,
+                                            tail
+                                        )
                                     )
                                 })?;
                             }
@@ -493,7 +506,7 @@ impl MirRelationExpr {
                                             f,
                                             "{}{}",
                                             ctx.indent,
-                                            join_order(pos, &None, chain)
+                                            join_order(pos, &None, &None, chain)
                                         )?;
                                     }
                                     Ok(())

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2526,17 +2526,23 @@ impl AggregateExpr {
 pub enum JoinImplementation {
     /// Perform a sequence of binary differential dataflow joins.
     ///
-    /// The first argument indicates 1) the index of the starting collection
-    /// and 2) if it should be arranged, the keys to arrange it by.
+    /// The first argument indicates
+    /// 1) the index of the starting collection,
+    /// 2) if it should be arranged, the keys to arrange it by, and
+    /// 3) the characteristics of the starting collection (for EXPLAINing).
     /// The sequence that follows lists other relation indexes, and the key for
     /// the arrangement we should use when joining it in.
     /// The JoinInputCharacteristics are for EXPLAINing the characteristics that
     /// were used for join ordering.
     ///
-    /// Each collection index should occur exactly once, either in the first
-    /// position or somewhere in the list.
+    /// Each collection index should occur exactly once, either as the starting collection
+    /// or somewhere in the list.
     Differential(
-        (usize, Option<Vec<MirScalarExpr>>),
+        (
+            usize,
+            Option<Vec<MirScalarExpr>>,
+            Option<JoinInputCharacteristics>,
+        ),
         Vec<(usize, Vec<MirScalarExpr>, Option<JoinInputCharacteristics>)>,
     ),
     /// Perform independent delta query dataflows for each input.

--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -19,7 +19,7 @@ Return
   Project (#0..=#2, #0, #4, #5)
     Join on=(#0 = #3) type=differential
       implementation
-        %1:l0[#0] » %0:l0[#0]KA
+        %0:l0[#0]KA » %1:l0[#0]KA
       Get l0
       Get l0
 With
@@ -64,7 +64,7 @@ opt
 Return
   CrossJoin type=differential
     implementation
-      %1:l0[×] » %0:l0[×]Aef
+      %0:l0[×]Aef » %1:l0[×]Aef
     Get l0
     Get l0
 With
@@ -101,7 +101,7 @@ Project (#5, #1, #0, #0, #3, #4)
     Map (-(#1))
       Join on=(#0 = #2) type=differential
         implementation
-          %1:x[#0] » %0[#0]UKAf
+          %0[#0]UKAf » %1:x[#0]KAf
         ArrangeBy keys=[[#0]]
           Reduce group_by=[#0] aggregates=[sum(#1)]
             Project (#0, #1)
@@ -123,7 +123,7 @@ opt
 Project (#1, #2, #0, #2, #4)
   Join on=(#2 = #3) type=differential
     implementation
-      %0:x[#2] » %1[#0]UKAf
+      %1[#0]UKA » %0:x[#2]KAf
     ArrangeBy keys=[[#2]]
       Project (#0, #1, #3)
         Filter (#1 < #0)
@@ -147,19 +147,19 @@ opt
     [[#2 #3] [#1 #6]]
 )
 ----
-Project (#1, #7, #0, #0, #3, #4, #7, #6)
-  Filter (#1 < #7)
-    Map (-(#1))
-      Join on=(#0 = #2 AND #5 = -(#1)) type=differential
-        implementation
-          %1:x[#0] » %0[#0]UKAf » %2[#0]UKAf
-        ArrangeBy keys=[[#0]]
+Project (#1, #2, #0, #0, #4, #5, #2, #7)
+  Join on=(#0 = #3 AND #2 = #6) type=differential
+    implementation
+      %2[#0]UKA » %0[#2]KAf » %1:x[#0]KAf
+    ArrangeBy keys=[[#2]]
+      Filter (#1 < #2)
+        Map (-(#1))
           Reduce group_by=[#0] aggregates=[sum(#1)]
             Project (#0, #1)
               Get x
-        ArrangeBy keys=[[#0]]
+    ArrangeBy keys=[[#0]]
+      Get x
+    ArrangeBy keys=[[#0]]
+      Reduce group_by=[#0] aggregates=[max(#1)]
+        Project (#1, #2)
           Get x
-        ArrangeBy keys=[[#0]]
-          Reduce group_by=[#0] aggregates=[max(#1)]
-            Project (#1, #2)
-              Get x

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -65,7 +65,7 @@ Return // { types: "(Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)", keys: "()
   Project (#0..=#4, #2) // { types: "(Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)", keys: "()" }
     Join on=(#2 = #5) type=differential // { types: "(Int32?, Int64?, Int32?, Int32?, Int64?, Int32?)", keys: "()" }
       implementation
-        %1:l0[#2] » %0:l0[#2]KA
+        %0:l0[#2]KA » %1:l0[#2]KA
       Get l0 // { types: "(Int32?, Int64?, Int32?)", keys: "([0], [1])" }
       Get l0 // { types: "(Int32?, Int64?, Int32?)", keys: "([0], [1])" }
 With

--- a/src/transform/tests/testdata/reduction-pushdown
+++ b/src/transform/tests/testdata/reduction-pushdown
@@ -184,13 +184,13 @@ opt
 Project (#0, #0)
   Join on=(#0 = #1) type=differential
     implementation
-      %1[#0] » %0[#0]UKA
+      %0[#0]UKA » %1[#0]UKA
     ArrangeBy keys=[[#0]]
       Distinct group_by=[#0]
         Project (#2)
           Join on=(#0 = #1) type=differential
             implementation
-              %1:y[#0] » %0:x[#0]KA
+              %0:x[#0]KA » %1:y[#0]KA
             ArrangeBy keys=[[#0]]
               Project (#0)
                 Get x
@@ -201,7 +201,7 @@ Project (#0, #0)
         Project (#1)
           Join on=(#0 = #2) type=differential
             implementation
-              %1:w[#0] » %0:z[#0]KA
+              %0:z[#0]KA » %1:w[#0]KA
             ArrangeBy keys=[[#0]]
               Get z
             ArrangeBy keys=[[#0]]

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -108,13 +108,13 @@ Applied Fixpoint { transforms: [PredicatePushdown { recursion_guard: RecursionGu
 No change: Fixpoint { transforms: [SemijoinIdempotence, ReductionPushdown, ReduceElision, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, RelationCSE { normalize_lets: NormalizeLets { inline_mfp: false } }, FuseAndCollapse { transforms: [ProjectionExtraction, ProjectionLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Fusion, FlatMapToMap, Join, NormalizeLets { inline_mfp: false }, Reduce, UnionNegate, UnionBranchCancellation, NormalizeLets { inline_mfp: false }, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }] }], limit: 100 }, ProjectionPushdown, NormalizeLets { inline_mfp: false }, Fusion, Fixpoint { transforms: [CanonicalizeMfp, ThresholdElision, Join, RedundantJoin { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, Fusion, UnionNegate, UnionBranchCancellation, RelationCSE { normalize_lets: NormalizeLets { inline_mfp: true } }, FoldConstants { limit: Some(10000) }], limit: 100 }, LiteralConstraints
 ====
 Applied Fixpoint { transforms: [JoinImplementation { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, ColumnKnowledge { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, FoldConstants { limit: Some(10000) }, Demand { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }, LiteralLifting { recursion_guard: RecursionGuard { depth: RefCell { value: 0 }, limit: 2048 } }], limit: 100 }:
-(Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 [(CallBinary AddInt64 #0 (1 Int64))]] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [0 [#0] (false 1 true (false false false 0 false) 0)] [[1 [(CallBinary AddInt64 #0 (1 Int64))] (false 1 true (false false false 0 false) 1)]]))
 
 ====
 No change: CanonicalizeMfp, RelationCSE { normalize_lets: NormalizeLets { inline_mfp: false } }, FoldConstants { limit: Some(10000) }, ThresholdElision
 ====
 Final:
-(Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [1 [(CallBinary AddInt64 #0 (1 Int64))]] [[0 [#0] (false 1 true (false false false 0 false) 0)]]))
+(Join [(ArrangeBy (get u1) [[#0]]) (ArrangeBy (get x) [[(CallBinary AddInt64 #0 (1 Int64))]])] [[#0 (CallBinary AddInt64 #2 (1 Int64))]] (Differential [0 [#0] (false 1 true (false false false 0 false) 0)] [[1 [(CallBinary AddInt64 #0 (1 Int64))] (false 1 true (false false false 0 false) 1)]]))
 
 ====
 ====

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -197,7 +197,7 @@ Explained Query:
     Filter ((#4 = 24) OR ((#3 = 6) AND (#4 <= 4) AND (#4 >= 3))) // { arity: 25 }
       Join on=(#0 = #16) type=differential // { arity: 25 }
         implementation
-          %1:orders[#0] » %0:lineitem[#0]KAeif
+          %0:lineitem[#0]KAeif » %1:orders[#0]KAeif
         ArrangeBy keys=[[#0]] // { arity: 16 }
           Get materialize.public.lineitem // { arity: 16 }
         ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -361,16 +361,14 @@ Explained Query:
   Reduce group_by=[(#2 * #3), #4] aggregates=[max(#1), max(#0)] // { arity: 4 }
     Project (#0..=#3, #17) // { arity: 5 }
       Filter (#19 < #8) AND (#19 <= #3) // { arity: 22 }
-        Join on=(#4 = #9 AND #6 = #14) type=delta // { arity: 22 }
+        Join on=(#4 = #9 AND #6 = #14) type=differential // { arity: 22 }
           implementation
-            %0:lineitem » %1:orders[#4]KA » %2:customer[#0]KA
-            %1:orders » %0:lineitem[#4]KAf » %2:customer[#0]KA
-            %2:customer » %1:orders[#1]KA » %0:lineitem[#4]KAf
+            %2:customer[#0]KA » %1:orders[#1]KA » %0:lineitem[#4]KAf
           ArrangeBy keys=[[#4]] // { arity: 5 }
             Project (#2..=#5, #12) // { arity: 5 }
               Filter (#3 != 1) AND (#3 != 2) AND (#3 != 6) // { arity: 16 }
                 Get materialize.public.lineitem // { arity: 16 }
-          ArrangeBy keys=[[#1], [#4]] // { arity: 9 }
+          ArrangeBy keys=[[#1]] // { arity: 9 }
             Get materialize.public.orders // { arity: 9 }
           ArrangeBy keys=[[#0]] // { arity: 8 }
             Get materialize.public.customer // { arity: 8 }
@@ -414,7 +412,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:l1[#1] » %1[#0]UKAif
+                    %1[#0]UKA » %0:l1[#1]KAif
                   ArrangeBy keys=[[#1]] // { arity: 2 }
                     Project (#4, #11) // { arity: 2 }
                       Get l1 // { arity: 16 }
@@ -435,7 +433,7 @@ Explained Query:
       Project (#0..=#4) // { arity: 5 }
         Join on=(#2 = #5) type=differential // { arity: 6 }
           implementation
-            %1:orders[#1] » %0:lineitem[#2]KA
+            %0:lineitem[#2]KA » %1:orders[#1]KA
           ArrangeBy keys=[[#2]] // { arity: 4 }
             Project (#0, #4, #11, #12) // { arity: 4 }
               Get materialize.public.lineitem // { arity: 16 }
@@ -476,25 +474,24 @@ WHERE l_quantity = 17
                     33)
 ----
 Explained Query:
-  Project (#11, #3) // { arity: 2 }
-    Filter (#12 <= #5) AND ((#1 = 7) OR (#1 = 33) OR ((#1 = 17) AND (#13 <= "x") AND (#13 >= "s"))) // { arity: 14 }
-      Join on=(#0 = #2) type=differential // { arity: 14 }
-        implementation
-          %2:customer[×] » %0:lineitem[×]Aef » %1:orders[#0]KAef
-        ArrangeBy keys=[[]] // { arity: 2 }
-          Project (#0, #4) // { arity: 2 }
-            Filter ((#4 = 7) OR (#4 = 17) OR (#4 = 33)) // { arity: 16 }
-              Get materialize.public.lineitem // { arity: 16 }
-        ArrangeBy keys=[[#0]] // { arity: 9 }
-          Get materialize.public.orders // { arity: 9 }
-        ArrangeBy keys=[[]] // { arity: 3 }
-          Project (#0, #5, #7) // { arity: 3 }
-            Get materialize.public.customer // { arity: 8 }
+  Project (#25, #17) // { arity: 2 }
+    Filter (#26 <= #19) AND (#28 OR #29 OR #30) AND (#28 OR #30 OR (#29 AND (#27 <= "x") AND (#27 >= "s"))) // { arity: 31 }
+      Map ((#4 = 7), (#4 = 17), (#4 = 33)) // { arity: 31 }
+        Join on=(#0 = #16) type=differential // { arity: 28 }
+          implementation
+            %0:lineitem[#0]KAef » %1:orders[#0]KAef » %2:customer[×]Aef
+          ArrangeBy keys=[[#0]] // { arity: 16 }
+            Get materialize.public.lineitem // { arity: 16 }
+          ArrangeBy keys=[[#0]] // { arity: 9 }
+            Get materialize.public.orders // { arity: 9 }
+          ArrangeBy keys=[[]] // { arity: 3 }
+            Project (#0, #5, #7) // { arity: 3 }
+              Get materialize.public.customer // { arity: 8 }
 
 Used Indexes:
   - materialize.public.pk_customer_custkey
   - materialize.public.pk_orders_orderkey
-  - materialize.public.pk_lineitem_orderkey_linenumber
+  - materialize.public.fk_lineitem_orderkey
 
 EOF
 
@@ -589,7 +586,7 @@ Explained Query:
         Filter (#1 < #6) AND (#16 > #5) AND (#16 >= #0) // { arity: 19 }
           Join on=(#3 = #11) type=differential // { arity: 19 }
             implementation
-              %2:customer[#0] » %1:orders[#1]KA » %0:lineitem[×]Af
+              %1:orders[#1]KA » %2:customer[#0]KA » %0:lineitem[×]Af
             ArrangeBy keys=[[]] // { arity: 2 }
               Project (#5, #10) // { arity: 2 }
                 Filter (#3 != 4) // { arity: 16 }
@@ -692,7 +689,7 @@ Explained Query:
       Filter (#10 <= 1994-03-17) AND (#0 >= 53) AND (#5 < #19) AND (#26 < #19) // { arity: 27 }
         Join on=(#0 = #16) type=differential // { arity: 27 }
           implementation
-            %1:orders[#0] » %0:lineitem[#0]KAiiiiif » %2:customer[×]Aiiiiif
+            %0:lineitem[#0]KAiiif » %1:orders[#0]KAiiiiif » %2:customer[×]Aiiiiif
           ArrangeBy keys=[[#0]] // { arity: 16 }
             Get materialize.public.lineitem // { arity: 16 }
           ArrangeBy keys=[[#0]] // { arity: 9 }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -304,7 +304,7 @@ Explained Query:
       Project (#2, #3, #12, #0, #1, #4, #6, #7) // { arity: 8 }
         Join on=(eq(#0, #8, #15) AND #2 = #10 AND #5 = #11 AND #9 = #16 AND #13 = #14) type=differential // { arity: 17 }
           implementation
-            %2:stock[#0, #1] » %5[#0, #1]UKKA » %0:item[#0]UKAlf » %1:supplier[#0]UKAlf » %3:nation[#0]UKAlf » %4:l0[#0]UKAlf
+            %0:item[#0]UKAlf » %5[#0]UKAlf » %2:stock[#0, #1]KKAlf » %1:supplier[#0]UKAlf » %3:nation[#0]UKAlf » %4:l0[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Project (#0, #2) // { arity: 2 }
               Filter "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -320,22 +320,19 @@ Explained Query:
             Project (#0..=#2) // { arity: 3 }
               Get materialize.public.nation // { arity: 4 }
           Get l0 // { arity: 1 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-            Filter (#1) IS NOT NULL // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-                Project (#0, #2) // { arity: 2 }
-                  Join on=(#17 = #18 AND #19 = #20 AND #21 = #22) type=differential // { arity: 23 }
-                    implementation
-                      %0:stock[#17] » %1:supplier[#0]UKA » %2:nation[#0]UKA » %3:l0[#0]UKAlf
-                    ArrangeBy keys=[[#17]] // { arity: 18 }
-                      Get materialize.public.stock // { arity: 18 }
-                    ArrangeBy keys=[[#0]] // { arity: 2 }
-                      Project (#0, #3) // { arity: 2 }
-                        Get materialize.public.supplier // { arity: 7 }
-                    ArrangeBy keys=[[#0]] // { arity: 2 }
-                      Project (#0, #2) // { arity: 2 }
-                        Get materialize.public.nation // { arity: 4 }
-                    Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Join on=(#17 = #18 AND #21 = #25 AND #27 = #29) type=differential // { arity: 30 }
+                  implementation
+                    %3:l0[#0]UKAlf » %2:nation[#2]KAlf » %1:supplier[#3]KAlf » %0:stock[#17]KAlf
+                  ArrangeBy keys=[[#17]] // { arity: 18 }
+                    Get materialize.public.stock // { arity: 18 }
+                  ArrangeBy keys=[[#3]] // { arity: 7 }
+                    Get materialize.public.supplier // { arity: 7 }
+                  ArrangeBy keys=[[#2]] // { arity: 4 }
+                    Get materialize.public.nation // { arity: 4 }
+                  Get l0 // { arity: 1 }
     With
       cte l0 =
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -378,22 +375,20 @@ Explained Query:
   Finish order_by=[#3 desc nulls_first, #4 asc nulls_last] output=[#0..=#4]
     Project (#0..=#2, #4, #3) // { arity: 5 }
       Reduce group_by=[#2, #1, #0, #3] aggregates=[sum(#4)] // { arity: 5 }
-        Project (#1..=#3, #10, #14) // { arity: 5 }
-          Join on=(#0 = #9 AND eq(#1, #4, #7, #12) AND eq(#2, #5, #8, #13) AND eq(#3, #6, #11)) type=differential // { arity: 15 }
-            implementation
-              %3:orderline[#0..=#2] » %2:order[#0..=#2]UKKKAif » %0:customer[#0..=#2]UKKKAlif » %1:neworder[#0..=#2]UKKKAlif
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Project (#0..=#2) // { arity: 3 }
-                Filter "A%" ~~(padchar(#9)) // { arity: 22 }
-                  Get materialize.public.customer // { arity: 22 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Get materialize.public.neworder // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-              Project (#0..=#4) // { arity: 5 }
-                Filter (#3) IS NOT NULL AND (date_to_timestamp(#4) > 2007-01-02 00:00:00) // { arity: 8 }
-                  Get materialize.public.order // { arity: 8 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-              Project (#0..=#2, #8) // { arity: 4 }
+        Project (#1..=#3, #10, #22) // { arity: 5 }
+          Filter (date_to_timestamp(#10) > 2007-01-02 00:00:00) // { arity: 24 }
+            Join on=(#0 = #9 AND eq(#1, #4, #7, #15) AND eq(#2, #5, #8, #16) AND eq(#3, #6, #14)) type=differential // { arity: 24 }
+              implementation
+                %0:customer[#2, #1, #0]UKKKAlf » %2:order[#2, #1, #3]KKKAlif » %1:neworder[#0..=#2]UKKKAlif » %3:orderline[#2, #1, #0]KKKAlif
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 3 }
+                Project (#0..=#2) // { arity: 3 }
+                  Filter "A%" ~~(padchar(#9)) // { arity: 22 }
+                    Get materialize.public.customer // { arity: 22 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                Get materialize.public.neworder // { arity: 3 }
+              ArrangeBy keys=[[#2, #1, #3]] // { arity: 8 }
+                Get materialize.public.order // { arity: 8 }
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
                 Get materialize.public.orderline // { arity: 10 }
 
 Used Indexes:
@@ -428,23 +423,22 @@ Explained Query:
         Project (#4) // { arity: 1 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 9 }
             implementation
-              %1[#0..=#3] » %0:l0[#0..=#3]UKKKKAiif
+              %0:l0[#0..=#3]UKKKKAiif » %1[#0..=#3]UKKKKAiif
             ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
               Project (#0..=#2, #4, #6) // { arity: 5 }
                 Get l0 // { arity: 9 }
             ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
               Distinct group_by=[#0..=#3] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
-                  Filter (#7 >= #3) // { arity: 8 }
-                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 8 }
+                  Filter (#10 >= #3) // { arity: 14 }
+                    Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
                       implementation
-                        %1:orderline[#0..=#2] » %0:l0[#0..=#2]UKKKAiif
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                        %0:l0[#2, #1, #0]UKKKAiif » %1:orderline[#2, #1, #0]KKKAiif
+                      ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
                         Project (#0..=#2, #4) // { arity: 4 }
                           Get l0 // { arity: 9 }
-                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                        Project (#0..=#2, #6) // { arity: 4 }
-                          Get materialize.public.orderline // { arity: 10 }
+                      ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+                        Get materialize.public.orderline // { arity: 10 }
     With
       cte l0 =
         Filter (#8 < 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) // { arity: 9 }
@@ -484,22 +478,20 @@ ORDER BY revenue DESC
 Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
     Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
-      Project (#12, #19) // { arity: 2 }
-        Join on=(#0 = #7 AND eq(#1, #5, #9) AND eq(#2, #6, #10, #14) AND eq(#3, #17, #18) AND #4 = #8 AND #11 = #13 AND #15 = #16 AND #20 = #21) type=differential // { arity: 22 }
+      Project (#16, #24) // { arity: 2 }
+        Join on=(#0 = #7 AND eq(#1, #5, #9) AND eq(#2, #6, #10, #19) AND eq(#3, #22, #23) AND #4 = #8 AND #12 = #18 AND #20 = #21 AND #25 = #26) type=differential // { arity: 27 }
           implementation
-            %2:orderline[#0..=#2] » %1:order[#0..=#2]UKKKAif » %0:customer[#0..=#2]UKKKAif » %3:stock[#0, #1]UKKAif » %4:supplier[#0, #1]UKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif
+            %1:order[#3, #1, #2]KKKAif » %0:customer[#0..=#2]UKKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif » %2:orderline[#2, #1, #0]KKKAeif » %3:stock[#0, #1]UKKAeif » %4:supplier[#0, #1]UKKAeif
           ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
             Project (#0..=#2, #21) // { arity: 4 }
               Filter (#21) IS NOT NULL // { arity: 22 }
                 Get materialize.public.customer // { arity: 22 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+          ArrangeBy keys=[[#3, #1, #2]] // { arity: 4 }
             Project (#0..=#3) // { arity: 4 }
               Filter (#3) IS NOT NULL AND (date_to_timestamp(#4) >= 2007-01-02 00:00:00) // { arity: 8 }
                 Get materialize.public.order // { arity: 8 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-            Project (#0..=#2, #4, #8) // { arity: 5 }
-              Filter (#4) IS NOT NULL // { arity: 10 }
-                Get materialize.public.orderline // { arity: 10 }
+          ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+            Get materialize.public.orderline // { arity: 10 }
           ArrangeBy keys=[[#0, #1]] // { arity: 3 }
             Project (#0, #1, #17) // { arity: 3 }
               Get materialize.public.stock // { arity: 18 }
@@ -597,7 +589,7 @@ Explained Query:
           Filter (((#22 = "GERMANY") AND (#24 = "CAMBODIA")) OR ((#22 = "CAMBODIA") AND (#24 = "GERMANY"))) // { arity: 25 }
             Join on=(#0 = #4 AND #1 = #21 AND #2 = #8 AND #3 = #9 AND #5 = #11 AND eq(#6, #12, #17) AND eq(#7, #13, #18) AND #14 = #16 AND #20 = #23) type=differential // { arity: 25 }
               implementation
-                %2:orderline[#0..=#2] » %3:order[#0..=#2]UKKKAiif » %4:customer[#0..=#2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
+                %2:orderline[#0..=#2]KKKAiif » %3:order[#0..=#2]UKKKAiif » %4:customer[#0..=#2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
               ArrangeBy keys=[[#0]] // { arity: 2 }
                 Project (#0, #3) // { arity: 2 }
                   Get materialize.public.supplier // { arity: 7 }
@@ -669,44 +661,43 @@ Explained Query:
     Project (#0, #3) // { arity: 2 }
       Map ((#1 / case when (#2 = 0) then 1 else #2 end)) // { arity: 4 }
         Reduce group_by=[extract_year_d(#1)] aggregates=[sum(case when (#2 = "GERMANY") then #0 else 0 end), sum(#0)] // { arity: 3 }
-          Project (#11, #16, #24) // { arity: 3 }
-            Join on=(eq(#0, #3, #9) AND #1 = #5 AND #2 = #23 AND #4 = #10 AND #6 = #12 AND eq(#7, #13, #18) AND eq(#8, #14, #19) AND #15 = #17 AND #20 = #21 AND #22 = #25) type=differential // { arity: 26 }
-              implementation
-                %3:orderline[#0..=#2] » %4:order[#0..=#2]UKKKAiiif » %5:customer[#0..=#2]UKKKAiiif » %2:stock[#0, #1]UKKAiiiif » %0:item[#0]UKAliiiiif » %1:supplier[#0]UKAliiiiif » %6:nation[#0]UKAliiiiif » %8:region[#0]UKAeliiiiif » %7:nation[#0]UKAeliiiiif
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#0 < 1000) AND "%b" ~~(padchar(#4)) // { arity: 5 }
-                    Get materialize.public.item // { arity: 5 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Project (#0, #3) // { arity: 2 }
-                  Get materialize.public.supplier // { arity: 7 }
-              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                Project (#0, #1, #17) // { arity: 3 }
-                  Filter (#0 < 1000) // { arity: 18 }
-                    Get materialize.public.stock // { arity: 18 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
-                Project (#0..=#2, #4, #5, #8) // { arity: 6 }
-                  Filter (#4 < 1000) AND (#5) IS NOT NULL // { arity: 10 }
-                    Get materialize.public.orderline // { arity: 10 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                Project (#0..=#4) // { arity: 5 }
-                  Filter (#8 <= 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) AND (#3) IS NOT NULL // { arity: 9 }
-                    Map (date_to_timestamp(#4)) // { arity: 9 }
-                      Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                Project (#0..=#2, #21) // { arity: 4 }
-                  Filter (#21) IS NOT NULL // { arity: 22 }
-                    Get materialize.public.customer // { arity: 22 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Project (#0, #2) // { arity: 2 }
-                  Get materialize.public.nation // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Get materialize.public.nation // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Filter (#1 = "EUROPE") // { arity: 3 }
-                    Get materialize.public.region // { arity: 3 }
+          Project (#14, #20, #28) // { arity: 3 }
+            Filter (#0 < 1000) // { arity: 30 }
+              Join on=(eq(#0, #3, #10) AND #1 = #5 AND #2 = #27 AND #4 = #11 AND #6 = #16 AND eq(#7, #17, #22) AND eq(#8, #18, #23) AND #19 = #21 AND #24 = #25 AND #26 = #29) type=differential // { arity: 30 }
+                implementation
+                  %4:order[#3, #1, #2]KKKAiif » %5:customer[#0..=#2]UKKKAiif » %6:nation[#0]UKAiif » %8:region[#0]UKAeiif » %3:orderline[#2, #1, #0]KKKAeiiif » %2:stock[#0, #1]UKKAeiiiiif » %0:item[#0]UKAeliiiiiiif » %1:supplier[#0]UKAeliiiiiiif » %7:nation[#0]UKAeliiiiiiif
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Filter (#0 < 1000) AND "%b" ~~(padchar(#4)) // { arity: 5 }
+                      Get materialize.public.item // { arity: 5 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Project (#0, #3) // { arity: 2 }
+                    Get materialize.public.supplier // { arity: 7 }
+                ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                  Project (#0, #1, #17) // { arity: 3 }
+                    Filter (#0 < 1000) // { arity: 18 }
+                      Get materialize.public.stock // { arity: 18 }
+                ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+                  Get materialize.public.orderline // { arity: 10 }
+                ArrangeBy keys=[[#3, #1, #2]] // { arity: 5 }
+                  Project (#0..=#4) // { arity: 5 }
+                    Filter (#8 <= 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) AND (#3) IS NOT NULL // { arity: 9 }
+                      Map (date_to_timestamp(#4)) // { arity: 9 }
+                        Get materialize.public.order // { arity: 8 }
+                ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                  Project (#0..=#2, #21) // { arity: 4 }
+                    Filter (#21) IS NOT NULL // { arity: 22 }
+                      Get materialize.public.customer // { arity: 22 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Project (#0, #2) // { arity: 2 }
+                    Get materialize.public.nation // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Get materialize.public.nation // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Filter (#1 = "EUROPE") // { arity: 3 }
+                      Get materialize.public.region // { arity: 3 }
 
 Source materialize.public.item
   filter=((#0 < 1000) AND "%b" ~~(padchar(#4)))
@@ -745,10 +736,10 @@ ORDER BY n_name, l_year DESC
 Explained Query:
   Finish order_by=[#0 asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
     Reduce group_by=[#2, extract_year_d(#1)] aggregates=[sum(#0)] // { arity: 3 }
-      Project (#11, #15, #17) // { arity: 3 }
-        Join on=(eq(#0, #1, #9) AND #2 = #10 AND #3 = #4 AND #5 = #16 AND #6 = #12 AND #7 = #13 AND #8 = #14) type=differential // { arity: 18 }
+      Project (#14, #19, #21) // { arity: 3 }
+        Join on=(eq(#0, #1, #10) AND #2 = #11 AND #3 = #4 AND #5 = #20 AND #6 = #16 AND #7 = #17 AND #8 = #18) type=differential // { arity: 22 }
           implementation
-            %3:orderline[#0..=#2] » %4:order[#0..=#2]UKKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
+            %4:order[#2, #1, #0]UKKKA » %3:orderline[#2, #1, #0]KKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter "%BB" ~~(padchar(#4)) // { arity: 5 }
@@ -759,11 +750,9 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Project (#0, #3) // { arity: 2 }
               Get materialize.public.supplier // { arity: 7 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
-            Project (#0..=#2, #4, #5, #8) // { arity: 6 }
-              Filter (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 10 }
-                Get materialize.public.orderline // { arity: 10 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+          ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+            Get materialize.public.orderline // { arity: 10 }
+          ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
             Project (#0..=#2, #4) // { arity: 4 }
               Get materialize.public.order // { arity: 8 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -804,22 +793,21 @@ Explained Query:
   Finish order_by=[#2 desc nulls_first] output=[#0..=#5]
     Project (#0, #1, #5, #2..=#4) // { arity: 6 }
       Reduce group_by=[#0..=#3, #5] aggregates=[sum(#4)] // { arity: 6 }
-        Project (#0, #3..=#5, #16, #18) // { arity: 6 }
-          Filter (#11 <= #15) // { arity: 19 }
-            Join on=(#0 = #10 AND eq(#1, #8, #13) AND eq(#2, #9, #14) AND #6 = #17 AND #7 = #12) type=differential // { arity: 19 }
+        Project (#0, #3..=#5, #20, #23) // { arity: 6 }
+          Filter (#11 <= #18) // { arity: 24 }
+            Join on=(#0 = #10 AND eq(#1, #8, #13) AND eq(#2, #9, #14) AND #6 = #22 AND #7 = #12) type=differential // { arity: 24 }
               implementation
-                %2:orderline[#0..=#2] » %1:order[#0..=#2]UKKKAif » %0:customer[#0..=#2]UKKKAif » %3:nation[#0]UKAif
+                %1:order[#3, #1, #2]KKKAif » %0:customer[#0..=#2]UKKKAif » %3:nation[#0]UKAif » %2:orderline[#2, #1, #0]KKKAif
               ArrangeBy keys=[[#0..=#2]] // { arity: 7 }
                 Project (#0..=#2, #5, #8, #11, #21) // { arity: 7 }
                   Filter (#21) IS NOT NULL // { arity: 22 }
                     Get materialize.public.customer // { arity: 22 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
+              ArrangeBy keys=[[#3, #1, #2]] // { arity: 5 }
                 Project (#0..=#4) // { arity: 5 }
                   Filter (#3) IS NOT NULL AND (date_to_timestamp(#4) >= 2007-01-02 00:00:00) // { arity: 8 }
                     Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                Project (#0..=#2, #6, #8) // { arity: 5 }
-                  Get materialize.public.orderline // { arity: 10 }
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+                Get materialize.public.orderline // { arity: 10 }
               ArrangeBy keys=[[#0]] // { arity: 2 }
                 Project (#0, #1) // { arity: 2 }
                   Get materialize.public.nation // { arity: 4 }
@@ -857,7 +845,7 @@ Explained Query:
         Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0[×] » %1[×]UA
+              %1[×]UA » %0[×]A
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
                 Get l0 // { arity: 2 }
@@ -868,14 +856,13 @@ Explained Query:
     With
       cte l0 =
         Project (#0, #14) // { arity: 2 }
-          Join on=(#17 = #18 AND #19 = #20) type=differential // { arity: 21 }
+          Join on=(#17 = #18 AND #21 = #25) type=differential // { arity: 26 }
             implementation
-              %0:stock[#17] » %1:supplier[#0]UKA » %2:nation[#0]UKAef
+              %2:nation[#0]UKAef » %1:supplier[#3]KAef » %0:stock[#17]KAef
             ArrangeBy keys=[[#17]] // { arity: 18 }
               Get materialize.public.stock // { arity: 18 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Project (#0, #3) // { arity: 2 }
-                Get materialize.public.supplier // { arity: 7 }
+            ArrangeBy keys=[[#3]] // { arity: 7 }
+              Get materialize.public.supplier // { arity: 7 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#1 = "GERMANY") // { arity: 4 }
@@ -909,17 +896,15 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     Reduce group_by=[#1] aggregates=[sum(case when ((#0 = 1) OR (#0 = 2)) then 1 else 0 end), sum(case when ((#0 != 1) AND (#0 != 2)) then 1 else 0 end)] // { arity: 3 }
       Project (#4, #5) // { arity: 2 }
-        Filter (#3 <= #9) // { arity: 10 }
-          Join on=(#0 = #6 AND #1 = #7 AND #2 = #8) type=differential // { arity: 10 }
+        Filter (date_to_timestamp(#12) < 2020-01-01 00:00:00) AND (#3 <= #12) // { arity: 16 }
+          Join on=(#0 = #6 AND #1 = #7 AND #2 = #8) type=differential // { arity: 16 }
             implementation
-              %1:orderline[#0..=#2] » %0:order[#0..=#2]UKKKAif
-            ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
+              %0:order[#2, #1, #0]UKKKA » %1:orderline[#2, #1, #0]KKKAif
+            ArrangeBy keys=[[#2, #1, #0]] // { arity: 6 }
               Project (#0..=#2, #4..=#6) // { arity: 6 }
                 Get materialize.public.order // { arity: 8 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-              Project (#0..=#2, #6) // { arity: 4 }
-                Filter (date_to_timestamp(#6) < 2020-01-01 00:00:00) // { arity: 10 }
-                  Get materialize.public.orderline // { arity: 10 }
+            ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+              Get materialize.public.orderline // { arity: 10 }
 
 Used Indexes:
   - materialize.public.fk_order_customer
@@ -964,15 +949,14 @@ Explained Query:
     With
       cte l0 =
         Project (#0..=#22) // { arity: 23 }
-          Join on=(#0 = #25 AND #1 = #23 AND #2 = #24) type=differential // { arity: 26 }
-            implementation
-              %1:order[#3, #1, #2] » %0:customer[#0..=#2]UKKKAif
-            ArrangeBy keys=[[#0..=#2]] // { arity: 22 }
-              Get materialize.public.customer // { arity: 22 }
-            ArrangeBy keys=[[#3, #1, #2]] // { arity: 4 }
-              Project (#0..=#3) // { arity: 4 }
-                Filter (#5 > 8) AND (#3) IS NOT NULL // { arity: 8 }
-                  Get materialize.public.order // { arity: 8 }
+          Filter (#27 > 8) // { arity: 30 }
+            Join on=(#0 = #25 AND #1 = #23 AND #2 = #24) type=differential // { arity: 30 }
+              implementation
+                %0:customer[#2, #1, #0]UKKKA » %1:order[#2, #1, #3]KKKAif
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 22 }
+                Get materialize.public.customer // { arity: 22 }
+              ArrangeBy keys=[[#2, #1, #3]] // { arity: 8 }
+                Get materialize.public.order // { arity: 8 }
 
 Used Indexes:
   - materialize.public.fk_customer_district
@@ -1011,7 +995,7 @@ Explained Query:
             Map (date_to_timestamp(#6)) // { arity: 13 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
-                  %0:orderline[#4] » %1:item[#0]UKAiif
+                  %1:item[#0]UKA » %0:orderline[#4]KAiif
                 ArrangeBy keys=[[#4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1061,7 +1045,7 @@ Explained Query:
       Project (#0..=#3, #5) // { arity: 5 }
         Join on=(#0 = #4 AND #5 = #6) type=differential // { arity: 7 }
           implementation
-            %1:l0[#0] » %0:supplier[#0]UKA » %2[#0]UKA
+            %0:supplier[#0]UKA » %1:l0[#0]UKA » %2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 4 }
             Project (#0..=#2, #4) // { arity: 4 }
               Get materialize.public.supplier // { arity: 7 }
@@ -1075,20 +1059,19 @@ Explained Query:
     With
       cte l0 =
         Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
-          Project (#2, #5) // { arity: 2 }
-            Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 6 }
-              implementation
-                %0:orderline[#0, #1] » %1:stock[#0, #1]UKKAif
-              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                Project (#4, #5, #8) // { arity: 3 }
-                  Filter (#4) IS NOT NULL AND (#5) IS NOT NULL AND (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 10 }
-                    Get materialize.public.orderline // { arity: 10 }
-              ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                Project (#0, #1, #17) // { arity: 3 }
-                  Get materialize.public.stock // { arity: 18 }
+          Project (#8, #12) // { arity: 2 }
+            Filter (date_to_timestamp(#6) >= 2007-01-02 00:00:00) // { arity: 13 }
+              Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 13 }
+                implementation
+                  %1:stock[#1, #0]UKKA » %0:orderline[#5, #4]KKAif
+                ArrangeBy keys=[[#5, #4]] // { arity: 10 }
+                  Get materialize.public.orderline // { arity: 10 }
+                ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                  Project (#0, #1, #17) // { arity: 3 }
+                    Get materialize.public.stock // { arity: 18 }
 
 Used Indexes:
-  - materialize.public.fk_orderline_order
+  - materialize.public.fk_orderline_stock
   - materialize.public.fk_stock_warehouse
   - materialize.public.fk_supplier_nationkey
 
@@ -1118,7 +1101,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %1[#0] » %0:l0[#0]KA
+              %0:l0[#0]KA » %1[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Get l0 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1127,7 +1110,7 @@ Explained Query:
                   Project (#0) // { arity: 1 }
                     Join on=(#0 = #1) type=differential // { arity: 2 }
                       implementation
-                        %1:supplier[#0] » %0:l1[#0]UKAlf
+                        %1:supplier[#0]UKAlf » %0:l1[#0]UKAlf
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Get l1 // { arity: 1 }
                       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1144,7 +1127,7 @@ Explained Query:
         Project (#17, #19..=#21) // { arity: 4 }
           Join on=(#0 = #18) type=differential // { arity: 22 }
             implementation
-              %0:stock[#0] » %1:item[#0]UKAf
+              %1:item[#0]UKAf » %0:stock[#0]KAf
             ArrangeBy keys=[[#0]] // { arity: 18 }
               Get materialize.public.stock // { arity: 18 }
             ArrangeBy keys=[[#0]] // { arity: 4 }
@@ -1197,14 +1180,14 @@ Explained Query:
           Filter (integer_to_double(#7) < (bigint_to_double(#11) / bigint_to_double(case when (#12 = 0) then null else #12 end))) // { arity: 13 }
             Join on=(#4 = #10) type=differential // { arity: 13 }
               implementation
-                %0:l0[#4] » %1[#0]UKA
+                %1[#0]UKA » %0:l0[#4]KA
               Get l0 // { arity: 10 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Reduce group_by=[#0] aggregates=[sum(#1), count(#1)] // { arity: 3 }
                   Project (#0, #8) // { arity: 2 }
                     Join on=(#0 = #5) type=differential // { arity: 11 }
                       implementation
-                        %1:l0[#4] » %0:item[#0]UKAlf
+                        %0:item[#0]UKAlf » %1:l0[#4]KAlf
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Filter "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -1242,20 +1225,17 @@ Explained Query:
     Project (#4, #3, #0, #5..=#7) // { arity: 6 }
       Filter (#7 > 200) // { arity: 8 }
         Reduce group_by=[#4, #2, #1, #0, #3, #5, #6] aggregates=[sum(#7)] // { arity: 8 }
-          Project (#0..=#4, #8, #9, #13) // { arity: 8 }
-            Join on=(#0 = #7 AND eq(#1, #5, #11) AND eq(#2, #6, #12) AND #4 = #10) type=differential // { arity: 14 }
+          Project (#0..=#4, #8, #10, #20) // { arity: 8 }
+            Join on=(#0 = #7 AND eq(#1, #5, #13) AND eq(#2, #6, #14) AND #4 = #12) type=differential // { arity: 22 }
               implementation
-                %2:orderline[#0..=#2] » %1:order[#0..=#2]UKKKA » %0:customer[#0..=#2]UKKKA
-              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                %0:customer[#2, #1, #0]UKKKA » %1:order[#2, #1, #3]KKKA » %2:orderline[#2, #1, #0]KKKA
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
                 Project (#0..=#2, #5) // { arity: 4 }
                   Get materialize.public.customer // { arity: 22 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
-                Project (#0..=#4, #6) // { arity: 6 }
-                  Filter (#3) IS NOT NULL // { arity: 8 }
-                    Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
-                Project (#0..=#2, #8) // { arity: 4 }
-                  Get materialize.public.orderline // { arity: 10 }
+              ArrangeBy keys=[[#2, #1, #3]] // { arity: 8 }
+                Get materialize.public.order // { arity: 8 }
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+                Get materialize.public.orderline // { arity: 10 }
 
 Used Indexes:
   - materialize.public.fk_customer_district
@@ -1311,7 +1291,7 @@ Explained Query:
             Map ((#2 = 1), (#2 = 2), (#2 = 3), (#2 = 4), (#2 = 5), padchar(#11)) // { arity: 18 }
               Join on=(#4 = #10) type=differential // { arity: 12 }
                 implementation
-                  %0:orderline[#4] » %1:item[#0]UKAeliiiif
+                  %1:item[#0]UKAliif » %0:orderline[#4]KAeliiiif
                 ArrangeBy keys=[[#4]] // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
                 ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1354,7 +1334,7 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            %1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1366,7 +1346,7 @@ Explained Query:
                       Filter (date_to_timestamp(#25) > 2010-05-23 12:00:00) // { arity: 30 }
                         Join on=(eq(#1, #23, #29)) type=differential // { arity: 30 }
                           implementation
-                            %2:orderline[#4] » %3:item[#0]UKAlif » %1:stock[#0]KAlif » %0:l0[×]Alif
+                            %3:item[#0]UKAlf » %2:orderline[#4]KAlif » %1:stock[#0]KAlif » %0:l0[×]Alif
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l0 // { arity: 3 }
@@ -1383,7 +1363,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#3 = #7) type=differential // { arity: 8 }
             implementation
-              %0:supplier[#3] » %1:nation[#0]UKAef
+              %1:nation[#0]UKAef » %0:supplier[#3]KAef
             ArrangeBy keys=[[#3]] // { arity: 7 }
               Get materialize.public.supplier // { arity: 7 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1436,9 +1416,9 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
             implementation
-              %1[#0..=#3] » %0:l0[#1..=#4]KKKKA
+              %0:l1[#1..=#4]KKKKA » %1[#0..=#3]KKKKA
             ArrangeBy keys=[[#1..=#4]] // { arity: 5 }
-              Get l0 // { arity: 5 }
+              Get l1 // { arity: 5 }
             ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
@@ -1447,31 +1427,27 @@ Explained Query:
                       Filter (#10 > #3) // { arity: 14 }
                         Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
                           implementation
-                            %1:orderline[#2, #1, #0] » %0:l1[#2, #1, #0]KKKA
+                            %0:l2[#2, #1, #0]KKKA » %1:l0[#2, #1, #0]KKKA
                           ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
-                            Get l1 // { arity: 4 }
-                          ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
-                            Get materialize.public.orderline // { arity: 10 }
-                Get l1 // { arity: 4 }
+                            Get l2 // { arity: 4 }
+                          Get l0 // { arity: 10 }
+                Get l2 // { arity: 4 }
     With
-      cte l1 =
+      cte l2 =
         Distinct group_by=[#0..=#3] // { arity: 4 }
           Project (#1..=#4) // { arity: 4 }
-            Get l0 // { arity: 5 }
-      cte l0 =
-        Project (#1, #3..=#5, #7) // { arity: 5 }
-          Filter (#7 > #11) // { arity: 16 }
-            Join on=(#0 = #14 AND #2 = #15 AND #3 = #8 AND #4 = #9 AND eq(#5, #10, #13) AND #6 = #12) type=differential // { arity: 16 }
+            Get l1 // { arity: 5 }
+      cte l1 =
+        Project (#1, #3..=#5, #9) // { arity: 5 }
+          Filter (#9 > #16) // { arity: 21 }
+            Join on=(#0 = #19 AND #2 = #20 AND #3 = #13 AND #4 = #14 AND eq(#5, #15, #18) AND #7 = #17) type=differential // { arity: 21 }
               implementation
-                %1:orderline[#0..=#2] » %2:order[#0..=#2]UKKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
+                %2:order[#2, #1, #0]UKKKA » %1:l0[#2, #1, #0]KKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Project (#0, #1, #3) // { arity: 3 }
                   Get materialize.public.supplier // { arity: 7 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
-                Project (#0..=#2, #4, #6) // { arity: 5 }
-                  Filter (#4) IS NOT NULL // { arity: 10 }
-                    Get materialize.public.orderline // { arity: 10 }
-              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+              Get l0 // { arity: 10 }
+              ArrangeBy keys=[[#2, #1, #0]] // { arity: 4 }
                 Project (#0..=#2, #4) // { arity: 4 }
                   Get materialize.public.order // { arity: 8 }
               ArrangeBy keys=[[#0, #1]] // { arity: 3 }
@@ -1481,6 +1457,9 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Filter (#1 = "GERMANY") // { arity: 4 }
                     Get materialize.public.nation // { arity: 4 }
+      cte l0 =
+        ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
+          Get materialize.public.orderline // { arity: 10 }
 
 Used Indexes:
   - materialize.public.fk_order_customer
@@ -1521,7 +1500,7 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
-              %1[#0..=#2] » %0:l1[#0..=#2]UKKKA
+              %0:l1[#0..=#2]UKKKA » %1[#0..=#2]KKKA
             ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
               Get l1 // { arity: 5 }
             ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
@@ -1530,7 +1509,7 @@ Explained Query:
                   Project (#0..=#2) // { arity: 3 }
                     Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                       implementation
-                        %1[#0..=#2] » %0:l2[#0..=#2]UKKKA
+                        %0:l2[#0..=#2]UKKKA » %1[#0..=#2]UKKKA
                       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                         Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
@@ -1548,7 +1527,7 @@ Explained Query:
           Filter (numeric_to_double(#4) > (numeric_to_double(#5) / bigint_to_double(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
             CrossJoin type=differential // { arity: 7 }
               implementation
-                %0:l0[×] » %1[×]UAef
+                %1[×]UA » %0:l0[×]Aef
               ArrangeBy keys=[[]] // { arity: 5 }
                 Project (#0..=#2, #9, #16) // { arity: 5 }
                   Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -44,7 +44,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 , t2 WHERE t1.f1 = 123 AND t1.f
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:t2[×] » %0:t1[×]UAef
+      %0:t1[×]UAef » %1:t2[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -80,7 +80,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1:t2[×] » %0:l0[×]UAef
+          %0:l0[×]UAef » %1:t2[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 2 }
@@ -114,7 +114,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 3 }
         implementation
-          %1:t2[×] » %0:l0[×]UAef
+          %0:l0[×]UAef » %1:t2[×]UAef
         ArrangeBy keys=[[]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 1 }
@@ -138,7 +138,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 ON (TRUE) WHERE t1
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:t2[×] » %0:t1[×]UAef
+      %0:t1[×]UAef » %1:t2[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -192,7 +192,7 @@ Explained Query:
   Map (123) // { arity: 1 }
     CrossJoin type=differential // { arity: 0 }
       implementation
-        %1:t2[×] » %0:t1[×]UAef
+        %0:t1[×]UAef » %1:t2[×]UAef
       ArrangeBy keys=[[]] // { arity: 0 }
         Project () // { arity: 0 }
           Filter (#0 = 123) // { arity: 2 }
@@ -220,7 +220,7 @@ Explained Query:
   Return // { arity: 1 }
     CrossJoin type=differential // { arity: 1 }
       implementation
-        %1[×] » %0:l1[×]UAef
+        %0:l1[×]UAef » %1[×]UAef
       Get l1 // { arity: 0 }
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
@@ -235,7 +235,7 @@ Explained Query:
     cte l2 =
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:t1[×] » %0:l1[×]UAef
+          %0:l1[×]UAef » %1:t1[×]UAef
         Get l1 // { arity: 0 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#0) // { arity: 1 }
@@ -266,7 +266,7 @@ Explained Query:
       Map ((#0 = 123)) // { arity: 2 }
         CrossJoin type=differential // { arity: 1 }
           implementation
-            %1[×] » %0:t2[×]UAef
+            %0:t2[×]UAef » %1[×]Aef
           ArrangeBy keys=[[]] // { arity: 0 }
             Project () // { arity: 0 }
               Filter (#0 = 123) // { arity: 2 }
@@ -305,7 +305,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND EXISTS (S
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1:t2[×] » %0:t1[×]UAef
+      %0:t1[×]UAef » %1:t2[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -357,7 +357,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, (SELECT t2.f1 FROM t2) AS dt1 
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1:t2[×] » %0:t1[×]UAef
+      %0:t1[×]UAef » %1:t2[×]UAef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -379,7 +379,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE 123 = (SELECT t2.f1 FROM 
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1[×] » %0:t1[×]A
+      %0:t1[×]A » %1[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[]] // { arity: 0 }
@@ -401,7 +401,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE t1.f1 = 123 AND t1.f1 = (
 Explained Query:
   CrossJoin type=differential // { arity: 2 }
     implementation
-      %1[×] » %0:t1[×]UAef
+      %0:t1[×]UAef » %1[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -513,7 +513,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1, t2 WHERE t1.f1 = 123 AND t1.f1
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:t2[×] » %0:t1[×]UAeif
+      %0:t1[×]UAef » %1:t2[×]Aeif
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 123) // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
@@ -542,7 +542,7 @@ explain with(arity, join_impls) select * from int_table, double_table where int_
 Explained Query:
   Join on=(#1 = integer_to_double(#0)) type=differential // { arity: 2 }
     implementation
-      %1:double_table[#0] » %0:int_table[integer_to_double(#0)]KA
+      %0:int_table[integer_to_double(#0)]KA » %1:double_table[#0]KA
     ArrangeBy keys=[[integer_to_double(#0)]] // { arity: 1 }
       Get materialize.public.int_table // { arity: 1 }
     ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -1416,12 +1416,25 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                         "implementation": {
                                           "Differential": [
                                             [
-                                              1,
-                                              []
+                                              0,
+                                              [],
+                                              {
+                                                "unique_key": false,
+                                                "key_length": 0,
+                                                "arranged": true,
+                                                "filters": {
+                                                  "literal_equality": false,
+                                                  "like": false,
+                                                  "is_null": false,
+                                                  "literal_inequality": 0,
+                                                  "any_filter": false
+                                                },
+                                                "input": 0
+                                              }
                                             ],
                                             [
                                               [
-                                                0,
+                                                1,
                                                 [],
                                                 {
                                                   "unique_key": false,
@@ -1434,7 +1447,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                     "literal_inequality": 0,
                                                     "any_filter": false
                                                   },
-                                                  "input": 0
+                                                  "input": 1
                                                 }
                                               ]
                                             ]
@@ -1495,23 +1508,36 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                   "implementation": {
                     "Differential": [
                       [
-                        0,
+                        1,
                         [
                           {
                             "Column": 0
                           }
-                        ]
+                        ],
+                        {
+                          "unique_key": true,
+                          "key_length": 1,
+                          "arranged": true,
+                          "filters": {
+                            "literal_equality": false,
+                            "like": false,
+                            "is_null": false,
+                            "literal_inequality": 0,
+                            "any_filter": false
+                          },
+                          "input": 1
+                        }
                       ],
                       [
                         [
-                          1,
+                          0,
                           [
                             {
                               "Column": 0
                             }
                           ],
                           {
-                            "unique_key": true,
+                            "unique_key": false,
                             "key_length": 1,
                             "arranged": true,
                             "filters": {
@@ -1521,7 +1547,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                               "literal_inequality": 0,
                               "any_filter": false
                             },
-                            "input": 1
+                            "input": 0
                           }
                         ]
                       ]
@@ -1669,12 +1695,25 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                         "implementation": {
                                           "Differential": [
                                             [
-                                              1,
-                                              []
+                                              0,
+                                              [],
+                                              {
+                                                "unique_key": false,
+                                                "key_length": 0,
+                                                "arranged": true,
+                                                "filters": {
+                                                  "literal_equality": false,
+                                                  "like": false,
+                                                  "is_null": false,
+                                                  "literal_inequality": 0,
+                                                  "any_filter": false
+                                                },
+                                                "input": 0
+                                              }
                                             ],
                                             [
                                               [
-                                                0,
+                                                1,
                                                 [],
                                                 {
                                                   "unique_key": false,
@@ -1687,7 +1726,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                                     "literal_inequality": 0,
                                                     "any_filter": false
                                                   },
-                                                  "input": 0
+                                                  "input": 1
                                                 }
                                               ]
                                             ]
@@ -1748,23 +1787,36 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                   "implementation": {
                     "Differential": [
                       [
-                        0,
+                        1,
                         [
                           {
-                            "Column": 1
+                            "Column": 0
                           }
-                        ]
+                        ],
+                        {
+                          "unique_key": true,
+                          "key_length": 1,
+                          "arranged": true,
+                          "filters": {
+                            "literal_equality": false,
+                            "like": false,
+                            "is_null": false,
+                            "literal_inequality": 0,
+                            "any_filter": false
+                          },
+                          "input": 1
+                        }
                       ],
                       [
                         [
-                          1,
+                          0,
                           [
                             {
-                              "Column": 0
+                              "Column": 1
                             }
                           ],
                           {
-                            "unique_key": true,
+                            "unique_key": false,
                             "key_length": 1,
                             "arranged": true,
                             "filters": {
@@ -1774,7 +1826,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                               "literal_inequality": 0,
                               "any_filter": false
                             },
-                            "input": 1
+                            "input": 0
                           }
                         ]
                       ]
@@ -2002,23 +2054,36 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                   "implementation": {
                                     "Differential": [
                                       [
-                                        1,
+                                        0,
                                         [
                                           {
-                                            "Column": 1
+                                            "Column": 0
                                           }
-                                        ]
+                                        ],
+                                        {
+                                          "unique_key": true,
+                                          "key_length": 1,
+                                          "arranged": true,
+                                          "filters": {
+                                            "literal_equality": false,
+                                            "like": false,
+                                            "is_null": false,
+                                            "literal_inequality": 0,
+                                            "any_filter": false
+                                          },
+                                          "input": 0
+                                        }
                                       ],
                                       [
                                         [
-                                          0,
+                                          1,
                                           [
                                             {
-                                              "Column": 0
+                                              "Column": 1
                                             }
                                           ],
                                           {
-                                            "unique_key": true,
+                                            "unique_key": false,
                                             "key_length": 1,
                                             "arranged": true,
                                             "filters": {
@@ -2028,7 +2093,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                               "literal_inequality": 0,
                                               "any_filter": false
                                             },
-                                            "input": 0
+                                            "input": 1
                                           }
                                         ]
                                       ]
@@ -2151,23 +2216,36 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                       "implementation": {
                                         "Differential": [
                                           [
-                                            1,
+                                            0,
                                             [
                                               {
-                                                "Column": 1
+                                                "Column": 0
                                               }
-                                            ]
+                                            ],
+                                            {
+                                              "unique_key": true,
+                                              "key_length": 1,
+                                              "arranged": true,
+                                              "filters": {
+                                                "literal_equality": false,
+                                                "like": false,
+                                                "is_null": false,
+                                                "literal_inequality": 0,
+                                                "any_filter": false
+                                              },
+                                              "input": 0
+                                            }
                                           ],
                                           [
                                             [
-                                              0,
+                                              1,
                                               [
                                                 {
-                                                  "Column": 0
+                                                  "Column": 1
                                                 }
                                               ],
                                               {
-                                                "unique_key": true,
+                                                "unique_key": false,
                                                 "key_length": 1,
                                                 "arranged": true,
                                                 "filters": {
@@ -2177,7 +2255,7 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
                                                   "literal_inequality": 0,
                                                   "any_filter": false
                                                 },
-                                                "input": 0
+                                                "input": 1
                                               }
                                             ]
                                           ]
@@ -3146,23 +3224,36 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                           "implementation": {
                                             "Differential": [
                                               [
-                                                0,
+                                                1,
                                                 [
                                                   {
                                                     "Column": 0
                                                   }
-                                                ]
+                                                ],
+                                                {
+                                                  "unique_key": true,
+                                                  "key_length": 1,
+                                                  "arranged": true,
+                                                  "filters": {
+                                                    "literal_equality": false,
+                                                    "like": false,
+                                                    "is_null": false,
+                                                    "literal_inequality": 0,
+                                                    "any_filter": false
+                                                  },
+                                                  "input": 1
+                                                }
                                               ],
                                               [
                                                 [
-                                                  1,
+                                                  0,
                                                   [
                                                     {
                                                       "Column": 0
                                                     }
                                                   ],
                                                   {
-                                                    "unique_key": true,
+                                                    "unique_key": false,
                                                     "key_length": 1,
                                                     "arranged": true,
                                                     "filters": {
@@ -3172,7 +3263,7 @@ RIGHT JOIN t as t3 ON t2.b = t3.b
                                                       "literal_inequality": 0,
                                                       "any_filter": false
                                                     },
-                                                    "input": 1
+                                                    "input": 0
                                                   }
                                                 ]
                                               ]
@@ -3489,12 +3580,25 @@ FROM
                                             "implementation": {
                                               "Differential": [
                                                 [
-                                                  1,
-                                                  []
+                                                  0,
+                                                  [],
+                                                  {
+                                                    "unique_key": false,
+                                                    "key_length": 0,
+                                                    "arranged": true,
+                                                    "filters": {
+                                                      "literal_equality": false,
+                                                      "like": false,
+                                                      "is_null": false,
+                                                      "literal_inequality": 0,
+                                                      "any_filter": false
+                                                    },
+                                                    "input": 0
+                                                  }
                                                 ],
                                                 [
                                                   [
-                                                    0,
+                                                    1,
                                                     [],
                                                     {
                                                       "unique_key": false,
@@ -3507,7 +3611,7 @@ FROM
                                                         "literal_inequality": 0,
                                                         "any_filter": false
                                                       },
-                                                      "input": 0
+                                                      "input": 1
                                                     }
                                                   ]
                                                 ]
@@ -3564,23 +3668,36 @@ FROM
                               "implementation": {
                                 "Differential": [
                                   [
-                                    0,
+                                    1,
                                     [
                                       {
                                         "Column": 0
                                       }
-                                    ]
+                                    ],
+                                    {
+                                      "unique_key": true,
+                                      "key_length": 1,
+                                      "arranged": true,
+                                      "filters": {
+                                        "literal_equality": false,
+                                        "like": false,
+                                        "is_null": false,
+                                        "literal_inequality": 0,
+                                        "any_filter": true
+                                      },
+                                      "input": 1
+                                    }
                                   ],
                                   [
                                     [
-                                      1,
+                                      0,
                                       [
                                         {
                                           "Column": 0
                                         }
                                       ],
                                       {
-                                        "unique_key": true,
+                                        "unique_key": false,
                                         "key_length": 1,
                                         "arranged": true,
                                         "filters": {
@@ -3590,7 +3707,7 @@ FROM
                                           "literal_inequality": 0,
                                           "any_filter": true
                                         },
-                                        "input": 1
+                                        "input": 0
                                       }
                                     ]
                                   ]
@@ -3740,12 +3857,25 @@ FROM
                                             "implementation": {
                                               "Differential": [
                                                 [
-                                                  1,
-                                                  []
+                                                  0,
+                                                  [],
+                                                  {
+                                                    "unique_key": false,
+                                                    "key_length": 0,
+                                                    "arranged": true,
+                                                    "filters": {
+                                                      "literal_equality": false,
+                                                      "like": false,
+                                                      "is_null": false,
+                                                      "literal_inequality": 0,
+                                                      "any_filter": false
+                                                    },
+                                                    "input": 0
+                                                  }
                                                 ],
                                                 [
                                                   [
-                                                    0,
+                                                    1,
                                                     [],
                                                     {
                                                       "unique_key": false,
@@ -3758,7 +3888,7 @@ FROM
                                                         "literal_inequality": 0,
                                                         "any_filter": false
                                                       },
-                                                      "input": 0
+                                                      "input": 1
                                                     }
                                                   ]
                                                 ]
@@ -3815,23 +3945,36 @@ FROM
                               "implementation": {
                                 "Differential": [
                                   [
-                                    0,
+                                    1,
                                     [
                                       {
                                         "Column": 0
                                       }
-                                    ]
+                                    ],
+                                    {
+                                      "unique_key": true,
+                                      "key_length": 1,
+                                      "arranged": true,
+                                      "filters": {
+                                        "literal_equality": false,
+                                        "like": false,
+                                        "is_null": true,
+                                        "literal_inequality": 0,
+                                        "any_filter": false
+                                      },
+                                      "input": 1
+                                    }
                                   ],
                                   [
                                     [
-                                      1,
+                                      0,
                                       [
                                         {
                                           "Column": 0
                                         }
                                       ],
                                       {
-                                        "unique_key": true,
+                                        "unique_key": false,
                                         "key_length": 1,
                                         "arranged": true,
                                         "filters": {
@@ -3841,7 +3984,7 @@ FROM
                                           "literal_inequality": 0,
                                           "any_filter": false
                                         },
-                                        "input": 1
+                                        "input": 0
                                       }
                                     ]
                                   ]
@@ -4013,12 +4156,25 @@ SELECT t1.a, t2.a FROM t as t1, t as t2
               "implementation": {
                 "Differential": [
                   [
-                    1,
-                    []
+                    0,
+                    [],
+                    {
+                      "unique_key": false,
+                      "key_length": 0,
+                      "arranged": true,
+                      "filters": {
+                        "literal_equality": false,
+                        "like": false,
+                        "is_null": false,
+                        "literal_inequality": 0,
+                        "any_filter": false
+                      },
+                      "input": 0
+                    }
                   ],
                   [
                     [
-                      0,
+                      1,
                       [],
                       {
                         "unique_key": false,
@@ -4031,7 +4187,7 @@ SELECT t1.a, t2.a FROM t as t1, t as t2
                           "literal_inequality": 0,
                           "any_filter": false
                         },
-                        "input": 0
+                        "input": 1
                       }
                     ]
                   ]
@@ -4595,16 +4751,29 @@ WHERE a = c and d = e and b = f
                   "implementation": {
                     "Differential": [
                       [
-                        1,
+                        0,
                         [
                           {
                             "Column": 0
                           }
-                        ]
+                        ],
+                        {
+                          "unique_key": false,
+                          "key_length": 1,
+                          "arranged": true,
+                          "filters": {
+                            "literal_equality": false,
+                            "like": false,
+                            "is_null": false,
+                            "literal_inequality": 0,
+                            "any_filter": false
+                          },
+                          "input": 0
+                        }
                       ],
                       [
                         [
-                          0,
+                          1,
                           [
                             {
                               "Column": 0
@@ -4621,7 +4790,7 @@ WHERE a = c and d = e and b = f
                               "literal_inequality": 0,
                               "any_filter": false
                             },
-                            "input": 0
+                            "input": 1
                           }
                         ],
                         [

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -577,7 +577,7 @@ Explained Query:
     Filter (#0) IS NOT NULL
       Join on=(#0 = #2 AND #1 = #5 AND #3 = #4) type=differential
         implementation
-          %1:u[#0] » %0:t[#0]KA » %2:v[#0, #1]KKA
+          %0:t[#0]KA » %1:u[#0]KA » %2:v[#0, #1]KKA
         ArrangeBy keys=[[#0]]
           Get materialize.public.t
         ArrangeBy keys=[[#0]]

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -4594,15 +4594,15 @@ WHERE a = c AND d = e AND b + d > 42
                     [
                       [
                         {
-                          "Column": 1
+                          "Column": 0
                         }
                       ],
                       {
-                        "0": 1,
-                        "1": 0
+                        "0": 0,
+                        "1": 1
                       },
                       [
-                        0
+                        1
                       ]
                     ]
                   ]
@@ -4674,7 +4674,7 @@ WHERE a = c AND d = e AND b + d > 42
           ],
           "plan": {
             "Linear": {
-              "source_relation": 2,
+              "source_relation": 0,
               "source_key": [
                 {
                   "Column": 0
@@ -4684,34 +4684,6 @@ WHERE a = c AND d = e AND b + d > 42
               "stage_plans": [
                 {
                   "lookup_relation": 1,
-                  "stream_key": [
-                    {
-                      "Column": 0
-                    }
-                  ],
-                  "stream_thinning": [],
-                  "lookup_key": [
-                    {
-                      "Column": 1
-                    }
-                  ],
-                  "closure": {
-                    "ready_equivalences": [],
-                    "before": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [
-                          1,
-                          0
-                        ],
-                        "input_arity": 2
-                      }
-                    }
-                  }
-                },
-                {
-                  "lookup_relation": 0,
                   "stream_key": [
                     {
                       "Column": 0
@@ -4734,10 +4706,10 @@ WHERE a = c AND d = e AND b + d > 42
                             "CallBinary": {
                               "func": "AddInt32",
                               "expr1": {
-                                "Column": 2
+                                "Column": 1
                               },
                               "expr2": {
-                                "Column": 1
+                                "Column": 2
                               }
                             }
                           },
@@ -4748,7 +4720,7 @@ WHERE a = c AND d = e AND b + d > 42
                                 "Column": 0
                               },
                               "expr2": {
-                                "Column": 1
+                                "Column": 2
                               }
                             }
                           }
@@ -4786,8 +4758,40 @@ WHERE a = c AND d = e AND b + d > 42
                           ]
                         ],
                         "projection": [
+                          2,
                           3,
                           4
+                        ],
+                        "input_arity": 3
+                      }
+                    }
+                  }
+                },
+                {
+                  "lookup_relation": 2,
+                  "stream_key": [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  "stream_thinning": [
+                    1,
+                    2
+                  ],
+                  "lookup_key": [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  "closure": {
+                    "ready_equivalences": [],
+                    "before": {
+                      "mfp": {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1,
+                          2
                         ],
                         "input_arity": 3
                       }
@@ -5056,15 +5060,15 @@ WHERE a = c AND d = e AND f = a
                     [
                       [
                         {
-                          "Column": 0
+                          "Column": 1
                         },
                         {
-                          "Column": 1
+                          "Column": 0
                         }
                       ],
                       {
-                        "0": 0,
-                        "1": 1
+                        "0": 1,
+                        "1": 0
                       },
                       []
                     ]
@@ -5178,15 +5182,15 @@ WHERE a = c AND d = e AND f = a
                     [
                       [
                         {
-                          "Column": 1
+                          "Column": 0
                         },
                         {
-                          "Column": 0
+                          "Column": 1
                         }
                       ],
                       {
-                        "0": 1,
-                        "1": 0
+                        "0": 0,
+                        "1": 1
                       },
                       []
                     ]
@@ -5207,7 +5211,7 @@ WHERE a = c AND d = e AND f = a
           ],
           "plan": {
             "Linear": {
-              "source_relation": 2,
+              "source_relation": 1,
               "source_key": [
                 {
                   "Column": 1
@@ -5219,7 +5223,7 @@ WHERE a = c AND d = e AND f = a
               "initial_closure": null,
               "stage_plans": [
                 {
-                  "lookup_relation": 1,
+                  "lookup_relation": 2,
                   "stream_key": [
                     {
                       "Column": 1
@@ -5256,11 +5260,11 @@ WHERE a = c AND d = e AND f = a
                   "lookup_relation": 0,
                   "stream_key": [
                     {
-                      "Column": 1
+                      "Column": 0
                     }
                   ],
                   "stream_thinning": [
-                    0
+                    1
                   ],
                   "lookup_key": [
                     {

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -652,23 +652,23 @@ Explained Query:
       project=(#0, #1, #1)
     linear_stage[1]
       closure
-        project=(#3, #4)
-        filter=((#3 > 42))
-        map=((#2 + #1), (#0 + #1))
-      lookup={ relation=0, key=[#0] }
-      stream={ key=[#0], thinning=(#1) }
+        project=(#1, #2)
+      lookup={ relation=2, key=[#0] }
+      stream={ key=[#0], thinning=(#1, #2) }
     linear_stage[0]
       closure
-        project=(#1, #0)
-      lookup={ relation=1, key=[#1] }
-      stream={ key=[#0], thinning=() }
-    source={ relation=2, key=[#0] }
+        project=(#2..=#4)
+        filter=((#3 > 42))
+        map=((#1 + #2), (#0 + #2))
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
     ArrangeBy
       raw=true
-      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
       Get::Collection materialize.public.u
         raw=true
     ArrangeBy
@@ -714,19 +714,19 @@ Explained Query:
       closure
         project=(#0, #2, #1)
       lookup={ relation=0, key=[#0] }
-      stream={ key=[#1], thinning=(#0) }
+      stream={ key=[#0], thinning=(#1) }
     linear_stage[0]
       closure
         project=(#1, #0)
-      lookup={ relation=1, key=[#0, #1] }
+      lookup={ relation=2, key=[#0, #1] }
       stream={ key=[#1, #0], thinning=() }
-    source={ relation=2, key=[#1, #0] }
+    source={ relation=1, key=[#1, #0] }
     Get::PassArrangements materialize.public.t
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
     ArrangeBy
       raw=true
-      arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+      arrangements[0]={ key=[#1, #0], permutation={#0: #1, #1: #0}, thinning=() }
       Get::Arrangement materialize.public.u
         filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
         key=#0
@@ -734,7 +734,7 @@ Explained Query:
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
     ArrangeBy
       raw=true
-      arrangements[0]={ key=[#1, #0], permutation={#0: #1, #1: #0}, thinning=() }
+      arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
       Get::Arrangement materialize.public.v
         filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
         key=#0

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -247,7 +247,7 @@ Explained Query:
     Map (date_truncts(#0, #1)) // { arity: 3 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:date_trunc_timestamps[×] » %0:date_trunc_fields[×]A
+          %0:date_trunc_fields[×]A » %1:date_trunc_timestamps[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.date_trunc_fields // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -34,7 +34,7 @@ Explained Query:
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
-        %1[×] » %0:test1[×]A
+        %0:test1[×]A » %1[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.test1 // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -43,11 +43,11 @@ Explained Query:
       stream={ key=[#1], thinning=(#0, #2) }
     linear_stage[0]
       closure
-        project=(#2, #3, #1)
-        filter=((#0) IS NOT NULL AND (#3) IS NOT NULL)
-      lookup={ relation=0, key=[#1] }
-      stream={ key=[#1], thinning=(#0) }
-    source={ relation=1, key=[#1] }
+        project=(#1..=#3)
+        filter=((#0) IS NOT NULL AND (#2) IS NOT NULL)
+      lookup={ relation=1, key=[#1] }
+      stream={ key=[#1], thinning=(#0, #2) }
+    source={ relation=0, key=[#1] }
     Get::PassArrangements materialize.public.t1
       raw=false
       arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0, #2) }

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -68,9 +68,9 @@ Explained Query:
       linear_stage[0]
         closure
           project=()
-        lookup={ relation=1, key=[#0] }
+        lookup={ relation=0, key=[#0] }
         stream={ key=[#0], thinning=() }
-      source={ relation=0, key=[#0] }
+      source={ relation=1, key=[#0] }
       ArrangeBy
         raw=true
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
@@ -88,9 +88,9 @@ Explained Query:
             lookup={ relation=0, key=[] }
             stream={ key=[], thinning=(#0, #1) }
           linear_stage[0]
-            lookup={ relation=1, key=[#0] }
-            stream={ key=[#0], thinning=(#1) }
-          source={ relation=2, key=[#0] }
+            lookup={ relation=2, key=[#0] }
+            stream={ key=[#0], thinning=() }
+          source={ relation=1, key=[#0] }
           ArrangeBy
             raw=true
             arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
@@ -113,9 +113,9 @@ Explained Query:
     cte l0 =
       Join::Linear
         linear_stage[0]
-          lookup={ relation=0, key=[] }
-          stream={ key=[], thinning=() }
-        source={ relation=1, key=[] }
+          lookup={ relation=1, key=[] }
+          stream={ key=[], thinning=(#0) }
+        source={ relation=0, key=[] }
         ArrangeBy
           raw=true
           arrangements[0]={ key=[], permutation=id, thinning=(#0) }

--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -20,7 +20,7 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        %0:t1[#0] » %1[#0]UKA
+        %1[#0]UKA » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -69,7 +69,7 @@ Explained Query:
     Project (#0, #2, #3, #1) // { arity: 4 }
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1[×] » %0:table_f1[×]A
+          %0:table_f1[×]A » %1[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.table_f1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 3 }
@@ -78,7 +78,7 @@ Explained Query:
               Project (#0..=#2) // { arity: 3 }
                 Join on=(#0 = #3) type=differential // { arity: 4 }
                   implementation
-                    %1[#0] » %0:l1[#0]KAf
+                    %0:l1[#0]KAf » %1[#0]KAf
                   ArrangeBy keys=[[#0]] // { arity: 3 }
                     Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -97,7 +97,7 @@ Explained Query:
       Project (#0..=#2) // { arity: 3 }
         Join on=(#1 = #3) type=differential // { arity: 4 }
           implementation
-            %1:table_f5_f6[#0] » %0:table_f4_f5_f6[#1]KAf
+            %0:table_f4_f5_f6[#1]KAf » %1:table_f5_f6[#0]KAf
           ArrangeBy keys=[[#1]] // { arity: 3 }
             Filter (#1 = #2) // { arity: 3 }
               Get materialize.public.table_f4_f5_f6 // { arity: 3 }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -115,7 +115,7 @@ Explained Query:
     Project (#0, #2, #4) // { arity: 3 }
       Join on=(#1 = (#0 + 1) AND #3 = (#0 + #1)) type=differential // { arity: 5 }
         implementation
-          %1:l1[#0] » %0:l0[(#0 + 1)]KA » %2:l1[#0]KA
+          %0:l0[(#0 + 1)]KA » %1:l1[#0]KA » %2:l1[#0]KA
         ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 2 }
@@ -158,7 +158,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %0:l[#0] » %1[#0]UKA
+          %1[#0]UKA » %0:l[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.l // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -186,7 +186,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:l0[×] » %0[×]A
+          %0[×]A » %1:l0[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Distinct group_by=[#0] // { arity: 1 }
             Get l0 // { arity: 1 }
@@ -324,7 +324,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %0:l[#0] » %1[#0]UKA
+                  %1[#0]UKA » %0:l[#0]KA
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Get materialize.public.l // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -339,7 +339,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:r[#0] » %0:l[#0]KA
+            %0:l[#0]KA » %1:r[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -366,7 +366,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:r[#0] » %1[#0]UKA
+                    %1[#0]UKA » %0:r[#0]KA
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.r // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -381,7 +381,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:r[#0] » %0:l[#0]KA
+            %0:l[#0]KA » %1:r[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -408,7 +408,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:r[#0] » %1:l1[#0]UKA
+                    %1:l1[#0]UKA » %0:r[#0]KA
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.r // { arity: 2 }
                   Get l1 // { arity: 1 }
@@ -419,7 +419,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %0:l[#0] » %1:l1[#0]UKA
+                  %1:l1[#0]UKA » %0:l[#0]KA
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Get materialize.public.l // { arity: 2 }
                 Get l1 // { arity: 1 }
@@ -436,7 +436,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:r[#0] » %0:l[#0]KA
+            %0:l[#0]KA » %1:r[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.l // { arity: 2 }
@@ -463,7 +463,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = m
 Explained Query:
   Join on=((#0 % 2) = (#2 % 2)) type=differential // { arity: 4 }
     implementation
-      %1:r[(#0 % 2)] » %0:l[(#0 % 2)]KA
+      %0:l[(#0 % 2)]KA » %1:r[(#0 % 2)]KA
     ArrangeBy keys=[[(#0 % 2)]] // { arity: 2 }
       Filter (#0) IS NOT NULL // { arity: 2 }
         Get materialize.public.l // { arity: 2 }
@@ -521,7 +521,7 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %1[#0] » %0:t4362[#0]KA
+          %0:t4362[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.t4362 // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -592,7 +592,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1:r3[#0] » %0:l3[#0]KA
+        %0:l3[#0]KA » %1:r3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.l3 // { arity: 2 }
@@ -620,7 +620,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1:r3[#0] » %0:l3[#0]KA
+        %0:l3[#0]KA » %1:r3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.l3 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -642,7 +642,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       implementation
-        %1:r3[#0] » %0:l3[#0]KA
+        %0:l3[#0]KA » %1:r3[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.l3 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -675,7 +675,7 @@ Explained Query:
     Filter (#0) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #3) type=differential // { arity: 6 }
         implementation
-          %1:t2[#0] » %0:t1[#0]KAe
+          %0:t1[#0]KAe » %1:t2[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
           ReadExistingIndex materialize.public.t1 lookup_values=[("l2"); ("l3")]
         ArrangeBy keys=[[#0]] // { arity: 3 }
@@ -710,7 +710,7 @@ Explained Query:
     Filter (#0) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #3) type=differential // { arity: 6 }
         implementation
-          %1:t2[#0] » %0:t1[#0]KAe
+          %0:t1[#0]KAe » %1:t2[#0]KAe
         ArrangeBy keys=[[#0]] // { arity: 3 }
           ReadExistingIndex materialize.public.t1 lookup_value=("l2")
         ArrangeBy keys=[[#0]] // { arity: 3 }
@@ -745,7 +745,7 @@ WHERE
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1:t2[×] » %0:t1[×]Ae
+      %0:t1[×]Ae » %1:t2[×]Ae
     ArrangeBy keys=[[]] // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
         ReadExistingIndex materialize.public.t1 lookup_value=(2, "l2")

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -646,7 +646,7 @@ Explained Query:
   Return // { types: "(boolean, boolean, boolean?)" }
     Project (#2, #5, #7) // { types: "(boolean, boolean, boolean?)" }
       Join on=(eq(#0, #3, #6) AND #1 = #4) type=differential // { types: "(integer?, integer, boolean, integer?, integer, boolean, integer?, boolean?)" }
-        ArrangeBy keys=[[]] // { types: "(integer?, integer)" }
+        ArrangeBy keys=[[#0]] // { types: "(integer?, integer)" }
           Get materialize.public.int_table // { types: "(integer?, integer)" }
         ArrangeBy keys=[[]] // { types: "(boolean)" }
           Union // { types: "(boolean)" }

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -33,7 +33,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0[×] » %0:l0[×]A
+        %0:l0[×]A » %1:l0[×]A
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -80,7 +80,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0[×] » %0:l0[×]Ae
+        %0:l0[×]Ae » %1:l0[×]Ae
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -129,7 +129,7 @@ Explained Query:
   Return // { arity: 3 }
     CrossJoin type=differential // { arity: 3 }
       implementation
-        %1:l0[×] » %0:l0[×]Ae
+        %0:l0[×]Ae » %1:l0[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Get l0 // { arity: 3 }
@@ -157,10 +157,9 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
         implementation
-          %2:l0[#0] » %0:t1[#1]KA » %1:l0[#0]KA
-        ArrangeBy keys=[[#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
+          %0:t1[#0]KA » %1:l0[#0]KA » %2:l0[#0]KA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Get materialize.public.t1 // { arity: 2 }
         Get l0 // { arity: 1 }
         Get l0 // { arity: 1 }
   With
@@ -190,26 +189,27 @@ Explained Query:
     Project (#0, #1) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
         implementation
-          %2:l1[#0] » %0:t1[#1]KA » %1:l1[#0]KA
-        ArrangeBy keys=[[#1]] // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
-            Get materialize.public.t1 // { arity: 2 }
-        Get l1 // { arity: 1 }
-        Get l1 // { arity: 1 }
+          %0:l0[#0]KA » %1:l2[#0]KA » %2:l2[#0]KA
+        Get l0 // { arity: 2 }
+        Get l2 // { arity: 1 }
+        Get l2 // { arity: 1 }
   With
-    cte l1 =
+    cte l2 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Union // { arity: 1 }
           Project (#0) // { arity: 1 }
-            Get l0 // { arity: 3 }
+            Get l1 // { arity: 3 }
           Map (error("more than one record produced in subquery")) // { arity: 1 }
             Project () // { arity: 0 }
               Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
                 Reduce aggregates=[count(*)] // { arity: 1 }
                   Project () // { arity: 0 }
-                    Get l0 // { arity: 3 }
-    cte l0 =
+                    Get l1 // { arity: 3 }
+    cte l1 =
       ReadExistingIndex materialize.public.t1 lookup_value=(1)
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
   - materialize.public.i1
@@ -223,7 +223,7 @@ Explained Query:
   Project (#0, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 3 }
       implementation
-        %1[#0] » %0:t1[#0]KA
+        %0:t1[#0]KA » %1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -302,7 +302,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0[×] » %0:l0[×]Ae
+        %0:l0[×]Ae » %1:l0[×]Ae
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -327,7 +327,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0[×] » %0:l0[×]Aef
+        %0:l0[×]Aef » %1:l0[×]Aef
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With
@@ -354,7 +354,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:l0[×] » %0:l0[×]Aef
+        %0:l0[×]Aef » %1:l0[×]Aef
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           Filter (#1 = 2) // { arity: 3 }
@@ -429,7 +429,7 @@ Explained Query:
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1[×] » %0:t1[×]A
+          %0:t1[×]A » %1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t1 // { arity: 2 }
@@ -582,7 +582,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1[×] » %0:t1[×]A
+          %0:t1[×]A » %1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t1 // { arity: 2 }
@@ -642,7 +642,7 @@ Explained Query:
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1:l0[×] » %0:l0[×]A
+          %0:l0[×]A » %1:l0[×]A
         Get l0 // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
@@ -675,7 +675,7 @@ Explained Query:
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
                 implementation
-                  %0:l0[#0] » %1[#0]UKA
+                  %1[#0]UKA » %0:l0[#0]KA
                 Get l0 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
@@ -687,7 +687,7 @@ Explained Query:
         Filter (#0) IS NOT NULL // { arity: 4 }
           Join on=(#0 = #2) type=differential // { arity: 4 }
             implementation
-              %1:l0[#0] » %0:l0[#0]KA
+              %0:l0[#0]KA » %1:l0[#0]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
     cte l0 =
@@ -710,7 +710,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l1[×] » %0:l1[×]Ae
+          %0:l1[×]Ae » %1:l1[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l1 // { arity: 3 }
@@ -719,7 +719,7 @@ Explained Query:
             Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l2[×] » %0:l2[×]Ae
+          %0:l2[×]Ae » %1:l2[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l2 // { arity: 3 }
@@ -887,7 +887,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1[×] » %1[×]UA
+          %1[×]UA » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
@@ -916,7 +916,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1[#0] » %0:l0[#0]KA
+            %0:l0[#0]KA » %1[#0]KA
           Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Union // { arity: 1 }
@@ -1134,7 +1134,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1[×] » %1[×]UA
+          %1[×]UA » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
@@ -1168,7 +1168,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1[×] » %1[×]UA
+          %1[×]UA » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
@@ -1192,13 +1192,13 @@ Explained Query:
     Union // { arity: 2 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t1[×] » %1:l0[×]UA
+          %1:l0[×]UA » %0:t1[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
         Get l0 // { arity: 0 }
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %0:t2[×] » %1:l0[×]UA
+          %1:l0[×]UA » %0:t2[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Get materialize.public.t2 // { arity: 2 }
         Get l0 // { arity: 0 }
@@ -1223,7 +1223,7 @@ Explained Query:
   Return // { arity: 2 }
     CrossJoin type=differential // { arity: 2 }
       implementation
-        %1[×] » %0[×]A
+        %0[×]A » %1[×]A
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
           Project (#0) // { arity: 1 }
@@ -1279,7 +1279,7 @@ Explained Query:
   Return // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:t1[×] » %0:t1[×]Ae
+        %0:t1[×]Ae » %1:t1[×]Ae
       ArrangeBy keys=[[]] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
           ReadExistingIndex materialize.public.t1 lookup_value=(1)
@@ -1307,7 +1307,7 @@ Explained Query:
     Union // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l1[×] » %0:l1[×]Ae
+          %0:l1[×]Ae » %1:l1[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l1 // { arity: 3 }
@@ -1316,7 +1316,7 @@ Explained Query:
             Get l1 // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:l2[×] » %0:l2[×]Ae
+          %0:l2[×]Ae » %1:l2[×]Ae
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get l2 // { arity: 3 }

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -53,7 +53,7 @@ Explained Query:
     Project (#0, #0) // { arity: 2 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1[×] » %0:t2[×]A
+          %0:t2[×]A » %1[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Project () // { arity: 0 }
             Get materialize.public.t2 // { arity: 1 }
@@ -93,7 +93,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1[#0] » %0:t2[#0]KA
+          %0:t2[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -120,7 +120,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -155,7 +155,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1[#0] » %0:t2[#0]KA
+          %0:t2[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -182,13 +182,13 @@ Explained Query:
       Union // { arity: 2 }
         Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
           implementation
-            %1:l2[#0] » %0:l1[(#0 + 1)]KA
+            %0:l1[(#0 + 1)]KA » %1:l2[#0]KA
           ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Get l2 // { arity: 1 }
         Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
           implementation
-            %1:l2[#0] » %0:l1[(#0 + 2)]KA
+            %0:l1[(#0 + 2)]KA » %1:l2[#0]KA
           ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
             Get l1 // { arity: 1 }
           Get l2 // { arity: 1 }
@@ -258,7 +258,7 @@ Explained Query:
     cte l5 =
       Join on=(#1 = (#0 + 2)) type=differential // { arity: 2 }
         implementation
-          %1:l2[#0] » %0:l1[(#0 + 2)]KA
+          %0:l1[(#0 + 2)]KA » %1:l2[#0]KA
         ArrangeBy keys=[[(#0 + 2)]] // { arity: 1 }
           Get l1 // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -274,7 +274,7 @@ Explained Query:
     cte l3 =
       Join on=(#1 = (#0 + 1)) type=differential // { arity: 2 }
         implementation
-          %1:l2[#0] » %0:l1[(#0 + 1)]KA
+          %0:l1[(#0 + 1)]KA » %1:l2[#0]KA
         ArrangeBy keys=[[(#0 + 1)]] // { arity: 1 }
           Get l1 // { arity: 1 }
         Get l2 // { arity: 1 }
@@ -359,7 +359,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -441,7 +441,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -475,7 +475,7 @@ Explained Query:
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1[#0] » %0:t3[#0]KA
+          %0:t3[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t3 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -502,7 +502,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1[#0] » %0:l1[#0]KA
+            %0:l1[#0]KA » %1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l1 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -528,7 +528,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t1[#0] » %0:l2[#0]UKA
+            %0:l2[#0]UKA » %1:t1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l2 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -541,7 +541,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -589,7 +589,7 @@ Explained Query:
         Project (#1, #3) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 4 }
             implementation
-              %1[#0] » %0:l4[#0]KA
+              %0:l4[#0]KA » %1[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Get l4 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -615,7 +615,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:l1[#0] » %0:l5[#0]UKA
+            %0:l5[#0]UKA » %1:l1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l5 // { arity: 1 }
           Get l1 // { arity: 1 }
@@ -627,7 +627,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1[#0] » %0:t2[#0]KA
+            %0:t2[#0]KA » %1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.t2 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -653,7 +653,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:l1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1:l1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           Get l1 // { arity: 1 }
@@ -691,7 +691,7 @@ Explained Query:
     Project (#2, #2) // { arity: 2 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1[#0] » %0:t3[#0]KA
+          %0:t3[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t3 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -766,7 +766,7 @@ Explained Query:
     Project (#4, #4) // { arity: 2 }
       Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 5 }
         implementation
-          %1[#0, #1] » %0:l0[#0, #1]KKA
+          %0:l0[#0, #1]KKA » %1[#0, #1]KKA
         ArrangeBy keys=[[#0, #1]] // { arity: 2 }
           Get l0 // { arity: 2 }
         ArrangeBy keys=[[#0, #1]] // { arity: 3 }
@@ -793,7 +793,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t1[#0] » %0:l1[#0]UKAf
+            %0:l1[#0]UKAf » %1:t1[#0]KAf
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0 = #1) // { arity: 2 }
               Get l1 // { arity: 2 }
@@ -806,7 +806,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:t3[×] » %0:t2[×]A
+          %0:t2[×]A » %1:t3[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -249,7 +249,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 Explained Query:
   CrossJoin type=differential // { arity: 1 }
     implementation
-      %0:t1[×] » %1[×]UA
+      %1[×]UA » %0:t1[×]A
     ArrangeBy keys=[[]] // { arity: 1 }
       Get materialize.public.t1 // { arity: 1 }
     ArrangeBy keys=[[]] // { arity: 0 }
@@ -266,10 +266,10 @@ Explained Query:
   Project (#0, #0, #2) // { arity: 3 }
     Join on=(#0 = #1) type=differential // { arity: 3 }
       implementation
-        %1:t3[×] » %2[×]UA » %0:t1[#0]KA
-      ArrangeBy keys=[[#0]] // { arity: 1 }
+        %2[×]UA » %0:t1[×]A » %1:t3[#0]KA
+      ArrangeBy keys=[[]] // { arity: 1 }
         Get materialize.public.t1 // { arity: 1 }
-      ArrangeBy keys=[[]] // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
         Get materialize.public.t3 // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 0 }
         Distinct // { arity: 0 }
@@ -285,7 +285,7 @@ Explained Query:
   Project (#0, #0, #2) // { arity: 3 }
     Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 4 }
       implementation
-        %1:t3[#1] » %2[#0]UKA » %0:t1[#0]KA
+        %2[#0]UKA » %1:t3[#1]KA » %0:t1[#0]KA
       ArrangeBy keys=[[#0]] // { arity: 1 }
         Get materialize.public.t1 // { arity: 1 }
       ArrangeBy keys=[[#1]] // { arity: 2 }
@@ -317,7 +317,7 @@ Explained Query:
     Map ((ascii(substr(replace(#1, "o", "i"), 2, 1)) * 2)) // { arity: 5 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1:age[#0] » %0:likes[#0]KA
+          %0:likes[#0]KA » %1:age[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL // { arity: 2 }
             Get materialize.public.likes // { arity: 2 }
@@ -440,7 +440,7 @@ Explained Query:
     Project (#2) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 3 }
         implementation
-          %1[#0] » %0:y[#0]KA
+          %0:y[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -457,7 +457,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -478,7 +478,7 @@ Explained Query:
       Map (NOT(#2)) // { arity: 4 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1[#0] » %0:y[#0]KA
+            %0:y[#0]KA » %1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.y // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -495,7 +495,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1[#0] » %0:l0[#0]UKA
+            %0:l0[#0]UKA » %1[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -517,7 +517,7 @@ Explained Query:
       Map (NOT(#2)) // { arity: 4 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1[#0] » %0:y[#0]KA
+            %0:y[#0]KA » %1[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get materialize.public.y // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -536,7 +536,7 @@ Explained Query:
           Filter (#0 <= #1) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
               implementation
-                %1:x[×] » %0:l0[×]A
+                %0:l0[×]A » %1:x[×]A
               ArrangeBy keys=[[]] // { arity: 1 }
                 Get l0 // { arity: 1 }
               ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -206,7 +206,7 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM x, generate_series(1, 10)
 Explained Query:
   CrossJoin type=differential // { arity: 3 }
     implementation
-      %1[×] » %0:x[×]A
+      %0:x[×]A » %1[×]A
     ArrangeBy keys=[[]] // { arity: 2 }
       Get materialize.public.x // { arity: 2 }
     ArrangeBy keys=[[]] // { arity: 1 }
@@ -243,7 +243,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#1 = #3) type=differential // { arity: 4 }
             implementation
-              %1:l0[#1] » %0:l0[#1]KA
+              %0:l0[#1]KA » %1:l0[#1]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
   With
@@ -267,7 +267,7 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#1 = #3) type=differential // { arity: 4 }
             implementation
-              %1:l0[#1] » %0:l0[#1]KA
+              %0:l0[#1]KA » %1:l0[#1]KA
             Get l0 // { arity: 2 }
             Get l0 // { arity: 2 }
   With
@@ -294,7 +294,7 @@ Explained Query:
           Project (#0..=#2) // { arity: 3 }
             Join on=(#1 = #3) type=differential // { arity: 4 }
               implementation
-                %1:l0[#1] » %0:l0[#1]KA
+                %0:l0[#1]KA » %1:l0[#1]KA
               Get l0 // { arity: 2 }
               Get l0 // { arity: 2 }
   With

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -243,7 +243,7 @@ Explained Query:
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
         Join on=(#0 = #9 AND #7 = #10) type=differential // { arity: 11 }
           implementation
-            %0:l4[#0, #7] » %1[#0, #1]UKKA
+            %1[#0, #1]UKKA » %0:l4[#0, #7]KKA
           ArrangeBy keys=[[#0, #7]] // { arity: 9 }
             Get l4 // { arity: 9 }
           ArrangeBy keys=[[#0, #1]] // { arity: 2 }
@@ -448,7 +448,7 @@ Explained Query:
         Filter (#40 = "ASIA") AND (#12 < 1995-01-01) AND (#12 >= 1994-01-01) // { arity: 42 }
           Join on=(#0 = #9 AND eq(#3, #34, #35) AND #8 = #17 AND #19 = #33 AND #37 = #39) type=differential // { arity: 42 }
             implementation
-              %5:region[#0] » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKAeiif
+              %5:region[#0]KAef » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKAeiif
             ArrangeBy keys=[[#3]] // { arity: 8 }
               Get materialize.public.customer // { arity: 8 }
             ArrangeBy keys=[[#1]] // { arity: 9 }
@@ -869,7 +869,7 @@ Explained Query:
         Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0[×] » %1[×]UA
+              %1[×]UA » %0[×]A
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum((#2 * integer_to_numeric(#1)))] // { arity: 2 }
                 Get l0 // { arity: 3 }
@@ -940,7 +940,7 @@ Explained Query:
         Filter (#21 >= 1994-01-01) AND (#19 < #20) AND (#20 < #21) AND (date_to_timestamp(#21) < 1995-01-01 00:00:00) AND ((#23 = "MAIL") OR (#23 = "SHIP")) // { arity: 25 }
           Join on=(#0 = #9) type=differential // { arity: 25 }
             implementation
-              %1:lineitem[#0] » %0:orders[#0]KAeiif
+              %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.orders // { arity: 9 }
             ArrangeBy keys=[[#0]] // { arity: 16 }
@@ -989,7 +989,7 @@ Explained Query:
                 Map (null) // { arity: 17 }
                   Join on=(#0 = #8 AND #1 = #9 AND #2 = #10 AND #3 = #11 AND #4 = #12 AND #5 = #13 AND #6 = #14 AND #7 = #15) type=differential // { arity: 16 }
                     implementation
-                      %1:customer[#0..=#7] » %0[#0..=#7]KKKKKKKKA
+                      %0[#0..=#7]KKKKKKKKA » %1:customer[#0..=#7]KKKKKKKKA
                     ArrangeBy keys=[[#0..=#7]] // { arity: 8 }
                       Union // { arity: 8 }
                         Negate // { arity: 8 }
@@ -1006,7 +1006,7 @@ Explained Query:
           Filter NOT("%special%requests%" ~~(varchar_to_text(#16))) // { arity: 17 }
             Join on=(#0 = #9) type=differential // { arity: 17 }
               implementation
-                %1:orders[#1] » %0:customer[#0]KAf
+                %1:orders[#1]KAf » %0:customer[#0]KAf
               ArrangeBy keys=[[#0]] // { arity: 8 }
                 Get materialize.public.customer // { arity: 8 }
               ArrangeBy keys=[[#1]] // { arity: 9 }
@@ -1055,7 +1055,7 @@ Explained Query:
           Filter (#10 >= 1995-09-01) AND (date_to_timestamp(#10) < 1995-10-01 00:00:00) // { arity: 25 }
             Join on=(#1 = #16) type=differential // { arity: 25 }
               implementation
-                %1:part[#0] » %0:lineitem[#1]KAiif
+                %0:lineitem[#1]KAiif » %1:part[#0]KAiif
               ArrangeBy keys=[[#1]] // { arity: 16 }
                 Get materialize.public.lineitem // { arity: 16 }
               ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1109,7 +1109,7 @@ Explained Query:
       Project (#0..=#2, #4, #8) // { arity: 5 }
         Join on=(#0 = #7 AND #8 = #9) type=differential // { arity: 10 }
           implementation
-            %0:supplier[#0] » %1:l0[#0]UKA » %2[#0]UKA
+            %0:supplier[#0]KA » %1:l0[#0]UKA » %2[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 7 }
             Get materialize.public.supplier // { arity: 7 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1175,7 +1175,7 @@ Explained Query:
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation
-              %1[#0] » %0:l0[#0]KA
+              %0:l0[#0]KA » %1[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 4 }
               Get l0 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1186,7 +1186,7 @@ Explained Query:
                       Filter ((#1) IS NULL OR (#0 = #1)) // { arity: 2 }
                         CrossJoin type=differential // { arity: 2 }
                           implementation
-                            %1:supplier[×] » %0:l1[×]Alf
+                            %1:supplier[×]Alf » %0:l1[×]Alf
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Get l1 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 1 }
@@ -1204,7 +1204,7 @@ Explained Query:
           Filter (#8 != "Brand#45") AND NOT("MEDIUM POLISHED%" ~~(varchar_to_text(#9))) AND ((#10 = 3) OR (#10 = 9) OR (#10 = 14) OR (#10 = 19) OR (#10 = 23) OR (#10 = 36) OR (#10 = 45) OR (#10 = 49)) // { arity: 14 }
             Join on=(#0 = #5) type=differential // { arity: 14 }
               implementation
-                %1:part[#0] » %0:partsupp[#0]KAef
+                %1:part[#0]KAef » %0:partsupp[#0]KAef
               ArrangeBy keys=[[#0]] // { arity: 5 }
                 Get materialize.public.partsupp // { arity: 5 }
               ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1258,7 +1258,7 @@ Explained Query:
           Filter (numeric_to_double(#1) < (0.2 * (numeric_to_double(#4) / bigint_to_double(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
             Join on=(#0 = #3) type=differential // { arity: 6 }
               implementation
-                %0:l1[#0] » %1[#0]UKA
+                %1[#0]UKA » %0:l1[#0]KA
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Get l1 // { arity: 3 }
               ArrangeBy keys=[[#0]] // { arity: 3 }
@@ -1266,7 +1266,7 @@ Explained Query:
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #2) type=differential // { arity: 17 }
                       implementation
-                        %1:l0[#1] » %0[#0]UKA
+                        %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#0) // { arity: 1 }
@@ -1277,7 +1277,7 @@ Explained Query:
         Filter (#19 = "Brand#23") AND (#22 = "MED BOX") // { arity: 25 }
           Join on=(#1 = #16) type=differential // { arity: 25 }
             implementation
-              %1:part[#0] » %0:l0[#1]KAef
+              %1:part[#0]KAef » %0:l0[#1]KAef
             Get l0 // { arity: 16 }
             ArrangeBy keys=[[#0]] // { arity: 9 }
               Get materialize.public.part // { arity: 9 }
@@ -1335,7 +1335,7 @@ Explained Query:
           Filter (#7 > 300) // { arity: 8 }
             Join on=(#2 = #6) type=differential // { arity: 8 }
               implementation
-                %0:l1[#2] » %1[#0]UKAif
+                %1[#0]UKAif » %0:l1[#2]KAif
               ArrangeBy keys=[[#2]] // { arity: 6 }
                 Get l1 // { arity: 6 }
               ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1343,7 +1343,7 @@ Explained Query:
                   Project (#0, #5) // { arity: 2 }
                     Join on=(#0 = #1) type=differential // { arity: 17 }
                       implementation
-                        %1:l0[#0] » %0[#0]UKA
+                        %0[#0]UKA » %1:l0[#0]KA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#2) // { arity: 1 }
@@ -1432,7 +1432,7 @@ Explained Query:
             Map ((#4 <= 20), (#4 >= 10), (#4 <= 30), (#4 >= 20), (#4 <= 11), (#4 >= 1), (#19 = "Brand#12"), (#21 <= 5), ((#22 = "SM BOX") OR (#22 = "SM PKG") OR (#22 = "SM CASE") OR (#22 = "SM PACK")), (#19 = "Brand#23"), (#21 <= 10), ((#22 = "MED BAG") OR (#22 = "MED BOX") OR (#22 = "MED PKG") OR (#22 = "MED PACK")), (#19 = "Brand#34"), (#21 <= 15), ((#22 = "LG BOX") OR (#22 = "LG PKG") OR (#22 = "LG CASE") OR (#22 = "LG PACK"))) // { arity: 40 }
               Join on=(#1 = #16) type=differential // { arity: 25 }
                 implementation
-                  %1:part[#0] » %0:lineitem[#1]KAeiiiiif
+                  %1:part[#0]KAeiiif » %0:lineitem[#1]KAeiiiiif
                 ArrangeBy keys=[[#1]] // { arity: 16 }
                   Get materialize.public.lineitem // { arity: 16 }
                 ArrangeBy keys=[[#0]] // { arity: 9 }
@@ -1491,39 +1491,41 @@ Explained Query:
       Project (#1, #2) // { arity: 2 }
         Join on=(#0 = #3) type=differential // { arity: 4 }
           implementation
-            %0:l0[#0] » %1[#0]UKA
+            %1[#0]UKA » %0:l0[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Distinct group_by=[#0] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (integer_to_numeric(#2) > (0.5 * #5)) // { arity: 6 }
+                Filter (integer_to_numeric(#2) > #5) // { arity: 6 }
                   Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
                     implementation
-                      %0:l1[#1, #0] » %1[#0, #1]UKKAf
-                    ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                      %1[#1, #0]UKKA » %0:l1[#0, #1]KKAf
+                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
                         Filter (#0 = #2) // { arity: 4 }
                           Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                      Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
-                        Project (#0, #1, #6) // { arity: 3 }
-                          Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
-                            Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 18 }
-                              implementation
-                                %1:lineitem[#1, #2] » %0[#0, #1]UKKAiif
-                              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                                Distinct group_by=[#0, #1] // { arity: 2 }
-                                  Project (#1, #2) // { arity: 2 }
-                                    Get l1 // { arity: 4 }
-                              ArrangeBy keys=[[#1, #2]] // { arity: 16 }
-                                Get materialize.public.lineitem // { arity: 16 }
+                    ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                      Project (#0, #1, #3) // { arity: 3 }
+                        Map ((0.5 * #2)) // { arity: 4 }
+                          Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+                            Project (#0, #1, #6) // { arity: 3 }
+                              Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
+                                Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 18 }
+                                  implementation
+                                    %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
+                                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                                    Distinct group_by=[#0, #1] // { arity: 2 }
+                                      Project (#1, #2) // { arity: 2 }
+                                        Get l1 // { arity: 4 }
+                                  ArrangeBy keys=[[#1, #2]] // { arity: 16 }
+                                    Get materialize.public.lineitem // { arity: 16 }
     With
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#1 = #6) type=differential // { arity: 7 }
             implementation
-              %1:partsupp[#0] » %2[#0]UKA » %0[×]A
+              %2[#0]UKA » %1:partsupp[#0]KA » %0[×]A
             ArrangeBy keys=[[]] // { arity: 1 }
               Distinct group_by=[#0] // { arity: 1 }
                 Project (#0) // { arity: 1 }
@@ -1540,7 +1542,7 @@ Explained Query:
           Filter (#8 = "CANADA") // { arity: 11 }
             Join on=(#3 = #7) type=differential // { arity: 11 }
               implementation
-                %1:nation[#0] » %0:supplier[#3]KAef
+                %1:nation[#0]KAef » %0:supplier[#3]KAef
               ArrangeBy keys=[[#3]] // { arity: 7 }
                 Get materialize.public.supplier // { arity: 7 }
               ArrangeBy keys=[[#0]] // { arity: 4 }
@@ -1605,10 +1607,10 @@ Explained Query:
         Project (#1) // { arity: 1 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
-              %1[#1, #0] » %0:l2[#0, #2]KKA
-            ArrangeBy keys=[[#0, #2]] // { arity: 3 }
+              %0:l2[#2, #0]KKA » %1[#0, #1]KKA
+            ArrangeBy keys=[[#2, #0]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#1, #0]] // { arity: 2 }
+            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Distinct group_by=[#0, #1] // { arity: 2 }
@@ -1616,7 +1618,7 @@ Explained Query:
                       Filter (#1 != #4) AND (#14 > #13) // { arity: 18 }
                         Join on=(#0 = #2) type=differential // { arity: 18 }
                           implementation
-                            %1:l1[#0] » %0:l3[#0]KAf
+                            %1:l1[#0]KAf » %0:l3[#0]KAf
                           ArrangeBy keys=[[#0]] // { arity: 2 }
                             Get l3 // { arity: 2 }
                           Get l1 // { arity: 16 }
@@ -1630,16 +1632,16 @@ Explained Query:
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
             implementation
-              %0:l0[#2, #0] » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#2, #0]] // { arity: 3 }
+              %1[#1, #0]UKKA » %0:l0[#0, #2]KKA
+            ArrangeBy keys=[[#0, #2]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[#1, #0]] // { arity: 2 }
               Distinct group_by=[#0, #1] // { arity: 2 }
                 Project (#0, #1) // { arity: 2 }
                   Filter (#1 != #4) // { arity: 18 }
                     Join on=(#0 = #2) type=differential // { arity: 18 }
                       implementation
-                        %1:l1[#0] » %0[#0]KA
+                        %0[#0]KA » %1:l1[#0]KA
                       ArrangeBy keys=[[#0]] // { arity: 2 }
                         Distinct group_by=[#1, #0] // { arity: 2 }
                           Project (#0, #2) // { arity: 2 }
@@ -1734,7 +1736,7 @@ Explained Query:
         Project (#1, #2) // { arity: 2 }
           Join on=(#0 = #3) type=differential // { arity: 4 }
             implementation
-              %1[#0] » %0:l1[#0]KA
+              %0:l1[#0]KA » %1[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 3 }
               Get l1 // { arity: 3 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1743,7 +1745,7 @@ Explained Query:
                   Project (#0) // { arity: 1 }
                     Join on=(#0 = #1) type=differential // { arity: 2 }
                       implementation
-                        %1[#0] » %0:l2[#0]UKA
+                        %0:l2[#0]UKA » %1[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Get l2 // { arity: 1 }
                       ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -1761,7 +1763,7 @@ Explained Query:
           Filter (numeric_to_double(#2) > (numeric_to_double(#3) / bigint_to_double(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
-                %0:l0[×] » %1[×]UAef
+                %1[×]UA » %0:l0[×]Aef
               ArrangeBy keys=[[]] // { arity: 3 }
                 Project (#0, #4, #5) // { arity: 3 }
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -33,7 +33,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %0:l1[#0] » %1[#0]UKA
+                      %1[#0]UKA » %0:l1[#0]KA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -50,7 +50,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -81,7 +81,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -116,7 +116,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:t1[#0] » %1[#0]UKA
+                    %1[#0]UKA » %0:t1[#0]KA
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -131,7 +131,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -159,7 +159,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      %0:t1[#0] » %1[#0]UKA
+                      %1[#0]UKA » %0:t1[#0]KA
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -174,7 +174,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -202,7 +202,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#0 = #2) type=differential // { arity: 3 }
                     implementation
-                      %0:t1[#0] » %1[#0]UKA
+                      %1[#0]UKA » %0:t1[#0]KA
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -217,7 +217,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -261,7 +261,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -288,7 +288,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -320,7 +320,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %0:l1[#0] » %1[#0]UKA
+                      %1[#0]UKA » %0:l1[#0]KA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -338,7 +338,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -362,7 +362,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -388,7 +388,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -420,7 +420,7 @@ Explained Query:
                 Project (#0) // { arity: 1 }
                   Join on=(#0 = #1) type=differential // { arity: 2 }
                     implementation
-                      %0:l1[#0] » %1[#0]UKA
+                      %1[#0]UKA » %0:l1[#0]KA
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -437,7 +437,7 @@ Explained Query:
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -466,7 +466,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    %0:l1[#0] » %1[#0]UKA
+                    %1[#0]UKA » %0:l1[#0]KA
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -483,7 +483,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -511,7 +511,7 @@ Explained Query:
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) type=differential // { arity: 2 }
                   implementation
-                    %0:l1[#0] » %1[#0]UKA
+                    %1[#0]UKA » %0:l1[#0]KA
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -528,7 +528,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -552,7 +552,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (#0) IS NOT NULL // { arity: 2 }
@@ -578,7 +578,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2[#0] » %0:t1[#0]KA
+            %0:t1[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -635,7 +635,7 @@ Explained Query:
               Project (#0, #1) // { arity: 2 }
                 Join on=(#1 = #2) type=differential // { arity: 3 }
                   implementation
-                    %0:t1[#1] » %1[#0]UKA
+                    %1[#0]UKA » %0:t1[#1]KA
                   ArrangeBy keys=[[#1]] // { arity: 2 }
                     Get materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -649,7 +649,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2[#0] » %0:t1[#1]KA
+            %0:t1[#1]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -676,7 +676,7 @@ Explained Query:
                 Project (#0, #1) // { arity: 2 }
                   Join on=(#1 = #2) type=differential // { arity: 3 }
                     implementation
-                      %0:t1[#1] » %1[#0]UKA
+                      %1[#0]UKA » %0:t1[#1]KA
                     ArrangeBy keys=[[#1]] // { arity: 2 }
                       Get materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -690,7 +690,7 @@ Explained Query:
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2[#0] » %0:t1[#1]KA
+            %0:t1[#1]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -713,7 +713,7 @@ Explained Query:
       Project (#0, #3) // { arity: 2 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
           implementation
-            %1:t2[#0] » %0:t1[#1]KA
+            %0:t1[#1]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#1]] // { arity: 2 }
             Filter (#1) IS NOT NULL // { arity: 2 }
               Get materialize.public.t1 // { arity: 2 }
@@ -810,7 +810,7 @@ Explained Query:
     Project (#1) // { arity: 1 }
       Join on=(#0 = #2) type=differential // { arity: 3 }
         implementation
-          %0:t1[#0] » %1[#1]UKA
+          %1[#1]UKA » %0:t1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Get materialize.public.t1 // { arity: 2 }
@@ -824,7 +824,7 @@ Explained Query:
                   Map (null) // { arity: 5 }
                     Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
                       implementation
-                        %1:t3[#0, #1] » %0[#0, #1]KKA
+                        %0[#0, #1]KKA » %1:t3[#0, #1]KKA
                       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                         Union // { arity: 2 }
                           Map (6) // { arity: 2 }
@@ -840,7 +840,7 @@ Explained Query:
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation
-          %1:t3[×] » %0:t2[×]Aef
+          %1:t3[×]Aef » %0:t2[×]Aef
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             Get materialize.public.t2 // { arity: 2 }
@@ -890,7 +890,7 @@ Explained Query:
             Map (null) // { arity: 3 }
               Join on=(#0 = #1) type=differential // { arity: 2 }
                 implementation
-                  %1:t2[#0] » %0[#0]KA
+                  %0[#0]KA » %1:t2[#0]KA
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
@@ -906,7 +906,7 @@ Explained Query:
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin type=differential // { arity: 2 }
           implementation
-            %1:t1[×] » %0:t2[×]A
+            %0:t2[×]A » %1:t1[×]A
           ArrangeBy keys=[[]] // { arity: 1 }
             Get materialize.public.t2 // { arity: 1 }
           ArrangeBy keys=[[]] // { arity: 1 }

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -75,7 +75,7 @@ explain with(arity, join_impls) select * from foo, bar where foo.a = abs(bar.a) 
 Explained Query:
   CrossJoin type=differential // { arity: 6 }
     implementation
-      %1:bar[×] » %0:foo[×]Aef
+      %0:foo[×]Aef » %1:bar[×]Aef
     ArrangeBy keys=[[]] // { arity: 3 }
       Filter (#0 = 3) // { arity: 3 }
         Get materialize.public.foo // { arity: 3 }

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -31,7 +31,7 @@ Explained Query:
   Project () // { arity: 0 }
     Join on=(#0 = (#1 + #2)) type=differential // { arity: 3 }
       implementation
-        %1:t2[×] » %0:t1[×]A
+        %0:t1[×]A » %1:t2[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -52,7 +52,7 @@ Explained Query:
     Project () // { arity: 0 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         implementation
-          %0:l0[#0] » %1[#0]UKA
+          %1[#0]UKA » %0:l0[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -35,7 +35,7 @@ Explained Query:
     Filter (#0 <= #2) // { arity: 6 }
       Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
         implementation
-          %2:t3[#0] » %0:t1[#0]KAiif » %1:t2[#1]KAiif
+          %0:t1[#0]KAif » %2:t3[#0]KAiif » %1:t2[#1]KAiif
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0 > 0) AND (#1) IS NOT NULL // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -116,8 +116,8 @@ Explained Query:
     Filter (#5 != #11) AND (#14 >= #10) // { arity: 15 }
       Join on=(#0 = #8 AND date_to_timestamp(#11) = (#5 - 9 months)) type=differential // { arity: 15 }
         implementation
-          %2:customer[×] » %0:lineitem[×]A » %1:orders[#0, date_to_timestamp(#3)]KKA
-        ArrangeBy keys=[[]] // { arity: 8 }
+          %0:lineitem[#0, (#5 - 9 months)]KKA » %1:orders[#0, date_to_timestamp(#3)]KKA » %2:customer[×]A
+        ArrangeBy keys=[[#0, (#5 - 9 months)]] // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }
         ArrangeBy keys=[[#0, date_to_timestamp(#3)]] // { arity: 4 }
           Filter (#0) IS NOT NULL // { arity: 4 }
@@ -155,26 +155,27 @@ Explained Query:
     cte l1 =
       Reduce aggregates=[min(#0)] // { arity: 1 }
         Project (#1) // { arity: 1 }
-          Filter (#1 <= 195) AND (#1 >= 38) AND (1997-08-25 00:00:00 = date_to_timestamp(#4)) // { arity: 6 }
-            Join on=(#0 = #3 AND #1 = #5) type=differential // { arity: 6 }
-              implementation
-                %2[#0] » %1:orders[#0]KAeiiiif » %0:lineitem[#0]KAeiiiif
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Project (#4) // { arity: 1 }
-                  Filter (#6 = 1997-01-25) // { arity: 8 }
-                    Get materialize.public.lineitem // { arity: 8 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
-                Get materialize.public.orders // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Union // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Get l0 // { arity: 9 }
-                  Map (error("more than one record produced in subquery")) // { arity: 1 }
-                    Project () // { arity: 0 }
-                      Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
-                        Reduce aggregates=[count(*)] // { arity: 1 }
-                          Project () // { arity: 0 }
-                            Get l0 // { arity: 9 }
+          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+            implementation
+              %1:orders[#1]KAeiif » %0:lineitem[#0]KAeiif » %2[#0]KAeiif
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Project (#4) // { arity: 1 }
+                Filter (#6 = 1997-01-25) // { arity: 8 }
+                  Get materialize.public.lineitem // { arity: 8 }
+            ArrangeBy keys=[[#1]] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Filter (#0 <= 195) AND (#0 >= 38) AND (1997-08-25 00:00:00 = date_to_timestamp(#3)) // { arity: 4 }
+                  Get materialize.public.orders // { arity: 4 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Union // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l0 // { arity: 9 }
+                Map (error("more than one record produced in subquery")) // { arity: 1 }
+                  Project () // { arity: 0 }
+                    Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
+                        Project () // { arity: 0 }
+                          Get l0 // { arity: 9 }
     cte l0 =
       ReadExistingIndex materialize.public.lineitem lookup_value=(38)
 
@@ -196,12 +197,12 @@ Explained Query:
   Project (#1, #0, #1) // { arity: 3 }
     Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
       implementation
-        %2:customer[×] » %1:orders[×]Aef » %0:lineitem[#2, #3]KKAef
+        %1:orders[#0, #1]KKAef » %0:lineitem[#2, #3]KKAef » %2:customer[×]Aef
       ArrangeBy keys=[[#2, #3]] // { arity: 4 }
         Project (#0, #1, #4, #6) // { arity: 4 }
           Filter (#4 = (#4 % 5)) // { arity: 8 }
             Get materialize.public.lineitem // { arity: 8 }
-      ArrangeBy keys=[[]] // { arity: 2 }
+      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
         Project (#2, #3) // { arity: 2 }
           Filter (#2 = (#2 % 5)) // { arity: 5 }
             ReadExistingIndex materialize.public.orders lookup_value=(134)
@@ -228,7 +229,7 @@ Explained Query:
   Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
     Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 15 }
       implementation
-        %1:orders[#2, #3] » %0:lineitem[#4, #5]KKAef » %2:customer[×]Aef
+        %1:orders[#2, #3]KKAe » %0:lineitem[#4, #5]KKAef » %2:customer[×]Aef
       ArrangeBy keys=[[#4, #5]] // { arity: 8 }
         Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
           Get materialize.public.lineitem // { arity: 8 }

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -32,7 +32,7 @@ EXPLAIN WITH(arity, join_impls) select * from foo inner join bar on foo.a = bar.
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:bar[×] » %0:foo[×]Aef
+      %0:foo[×]Aef » %1:bar[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 1) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -62,7 +62,7 @@ EXPLAIN WITH(arity, join_impls) select * from foo inner join bar on foo.a = abs(
 Explained Query:
   Join on=(#0 = abs(#2)) type=differential // { arity: 4 }
     implementation
-      %1:bar[abs(#0)] » %0:foo[#0]KAef
+      %0:foo[#0]KAef » %1:bar[abs(#0)]KAef
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Filter (1 = (#0 % 2)) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -97,7 +97,7 @@ EXPLAIN WITH(arity, join_impls) select * from (select * from foo where a = 1) fi
 Explained Query:
   CrossJoin type=differential // { arity: 4 }
     implementation
-      %1:bar[×] » %0:foo[×]Aef
+      %0:foo[×]Aef » %1:bar[×]Aef
     ArrangeBy keys=[[]] // { arity: 2 }
       Filter (#0 = 1) // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
@@ -142,16 +142,16 @@ where foo.a = bar.a
 ----
 Explained Query:
   Project (#0, #5) // { arity: 2 }
-    Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
-      implementation
-        %1:bar[#1] » %2:baz[#0]UKA » %0:foo[#0]KA
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Get materialize.public.foo // { arity: 2 }
-      ArrangeBy keys=[[#1]] // { arity: 2 }
-        Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
+    Filter (#0) IS NOT NULL // { arity: 6 }
+      Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
+        implementation
+          %0:foo[#0]KA » %1:bar[#0]KA » %2:baz[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Get materialize.public.foo // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.bar // { arity: 2 }
-      ArrangeBy keys=[[#0]] // { arity: 2 }
-        Get materialize.public.baz // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Get materialize.public.baz // { arity: 2 }
 
 Used Indexes:
   - materialize.public.foo_idx
@@ -193,7 +193,7 @@ Explained Query:
     Filter (#0) IS NOT NULL AND (#3) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #3 = #4) type=differential // { arity: 6 }
         implementation
-          %1:bar[#0] » %0:foo[#0]KA » %2:baz[#0]KA
+          %0:foo[#0]KA » %1:bar[#0]KA » %2:baz[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -236,7 +236,7 @@ Explained Query:
     Filter (#2) IS NOT NULL AND (case when (#0 = 0) then null else #0 end) IS NOT NULL // { arity: 4 }
       Join on=(-(#2) = case when (#0 = 0) then null else #0 end) type=differential // { arity: 4 }
         implementation
-          %1:bar[-(#0)] » %0:foo[case when (#0 = 0) then null else #0 end]KA
+          %0:foo[case when (#0 = 0) then null else #0 end]KA » %1:bar[-(#0)]KA
         ArrangeBy keys=[[case when (#0 = 0) then null else #0 end]] // { arity: 2 }
           Get materialize.public.foo // { arity: 2 }
         ArrangeBy keys=[[-(#0)]] // { arity: 2 }
@@ -279,7 +279,7 @@ Explained Query:
     Filter (#0) IS NOT NULL AND (#4) IS NOT NULL // { arity: 6 }
       Join on=(#0 = #2 AND #4 = (#0 + 4)) type=differential // { arity: 6 }
         implementation
-          %2:baz[#0] » %0:bar[(#0 + 4)]KA » %1:foo[#0]KA
+          %2:baz[#0]KA » %0:bar[(#0 + 4)]KA » %1:foo[#0]KA
         ArrangeBy keys=[[(#0 + 4)]] // { arity: 2 }
           Get materialize.public.bar // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -316,7 +316,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(1 = (#0 / #2)) type=differential // { arity: 4 }
       implementation
-        %1:bar[×] » %0:foo[×]A
+        %0:foo[×]A » %1:bar[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
@@ -347,7 +347,7 @@ Explained Query:
   Project (#1, #3) // { arity: 2 }
     Join on=(eq(-1, (#3 - #1), (#0 / #2))) type=differential // { arity: 4 }
       implementation
-        %1:bar[×] » %0:foo[×]A
+        %0:foo[×]A » %1:bar[×]A
       ArrangeBy keys=[[]] // { arity: 2 }
         Get materialize.public.foo // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 2 }
@@ -371,8 +371,7 @@ and bar.b - foo.b = foo.a / bar.a
 statement ok
 DROP INDEX baz_idx
 
-# materialize#8002: it would be nice if this join used the indexes on foo(a)
-# and bar(a+4)
+# materialize#8002: it would be nice if this join used the indexes on bar(a+4)
 
 query T multiline
 EXPLAIN WITH(arity, join_impls)
@@ -385,10 +384,9 @@ Explained Query:
   Project (#1, #3, #5) // { arity: 3 }
     Join on=(#0 = #2 AND #4 = (#0 + 4)) type=differential // { arity: 6 }
       implementation
-        %2:baz[#0] » %0:foo[(#0 + 4)]KA » %1:bar[#0]KA
-      ArrangeBy keys=[[(#0 + 4)]] // { arity: 2 }
-        Filter (#0) IS NOT NULL // { arity: 2 }
-          Get materialize.public.foo // { arity: 2 }
+        %0:foo[#0]KA » %1:bar[#0]KA » %2:baz[#0]KA
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Get materialize.public.foo // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
         Filter (#0) IS NOT NULL // { arity: 2 }
           Get materialize.public.bar // { arity: 2 }

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -113,7 +113,7 @@ Explained Query:
     Map (1) // { arity: 4 }
       CrossJoin type=differential // { arity: 3 }
         implementation
-          %1:t[×] » %0:t[×]A
+          %0:t[×]A » %1:t[×]A
         ArrangeBy keys=[[]] // { arity: 1 }
           Project (#2) // { arity: 1 }
             Map ((#0 + 1)) // { arity: 3 }
@@ -132,7 +132,7 @@ Explained Query:
     Map (2, 1) // { arity: 6 }
       CrossJoin type=differential // { arity: 4 }
         implementation
-          %1:t[×] » %0:t[×]A
+          %0:t[×]A » %1:t[×]A
         ArrangeBy keys=[[]] // { arity: 2 }
           Project (#2, #3) // { arity: 2 }
             Map ((#1 + 1), (#0 + 1)) // { arity: 4 }
@@ -151,7 +151,7 @@ Explained Query:
     Map (3, 2, 1) // { arity: 8 }
       CrossJoin type=differential // { arity: 5 }
         implementation
-          %1:t[×] » %0:t[×]A
+          %0:t[×]A » %1:t[×]A
         ArrangeBy keys=[[]] // { arity: 3 }
           Project (#2..=#4) // { arity: 3 }
             Map ((#1 + 1), (#0 + 2), (#0 + 1)) // { arity: 5 }
@@ -193,7 +193,7 @@ Explained Query:
     Map ((1 + #0), 1) // { arity: 3 }
       CrossJoin type=differential // { arity: 1 }
         implementation
-          %1:t[×] » %0[×]A
+          %0[×]A » %1:t[×]A
         ArrangeBy keys=[[]] // { arity: 0 }
           Constant // { arity: 0 }
             - (() x 7)
@@ -647,7 +647,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %1[#0] » %0:t_pk[#0]UKAiif
+              %0:t_pk[#0]UKAiif » %1[#0]KAiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
@@ -693,7 +693,7 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) type=differential // { arity: 2 }
             implementation
-              %1[#0] » %0:t[#0]KAiif
+              %0:t[#0]KAiif » %1[#0]KAiif
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 <= 195) AND (#0 >= 38) // { arity: 2 }
@@ -747,7 +747,6 @@ select min(a) from t_pk where a between 38 and 195 and a = (select a from t wher
 
 # check that literal errors are not lifted beyond Joins, but also that that doesn't lead to
 # a stack overflow due to LiteralLifting and JoinImplementation fighting against each other
-# Also, this query has a tricky join ordering, see comment in `differential::plan`.
 statement ok
 create table t1 (f1 double precision, f2 double precision not null);
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -149,7 +149,7 @@ Explained Query:
   Project (#0, #1, #0, #1) // { arity: 4 }
     Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
       implementation
-        %1:t2[#0, #1] » %0:t1[#0, #1]KKA
+        %0:t1[#0, #1]KKA » %1:t2[#0, #1]KKA
       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
         Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -172,7 +172,7 @@ select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and t2.f1 is null
 Explained Query:
   Join on=(#0 = (#2 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2[(#0 + 1)] » %0:t1[#0]KA
+      %0:t1[#0]KA » %1:t2[(#0 + 1)]KA
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
@@ -187,7 +187,7 @@ select * from t1, t2 where t1.f1 = t2.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 Explained Query:
   Join on=(#0 = (#2 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2[(#0 + 1)] » %0:t1[#0]KA
+      %0:t1[#0]KA » %1:t2[(#0 + 1)]KA
     ArrangeBy keys=[[#0]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
@@ -202,7 +202,7 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and (t2.f1 + 1) i
 Explained Query:
   Join on=(#2 = (#0 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2[#0] » %0:t1[(#0 + 1)]KA
+      %0:t1[(#0 + 1)]KA » %1:t2[#0]KA
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -217,7 +217,7 @@ select * from t1, t2 where t2.f1 = t1.f1 + 1 or (t1.f1 is null and ((t2.f1 + 1) 
 Explained Query:
   Join on=(#2 = (#0 + 1)) type=differential // { arity: 4 }
     implementation
-      %1:t2[#0] » %0:t1[(#0 + 1)]KA
+      %0:t1[(#0 + 1)]KA » %1:t2[#0]KA
     ArrangeBy keys=[[(#0 + 1)]] // { arity: 2 }
       Get materialize.public.t1 // { arity: 2 }
     ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -236,7 +236,7 @@ Explained Query:
     Filter (((#1 = 3) AND (#3 = 4)) OR ((#1 = 5) AND (#3 = 6))) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1:t2[#0] » %0:t1[#0]KAef
+          %0:t1[#0]KAef » %1:t2[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND ((#1 = 3) OR (#1 = 5)) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -260,7 +260,7 @@ Explained Query:
     Filter ((#1 = 5) OR ((#1 = 3) AND (#3 = 4))) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %1:t2[#0] » %0:t1[#0]KAef
+          %0:t1[#0]KAef » %1:t2[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Filter (#0) IS NOT NULL AND ((#1 = 3) OR (#1 = 5)) // { arity: 2 }
             Get materialize.public.t1 // { arity: 2 }
@@ -284,7 +284,7 @@ Explained Query:
   Filter ((#1 = 27) OR ((#0 = #2) AND (#1 <= 1995))) // { arity: 4 }
     CrossJoin type=differential // { arity: 4 }
       implementation
-        %1:t2[×] » %0:t1[×]Aeiif
+        %0:t1[×]Aeiif » %1:t2[×]Aeiif
       ArrangeBy keys=[[]] // { arity: 2 }
         Filter ((#1 = 27) OR (#1 <= 1995)) // { arity: 2 }
           Get materialize.public.t1 // { arity: 2 }
@@ -316,12 +316,11 @@ Explained Query:
       project=(#0, #1, #0, #2)
     linear_stage[0]
       closure
-        project=(#0, #2, #1)
         filter=((#0) IS NOT NULL AND (#3 OR #4) AND (#5 OR #6) AND ((#3 AND #5) OR (#4 AND #6)))
-        map=((#2 = 3), (#2 = 5), (#1 = 4), (#1 = 6))
-      lookup={ relation=0, key=[#0] }
+        map=((#1 = 3), (#1 = 5), (#2 = 4), (#2 = 6))
+      lookup={ relation=1, key=[#0] }
       stream={ key=[#0], thinning=(#1) }
-    source={ relation=1, key=[#0] }
+    source={ relation=0, key=[#0] }
     Get::PassArrangements materialize.public.t1
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
@@ -374,7 +373,7 @@ Explained Query:
     Filter ((#4 = "materialized-view") OR ((#4 = "view") AND (#1 != "doesntmatter"))) // { arity: 5 }
       Join on=(#0 = #2) type=differential // { arity: 5 }
         implementation
-          %1[#0] » %0:mz_schemas[#0]KAef
+          %1[#0]KAef » %0:mz_schemas[#0]KAef
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Project (#0, #3) // { arity: 2 }
             Get mz_catalog.mz_schemas // { arity: 4 }

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -138,7 +138,7 @@ Explained Query:
         Project (#0, #1) // { arity: 2 }
           Join on=(#0 = #2) type=differential // { arity: 3 }
             implementation
-              %0:t3[#0] » %1[#0]UKA
+              %1[#0]UKA » %0:t3[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 2 }
               Get materialize.public.t3 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -152,7 +152,7 @@ Explained Query:
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
           implementation
-            %1:t2[#0] » %0:t3[#0]KA
+            %0:t3[#0]KA » %1:t2[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Filter (#0) IS NOT NULL // { arity: 2 }
               Get materialize.public.t3 // { arity: 2 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -227,7 +227,7 @@ Explained Query:
     Project (#0) // { arity: 1 }
       Join on=(#0 = #1) type=differential // { arity: 2 }
         implementation
-          %0:l0[#0] » %1[#0]UKA
+          %1[#0]UKA » %0:l0[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
@@ -239,7 +239,7 @@ Explained Query:
                     Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
                       CrossJoin type=differential // { arity: 3 }
                         implementation
-                          %1:t2[×] » %0[×]A
+                          %0[×]A » %1:t2[×]A
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Distinct group_by=[#0] // { arity: 1 }
                             Get l0 // { arity: 1 }

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -31,7 +31,7 @@ count
 1
 
 > EXPLAIN WITH(join_impls) VIEW delta_join;
-"delta_join:  Project (#0, #1, #0, #3)    Filter (#0) IS NOT NULL      Join on=(#0 = #2) type=differential        implementation          %1:t2[#0] » %0:t1[#0]KA        ArrangeBy keys=[[#0]]          Get t1        ArrangeBy keys=[[#0]]          Get t2Used Indexes:  - i1  - i2"
+"delta_join:  Project (#0, #1, #0, #3)    Filter (#0) IS NOT NULL      Join on=(#0 = #2) type=differential        implementation          %0:t1[#0]KA » %1:t2[#0]KA        ArrangeBy keys=[[#0]]          Get t1        ArrangeBy keys=[[#0]]          Get t2Used Indexes:  - i1  - i2"
 
 > SELECT count(*) AS count FROM delta_join;
 count


### PR DESCRIPTION
The differential join planning in `JoinImplementation` has some `skip(1)` to skip looking at the `JoinInputCharacteristics` of the first input. This made sense before https://github.com/MaterializeInc/materialize/pull/16099, when we were not able to reuse an arrangement on the starting input. But after that PR, the starting input is not special in terms of arrangement reuse, so now we can remove the `skip(1)`.

### Motivation

  * This PR fixes a recognized bug: The ordering code was not mindful about arrangement reuse on the starting input (https://github.com/MaterializeInc/materialize/issues/16368)

  * This PR fixes a previously unreported bug: Turns out that the `JoinInputCharacteristics` for the starting input were wrong. (It was also not used before, due to the `skip(1)`.) The first commit in this PR fixes this.

   * This PR refactors existing code: Somehow we had two similar code blocks for coming up with a `start_key`: one near the end of `differential::plan`, and the other at the end of `optimize_order_for`. The latter was dead code, because we were just throwing away the key of `order[0]` just before the other code block. In the first commit of this PR I merged these two code blocks into one, and this new code is now only in `optimize_order_for`. There were some adjustments to make:
     * The old code in `optimize_order_for` was accepting the key only if there is already an existing arrangement with that key. I removed this condition. (I don't know why it was this way.)
     * The old code in `optimize_order_for` was slightly simpler than the code in `differential::plan`, by reusing more code from `JoinInputMapper`. I adopted this simpler way.
     * The old code in `differential::plan` worried about not finding a matching key field for each of the key fields of the second input. In such a case, it would pass `None` as the start key. I don't think this problem can actually happen. I added an `unreachable!`, and some explanation in a comment. Now we always pass `Some` start key.

### Tips for reviewer

The first commit has the refactoring of the `start_key` stuff (which also fixes the `JoinInputCharacteristics` of the starting input). The second commit has the actual removing of the `skip(1)`, plus adding the starting input's characteristics to EXPLAIN by passing it through `JoinImplementation` (similarly as for the other inputs' characteristics).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  - [ ] I checked the plan changes, they look ok.
  - [ ] Checking the first commit separately:
    - I checked that there are no plan changes after only the first commit.
    - I checked that the two old code blocks for coming up with a start key always had the same result (after removing the condition of accepting the key only if there is a pre-existing arrangement).
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Slightly better join orders.
