### PR TITLE
make mz_cluster_replica_sizes static

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2531,12 +2531,11 @@ impl<S: Append> Catalog<S> {
             builtin_table_updates.push(catalog.state.pack_compute_instance_update(name, 1));
             let instance = &catalog.state.compute_instances_by_id[id];
             for (replica_name, replica_id) in &instance.replica_id_by_name {
-                builtin_table_updates.extend(
-                    catalog
-                        .state
-                        .pack_compute_replica_updates(*id, replica_name, 1)
-                        .into_iter(),
-                );
+                builtin_table_updates.push(catalog.state.pack_compute_replica_update(
+                    *id,
+                    replica_name,
+                    1,
+                ));
                 let replica = catalog.state.get_compute_replica(*id, *replica_id);
                 for process_id in 0..replica.config.location.num_processes() {
                     let update = catalog.state.pack_compute_replica_status_update(
@@ -4457,11 +4456,11 @@ impl<S: Append> Catalog<S> {
                         builtin_table_updates.push(update);
                     }
 
-                    builtin_table_updates.extend(
-                        state
-                            .pack_compute_replica_updates(instance.id, &name, -1)
-                            .into_iter(),
-                    );
+                    builtin_table_updates.push(state.pack_compute_replica_update(
+                        instance.id,
+                        &name,
+                        -1,
+                    ));
 
                     let details =
                         EventDetails::DropComputeReplicaV1(mz_audit_log::DropComputeReplicaV1 {
@@ -4828,11 +4827,11 @@ impl<S: Append> Catalog<S> {
                     for id in introspection_ids {
                         builtin_table_updates.extend(state.pack_item_update(id, 1));
                     }
-                    builtin_table_updates.extend(
-                        state
-                            .pack_compute_replica_updates(on_cluster_id, &name, 1)
-                            .into_iter(),
-                    );
+                    builtin_table_updates.push(state.pack_compute_replica_update(
+                        on_cluster_id,
+                        &name,
+                        1,
+                    ));
                     for process_id in 0..num_processes {
                         let update = state.pack_compute_replica_status_update(
                             on_cluster_id,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1393,8 +1393,9 @@ pub static MZ_CLUSTER_REPLICA_SIZES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
     name: "mz_cluster_replica_sizes",
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
-        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("size", ScalarType::String.nullable(false))
         .with_column("processes", ScalarType::UInt64.nullable(false))
+        .with_column("workers", ScalarType::UInt64.nullable(false))
         .with_column("cpu_nano_cores", ScalarType::UInt64.nullable(false))
         .with_column("memory_bytes", ScalarType::UInt64.nullable(false)),
 });

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -126,41 +126,27 @@ impl CatalogState {
         }
     }
 
-    pub(super) fn pack_compute_replica_updates(
+    pub(super) fn pack_compute_replica_update(
         &self,
         compute_instance_id: ComputeInstanceId,
         name: &str,
         diff: Diff,
-    ) -> Vec<BuiltinTableUpdate> {
+    ) -> BuiltinTableUpdate {
         let instance = &self.compute_instances_by_id[&compute_instance_id];
         let id = instance.replica_id_by_name[name];
         let replica = &instance.replicas_by_id[&id];
 
-        let (size, az, allocation) = match &replica.config.location {
+        let (size, az) = match &replica.config.location {
             ComputeReplicaLocation::Managed {
                 size,
                 availability_zone,
                 az_user_specified: _,
-                allocation,
-            } => (
-                Some(&**size),
-                Some(availability_zone.as_str()),
-                Some(*allocation),
-            ),
-            ComputeReplicaLocation::Remote { .. } => (None, None, None),
+                allocation: _,
+            } => (Some(&**size), Some(availability_zone.as_str())),
+            ComputeReplicaLocation::Remote { .. } => (None, None),
         };
 
-        let (processes, cpu, memory) = match allocation {
-            Some(ComputeReplicaAllocation {
-                memory_limit,
-                cpu_limit,
-                scale,
-                ..
-            }) => (Some(scale), cpu_limit, memory_limit),
-            None => (None, None, None),
-        };
-
-        let mut updates = vec![BuiltinTableUpdate {
+        BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
                 Datum::UInt64(id),
@@ -170,23 +156,7 @@ impl CatalogState {
                 Datum::from(az),
             ]),
             diff,
-        }];
-
-        if let (Some(processes), Some(cpu), Some(MemoryLimit(ByteSize(memory)))) =
-            (processes, cpu, memory)
-        {
-            updates.push(BuiltinTableUpdate {
-                id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_SIZES),
-                row: Row::pack_slice(&[
-                    Datum::UInt64(id),
-                    Datum::UInt64(u64::cast_from(processes.get())),
-                    Datum::UInt64(u64::cast_from(cpu.as_millicpus()) * 1_000_000),
-                    Datum::UInt64(memory),
-                ]),
-                diff,
-            })
         }
-        updates
     }
 
     pub(super) fn pack_compute_replica_status_update(
@@ -912,6 +882,42 @@ impl CatalogState {
         );
         let updates = rows
             .map(|row| BuiltinTableUpdate { id, row, diff })
+            .collect();
+        updates
+    }
+
+    pub fn pack_all_replica_size_updates(&self) -> Vec<BuiltinTableUpdate> {
+        let id = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_SIZES);
+        let updates = self
+            .cluster_replica_sizes
+            .0
+            .iter()
+            .filter_map(
+                |(
+                    size,
+                    ComputeReplicaAllocation {
+                        memory_limit,
+                        cpu_limit,
+                        scale,
+                        workers,
+                    },
+                )| {
+                    cpu_limit
+                        .and_then(|cpu_limit| {
+                            memory_limit.map(|memory_limit| (cpu_limit, memory_limit))
+                        })
+                        .map(|(cpu_limit, MemoryLimit(ByteSize(memory_bytes)))| {
+                            let row = Row::pack_slice(&[
+                                size.as_str().into(),
+                                u64::cast_from(scale.get()).into(),
+                                u64::cast_from(workers.get()).into(),
+                                (u64::cast_from(cpu_limit.as_millicpus()) * 1_000_000).into(),
+                                memory_bytes.into(),
+                            ]);
+                            BuiltinTableUpdate { id, row, diff: 1 }
+                        })
+                },
+            )
             .collect();
         updates
     }

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -911,7 +911,19 @@ impl CatalogState {
                                 size.as_str().into(),
                                 u64::cast_from(scale.get()).into(),
                                 u64::cast_from(workers.get()).into(),
-                                (u64::cast_from(cpu_limit.as_millicpus()) * 1_000_000).into(),
+                                // The largest possible value of a u64 is
+                                // 18_446_744_073_709_551_615,
+                                // so we won't overflow this
+                                // unless we have an instance with
+                                // ~18.45 billion cores.
+                                //
+                                // Such an instance seems unrealistic,
+                                // at least until we raise another few rounds
+                                // of funding ...
+                                (u64::cast_from(cpu_limit.as_millicpus())
+                                    .checked_mul(1_000_000)
+                                    .expect("Realistic number of cores"))
+                                .into(),
                                 memory_bytes.into(),
                             ]);
                             BuiltinTableUpdate { id, row, diff: 1 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -840,6 +840,9 @@ impl<S: Append + 'static> Coordinator<S> {
             )
         }
 
+        // Expose mapping from T-shirt sizes to actual sizes
+        builtin_table_updates.extend(self.catalog.state().pack_all_replica_size_updates());
+
         // Advance all tables to the current timestamp
         info!("coordinator init: advancing all tables to current timestamp");
         let WriteTimestamp {


### PR DESCRIPTION
Instead of a table with a row per replica, create a static one mapping replica sizes to concrete sizes.

### Motivation
Offline discussion with Joe and Nikhil

### Tips for reviewer

This is not tested (although I verified by hand that it works in cloud), but I am already planning to create a PR making this stuff testable. I think it should be fine to land this before doing so because it's no worse than what exists already.