### PR TITLE
[sinks] Relax our behaviour on upsert semantics

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -23,7 +23,6 @@ use once_cell::sync::Lazy;
 use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
 
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::CollectionExt;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, Row, RowPacker, ScalarType};
 
 use crate::avro::DiffPair;
@@ -157,15 +156,4 @@ pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
     } else {
         rp.push(Datum::Null);
     }
-}
-
-pub fn upsert_format(dps: Vec<DiffPair<Row>>, sink_id: GlobalId, from: GlobalId) -> Option<Row> {
-    let dp = dps.expect_element(|| {
-        format!(
-            "primary key error: expected at most one update per key and timestamp \
-          This can happen when the configured sink key is not a primary key of \
-          the sinked relation: sink {sink_id} created from {from}."
-        )
-    });
-    dp.after
 }


### PR DESCRIPTION
This is a weird one!

The previous strict check here is a bit surprising:
- It can't actually prevent all invalid key collisions: it will notice if two records show up with a single key at a single timestamp, but it would be just as illegal if they showed up at different timestamps, and that can't practically be detected.
- For debezium records we ignore any reused keys and just publish all the records.

So even if it's Against the Rules to have multiple records with the same key here, it doesn't seem worth trashing the process over.

There are a few ways one might choose to handle this. For now I'm just passing all the records through, to match what the Debezium envelope does.

### Motivation

Known bug: #16485.

### Tips for reviewer

I appreciate this is probably not the right end state! In particular, we'll want some better way to surface any errors here to the user. However, I think this is probably an improvement on the crash-loop-forever behaviour currently in `main`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - (This changes behaviour gated behind an undocumented feature, so I think we skip this? Otherwise it would be something like "Allow conflicting keys in UPSERT Kafka sinks.")
