### PR TITLE
Add API stub for real time recency

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -153,6 +153,13 @@ impl<T> Controller<T> {
         self.storage.remove_orphans(next_storage_host_id).await?;
         Ok(())
     }
+
+    /// Produces a timestamp that reflects all data available in
+    /// `source_ids` at the time of the function call.
+    #[allow(unused)]
+    pub async fn recent_timestamp(&self, source_ids: Vec<GlobalId>) -> mz_repr::Timestamp {
+        mz_repr::Timestamp::MIN
+    }
 }
 
 impl<T> Controller<T>

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -153,13 +153,6 @@ impl<T> Controller<T> {
         self.storage.remove_orphans(next_storage_host_id).await?;
         Ok(())
     }
-
-    /// Produces a timestamp that reflects all data available in
-    /// `source_ids` at the time of the function call.
-    #[allow(unused)]
-    pub async fn recent_timestamp(&self, source_ids: Vec<GlobalId>) -> mz_repr::Timestamp {
-        mz_repr::Timestamp::MIN
-    }
 }
 
 impl<T> Controller<T>
@@ -219,6 +212,14 @@ where
                 Ok(response.map(Into::into))
             }
         }
+    }
+
+    /// Produces a timestamp that reflects all data available in
+    /// `source_ids` at the time of the function call.
+    #[allow(unused)]
+    #[allow(clippy::unused_async)]
+    pub async fn recent_timestamp(&self, source_ids: Vec<GlobalId>) -> T {
+        T::minimum()
     }
 }
 

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -218,7 +218,7 @@ where
     /// `source_ids` at the time of the function call.
     #[allow(unused)]
     #[allow(clippy::unused_async)]
-    pub async fn recent_timestamp(&self, source_ids: Vec<GlobalId>) -> T {
+    pub async fn recent_timestamp(&self, source_ids: &[GlobalId]) -> T {
         T::minimum()
     }
 }


### PR DESCRIPTION
### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
