### PR TITLE
Update docs to describe and reference the mz_aws_privatelink_connections system table

### DIFF
--- a/doc/user/content/ops/network-security/privatelink.md
+++ b/doc/user/content/ops/network-security/privatelink.md
@@ -90,13 +90,14 @@ Before moving on, double-check that you have:
 
 1. #### Allow Access to the VPC Endpoint Service
 
-    After you create the endpoint service, you must [configure the permissions of your AWS PrivateLink service](https://docs.aws.amazon.com/vpc/latest/privatelink/add-endpoint-service-permissions.html) to accept connections from the following AWS principal: **`arn:aws:iam::664411391173:role/mz_<EXTERNAL-ID>_<CONNECTION-ID>`**
+    After you create the endpoint service, you must [configure the permissions of your AWS PrivateLink service](https://docs.aws.amazon.com/vpc/latest/privatelink/add-endpoint-service-permissions.html) to accept connections from the connection object's AWS principal. Get the AWS principal from the `mz_aws_privatelink_connections` table.
 
-    Fill in the values as follows:
-
-    a. **`EXTERNAL-ID`**: A unique ID associated with your Materialize region. You must **[contact support](https://materialize.com/docs/support/)** to determine this ID.
-
-    b. **`CONNECTION-ID`**: The ID of the AWS PrivateLink connection in your Materialize region. You can determine this ID by [`mz_connections`](https://github.com/MaterializeInc/materialize/blob/6aa1bf9ee6db3c3c73a617c9c863df5734233dbf/sql/system-catalog/mz_catalog/#mz_connections).
+     ```sql
+    SELECT principal
+        FROM mz_aws_privatelink_connections plc
+        JOIN mz_connections c ON plc.id = c.id
+        WHERE c.name = '<pl_conn_name>';
+    ```
 
 1. #### Accept the Endpoint Service Connection
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -35,6 +35,15 @@ Field           | Type                         | Meaning
 `user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
 
+### `mz_aws_privatelink_connections`
+
+The `mz_aws_privatelink_connections` table contains a row for each AWS PrivateLink connection in the system.
+
+Field       | Type      | Meaning
+------------|-----------|--------
+`id`        | [`text`]  | The ID of the connection.
+`principal` | [`text`]  | The AWS Principal that Materialize will use to connect to the VPC endpoint.
+
 ### `mz_base_types`
 
 The `mz_base_types` table contains a row for each base type in the system.


### PR DESCRIPTION
Resolves https://github.com/MaterializeInc/materialize/issues/16448.
1) Add documentation of `mz_aws_privatelink_connections` table in `mz_catalog` docs page
2) Update PrivateLink setup guide to utilize the table. Replaces telling customers to ask support for their external id. 

Note: do not merge this PR until https://github.com/MaterializeInc/materialize/issues/16446 and https://github.com/MaterializeInc/materialize/issues/16447 are released.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
