### PR TITLE
Add `mz_internal.mz_cluster_replica_sizes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,6 +3294,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "bytesize",
  "chrono",
  "const_format",
  "criterion",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 bytes = "1.2.1"
+bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 const_format = "0.2.30"
 dec = "0.4.8"

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2531,11 +2531,12 @@ impl<S: Append> Catalog<S> {
             builtin_table_updates.push(catalog.state.pack_compute_instance_update(name, 1));
             let instance = &catalog.state.compute_instances_by_id[id];
             for (replica_name, replica_id) in &instance.replica_id_by_name {
-                builtin_table_updates.push(catalog.state.pack_compute_replica_update(
-                    *id,
-                    replica_name,
-                    1,
-                ));
+                builtin_table_updates.extend(
+                    catalog
+                        .state
+                        .pack_compute_replica_updates(*id, replica_name, 1)
+                        .into_iter(),
+                );
                 let replica = catalog.state.get_compute_replica(*id, *replica_id);
                 for process_id in 0..replica.config.location.num_processes() {
                     let update = catalog.state.pack_compute_replica_status_update(
@@ -3713,7 +3714,6 @@ impl<S: Append> Catalog<S> {
                 name: QualifiedObjectName,
                 item: CatalogItem,
             },
-
             DropDatabase {
                 id: DatabaseId,
             },
@@ -4457,11 +4457,11 @@ impl<S: Append> Catalog<S> {
                         builtin_table_updates.push(update);
                     }
 
-                    builtin_table_updates.push(state.pack_compute_replica_update(
-                        instance.id,
-                        &name,
-                        -1,
-                    ));
+                    builtin_table_updates.extend(
+                        state
+                            .pack_compute_replica_updates(instance.id, &name, -1)
+                            .into_iter(),
+                    );
 
                     let details =
                         EventDetails::DropComputeReplicaV1(mz_audit_log::DropComputeReplicaV1 {
@@ -4828,11 +4828,11 @@ impl<S: Append> Catalog<S> {
                     for id in introspection_ids {
                         builtin_table_updates.extend(state.pack_item_update(id, 1));
                     }
-                    builtin_table_updates.push(state.pack_compute_replica_update(
-                        on_cluster_id,
-                        &name,
-                        1,
-                    ));
+                    builtin_table_updates.extend(
+                        state
+                            .pack_compute_replica_updates(on_cluster_id, &name, 1)
+                            .into_iter(),
+                    );
                     for process_id in 0..num_processes {
                         let update = state.pack_compute_replica_status_update(
                             on_cluster_id,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1389,6 +1389,16 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
         .with_column("updated_at", ScalarType::TimestampTz.nullable(false)),
 });
 
+pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_cluster_replica_sizes",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("processes", ScalarType::UInt64.nullable(false))
+        .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(false))
+        .with_column("memory_bytes", ScalarType::UInt64.nullable(false)),
+});
+
 pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_heartbeats",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2781,6 +2791,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_SSH_TUNNEL_CONNECTIONS),
         Builtin::Table(&MZ_CLUSTER_REPLICAS),
         Builtin::Table(&MZ_CLUSTER_REPLICA_METRICS),
+        Builtin::Table(&MZ_CLUSTER_REPLICA_SIZES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_STATUSES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
         Builtin::Table(&MZ_AUDIT_EVENTS),

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -270,6 +270,10 @@ mz_cluster_replica_metrics
 BASE TABLE
 materialize
 mz_internal
+mz_cluster_replica_sizes
+BASE TABLE
+materialize
+mz_internal
 mz_cluster_replica_statuses
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -528,6 +528,7 @@ name
 ----
 mz_cluster_replica_heartbeats
 mz_cluster_replica_metrics
+mz_cluster_replica_sizes
 mz_cluster_replica_statuses
 mz_storage_usage_by_shard
 mz_view_foreign_keys

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -573,7 +573,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-34
+35
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
Arjun and Seth have said it's okay to expose this.

### Motivation

  * This PR adds a known-desirable feature.

    (Not sure if there's an issue, @ggnall do you know?)
    
    We want to be able to expose the percentage of memory and CPU being used. The most elegant way to do this is to expose the sizes of the replicas, and create a view on top that divides the values in `mz_internal.mz_cluster_replica_metrics` by them.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

This is tough to test because we don't have memory/cpu limits, even in Cloudtest, but I verified by hand that it works in cloud.

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add mz_internal.mz_cluster_replica_sizes table.