### PR TITLE
storage: adjust the persist "purpose" strings with Aljoscha feedback

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -298,7 +298,7 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("persist_sink::mint_batch_descriptions {}", sink_id),
+                &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
             )
             .await
             .expect("could not open persist shard");
@@ -565,7 +565,7 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("persist_sink::write_batches {}", sink_id),
+                &format!("compute::persist_sink::write_batches {}", sink_id),
             )
             .await
             .expect("could not open persist shard");

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -105,7 +105,7 @@ where
             .expect("could not open persist client")
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 metadata.data_shard,
-                &format!("persist_sink::storage {}", src_id),
+                &format!("storage::persist_sink {}", src_id),
             )
             .await
             .expect("could not open persist shard");

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -95,7 +95,7 @@ impl Healthchecker {
         let (write_handle, read_handle) = persist_client
             .open(
                 storage_metadata.status_shard.unwrap(),
-                &format!("healthchecker {}", source_id),
+                &format!("healthcheck {}", source_id),
             )
             .await
             .context("error opening Healthchecker persist shard")?;
@@ -103,7 +103,7 @@ impl Healthchecker {
         let (since, upper) = (read_handle.since().clone(), write_handle.upper().clone());
 
         let bootstrap_read_handle = read_handle
-            .clone(&format!("healthchecker::bootstrap {}", source_id))
+            .clone(&format!("healthcheck::bootstrap {}", source_id))
             .await;
 
         // More details on why the listener starts at `since` instead of `upper` in the docstring for [`bootstrap_state`]


### PR DESCRIPTION
We did Aljoscha's review of #16201 as post merge, so we could get it into the release. This addresses his feedback.


### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Petros, can you take a particular look at sources.rs, please? Aljoscha wasn't sure this logic was correct.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
