### PR TITLE
compute: improve ReduceCollation unwrap error

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -299,7 +299,7 @@ where
     concatenate(scope, to_concat)
         .reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceCollation", {
             let mut row_buf = Row::default();
-            move |_key, input, output| {
+            move |key, input, output| {
                 // The inputs are pairs of a reduction type, and a row consisting of densely packed fused
                 // aggregate values.
                 // We need to reconstitute the final value by:
@@ -307,7 +307,6 @@ where
                 // 2. For each aggregate, figure out what type it is, and grab the relevant value
                 //    from the corresponding fused row.
                 // 3. Stitch all the values together into one row.
-
                 let mut accumulable = DatumList::empty().iter();
                 let mut hierarchical = DatumList::empty().iter();
                 let mut basic = DatumList::empty().iter();
@@ -339,16 +338,15 @@ where
                 // Merge results into the order they were asked for.
                 let mut row_packer = row_buf.packer();
                 for typ in aggregate_types.iter() {
-                    match typ {
-                        ReductionType::Accumulable => {
-                            row_packer.push(accumulable.next().unwrap())
-                        }
-                        ReductionType::Hierarchical => {
-                            row_packer.push(hierarchical.next().unwrap())
-                        }
-                        ReductionType::Basic => {
-                            row_packer.push(basic.next().unwrap())
-                        }
+                    let datum = match typ {
+                        ReductionType::Accumulable => accumulable.next(),
+                        ReductionType::Hierarchical => hierarchical.next(),
+                        ReductionType::Basic => basic.next(),
+                    };
+                    if let Some(datum) = datum {
+                        row_packer.push(datum);
+                    } else {
+                        panic!("[customer-data] Missing {typ:?} value for key: {key}");
                     }
                 }
                 output.push((row_buf.clone(), 1));


### PR DESCRIPTION
This PR adds more detail to the panic message shown when ReduceCollation fails to find all expected inputs. In particular, it adds the offending key to the message.

We see ReduceCollation crash in production, but so far we don't have enough data to diagnose the cause. The hope is that the improved error message can help us.

### Motivation

  * This PR fixes a recognized bug.

Advances https://github.com/MaterializeInc/materialize/issues/15496.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
