### PR TITLE
`FilterCharacteristics` behind Gets

### DIFF
--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -138,7 +138,7 @@ impl JoinImplementation {
                 // Here we conservatively use the rule that if sufficient arrangements exist we will
                 // use a delta query (except for 2-input joins).
                 // An arrangement is considered available for an input
-                // - if it is a global `Get` with columns present in `indexes`,
+                // - if it is a `Get` with columns present in `indexes`,
                 //   - or the same wrapped by an IndexedFilter,
                 // - if it is an `ArrangeBy` with the columns present (note that the ArrangeBy might
                 //   have been inserted by a previous run of JoinImplementation),
@@ -190,6 +190,7 @@ impl JoinImplementation {
                     // - From filters that could be pushed down from above the join to this input.
                     //   (In LIR, these will be executed right after the join path executes the join
                     //   for this input.)
+                    // - (No need to look behind Gets, see the inline_mfp argument of RelationCSE.)
                     let mut characteristics =
                         FilterCharacteristics::filter_characteristics(&filter)?;
                     if matches!(

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -374,12 +374,17 @@ impl Optimizer {
     pub fn physical_optimizer() -> Self {
         // Implementation transformations
         let transforms: Vec<Box<dyn crate::Transform>> = vec![
-            // It's important that there is a run of CanonicalizeMfp before JoinImplementation lifts
-            // away the Filters from the Gets.
+            // It's important that
+            // - there is a run of CanonicalizeMfp before JoinImplementation lifts away the Filters
+            //   from the Gets;
+            // - there is no RelationCSE between this CanonicalizeMfp and JoinImplementation,
+            //   because that could move an IndexedFilter behind a Get.
             Box::new(crate::canonicalize_mfp::CanonicalizeMfp),
             Box::new(crate::Fixpoint {
                 limit: 100,
                 transforms: vec![
+                    // The last RelationCSE before JoinImplementation should be with
+                    // inline_mfp = true.
                     Box::new(crate::join_implementation::JoinImplementation::default()),
                     Box::new(crate::column_knowledge::ColumnKnowledge::default()),
                     Box::new(crate::fold_constants::FoldConstants { limit: Some(10000) }),
@@ -425,6 +430,8 @@ impl Optimizer {
                     // This goes after union fusion so we can cancel out
                     // more branches at a time.
                     Box::new(crate::union_cancel::UnionBranchCancellation),
+                    // The last RelationCSE before JoinImplementation should be with
+                    // inline_mfp = true.
                     Box::new(crate::cse::relation_cse::RelationCSE::new(true)),
                     Box::new(crate::fold_constants::FoldConstants { limit: Some(10000) }),
                 ],

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -14,9 +14,9 @@
 //! and both is more complex than a `Get` or a `Constant` and occurs at
 //! least twice in the `body` of its binding.
 //!
-//! No effort is yet made to choose among the topological ordors of the
+//! No effort is yet made to choose among the topological orders of the
 //! bindings in some canonical way; this could be future work if we are
-//! excited amount it (I think we don't expect CSE to discover matches
+//! excited about it (I think we don't expect CSE to discover matches
 //! involving `Let` operator as they are all at the roots).
 //!
 //! The transform may remove some `Let` and `Get` operators, and does not
@@ -42,8 +42,8 @@ pub struct NormalizeLets {
     ///
     /// We want this value to be true for the NormalizeLets call that comes right
     /// before [crate::join_implementation::JoinImplementation] runs because
-    /// [crate::join_implementation::JoinImplementation] cannot lift MFPs
-    /// through a Let.
+    /// - JoinImplementation cannot lift MFPs through a Let.
+    /// - JoinImplementation can't extract FilterCharacteristics through a Let.
     ///
     /// Generally, though, we prefer to be more conservative in our inlining in
     /// order to be able to better detect CSEs.
@@ -121,7 +121,7 @@ impl NormalizeLets {
         // It is important that we do the substitution in-order and before reasoning
         // about the inlineability of each binding, to ensure that our conclusion about
         // the inlineability of a binding stays put. Specifically,
-        //   1. by going in order no substitition will increase the `Get`-count of an
+        //   1. by going in order no substitution will increase the `Get`-count of an
         //      identifier beyond one, as all in values with strictly greater identifiers.
         //   2. by performing the substitution before reasoning, the structure of the value
         //      as it would be substituted is fixed.

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -679,3 +679,50 @@ Used Indexes:
   - materialize.public.big_idx_y
 
 EOF
+
+# FilterCharacteristics from behind a Get. %2 should come at the first or second position in every Delta path,
+# and %2 should have an "e", indicating the join ordering code's awareness of the equality filter.
+# The magic that makes this work is as follows:
+# - inline_mfp has to be true on the last RelationCSE call before JoinImplementation (i.e., in logical_cleanup_pass);
+# - There shouldn't be a RelationCSE between the CanonicalizeMfp that is before JoinImplementation and JoinImplementation.
+query T multiline
+EXPLAIN WITH(arity, join_impls)
+WITH t(x) AS (
+  SELECT a
+  FROM big
+  WHERE a = 5
+)
+(
+  SELECT b1.a
+  FROM big as b1, big as b2, t
+)
+UNION ALL
+(SELECT * FROM t);
+----
+Explained Query:
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      CrossJoin type=delta // { arity: 1 }
+        implementation
+          %0:big » %2:l0[×]Ae » %1:big[×]A
+          %1:big » %2:l0[×]Ae » %0:big[×]A
+          %2:l0 » %0:big[×]A » %1:big[×]A
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get materialize.public.big // { arity: 14 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Get materialize.public.big // { arity: 14 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            Get l0 // { arity: 15 }
+      Project (#0) // { arity: 1 }
+        Get l0 // { arity: 15 }
+  With
+    cte l0 =
+      ReadExistingIndex materialize.public.big lookup_value=(5)
+
+Used Indexes:
+  - materialize.public.big_idx_a
+
+EOF


### PR DESCRIPTION
This is for #16494. It turns out that #16494 is not an issue at the moment! So this PR just adds a regression test for it and adds some code comments to explain the situation.

Unfortunately, #16494 is not an issue only due to some brittle invariants in our optimizer pipeline:
1. inline_mfp has to be true on the last RelationCSE call before JoinImplementation (i.e., in logical_cleanup_pass), so that filters are not hidden behind Gets;
2. There shouldn't be a RelationCSE between the CanonicalizeMfp that is before JoinImplementation and JoinImplementation, because it could hide an IndexedFilter behind a Get.

This looks quite brittle, so, as an alternative to this PR, we might want to actually smarten JoinImplementation to look behind local Gets. This would remove the need for 2. Unfortunately, it wouldn't remove the need for 1., because that is also needed for the MFP lifting of JoinImplementation. (When the only thing preventing arrangement reuse on a join input is an MFP, then JoinImplementation lifts away that MFP to after the join. But it cannot do this from behind a Get.) I have the code for smartening JoinImplementation here: https://github.com/ggevay/materialize/tree/filters_on_ctes (the last 2 commits). I'm not really sure whether having that extra code complexity is worth it to avoid having the 2. invariant. Please let me know what you think!

### Motivation

This PR
  * Adds a regression test for #16494
  * Adds some code comments to explain why #16494 is not an issue at the moment.

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
