### PR TITLE
Adapter: Remove timestamps from constant peeks

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -18,6 +18,7 @@ use std::{collections::HashMap, num::NonZeroUsize};
 
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
+use timely::progress::Timestamp;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -66,17 +67,17 @@ pub struct PeekDataflowPlan<T = mz_repr::Timestamp> {
 }
 
 #[derive(Debug)]
-pub enum FastPathPlan<T = mz_repr::Timestamp> {
+pub enum FastPathPlan {
     /// The view evaluates to a constant result that can be returned.
     ///
     /// The [RelationType] is unnecessary for evaluating the constant result but
     /// may be helpful when printing out an explanation.
-    Constant(Result<Vec<(Row, T, Diff)>, EvalError>, RelationType),
+    Constant(Result<Vec<(Row, Diff)>, EvalError>, RelationType),
     /// The view can be read out of an existing arrangement.
     PeekExisting(GlobalId, Option<Vec<Row>>, mz_expr::SafeMfpPlan),
 }
 
-impl<'a, C, T> DisplayText<C> for FastPathPlan<T>
+impl<'a, C> DisplayText<C> for FastPathPlan
 where
     C: AsMut<Indent> + AsRef<&'a dyn ExprHumanizer>,
 {
@@ -88,7 +89,7 @@ where
                     *ctx.as_mut() += 1;
                     fmt_text_constant_rows(
                         f,
-                        rows.iter().map(|(row, _, diff)| (row, diff)),
+                        rows.iter().map(|(row, diff)| (row, diff)),
                         ctx.as_mut(),
                     )?;
                     *ctx.as_mut() -= 1;
@@ -142,7 +143,7 @@ pub struct PlannedPeek {
 /// Possible ways in which the coordinator could produce the result for a goal view.
 #[derive(Debug)]
 pub enum PeekPlan<T = mz_repr::Timestamp> {
-    FastPath(FastPathPlan<T>),
+    FastPath(FastPathPlan),
     /// The view must be installed as a dataflow and then read.
     SlowPath(PeekDataflowPlan<T>),
 }
@@ -175,7 +176,7 @@ fn permute_oneshot_mfp_around_index(
 pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
     dataflow_plan: &mut DataflowDescription<mz_expr::OptimizedMirRelationExpr, (), T>,
     view_id: GlobalId,
-) -> Result<Option<FastPathPlan<T>>, AdapterError> {
+) -> Result<Option<FastPathPlan>, AdapterError> {
     // At this point, `dataflow_plan` contains our best optimized dataflow.
     // We will check the plan to see if there is a fast path to escape full dataflow construction.
 
@@ -187,11 +188,8 @@ pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
         if let Some((rows, ..)) = mir.as_const() {
             // In the case of a constant, we can return the result now.
             return Ok(Some(FastPathPlan::Constant(
-                rows.clone().map(|rows| {
-                    rows.into_iter()
-                        .map(|(row, diff)| (row, T::minimum(), diff))
-                        .collect()
-                }),
+                rows.clone()
+                    .map(|rows| rows.into_iter().map(|(row, diff)| (row, diff)).collect()),
                 // For best accuracy, we need to recalculate typ.
                 mir.typ(),
             )));
@@ -308,26 +306,15 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
 
         // If the dataflow optimizes to a constant expression, we can immediately return the result.
         if let PeekPlan::FastPath(FastPathPlan::Constant(rows, _)) = fast_path {
-            let mut rows = match rows {
+            let rows = match rows {
                 Ok(rows) => rows,
                 Err(e) => return Err(e.into()),
             };
-            // retain exactly those updates less or equal to `timestamp`.
-            for (_, time, diff) in rows.iter_mut() {
-                use timely::PartialOrder;
-                if time.less_equal(&timestamp) {
-                    // clobber the timestamp, so consolidation occurs.
-                    *time = timestamp.clone();
-                } else {
-                    // zero the difference, to prevent a contribution.
-                    *diff = 0;
-                }
-            }
             // Consolidate down the results to get correct totals.
-            differential_dataflow::consolidation::consolidate_updates(&mut rows);
+            let rows = consolidate_constant_updates(rows);
 
             let mut results = Vec::new();
-            for (row, _time, count) in rows {
+            for (row, count) in rows {
                 if count < 0 {
                     Err(EvalError::InvalidParameterValue(format!(
                         "Negative multiplicity in constant result: {}",
@@ -550,6 +537,19 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
     }
 }
 
+fn consolidate_constant_updates(rows: Vec<(Row, Diff)>) -> Vec<(Row, Diff)> {
+    // The consolidate API requires timestamps for all rows, so we assigned every row the
+    // same timestamp. The actual value of that timestamp doesn't matter.
+    let mut rows = rows
+        .into_iter()
+        .map(|(row, diff)| (row, mz_repr::Timestamp::minimum(), diff))
+        .collect();
+    differential_dataflow::consolidation::consolidate_updates(&mut rows);
+    rows.into_iter()
+        .map(|(row, _time, diff)| (row, diff))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use mz_expr::{func::IsNull, MapFilterProject, UnaryFunc};
@@ -567,11 +567,8 @@ mod tests {
             scalar_type: ScalarType::String,
             nullable: false,
         }]);
-        let constant_err = FastPathPlan::<mz_repr::Timestamp>::Constant(
-            Err(EvalError::DivisionByZero),
-            typ.clone(),
-        );
-        let no_lookup = FastPathPlan::<mz_repr::Timestamp>::PeekExisting(
+        let constant_err = FastPathPlan::Constant(Err(EvalError::DivisionByZero), typ.clone());
+        let no_lookup = FastPathPlan::PeekExisting(
             GlobalId::User(10),
             None,
             MapFilterProject::new(4)
@@ -582,7 +579,7 @@ mod tests {
                 .into_nontemporal()
                 .unwrap(),
         );
-        let lookup = FastPathPlan::<mz_repr::Timestamp>::PeekExisting(
+        let lookup = FastPathPlan::PeekExisting(
             GlobalId::User(11),
             Some(vec![Row::pack(Some(Datum::Int32(5)))]),
             MapFilterProject::new(3)
@@ -607,9 +604,9 @@ mod tests {
         assert_eq!(text_string_at(&lookup, ctx_gen), lookup_exp);
 
         let mut constant_rows = vec![
-            (Row::pack(Some(Datum::String("hello"))), 0, 1),
-            (Row::pack(Some(Datum::String("world"))), 0, 2),
-            (Row::pack(Some(Datum::String("star"))), 0, 500),
+            (Row::pack(Some(Datum::String("hello"))), 1),
+            (Row::pack(Some(Datum::String("world"))), 2),
+            (Row::pack(Some(Datum::String("star"))), 500),
         ];
         let constant_exp1 =
             "Constant\n  - (\"hello\")\n  - ((\"world\") x 2)\n  - ((\"star\") x 500)\n";
@@ -620,8 +617,7 @@ mod tests {
             ),
             constant_exp1
         );
-        constant_rows
-            .extend((0..20).map(|i| (Row::pack(Some(Datum::String(&i.to_string()))), 0, 1)));
+        constant_rows.extend((0..20).map(|i| (Row::pack(Some(Datum::String(&i.to_string()))), 1)));
         let constant_exp2 =
             "Constant\n  total_rows (diffs absed): 523\n  first_rows:\n    - (\"hello\")\
         \n    - ((\"world\") x 2)\n    - ((\"star\") x 500)\n    - (\"0\")\n    - (\"1\")\

--- a/src/adapter/src/explain_new/optimizer_trace.rs
+++ b/src/adapter/src/explain_new/optimizer_trace.rs
@@ -13,12 +13,9 @@ use std::fmt::Debug;
 
 use mz_compute_client::{command::DataflowDescription, plan::Plan};
 use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
-use mz_repr::{
-    explain_new::{
-        text_string, DisplayText, Explain, ExplainConfig, ExplainError, ExplainFormat, PlanTrace,
-        TraceEntry,
-    },
-    Timestamp,
+use mz_repr::explain_new::{
+    text_string, DisplayText, Explain, ExplainConfig, ExplainError, ExplainFormat, PlanTrace,
+    TraceEntry,
 };
 use mz_sql::plan::{HirRelationExpr, HirScalarExpr};
 use tracing::dispatcher::{self, with_default};
@@ -90,7 +87,7 @@ impl OptimizerTrace {
         catalog: ConnCatalog,
         row_set_finishing: Option<RowSetFinishing>,
         used_indexes: Vec<mz_repr::GlobalId>,
-        fast_path_plan: Option<FastPathPlan<Timestamp>>,
+        fast_path_plan: Option<FastPathPlan>,
     ) -> Result<Vec<TraceEntry<String>>, ExplainError> {
         let mut results = vec![];
 


### PR DESCRIPTION
Previously, constant peek plans contained a timestamp for every row. This timestamp was always hardcoded as `T::minumum()` and never used. This commit removes the timestamps from constant peeks plans.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
