### PR TITLE
switch from a tag because main category items are not links.

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -164,7 +164,7 @@
     }
 
     li.level-1 {
-        &>a {
+        &>div {
             margin: 0 0 4px -2px;
             padding: 4px 0;
             color: var(--highlight);

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -5,9 +5,9 @@
       <div id="docsearch"></div>
       {{ range .Site.Menus.main.ByWeight }}
       <li class="level-1">
-        <a class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
+        <div class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
           {{.Name | markdownify}}
-        </a>
+        </div>
 
         {{- if .HasChildren }}
         <ul>


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

It was internally brought up by @ruf-io that main category items have a cursor pointer style set while they are linked nowhere that came from the fact that they were using a `<a>` element without having any `href` associated.

![image](https://user-images.githubusercontent.com/46004116/205893557-9cdad135-3061-4900-b525-e09320b71020.png)


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
