### PR TITLE
adapter: add end-to-end test for LaunchDarkly synchronization

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -149,6 +149,8 @@ case "$cmd" in
             --env CI
             --env GITHUB_TOKEN
             --env GPG_KEY
+            --env LAUNCHDARKLY_API_TOKEN
+            --env LAUNCHDARKLY_SDK_KEY
             --env PYPI_TOKEN
         )
         for env in $(printenv | grep '^BUILDKITE' | sed 's/=.*//'); do

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -19,6 +19,7 @@ isort==5.10.1
 junit-xml==1.9
 kubernetes==25.3.0
 kubernetes-stubs==22.6.0.post1
+launchdarkly-api==11.0.0
 mypy==0.991
 numpy==1.22.4
 pandas==1.5.2

--- a/ci/cleanup/launchdarkly.py
+++ b/ci/cleanup/launchdarkly.py
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from datetime import datetime, timedelta
+from os import environ
+
+import launchdarkly_api  # type: ignore
+from launchdarkly_api.api import feature_flags_api  # type: ignore
+
+MAX_AGE = timedelta(hours=24)
+
+# Access keys required for interacting with LaunchDarkly.
+LAUNCHDARKLY_API_TOKEN = environ.get("LAUNCHDARKLY_API_TOKEN")
+
+
+def clean_up_test_features() -> None:
+    print(f"Deleting LaunchDarkly features whose age exceeds {MAX_AGE}")
+
+    configuration = launchdarkly_api.Configuration(
+        api_key=dict(ApiKey=LAUNCHDARKLY_API_TOKEN)
+    )
+    with launchdarkly_api.ApiClient(configuration) as api_client:
+        api = feature_flags_api.FeatureFlagsApi(api_client)
+
+        project_key = "default"
+        now = datetime.utcnow()
+
+        flags = api.get_feature_flags(
+            project_key,
+            env="ci-cd",
+            tag="ci-test",
+            archived=True,
+        )
+
+        for flag in flags["items"]:
+            key = flag["key"]
+            age = now - datetime.fromtimestamp(flag["creation_date"] / 1000)
+            if age <= MAX_AGE:
+                print(f"Skipping flag {key} (age={age}) whose age is beneath threshold")
+            else:
+                try:
+                    print(f"Deleting flag {key} (age={age})")
+                    api.delete_feature_flag(project_key, key)
+                except Exception as e:
+                    print(f"Error while trying to delete flag {key}: {e}")
+
+
+def main() -> None:
+    clean_up_test_features()
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -21,3 +21,9 @@ steps:
       - us-east-2
     plugins:
        - ./ci/plugins/scratch-aws-access
+
+steps:
+  - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.launchdarkly
+    timeout_in_minutes: 10
+    agents:
+      queue: linux-x86_64

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -60,6 +60,7 @@ steps:
           - { value: persist-maelstrom-single-node }
           - { value: persist-maelstrom-multi-node }
           - { value: unused-deps }
+          - { value: launchdarkly }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -542,3 +543,13 @@ steps:
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
+
+  - id: launchdarkly
+    label: "LaunchDarkly"
+    artifact_paths: junit_mzcompose_*.xml
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: launchdarkly

--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -26,8 +26,16 @@ pub use params::{ModifiedParameter, SynchronizedParameters};
 pub async fn system_parameter_sync(
     frontend: Arc<SystemParameterFrontend>,
     mut backend: SystemParameterBackend,
-    tick_interval: Duration,
+    tick_interval: Option<Duration>,
 ) -> Result<(), anyhow::Error> {
+    let tick_interval = match tick_interval {
+        Some(tick_interval) => tick_interval,
+        None => {
+            tracing::info!("skipping system parameter sync as tick_interval = None");
+            return Ok(());
+        }
+    };
+
     // Ensure the frontend client is initialized.
     frontend.ensure_initialized().await;
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -421,6 +421,19 @@ pub struct Args {
     /// configuration parameters.
     #[clap(long, env = "LAUNCHDARKLY_SDK_KEY")]
     launchdarkly_sdk_key: Option<String>,
+    /// A list of PARAM_NAME=KEY_NAME pairs from system parameter names to
+    /// LaunchDarkly feature keys.
+    ///
+    /// This is used (so far only for testing purposes) when propagating values
+    /// from the latter to the former. The identity map is assumed for absent
+    /// parameter names.
+    #[clap(
+        long,
+        env = "LAUNCHDARKLY_KEY_MAP",
+        multiple = true,
+        value_delimiter = ';'
+    )]
+    launchdarkly_key_map: Vec<KeyValueArg<String, String>>,
     /// The interval in seconds at which to synchronize system parameter values.
     ///
     /// If this is not explicitly set, the loop that synchronizes LaunchDarkly
@@ -779,6 +792,11 @@ max log level: {max_log_level}",
         egress_ips: args.announce_egress_ip,
         aws_account_id: args.aws_account_id,
         launchdarkly_sdk_key: args.launchdarkly_sdk_key,
+        launchdarkly_key_map: args
+            .launchdarkly_key_map
+            .into_iter()
+            .map(|kv| (kv.key, kv.value))
+            .collect(),
         config_sync_loop_interval: args.config_sync_loop_interval,
     }))?;
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -416,18 +416,22 @@ pub struct Args {
     announce_egress_ip: Vec<Ipv4Addr>,
     /// An SDK key for LaunchDarkly.
     ///
-    /// Setting this will enable synchronization of LaunchDarkly features with
-    /// system configuration parameters.
+    /// Setting this in combination with [`Self::config_sync_loop_interval`]
+    /// will enable synchronization of LaunchDarkly features with system
+    /// configuration parameters.
     #[clap(long, env = "LAUNCHDARKLY_SDK_KEY")]
     launchdarkly_sdk_key: Option<String>,
     /// The interval in seconds at which to synchronize system parameter values.
+    ///
+    /// If this is not explicitly set, the loop that synchronizes LaunchDarkly
+    /// features with system configuration parameters will not run _even if
+    /// [`Self::launchdarkly_sdk_key`] is present_.
     #[clap(
         long,
         env = "CONFIG_SYNC_LOOP_INTERVAL",
         parse(try_from_str = humantime::parse_duration),
-        default_value = "15s"
     )]
-    config_sync_loop_interval: Duration,
+    config_sync_loop_interval: Option<Duration>,
 
     /// The 12-digit AWS account id, which is used to generate an AWS Principal.
     #[clap(long, env = "AWS_ACCOUNT_ID")]

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -693,16 +693,9 @@ max log level: {max_log_level}",
         dep_versions = build_info().join("\n"),
         invocation = {
             use shell_words::quote as escape;
-            env::vars_os()
-                .map(|(name, value)| {
-                    (
-                        name.to_string_lossy().into_owned(),
-                        value.to_string_lossy().into_owned(),
-                    )
-                })
-                .filter(|(name, _value)| name.starts_with("MZ_") || name == "FAILPOINTS")
-                .map(|(name, value)| format!("{}={}", escape(&name), escape(&value)))
-                .chain(env::args().into_iter().map(|arg| escape(&arg).into_owned()))
+            env::args()
+                .into_iter()
+                .map(|arg| escape(&arg).into_owned())
                 .join(" ")
         },
         os = os_info::get(),

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -129,7 +129,7 @@ pub struct Config {
     /// with LaunchDarkly.
     pub launchdarkly_sdk_key: Option<String>,
     /// The interval in seconds at which to synchronize system parameter values.
-    pub config_sync_loop_interval: Duration,
+    pub config_sync_loop_interval: Option<Duration>,
 
     // === Tracing options. ===
     /// The metrics registry to use.
@@ -395,7 +395,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         });
     }
 
-    // If system_parameter_frontend is present, start the system_parameter_sync loop.
+    // If system_parameter_frontend and config_sync_loop_interval are present,
+    // start the system_parameter_sync loop.
     if let Some(system_parameter_frontend) = system_parameter_frontend {
         let system_parameter_backend = SystemParameterBackend::new(adapter_client).await?;
         task::spawn(

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -253,7 +253,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         egress_ips: vec![],
         aws_account_id: None,
         launchdarkly_sdk_key: None,
-        config_sync_loop_interval: Duration::ZERO,
+        config_sync_loop_interval: None,
     }))?;
     let server = Server {
         inner,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -253,6 +253,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         egress_ips: vec![],
         aws_account_id: None,
         launchdarkly_sdk_key: None,
+        launchdarkly_key_map: Default::default(),
         config_sync_loop_interval: None,
     }))?;
     let server = Server {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -839,6 +839,7 @@ impl RunnerInner {
             egress_ips: vec![],
             aws_account_id: None,
             launchdarkly_sdk_key: None,
+            launchdarkly_key_map: Default::default(),
             config_sync_loop_interval: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -839,7 +839,7 @@ impl RunnerInner {
             egress_ips: vec![],
             aws_account_id: None,
             launchdarkly_sdk_key: None,
-            config_sync_loop_interval: Duration::ZERO,
+            config_sync_loop_interval: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/test/launchdarkly/mzcompose
+++ b/test/launchdarkly/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -1,0 +1,280 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from itertools import chain
+from os import environ
+from time import sleep
+from typing import Any, List, Optional
+from uuid import uuid1
+
+import launchdarkly_api  # type: ignore
+from launchdarkly_api.api import feature_flags_api  # type: ignore
+from launchdarkly_api.model.client_side_availability_post import (  # type: ignore
+    ClientSideAvailabilityPost,
+)
+from launchdarkly_api.model.defaults import Defaults  # type: ignore
+from launchdarkly_api.model.feature_flag_body import FeatureFlagBody  # type: ignore
+from launchdarkly_api.model.json_patch import JSONPatch  # type: ignore
+from launchdarkly_api.model.patch_operation import PatchOperation  # type: ignore
+from launchdarkly_api.model.patch_with_comment import PatchWithComment  # type: ignore
+from launchdarkly_api.model.variation import Variation  # type: ignore
+
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import Materialized, Testdrive
+from materialize.ui import UIError
+
+# Access keys required for interacting with LaunchDarkly.
+LAUNCHDARKLY_API_TOKEN = environ.get("LAUNCHDARKLY_API_TOKEN")
+LAUNCHDARKLY_SDK_KEY = environ.get("LAUNCHDARKLY_SDK_KEY")
+
+# We need those to derive feature flag name that guarantees that we won't have
+# collisions between runs.
+BUILDKITE_JOB_ID = environ.get("BUILDKITE_JOB_ID", uuid1())
+BUILDKITE_PULL_REQUEST = environ.get("BUILDKITE_PULL_REQUEST")
+
+# This should always coincide with the default ld_user_key passed to
+# SystemParameterFrontend::new in the Rust codebase.
+LD_USER_KEY = "anonymous-dev@materialize.com"
+# A unique feature flag key to use for this test.
+LD_FEATURE_FLAG_KEY = f"ci-test-{BUILDKITE_JOB_ID}"
+
+SERVICES = [
+    Materialized(
+        environment_extra=[
+            f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",
+            f"MZ_LAUNCHDARKLY_KEY_MAP=max_result_size={LD_FEATURE_FLAG_KEY}",
+            "MZ_LOG_FILTER=mz_adapter::catalog=debug,mz_adapter::config=debug,info",
+            "MZ_CONFIG_SYNC_LOOP_INTERVAL=1s",
+        ]
+    ),
+    Testdrive(no_reset=True, seed=1),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    if LAUNCHDARKLY_API_TOKEN is None:
+        raise UIError("Missing LAUNCHDARKLY_API_TOKEN environment variable")
+    if LAUNCHDARKLY_SDK_KEY is None:
+        raise UIError("Missing LAUNCHDARKLY_SDK_KEY environment variable")
+
+    # Create a LaunchDarkly client that simulates somebody interacting
+    # with the LaunchDarkly frontend.
+    ld_client = LaunchDarklyClient(
+        configuration=launchdarkly_api.Configuration(
+            api_key=dict(ApiKey=LAUNCHDARKLY_API_TOKEN),
+        ),
+        project_key="default",
+        environment_key="ci-cd",
+    )
+
+    try:
+        c.up("testdrive", persistent=True)
+
+        # Assert that the default max_result_size is served when sync is disabled.
+        with c.override(Materialized()):
+            c.start_and_wait_for_tcp(services=["materialized"])
+            c.testdrive("\n".join(["> SHOW max_result_size", "1073741824"]))
+            c.stop("materialized")
+
+        # Create a test feature flag unique for this test run. Based on the
+        # MZ_LAUNCHDARKLY_KEY_MAP value, the test feature will be mapped to the
+        # max_result_size system parameter.
+        ld_client.create_flag(
+            LD_FEATURE_FLAG_KEY,
+            tags=["ci-test", f"gh-{BUILDKITE_PULL_REQUEST}"]
+            if BUILDKITE_PULL_REQUEST is not None
+            else ["ci-test"],
+        )
+        # Turn on targeting. The default rule will now serve 2GiB for the test
+        # feature.
+        ld_client.update_targeting(
+            LD_FEATURE_FLAG_KEY,
+            on=True,
+        )
+
+        # 3 seconds should be enough to avoid race conditions between the update
+        # above and the query below.
+        sleep(3)
+
+        # Assert that the value is as expected after the initial parameter sync.
+        with c.override(
+            Materialized(
+                environment_extra=[
+                    f"MZ_LAUNCHDARKLY_SDK_KEY={LAUNCHDARKLY_SDK_KEY}",
+                    f"MZ_LAUNCHDARKLY_KEY_MAP=max_result_size={LD_FEATURE_FLAG_KEY}",
+                    "MZ_LOG_FILTER=mz_adapter::catalog=debug,mz_adapter::config=debug,info",
+                ]
+            )
+        ):
+            c.start_and_wait_for_tcp(services=["materialized"])
+            c.testdrive("\n".join(["> SHOW max_result_size", "2147483648"]))
+            c.stop("materialized")
+
+        # Assert that the last value is persisted and available upon restart,
+        # even if the parameter sync loop is not running.
+        with c.override(Materialized()):
+            c.start_and_wait_for_tcp(services=["materialized"])
+            c.testdrive("\n".join(["> SHOW max_result_size", "2147483648"]))
+            c.stop("materialized")
+
+        # Restart Materialized with the parameter sync loop running.
+        c.start_and_wait_for_tcp(services=["materialized"])
+
+        # Add a rule that targets the current user with the 3GiB variant.
+        ld_client.update_targeting(
+            LD_FEATURE_FLAG_KEY,
+            targets=[
+                {
+                    "values": [LD_USER_KEY],
+                    "variation": 2,
+                }
+            ],
+        )
+
+        # Assert that max_result_size is 3 GiB.
+        c.testdrive("\n".join(["> SHOW max_result_size", "3221225472"]))
+
+        # Add a rule that targets the current user with the 4GiB - 1 byte variant.
+        ld_client.update_targeting(
+            LD_FEATURE_FLAG_KEY,
+            targets=[
+                {
+                    "values": [LD_USER_KEY],
+                    "variation": 3,
+                }
+            ],
+        )
+
+        # Assert that max_result_size is 4 GiB - 1 byte.
+        c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))
+
+        # Remove custom targeting.
+        ld_client.update_targeting(
+            LD_FEATURE_FLAG_KEY,
+            targets=[],
+        )
+
+        # Assert that max_result_size is 2 GiB (the default when targeting is
+        # turned on).
+        c.testdrive("\n".join(["> SHOW max_result_size", "2147483648"]))
+
+        # Disable targeting.
+        ld_client.update_targeting(
+            LD_FEATURE_FLAG_KEY,
+            on=False,
+        )
+
+        # Assert that max_result_size is 1 GiB (the default when targeting is
+        # turned off).
+        c.testdrive("\n".join(["> SHOW max_result_size", "1073741824"]))
+
+        c.stop("materialized")
+    except launchdarkly_api.ApiException as e:
+        raise UIError(
+            "\n".join(
+                [
+                    "Error when calling the Launch Darkly API.",
+                    "- Status: %s." % e.status,
+                    "- Reason: %s." % e.reason,
+                ]
+            )
+        )
+    finally:
+        try:
+            ld_client.delete_flag(LD_FEATURE_FLAG_KEY)
+        except:
+            pass  # ignore exceptions on cleanup
+
+
+class LaunchDarklyClient:
+    """
+    A test-specific LaunchDarkly client that simulates a client modifying
+    a LaunchDarkly configuration.
+    """
+
+    def __init__(
+        self,
+        configuration: launchdarkly_api.Configuration,
+        project_key: str,
+        environment_key: str,
+    ) -> None:
+        self.configuration = configuration
+        self.project_key = project_key
+        self.environment_key = environment_key
+
+    def create_flag(self, feature_flag_key: str, tags: List[str] = []) -> Any:
+        with launchdarkly_api.ApiClient(self.configuration) as api_client:
+            api = feature_flags_api.FeatureFlagsApi(api_client)
+            return api.post_feature_flag(
+                project_key=self.project_key,
+                feature_flag_body=FeatureFlagBody(
+                    name=feature_flag_key,
+                    key=feature_flag_key,
+                    client_side_availability=ClientSideAvailabilityPost(
+                        using_environment_id=True,
+                        using_mobile_key=True,
+                    ),
+                    variations=[
+                        Variation(value=1073741824, name="1 GiB"),
+                        Variation(value=2147483648, name="2 GiB"),
+                        Variation(value=3221225472, name="3 GiB"),
+                        Variation(value=4294967295, name="4 GiB - 1 (max size)"),
+                    ],
+                    temporary=False,
+                    tags=tags,
+                    defaults=Defaults(
+                        off_variation=0,
+                        on_variation=1,
+                    ),
+                ),
+            )
+
+    def update_targeting(
+        self,
+        feature_flag_key: str,
+        on: Optional[bool] = None,
+        targets: Optional[List[Any]] = None,
+    ) -> Any:
+        with launchdarkly_api.ApiClient(self.configuration) as api_client:
+            api = feature_flags_api.FeatureFlagsApi(api_client)
+            return api.patch_feature_flag(
+                project_key=self.project_key,
+                feature_flag_key=feature_flag_key,
+                patch_with_comment=PatchWithComment(
+                    patch=JSONPatch(
+                        list(
+                            chain(
+                                [
+                                    PatchOperation(
+                                        op="replace",
+                                        path=f"/environments/{self.environment_key}/on",
+                                        value=on,
+                                    )
+                                ]
+                                if on is not None
+                                else [],
+                                [
+                                    PatchOperation(
+                                        op="replace",
+                                        path=f"/environments/{self.environment_key}/targets",
+                                        value=targets,
+                                    ),
+                                ]
+                                if targets is not None
+                                else [],
+                            )
+                        )
+                    )
+                ),
+            )
+
+    def delete_flag(self, feature_flag_key: str) -> Any:
+        with launchdarkly_api.ApiClient(self.configuration) as api_client:
+            api = feature_flags_api.FeatureFlagsApi(api_client)
+            return api.delete_feature_flag(self.project_key, feature_flag_key)


### PR DESCRIPTION
A follow-up of #16089 which makes some further changes required to add an end-to-end test and actually adds the end-to-end test.

### Motivation

  * This PR adds a known-desirable feature.

Closes #16583, #16587.

### Tips for reviewer

* ~I've disabled some large parts of `pipeline.template.yml` so I don't have to wait hours after every minor tweak. I will revert this before I merge.~ This is now present only in the nightlies config.
* I've taken the liberty to put a bunch of `type: ignore` hints on the `launchdarkly_api` imports to make `mypy` happy. I gave `stubgen -p launchdarkly_api` a try, but the result didn't work out of the box. If it is absolutely necessary to fix those lints the right way I will have to allocate some more time to do that, but I feel the right thing to do here is to ask the LD team to generate stubs for their Python client automated generation process.
* An open question for me is how exactly to handle the race conditions that occur between `ld_client.update_targeting` calls and the subsequent `c.testdrive` call. At the moment I have very sprinkled some `sleep(3)` statements, but for a more robust test we need to implement some retry logic. The options are: 
  * ~Make `ShowVariables` retry-able in `src/testdrive/src/action/sql.rs`.~
  * Do this ad-hoc in this specific test (given that `SHOW $var` will be deterministic in every other test I think this should be preferred for now). :heavy_check_mark: 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. See [the runs for this branch in nightlies section](https://buildkite.com/materialize/nightlies/builds?branch=aalexandrov%3Ald_sync_e2e_test).
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
