### PR TITLE
Support UDS listen address for tokio-console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,8 +1175,7 @@ dependencies = [
 [[package]]
 name = "console-api"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+source = "git+https://github.com/benesch/tokio-console.git?branch=uds#b409aa1a262f9196630c21406c8d11e61277cdcd"
 dependencies = [
  "prost",
  "prost-types",
@@ -1187,8 +1186,7 @@ dependencies = [
 [[package]]
 name = "console-subscriber"
 version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+source = "git+https://github.com/benesch/tokio-console.git?branch=uds#b409aa1a262f9196630c21406c8d11e61277cdcd"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "console-api"
 version = "0.4.0"
-source = "git+https://github.com/benesch/tokio-console.git?branch=uds#b409aa1a262f9196630c21406c8d11e61277cdcd"
+source = "git+https://github.com/MaterializeInc/console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
 dependencies = [
  "prost",
  "prost-types",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "console-subscriber"
 version = "0.1.8"
-source = "git+https://github.com/benesch/tokio-console.git?branch=uds#b409aa1a262f9196630c21406c8d11e61277cdcd"
+source = "git+https://github.com/MaterializeInc/console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -1,32 +1,45 @@
 # Developer guide: `tokio-console`
 
-This guide details how to run `tokio-console` with `materialized`
+This guide details how to run `tokio-console` with Materialize.
 
 ## Overview
 
-First, install `tokio-console`:
+First, install `tokio-console`. We require support for Unix domain sockets, [which is still pending
+upstream][uds-pr], so we need to install from a fork for now.
 
-```
-cargo install tokio-console
+```text
+cargo install tokio-console --git https://github.com/MaterializeInc/console.git
 ```
 
 Then run `environmentd`:
 
-```
+```text
 ./bin/environmentd --tokio-console
 ```
 
-(note that this may slow down `environmentd` a lot, as it increases the amount of tracing by a lot,
-and may inadvertently turn on debug logging for `rdkafka`)
+(Note that this may slow down `environmentd` a lot, as it increases the amount of tracing by a lot,
+and may inadvertently turn on debug logging for `rdkafka`.)
 
-Then, in a different tmux pane/terminal, run:
+In the output of the above command, take note of the `tokio-console` listen addresses for the
+different processes, e.g.:
 
+```text
+environmentd: [...]  INFO mz_ore::tracing: starting tokio console on http://127.0.0.1:6669
+compute-cluster-u1-replica-1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]3ee9
+compute-cluster-s1-replica-2: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]f5b6
+compute-cluster-s2-replica-3: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]7af2
 ```
-tokio-console
+
+Then, in a different tmux pane/terminal, run the `tokio-console` command with the listen address of
+your process of interest:
+
+```text
+tokio-console <listen-address>
 ```
 
 This [README] has some docs on how to navigate the ui.
 
+[uds-pr]: https://github.com/tokio-rs/console/pull/388
 [README]: https://github.com/tokio-rs/console/tree/main/tokio-console
 
 ### Notes on compilation times:

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -12,8 +12,6 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt;
-#[cfg(feature = "tokio-console")]
-use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(feature = "tokio-console")]
@@ -34,6 +32,8 @@ use mz_orchestrator::{
     ServiceProcessMetrics,
 };
 use mz_ore::cli::{DefaultTrue, KeyValueArg};
+#[cfg(feature = "tokio-console")]
+use mz_ore::netio::SocketAddr;
 #[cfg(feature = "tokio-console")]
 use mz_ore::tracing::TokioConsoleConfig;
 use mz_ore::tracing::{
@@ -227,13 +227,13 @@ impl From<&TracingCliArgs> for TracingConfig {
                 }
             }),
             #[cfg(feature = "tokio-console")]
-            tokio_console: args
-                .tokio_console_listen_addr
-                .map(|listen_addr| TokioConsoleConfig {
+            tokio_console: args.tokio_console_listen_addr.clone().map(|listen_addr| {
+                TokioConsoleConfig {
                     listen_addr,
                     publish_interval: args.tokio_console_publish_interval,
                     retention: args.tokio_console_retention,
-                }),
+                }
+            }),
             sentry: args.sentry_dsn.clone().map(|dsn| SentryConfig {
                 dsn,
                 tags: args

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -56,7 +56,7 @@ hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"], optional = true }
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
-console-subscriber = { git = "https://github.com/benesch/tokio-console.git", branch = "uds", optional = true }
+console-subscriber = { git = "https://github.com/MaterializeInc/console.git", optional = true }
 sentry-tracing = { version = "0.29.0", optional = true }
 
 [dev-dependencies]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -56,7 +56,7 @@ hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"], optional = true }
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
-console-subscriber = { version = "0.1.8", optional = true }
+console-subscriber = { git = "https://github.com/benesch/tokio-console.git", branch = "uds", optional = true }
 sentry-tracing = { version = "0.29.0", optional = true }
 
 [dev-dependencies]

--- a/src/ore/src/tracing/mod.rs
+++ b/src/ore/src/tracing/mod.rs
@@ -381,7 +381,7 @@ where
     if let Some(console_config) = config.tokio_console {
         let endpoint = match console_config.listen_addr {
             SocketAddr::Inet(addr) => format!("http://{addr}"),
-            SocketAddr::Unix(addr) => addr.to_string(),
+            SocketAddr::Unix(addr) => format!("file://localhost{addr}"),
         };
         tracing::info!("starting tokio console on {endpoint}");
     }


### PR DESCRIPTION
This PR fixes local tokio-console support, which was broken in ac1028d because tokio-console does not support Unix domain sockets (yet, see: https://github.com/tokio-rs/console/pull/388).

The fix involves adding that support by switching to @benesch's fork of concole-subscriber and using the `mz_ore::netio::SocketAddr` type for the tokio-console listen address.

It is now also required to use the forked version of the tokio-console CLI client. The developer docs are updated to reflect this.

### Motivation

  * This PR fixes a previously unreported bug.

Running `environmentd` with tokio-console support enabled is broken:

```
environmentd: 2022-12-09T12:23:53.131943Z  INFO mz_orchestrator_process: launching compute-cluster-s1-replica-2-0 via --controller-listen-addr=/var/folders/30/xdglsm2j3tz1rn1n7yygtm7c0000gn/T/3936d1d75b734cbabb3d0678b275c3deafe82812 --internal-http-listen-addr=/var/folders/30/xdglsm2j3tz1rn1n7yygtm7c0000gn/T/c489d7731630ec1fa5fb8ddba4c0da9dd9c9eafb --opentelemetry-resource=instance_id=s1 --opentelemetry-resource=replica_id=2 --log-filter=info --log-format=text --log-prefix=compute-cluster-s1-replica-2 --tokio-console-listen-addr=/var/folders/30/xdglsm2j3tz1rn1n7yygtm7c0000gn/T/1209e7e52cdc107ee25ca4998196aa23922fb9e4 --tokio-console-publish-interval=1000000 us --tokio-console-retention=3600000000 us --pid-file-location=/private/var/folders/30/xdglsm2j3tz1rn1n7yygtm7c0000gn/T/environmentd-local-az1-2ba6f456-fae2-4c9b-a8df-8f398ee4cb82-0/compute-cluster-s1-replica-2/0.pid --secrets-reader=process --secrets-reader-process-dir=/Users/jan/devel/materialize/mzdata/secrets...
error: Invalid value "/var/folders/30/xdglsm2j3tz1rn1n7yygtm7c0000gn/T/d8309b97c7d54152fe0a4ded500c397714d4b559" for '--tokio-console-listen-addr <TOKIO_CONSOLE_LISTEN_ADDR>': invalid socket address syntax

For more information try --help
environmentd: 2022-12-09T12:23:53.149669Z ERROR mz_orchestrator_process: compute-cluster-s2-replica-3-0 exited: ExitStatus(unix_wait_status(512)); relaunching in 5s
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
