### PR TITLE
Document the sink status tables

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -445,6 +445,36 @@ Field         | Type                          | Meaning
 `error`       | [`text`]                      | If the source is in an error state, the error message.
 `details`     | [`jsonb`]                     | Additional metadata provided by the source.
 
+### `mz_sink_status`
+
+The `mz_sink_status` view provides the current state for each sink in the
+system, including potential error messages and additional metadata helpful for
+debugging.
+
+Field                   | Type                          | Meaning
+------------------------|-------------------------------|--------
+`id`                    | [`text`]                      | The ID of the sink. Corresponds to [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks).
+`name`                  | [`text`]                      | The name of the sink.
+`type`                  | [`text`]                      | The type of the sink.
+`last_status_change_at` | [`timestamp with time zone`]  | Wall-clock timestamp of the sink status change.
+`status`                | [`text`]                      | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
+`error`                 | [`text`]                      | If the sink is in an error state, the error message.
+`details`               | [`jsonb`]                     | Additional metadata provided by the sink.
+
+### `mz_sink_status_history`
+
+The `mz_sink_status_history` table contains rows describing the
+history of changes to the status of each sink in the system, including potential error
+messages and additional metadata helpful for debugging.
+
+Field         | Type                          | Meaning
+--------------|-------------------------------|--------
+`occurred_at` | [`timestamp with time zone`]  | Wall-clock timestamp of the sink status change.
+`sink_id`     | [`text`]                      | The ID of the sink. Corresponds to [`mz_catalog.mz_sinks.id`](../mz_catalog#mz_sinks).
+`status`      | [`text`]                      | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
+`error`       | [`text`]                      | If the sink is in an error state, the error message.
+`details`     | [`jsonb`]                     | Additional metadata provided by the sink.
+
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list
 [`mz_timestamp`]: /sql/types/mz_timestamp


### PR DESCRIPTION
### Motivation

The sink counterpart of https://github.com/MaterializeInc/materialize/pull/16409.

### Tips for reviewer

More or less just the documentation for the source status tables with a search and replace, but I think that should cover it!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
