### PR TITLE
compute-client: remove unnecessary `allow`s

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -7,10 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// Tonic generates code that calls clone on an Arc. Allow this here.
-// TODO: Remove this once tonic does not produce this code anymore.
-#![allow(clippy::clone_on_ref_ptr)]
-
 //! Compute layer commands.
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/compute-client/src/plan/join/mod.rs
+++ b/src/compute-client/src/plan/join/mod.rs
@@ -27,9 +27,6 @@
 //! output column reckoning", as is what we use when reasoning about
 //! work still available to be done on the partial join results.
 
-// https://github.com/tokio-rs/prost/issues/237
-#![allow(missing_docs)]
-
 pub mod delta_join;
 pub mod linear_join;
 

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -9,8 +9,6 @@
 
 //! An explicit representation of a rendering plan for provided dataflows.
 
-// https://github.com/tokio-rs/prost/issues/237
-#![allow(missing_docs)]
 #![warn(missing_debug_implementations)]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -60,9 +60,6 @@
 //! type, we can specialize and render the dataflow to compute those aggregations in the correct order, and
 //! return the output arrangement directly and avoid the extra collation arrangement.
 
-// https://github.com/tokio-rs/prost/issues/237
-#![allow(missing_docs)]
-
 use mz_expr::permutation_for_arrangement;
 use mz_expr::AggregateExpr;
 use mz_expr::AggregateFunc;
@@ -144,7 +141,6 @@ pub enum ReducePlan {
     Distinct,
     /// Plan for not computing any aggregations, just determining the set of distinct keys. A
     /// specialization of [ReducePlan::Distinct] maintaining rows not in the output.
-    #[allow(dead_code)]
     DistinctNegated,
     /// Plan for computing only accumulable aggregations.
     Accumulable(AccumulablePlan),

--- a/src/compute-client/src/plan/threshold.rs
+++ b/src/compute-client/src/plan/threshold.rs
@@ -23,9 +23,6 @@
 //!     is beneficial to use this operator if the number of retractions is expected to be small, and
 //!     if a potential downstream operator does not expect its input to be arranged.
 
-// https://github.com/tokio-rs/prost/issues/237
-#![allow(missing_docs)]
-
 use std::collections::HashMap;
 
 use crate::plan::any_arranged_thin;

--- a/src/compute-client/src/plan/top_k.rs
+++ b/src/compute-client/src/plan/top_k.rs
@@ -17,8 +17,6 @@
 //! * A [MonotonicTopKPlan] maintains up to K rows per key and is suitable for monotonic inputs.
 //! * A [BasicTopKPlan] maintains up to K rows per key and can handle retractions.
 
-#![allow(missing_docs)]
-
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 

--- a/src/compute-client/src/response.rs
+++ b/src/compute-client/src/response.rs
@@ -7,10 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// Tonic generates code that calls clone on an Arc. Allow this here.
-// TODO: Remove this once tonic does not produce this code anymore.
-#![allow(clippy::clone_on_ref_ptr)]
-
 //! Compute layer responses.
 
 use std::num::NonZeroUsize;


### PR DESCRIPTION
This PR removes unneeded lint disables from the `mz-compute-client` code.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
