### PR TITLE
doc: document that SET works over HTTP

### DIFF
--- a/doc/user/content/integrations/http-api.md
+++ b/doc/user/content/integrations/http-api.md
@@ -32,7 +32,7 @@ The API:
     - `CLOSE`
     - `COPY`
     - `DECLARE`
-    - `SET`
+    - `FETCH`
     - `SUBSCRIBE`
 
 ### Transactional semantics

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -392,6 +392,11 @@ fn test_http_sql() {
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[["v"]],"col_names":["name"],"notices":[]}]}"#,
         },
+        TestCaseSimple {
+            query: "SET cluster = default",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"SET","notices":[]}]}"#,
+        },
     ];
 
     for tc in simple_test_cases {


### PR DESCRIPTION
Also, FETCH does not.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a