### PR TITLE
repr: fix merge skew prohibiting std::panic::catch_unwind

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2270,7 +2270,6 @@ mod tests {
     #[test]
     fn test_range_errors() {
         fn test_range_errors_inner<'a>(datums: Vec<Vec<Datum<'a>>>) -> Result<(), RangeError> {
-            println!("datums {:?}", datums);
             let mut row = Row::default();
             let row_len = row.byte_len();
             let mut packer = row.packer();
@@ -2319,7 +2318,9 @@ mod tests {
             vec![vec![Datum::Null], vec![Datum::Int32(2)]],
             vec![vec![Datum::Int32(1)], vec![Datum::Null]],
         ] {
-            assert!(std::panic::catch_unwind(|| test_range_errors_inner(panicking_case)).is_err());
+            assert!(
+                mz_ore::panic::catch_unwind(|| test_range_errors_inner(panicking_case)).is_err()
+            );
         }
 
         let e = test_range_errors_inner(vec![vec![Datum::Int32(2)], vec![Datum::Int32(1)]]);


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. https://buildkite.com/materialize/tests/builds/46247

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
