### PR TITLE
*: use hakari to manage a workspace-hack crate

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -1,0 +1,8 @@
+hakari-package = "workspace-hack"
+dep-format-version = "2"
+resolver = "2"
+platforms = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+]
+exact-versions = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,6 +3285,7 @@ dependencies = [
  "toml",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3350,6 +3351,7 @@ dependencies = [
  "tracing-subscriber",
  "uncased",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3361,6 +3363,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3384,6 +3387,7 @@ dependencies = [
  "snap",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3392,6 +3396,7 @@ version = "0.0.0"
 dependencies = [
  "quote",
  "syn",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3415,6 +3420,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3424,6 +3430,7 @@ dependencies = [
  "anyhow",
  "libc",
  "mz-ore",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3432,6 +3439,7 @@ version = "0.0.0"
 dependencies = [
  "compile-time-run",
  "semver",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3452,6 +3460,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3467,6 +3476,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3505,6 +3515,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3546,6 +3557,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3569,6 +3581,7 @@ dependencies = [
  "timely",
  "tokio",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3659,6 +3672,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3709,6 +3723,7 @@ dependencies = [
  "sha2",
  "uncased",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3724,6 +3739,7 @@ dependencies = [
  "proc-macro2",
  "serde",
  "serde_json",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3741,6 +3757,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3755,6 +3772,7 @@ dependencies = [
  "prometheus",
  "serde",
  "tracing-subscriber",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3784,6 +3802,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3809,6 +3828,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3816,6 +3836,7 @@ name = "mz-kinesis-util"
 version = "0.0.0"
 dependencies = [
  "aws-sdk-kinesis",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3829,6 +3850,7 @@ dependencies = [
  "proc-macro2",
  "serde",
  "serde_json",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3838,6 +3860,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3846,6 +3869,7 @@ version = "0.0.0"
 dependencies = [
  "reqwest",
  "serde",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3859,6 +3883,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3873,6 +3898,7 @@ dependencies = [
  "sha2",
  "tar",
  "walkdir",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3891,6 +3917,7 @@ dependencies = [
  "protobuf-src",
  "serde",
  "tonic-build",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3914,6 +3941,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3939,6 +3967,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3956,6 +3985,7 @@ dependencies = [
  "mz-repr",
  "opentelemetry",
  "tracing-subscriber",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -3997,6 +4027,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4018,6 +4049,7 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "tracing-subscriber",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4059,6 +4091,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4102,6 +4135,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4109,6 +4143,7 @@ name = "mz-persist-types"
 version = "0.0.0"
 dependencies = [
  "bytes",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4119,6 +4154,7 @@ dependencies = [
  "csv",
  "mz-pgrepr",
  "mz-repr",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4133,6 +4169,7 @@ dependencies = [
  "once_cell",
  "postgres-types",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4148,6 +4185,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4174,6 +4212,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-util",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4184,6 +4223,7 @@ dependencies = [
  "libc",
  "mz-ore",
  "tempfile",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4208,6 +4248,7 @@ dependencies = [
  "tokio-postgres",
  "tonic-build",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4235,6 +4276,7 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tokio",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4254,6 +4296,7 @@ dependencies = [
  "tokio-postgres",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4298,6 +4341,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4310,6 +4354,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "proc-macro2",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4327,6 +4372,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4336,6 +4382,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "mz-repr",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4348,6 +4395,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4376,6 +4424,7 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4426,6 +4475,7 @@ dependencies = [
  "typemap_rev",
  "uncased",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4444,6 +4494,7 @@ dependencies = [
  "tracing",
  "uncased",
  "unicode-width",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4485,6 +4536,7 @@ dependencies = [
  "tower-http",
  "uuid",
  "walkdir",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4500,6 +4552,7 @@ dependencies = [
  "ssh-key",
  "tempfile",
  "tracing",
+ "workspace-hack",
  "zeroize",
 ]
 
@@ -4524,6 +4577,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4544,6 +4598,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4616,6 +4671,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4672,6 +4728,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4687,6 +4744,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4758,6 +4816,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4773,6 +4832,7 @@ dependencies = [
  "timely",
  "timely_communication",
  "tokio",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4795,6 +4855,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "typemap_rev",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -4808,6 +4869,7 @@ dependencies = [
  "quote",
  "syn",
  "tempfile",
+ "workspace-hack",
 ]
 
 [[package]]
@@ -7869,6 +7931,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "workspace-hack"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "aws-sdk-sts",
+ "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-http",
+ "aws-types",
+ "axum",
+ "base64",
+ "bstr",
+ "byteorder",
+ "bytes",
+ "cc",
+ "chrono",
+ "clap",
+ "criterion",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "crypto-common",
+ "dec",
+ "digest",
+ "either",
+ "flate2",
+ "frunk_core",
+ "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "globset",
+ "hashbrown",
+ "hyper",
+ "indexmap",
+ "k8s-openapi",
+ "kube",
+ "kube-client",
+ "kube-core",
+ "libc",
+ "log",
+ "lru",
+ "memchr",
+ "native-tls",
+ "nix",
+ "nom",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "ordered-float",
+ "parking_lot",
+ "phf",
+ "phf_shared",
+ "postgres",
+ "postgres-types",
+ "proc-macro2",
+ "prometheus",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "quote",
+ "rand",
+ "rdkafka-sys",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "ring",
+ "schemars",
+ "scopeguard",
+ "security-framework",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "socket2",
+ "syn",
+ "textwrap",
+ "tikv-jemalloc-sys",
+ "time",
+ "time-macros",
+ "timely",
+ "timely_communication",
+ "tokio",
+ "tokio-postgres",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "uncased",
+ "url",
+ "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "src/transform",
     "src/cloud-resources",
     "src/walkabout",
+    "src/workspace-hack",
     "test/metabase/smoketest",
     "test/perf-kinesis",
     "test/test-util",

--- a/bin/lint
+++ b/bin/lint
@@ -44,6 +44,7 @@ copyright_files=$(grep -vE \
     -e '(^|/)go\.sum$' \
     -e '(^|/)(Cargo|askama)\.toml$' \
     -e '^\.cargo/config$' \
+    -e '^\.config/hakari.toml$' \
     -e '^Cargo\.lock$' \
     -e '^about\.toml$' \
     -e '^deny\.toml$' \

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -154,6 +154,7 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version "=0.5.2" cargo-about \
     && cargo install --root /usr/local --version "=1.40.5" cargo-deb \
     && cargo install --root /usr/local --version "=0.12.2" cargo-deny \
+    && cargo install --root /usr/local --version ="0.9.17" cargo-hakari \
     && cargo install --root /usr/local --version "=0.9.44" cargo-nextest \
     && cargo install --root /usr/local --version "=0.1.34" cargo-udeps  --features=vendored-openssl \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 ci_try bin/lint
 ci_try cargo --locked fmt -- --check
 ci_try cargo --locked deny check licenses bans sources
+ci_try cargo hakari generate --diff
+ci_try cargo hakari manage-deps --dry-run
 
 # Smoke out failures in generating the license metadata page, even though we
 # don't care about its output in the test pipeline, so that we don't only

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,7 @@ wrappers = [
     "ureq",
     "want",
     "wasm-bindgen-backend",
+    "workspace-hack",
 ]
 
 # We prefer the system's native TLS or OpenSSL to Rustls, since they are more

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -320,6 +320,25 @@ specifying the `--roots` flag with a comma separated list of crates:
 bin/crate-diagram --roots mz-sql,mz-dataflow
 ```
 
+#### `workspace-hack`
+
+The [`workspace-hack`](../../src/workspace-hack/) crate speeds up rebuilds by
+ensuring that all crates use the same features of all transitive dependencies in
+the graph. This prevents Cargo from recompiling huge chunks of the dependency
+graph when you move between crates in the worksapce. For details, see the
+[hakari documentation].
+
+If you add or remove dependencies on crates, you will likely need to regenerate
+the `workspace-hack` crate. You can do this by running:
+
+```
+cargo install cargo-hakari
+cargo hakari generate
+cargo hakari manage-deps
+```
+
+CI will enforce that the `workspace-hack` crate is kept up to date.
+
 ## Other repositories
 
 Where possible, we prefer to keep things in the main repository (a "monorepo"
@@ -458,6 +477,7 @@ source /path/to/materialize/misc/completions/zsh/*
 [demos]: https://github.com/MaterializeInc/demos
 [Docker Compose]: https://docs.docker.com/compose/
 [github-https]: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+[hakari documentation]: https://docs.rs/cargo-hakari/latest/cargo_hakari/about/index.html
 [Homebrew]: https://brew.sh
 [Kubernetes]: https://kubernetes.io
 [materialize-dbt-utils]: https://github.com/MaterializeInc/materialize-dbt-utils

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -64,6 +64,7 @@ tracing-subscriber = "0.3.16"
 thiserror = "1.0.37"
 uncased = "0.9.7"
 uuid = { version = "1.2.2", features = ["v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }

--- a/src/audit-log/Cargo.toml
+++ b/src/audit-log/Cargo.toml
@@ -12,3 +12,4 @@ mz-ore = { path = "../ore" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 serde_plain = "1.0.1"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -12,3 +12,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0.21"
 syn = { version = "1.0.103", features = ["full"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -29,6 +29,7 @@ sha2 = "0.10.6"
 snap = { version = "1.1.0", optional = true }
 tracing = "0.1.37"
 uuid = "1.2.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 once_cell = "1.16.0"

--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -22,6 +22,7 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 uuid = { version = "1.2.2", features = ["v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/build-id/Cargo.toml
+++ b/src/build-id/Cargo.toml
@@ -15,3 +15,4 @@ repository = "https://github.com/MaterializeInc/materialize"
 anyhow = "1.0.66"
 libc = "0.2.137"
 mz-ore = { path = "../ore", features = ["async"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/build-info/Cargo.toml
+++ b/src/build-info/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 compile-time-run = "0.2.12"
 semver = { version = "1.0.14", optional = true }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [features]
 default = ["semver"]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -14,6 +14,7 @@ reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls-ven
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 url = { version = "2.3.1", features = ["serde"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 hyper = { version = "0.14.23", features = ["server"] }

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -16,3 +16,4 @@ schemars = { version = "0.8", features = ["uuid1"] }
 serde = "1.0.147"
 serde_json = "1.0.89"
 uuid = { version = "1.2", features = ["serde", "v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -40,6 +40,7 @@ tokio-stream = "0.1.11"
 tonic = "0.8.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -38,6 +38,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 tokio = { version = "1.23.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # According to jemalloc developers, `background_threads` should always be

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1.0.147", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.23.0"
 uuid = { version = "1.2.2" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -80,6 +80,7 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = "2.3.1"
 uuid = "1.2.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # According to jemalloc developers, `background_threads` should always be

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -15,6 +15,7 @@ mz-repr-test-util = { path = "../repr-test-util" }
 proc-macro2 = "1.0.47"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 datadriven = "0.6.0"

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -21,7 +21,7 @@ build
   [[#0]]
   [int64])
 ----
-error: Punct { char: '#', spacing: Alone } cannot be interpreted as a literal.
+error: Punct { char: '#', spacing: Alone, span: bytes(536..537) } cannot be interpreted as a literal.
 
 build
 (arrange_by

--- a/src/expr-test-util/tests/testdata/scalar
+++ b/src/expr-test-util/tests/testdata/scalar
@@ -80,12 +80,12 @@ build-scalar
 build-scalar
 (ok)
 ----
-error: expected literal after Ident(ok)
+error: expected literal after Ident { sym: ok, span: bytes(4055..4057) }
 
 build-scalar
 (ok (ok true))
 ----
-error: expected literal after Ident(ok)
+error: expected literal after Ident { sym: ok, span: bytes(4061..4063) }
 
 build-scalar
 (err)

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -49,6 +49,7 @@ uncased = "0.9.7"
 uuid = "1.2.2"
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -18,3 +18,4 @@ thiserror = "1.0.37"
 tokio = { version = "1.23.0", features = ["macros"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -15,6 +15,7 @@ tracing-subscriber = "0.3.16"
 include_dir = "0.7.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
 prometheus = { version = "0.13.3", default-features = false, features = ["process"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]
 # Only used in macro generated code

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.23.0", features = ["macros", "sync"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 url = "2.3.1"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/kinesis-util/Cargo.toml
+++ b/src/kinesis-util/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 
 [dependencies]
 aws-sdk-kinesis = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/lowertest-derive/Cargo.toml
+++ b/src/lowertest-derive/Cargo.toml
@@ -13,3 +13,4 @@ proc-macro = true
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
 syn = { version = "1.0.103", features = ["extra-traits", "printing"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -12,6 +12,7 @@ mz-ore = { path = "../ore" }
 proc-macro2 = "1.0.47"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/src/metabase/Cargo.toml
+++ b/src/metabase/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 [dependencies]
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.147", features = ["derive"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -23,3 +23,4 @@ tokio = { version = "1.23.0", features = ["full"] }
 toml = "0.5.9"
 uuid = "1.2.2"
 url = "2.3.1"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/npm/Cargo.toml
+++ b/src/npm/Cargo.toml
@@ -15,3 +15,4 @@ reqwest = { version = "0.11.13", features = ["blocking", "native-tls-vendored"] 
 sha2 = "0.10.6"
 tar = "0.4.38"
 walkdir = "2.3.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 sha2 = "0.10.6"
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -26,3 +26,4 @@ sha1 = "0.10.5"
 sysinfo = "0.27.0"
 tokio = { version = "1.23.0", features = [ "fs", "process", "time" ] }
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -18,6 +18,7 @@ mz-ore = { path = "../ore", features = ["tracing_", "cli"] }
 mz-repr = { path = "../repr", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [features]
 tokio-console = ["mz-ore/tokio-console", "mz-repr", "humantime"]

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -17,6 +17,7 @@ mz-ore = { path = "../ore"}
 mz-proto = { path = "../proto" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = "1.0"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -58,6 +58,7 @@ opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.gi
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
 console-subscriber = { git = "https://github.com/MaterializeInc/console.git", optional = true }
 sentry-tracing = { version = "0.29.0", optional = true }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -53,6 +53,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 tokio = { version = "1.23.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [features]
 tokio-console = ["mz-ore/tokio-console"]

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
 bytes = "1.3.0"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -50,6 +50,7 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 url = "2.3.1"
 uuid = { version = "1.2.2", features = ["v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }

--- a/src/pgcopy/Cargo.toml
+++ b/src/pgcopy/Cargo.toml
@@ -11,3 +11,4 @@ bytes = "1.3.0"
 csv = "1.1.6"
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -15,3 +15,4 @@ once_cell = "1.16.0"
 mz-repr = { path = "../repr" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-1"] }
 uuid = "1.2.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -16,3 +16,4 @@ mz-ore = { path = "../ore", features = ["cli"] }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -27,3 +27,4 @@ tokio = "1.23.0"
 tokio-openssl = "0.6.3"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/pid-file/Cargo.toml
+++ b/src/pid-file/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 libc = "0.2.137"
 mz-ore = { path = "../ore", default-features = false }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1.0.37"
 tokio = { version = "1.23.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 tempfile = "3.2.0"
 tracing = "0.1.37"
 tokio = { version = "1.23.0", features = ["time"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 tikv-jemalloc-ctl = { version = "0.4.1", features = ["use_std"], optional = true }

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = "1.2.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/repr-test-util/Cargo.toml
+++ b/src/repr-test-util/Cargo.toml
@@ -12,6 +12,7 @@ mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 proc-macro2 = "1.0.47"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 datadriven = "0.6.0"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -51,6 +51,7 @@ thiserror = "1.0.37"
 # for the tracing_ feature
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", default-features = false, optional = true }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -18,3 +18,4 @@ mz-ore = { path = "../ore", features = ["cli"] }
 tokio = { version = "1.23.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 anyhow = "1.0.66"
 mz-repr = { path = "../repr" }
 async-trait = "0.1.59"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "1.0.89"
 tokio = { version = "1.23.0", features = ["sync"] }
 tracing = "0.1.37"
 uuid = "1.2.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -29,3 +29,4 @@ tonic = "0.8.2"
 tower = "0.4.13"
 tracing = "0.1.37"
 sentry-tracing = "0.29.0"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -15,6 +15,7 @@ phf = { version = "0.11.1", features = ["uncased"] }
 serde = { version = "1.0.147", features = ["derive"] }
 tracing = "0.1.37"
 uncased = "0.9.7"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 datadriven = "0.6.0"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -48,6 +48,7 @@ tracing = "0.1.37"
 typemap_rev = "0.3.0"
 uncased = "0.9.7"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 datadriven = "0.6.0"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -42,3 +42,4 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", feat
 tower-http = { version = "0.3.4", features = ["cors"] }
 uuid = "1.2.2"
 walkdir = "2.3.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -17,3 +17,4 @@ ssh-key = { version = "0.4.3" }
 tempfile = "3.3.0"
 tracing = "0.1.37"
 zeroize = { version = "1.5.7", features = ["serde"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -21,3 +21,4 @@ once_cell = "1.16.0"
 serde_json = "1.0.89"
 tokio = "1.23.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -24,6 +24,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 tokio = "1.23.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -55,6 +55,7 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -69,6 +69,7 @@ tracing-subscriber = "0.3.16"
 thiserror = { version = "1.0.37" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -72,3 +72,4 @@ tokio-util = { version = "0.7.4", features = ["compat"] }
 url = "2.3.1"
 uuid = "1.2.2"
 walkdir = "2.3.2"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -15,6 +15,7 @@ timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflo
 serde = { version = "1.0.147", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 tracing = "0.1.37"
 typemap_rev = "0.3.0"
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -12,6 +12,7 @@ itertools = "0.10.5"
 mz-ore = { path = "../ore", default-features = false }
 quote = "1.0.21"
 syn = { version = "1.0.103", features = ["extra-traits", "full", "parsing"] }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 datadriven = "0.6.0"

--- a/src/workspace-hack/.gitattributes
+++ b/src/workspace-hack/.gitattributes
@@ -1,0 +1,4 @@
+# Avoid putting conflict markers in the generated Cargo.toml file, since their presence breaks
+# Cargo.
+# Also do not check out the file as CRLF on Windows, as that's what hakari needs.
+Cargo.toml merge=binary -crlf

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -1,0 +1,238 @@
+[package]
+name = "workspace-hack"
+description = "workspace-hack package, managed by hakari"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+# The parts of the file between the BEGIN HAKARI SECTION and END HAKARI SECTION
+# comments are managed by hakari.
+#
+# To regenerate, run:
+#     cargo hakari generate
+
+### BEGIN HAKARI SECTION
+[dependencies]
+anyhow = { version = "1.0.66", features = ["backtrace", "std"] }
+aws-sdk-sts = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sig-auth = { version = "0.51.0", default-features = false, features = ["aws-smithy-eventstream", "sign-eventstream"] }
+aws-sigv4 = { version = "0.51.0", features = ["aws-smithy-eventstream", "bytes", "form_urlencoded", "http", "percent-encoding", "sign-eventstream", "sign-http"] }
+aws-smithy-http = { version = "0.51.0", default-features = false, features = ["aws-smithy-eventstream", "event-stream", "rt-tokio", "tokio", "tokio-util"] }
+aws-types = { version = "0.51.0", default-features = false, features = ["hardcoded-credentials"] }
+axum = { version = "0.5.17", features = ["form", "headers", "http1", "json", "matched-path", "original-uri", "query", "serde_json", "serde_urlencoded", "tower-log"] }
+base64 = { version = "0.13.1", features = ["alloc", "std"] }
+bstr = { version = "0.2.14", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+byteorder = { version = "1.4.3", features = ["std"] }
+bytes = { version = "1.3.0", features = ["std"] }
+chrono = { version = "0.4.23", default-features = false, features = ["alloc", "clock", "iana-time-zone", "serde", "std", "winapi"] }
+clap = { version = "3.2.20", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor", "terminal_size", "wrap_help"] }
+criterion = { version = "0.4.0", features = ["async", "async_tokio", "cargo_bench_support", "futures", "html_reports", "plotters", "rayon", "tokio"] }
+crossbeam-channel = { version = "0.5.6", features = ["crossbeam-utils", "std"] }
+crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
+crossbeam-epoch = { version = "0.9.13", features = ["alloc", "std"] }
+crossbeam-utils = { version = "0.8.7", features = ["lazy_static", "std"] }
+crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
+dec = { version = "0.4.8", default-features = false, features = ["serde"] }
+digest = { version = "0.10.6", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
+either = { version = "1.8.0", features = ["use_std"] }
+flate2 = { version = "1.0.24", features = ["any_zlib", "libz-sys", "miniz_oxide", "rust_backend", "zlib"] }
+frunk_core = { version = "0.4.0", default-features = false, features = ["std"] }
+futures = { version = "0.3.25", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3.25", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.25", features = ["alloc", "std"] }
+futures-executor = { version = "0.3.25", features = ["std"] }
+futures-io = { version = "0.3.25", features = ["std"] }
+futures-sink = { version = "0.3.25", features = ["alloc", "std"] }
+futures-task = { version = "0.3.25", features = ["alloc", "std"] }
+futures-util = { version = "0.3.25", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+globset = { version = "0.4.9", features = ["log", "serde", "serde1"] }
+hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["ahash", "inline-more", "raw"] }
+hyper = { version = "0.14.23", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+k8s-openapi = { version = "0.16.0", features = ["api", "http", "percent-encoding", "url", "v1_22"] }
+kube = { version = "0.76.0", features = ["client", "config", "derive", "kube-client", "kube-derive", "kube-runtime", "openssl-tls", "runtime", "ws"] }
+kube-client = { version = "0.76.0", default-features = false, features = ["__non_core", "base64", "bytes", "chrono", "client", "config", "dirs", "either", "futures", "http-body", "hyper", "hyper-openssl", "hyper-timeout", "jsonpatch", "jsonpath_lib", "openssl", "openssl-tls", "pem", "pin-project", "rand", "serde_yaml", "tokio", "tokio-tungstenite", "tokio-util", "tower", "tower-http", "tracing", "ws"] }
+kube-core = { version = "0.76.0", default-features = false, features = ["json-patch", "jsonpatch", "schema", "schemars", "ws"] }
+libc = { version = "0.2.137", features = ["extra_traits", "std"] }
+log = { version = "0.4.17", default-features = false, features = ["std"] }
+lru = { version = "0.8.1", features = ["hashbrown"] }
+memchr = { version = "2.4.1", features = ["std", "use_std"] }
+native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
+nix = { version = "0.26.1", features = ["acct", "aio", "dir", "env", "event", "feature", "fs", "hostname", "inotify", "ioctl", "kmod", "memoffset", "mman", "mount", "mqueue", "net", "personality", "pin-utils", "poll", "process", "pthread", "ptrace", "quota", "reboot", "resource", "sched", "signal", "socket", "term", "time", "ucontext", "uio", "user", "zerocopy"] }
+nom = { version = "7.1.0", features = ["alloc", "std"] }
+num-bigint = { version = "0.4.2", features = ["std"] }
+num-integer = { version = "0.1.44", features = ["i128", "std"] }
+num-traits = { version = "0.2.15", features = ["i128", "libm", "std"] }
+openssl = { version = "0.10.43", features = ["vendored"] }
+openssl-sys = { version = "0.9.79", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "3.4.0", features = ["serde", "std"] }
+parking_lot = { version = "0.12.0", features = ["send_guard"] }
+phf = { version = "0.11.1", features = ["std", "uncased"] }
+phf_shared = { version = "0.11.1", features = ["std", "uncased"] }
+postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["chrono-04", "serde-1", "serde_json-1", "uuid-1", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+proc-macro2 = { version = "1.0.47", features = ["proc-macro", "span-locations"] }
+prometheus = { version = "0.13.3", default-features = false, features = ["libc", "process", "procfs"] }
+prost = { version = "0.11.3", features = ["no-recursion-limit", "prost-derive", "std"] }
+prost-reflect = { version = "0.9.2", default-features = false, features = ["base64", "serde", "serde-value", "serde1"] }
+prost-types = { version = "0.11.2", features = ["std"] }
+quote = { version = "1.0.21", features = ["proc-macro"] }
+rand = { version = "0.8.5", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake", "cmake-build", "libz", "libz-static", "libz-sys", "openssl-sys", "ssl", "ssl-vendored", "zstd", "zstd-sys"] }
+regex = { version = "1.7.0", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6.28", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+reqwest = { version = "0.11.13", features = ["__tls", "blocking", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "native-tls-vendored", "serde_json", "tokio-native-tls"] }
+ring = { version = "0.16.20", features = ["alloc", "dev_urandom_fallback", "once_cell", "std"] }
+schemars = { version = "0.8.11", features = ["derive", "schemars_derive", "uuid1"] }
+scopeguard = { version = "1.1.0", features = ["use_std"] }
+semver = { version = "1.0.14", features = ["serde", "std"] }
+serde = { version = "1.0.147", features = ["alloc", "derive", "serde_derive", "std"] }
+serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "float_roundtrip", "indexmap", "preserve_order", "raw_value", "std"] }
+sha2 = { version = "0.10.6", features = ["std"] }
+smallvec = { version = "1.10.0", default-features = false, features = ["serde", "union", "write"] }
+socket2 = { version = "0.4.7", default-features = false, features = ["all"] }
+syn = { version = "1.0.103", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
+time = { version = "0.3.17", features = ["alloc", "formatting", "macros", "parsing", "quickcheck", "serde", "serde-well-known", "std"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode", "getopts", "getopts-dep"] }
+timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode", "getopts"] }
+tokio = { version = "1.23.0", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros", "tracing"] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["runtime", "serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+tokio-stream = { version = "0.1.11", features = ["net", "sync", "time", "tokio-util"] }
+tokio-util = { version = "0.7.4", features = ["codec", "compat", "futures-io", "io", "slab", "time", "tracing"] }
+tower = { version = "0.4.13", features = ["__common", "balance", "buffer", "discover", "filter", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "retry", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
+tower-http = { version = "0.3.4", features = ["auth", "base64", "cors", "map-response-body", "tower", "trace", "tracing", "util"] }
+tracing = { version = "0.1.37", features = ["attributes", "log", "std", "tracing-attributes"] }
+tracing-core = { version = "0.1.30", features = ["once_cell", "std"] }
+tracing-subscriber = { version = "0.3.16", features = ["alloc", "ansi", "env-filter", "fmt", "json", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "serde", "serde_json", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log", "tracing-serde"] }
+uncased = { version = "0.9.7", features = ["alloc"] }
+url = { version = "2.3.1", features = ["serde"] }
+uuid = { version = "1.2.2", features = ["getrandom", "rng", "serde", "std", "v4"] }
+zeroize = { version = "1.5.7", features = ["alloc", "serde"] }
+
+[build-dependencies]
+anyhow = { version = "1.0.66", features = ["backtrace", "std"] }
+aws-sdk-sts = { version = "0.21.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sig-auth = { version = "0.51.0", default-features = false, features = ["aws-smithy-eventstream", "sign-eventstream"] }
+aws-sigv4 = { version = "0.51.0", features = ["aws-smithy-eventstream", "bytes", "form_urlencoded", "http", "percent-encoding", "sign-eventstream", "sign-http"] }
+aws-smithy-http = { version = "0.51.0", default-features = false, features = ["aws-smithy-eventstream", "event-stream", "rt-tokio", "tokio", "tokio-util"] }
+aws-types = { version = "0.51.0", default-features = false, features = ["hardcoded-credentials"] }
+axum = { version = "0.5.17", features = ["form", "headers", "http1", "json", "matched-path", "original-uri", "query", "serde_json", "serde_urlencoded", "tower-log"] }
+base64 = { version = "0.13.1", features = ["alloc", "std"] }
+bstr = { version = "0.2.14", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+byteorder = { version = "1.4.3", features = ["std"] }
+bytes = { version = "1.3.0", features = ["std"] }
+cc = { version = "1.0.77", default-features = false, features = ["jobserver", "parallel"] }
+chrono = { version = "0.4.23", default-features = false, features = ["alloc", "clock", "iana-time-zone", "serde", "std", "winapi"] }
+clap = { version = "3.2.20", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor", "terminal_size", "wrap_help"] }
+criterion = { version = "0.4.0", features = ["async", "async_tokio", "cargo_bench_support", "futures", "html_reports", "plotters", "rayon", "tokio"] }
+crossbeam-channel = { version = "0.5.6", features = ["crossbeam-utils", "std"] }
+crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
+crossbeam-epoch = { version = "0.9.13", features = ["alloc", "std"] }
+crossbeam-utils = { version = "0.8.7", features = ["lazy_static", "std"] }
+crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
+dec = { version = "0.4.8", default-features = false, features = ["serde"] }
+digest = { version = "0.10.6", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
+either = { version = "1.8.0", features = ["use_std"] }
+flate2 = { version = "1.0.24", features = ["any_zlib", "libz-sys", "miniz_oxide", "rust_backend", "zlib"] }
+frunk_core = { version = "0.4.0", default-features = false, features = ["std"] }
+futures = { version = "0.3.25", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3.25", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.25", features = ["alloc", "std"] }
+futures-executor = { version = "0.3.25", features = ["std"] }
+futures-io = { version = "0.3.25", features = ["std"] }
+futures-sink = { version = "0.3.25", features = ["alloc", "std"] }
+futures-task = { version = "0.3.25", features = ["alloc", "std"] }
+futures-util = { version = "0.3.25", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+globset = { version = "0.4.9", features = ["log", "serde", "serde1"] }
+hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["ahash", "inline-more", "raw"] }
+hyper = { version = "0.14.23", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+k8s-openapi = { version = "0.16.0", features = ["api", "http", "percent-encoding", "url", "v1_22"] }
+kube = { version = "0.76.0", features = ["client", "config", "derive", "kube-client", "kube-derive", "kube-runtime", "openssl-tls", "runtime", "ws"] }
+kube-client = { version = "0.76.0", default-features = false, features = ["__non_core", "base64", "bytes", "chrono", "client", "config", "dirs", "either", "futures", "http-body", "hyper", "hyper-openssl", "hyper-timeout", "jsonpatch", "jsonpath_lib", "openssl", "openssl-tls", "pem", "pin-project", "rand", "serde_yaml", "tokio", "tokio-tungstenite", "tokio-util", "tower", "tower-http", "tracing", "ws"] }
+kube-core = { version = "0.76.0", default-features = false, features = ["json-patch", "jsonpatch", "schema", "schemars", "ws"] }
+libc = { version = "0.2.137", features = ["extra_traits", "std"] }
+log = { version = "0.4.17", default-features = false, features = ["std"] }
+lru = { version = "0.8.1", features = ["hashbrown"] }
+memchr = { version = "2.4.1", features = ["std", "use_std"] }
+native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
+nix = { version = "0.26.1", features = ["acct", "aio", "dir", "env", "event", "feature", "fs", "hostname", "inotify", "ioctl", "kmod", "memoffset", "mman", "mount", "mqueue", "net", "personality", "pin-utils", "poll", "process", "pthread", "ptrace", "quota", "reboot", "resource", "sched", "signal", "socket", "term", "time", "ucontext", "uio", "user", "zerocopy"] }
+nom = { version = "7.1.0", features = ["alloc", "std"] }
+num-bigint = { version = "0.4.2", features = ["std"] }
+num-integer = { version = "0.1.44", features = ["i128", "std"] }
+num-traits = { version = "0.2.15", features = ["i128", "libm", "std"] }
+openssl = { version = "0.10.43", features = ["vendored"] }
+openssl-sys = { version = "0.9.79", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "3.4.0", features = ["serde", "std"] }
+parking_lot = { version = "0.12.0", features = ["send_guard"] }
+phf = { version = "0.11.1", features = ["std", "uncased"] }
+phf_shared = { version = "0.11.1", features = ["std", "uncased"] }
+postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
+postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["chrono-04", "serde-1", "serde_json-1", "uuid-1", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+proc-macro2 = { version = "1.0.47", features = ["proc-macro", "span-locations"] }
+prometheus = { version = "0.13.3", default-features = false, features = ["libc", "process", "procfs"] }
+prost = { version = "0.11.3", features = ["no-recursion-limit", "prost-derive", "std"] }
+prost-reflect = { version = "0.9.2", default-features = false, features = ["base64", "serde", "serde-value", "serde1"] }
+prost-types = { version = "0.11.2", features = ["std"] }
+quote = { version = "1.0.21", features = ["proc-macro"] }
+rand = { version = "0.8.5", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake", "cmake-build", "libz", "libz-static", "libz-sys", "openssl-sys", "ssl", "ssl-vendored", "zstd", "zstd-sys"] }
+regex = { version = "1.7.0", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6.28", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+reqwest = { version = "0.11.13", features = ["__tls", "blocking", "default-tls", "hyper-tls", "json", "native-tls", "native-tls-crate", "native-tls-vendored", "serde_json", "tokio-native-tls"] }
+ring = { version = "0.16.20", features = ["alloc", "dev_urandom_fallback", "once_cell", "std"] }
+schemars = { version = "0.8.11", features = ["derive", "schemars_derive", "uuid1"] }
+scopeguard = { version = "1.1.0", features = ["use_std"] }
+semver = { version = "1.0.14", features = ["serde", "std"] }
+serde = { version = "1.0.147", features = ["alloc", "derive", "serde_derive", "std"] }
+serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "float_roundtrip", "indexmap", "preserve_order", "raw_value", "std"] }
+sha2 = { version = "0.10.6", features = ["std"] }
+smallvec = { version = "1.10.0", default-features = false, features = ["serde", "union", "write"] }
+socket2 = { version = "0.4.7", default-features = false, features = ["all"] }
+syn = { version = "1.0.103", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
+time = { version = "0.3.17", features = ["alloc", "formatting", "macros", "parsing", "quickcheck", "serde", "serde-well-known", "std"] }
+time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode", "getopts", "getopts-dep"] }
+timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode", "getopts"] }
+tokio = { version = "1.23.0", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros", "tracing"] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["runtime", "serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
+tokio-stream = { version = "0.1.11", features = ["net", "sync", "time", "tokio-util"] }
+tokio-util = { version = "0.7.4", features = ["codec", "compat", "futures-io", "io", "slab", "time", "tracing"] }
+tower = { version = "0.4.13", features = ["__common", "balance", "buffer", "discover", "filter", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "retry", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
+tower-http = { version = "0.3.4", features = ["auth", "base64", "cors", "map-response-body", "tower", "trace", "tracing", "util"] }
+tracing = { version = "0.1.37", features = ["attributes", "log", "std", "tracing-attributes"] }
+tracing-core = { version = "0.1.30", features = ["once_cell", "std"] }
+tracing-subscriber = { version = "0.3.16", features = ["alloc", "ansi", "env-filter", "fmt", "json", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "serde", "serde_json", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log", "tracing-serde"] }
+uncased = { version = "0.9.7", features = ["alloc"] }
+url = { version = "2.3.1", features = ["serde"] }
+uuid = { version = "1.2.2", features = ["getrandom", "rng", "serde", "std", "v4"] }
+zeroize = { version = "1.5.7", features = ["alloc", "serde"] }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
+libc = { version = "0.2.137", default-features = false, features = ["use_std"] }
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
+tikv-jemalloc-sys = { version = "0.4.2+5.2.1-patched.2", features = ["background_threads", "background_threads_runtime_support", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
+libc = { version = "0.2.137", default-features = false, features = ["use_std"] }
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
+tikv-jemalloc-sys = { version = "0.4.2+5.2.1-patched.2", features = ["background_threads", "background_threads_runtime_support", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+
+[target.x86_64-apple-darwin.dependencies]
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
+security-framework = { version = "2.0.0", features = ["OSX_10_9", "alpn"] }
+
+[target.x86_64-apple-darwin.build-dependencies]
+native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
+once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
+security-framework = { version = "2.0.0", features = ["OSX_10_9", "alpn"] }
+
+### END HAKARI SECTION

--- a/src/workspace-hack/build.rs
+++ b/src/workspace-hack/build.rs
@@ -1,0 +1,12 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// A build script is required for Cargo to honor build dependencies.
+
+fn main() {}

--- a/src/workspace-hack/src/lib.rs
+++ b/src/workspace-hack/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -14,3 +14,4 @@ mz-ore = { path = "../../../src/ore", features = ["network", "async", "test"] }
 tokio = { version = "1.23.0", features = ["macros"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack" }

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -22,3 +22,4 @@ tokio = "1.23.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+workspace-hack = { version = "0.0.0", path = "../../src/workspace-hack" }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -16,3 +16,4 @@ rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features
 tokio = "1.23.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
+workspace-hack = { version = "0.0.0", path = "../../src/workspace-hack" }


### PR DESCRIPTION
@danhhz turns out I nerdsniped myself into doing this. 🙈 

----

workspace-hack crates speed up builds when working across a workspace with many crates by ensuring that all crates use the same features for all transitive dependencies. For details, see the excellent hakari documentation on the subject. [0]

This commit uses hakari to generate such a workspace-hack crate, and teaches CI to enforce that it is kept up to date.

[0]: https://docs.rs/cargo-hakari/latest/cargo_hakari/about/index.html

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Make local development a bit faster.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
