### PR TITLE
Don't randomly divide memory metrics by 8

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -397,7 +397,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 }
             };
             let memory = match parse_k8s_quantity(mem_str) {
-                Ok(q) => match q.try_to_integer(3, false) {
+                Ok(q) => match q.try_to_integer(0, false) {
                     Some(i) => Some(i),
                     None => {
                         tracing::error!("Memory value {q:?} out of range");


### PR DESCRIPTION
I made _two_ mistakes when parsing the memory metrics:

* I thought we needed KiB, instead of bytes, so I passed a non-zero value to the "scale" parameter,
* I forgot that it needed to be binary, instead of decimal, so the correct value for KiB would have been 10, not 3.

Passing 3 gives us back the amount of memory in 8-byte chunks, not the amount of memory in bytes.

### Motivation

  * This PR fixes a previously unreported bug.

    Memory metrics are off by a factor of 8

