### PR TITLE
Mark implicit arrangements

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -351,6 +351,7 @@ pub fn construct<A: Allocate>(
 
         let frontier_delay = frontier_delay
             .as_collection()
+            // TODO(#16549): Use explicit arrangement
             .count_total_core::<i64>()
             .map({
                 move |((dataflow, source_id, worker, delay_pow), count)| {
@@ -376,15 +377,19 @@ pub fn construct<A: Allocate>(
         });
 
         // Duration statistics derive from the non-rounded event times.
-        let peek_duration = peek_duration.as_collection().count_total_core().map({
-            move |((worker, pow), count)| {
-                Row::pack_slice(&[
-                    Datum::UInt64(u64::cast_from(worker)),
-                    Datum::UInt64(pow.try_into().expect("pow too big")),
-                    Datum::UInt64(count),
-                ])
-            }
-        });
+        let peek_duration = peek_duration
+            .as_collection()
+            // TODO(#16549): Use explicit arrangement
+            .count_total_core()
+            .map({
+                move |((worker, pow), count)| {
+                    Row::pack_slice(&[
+                        Datum::UInt64(u64::cast_from(worker)),
+                        Datum::UInt64(pow.try_into().expect("pow too big")),
+                        Datum::UInt64(count),
+                    ])
+                }
+            });
 
         let logs = vec![
             (

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -110,6 +110,7 @@ where
         .as_collection(|k, _| k.clone())
         .negate()
         .concat(&oks)
+        // TODO(#16549): Use explicit arrangement
         .consolidate();
     CollectionBundle::from_collections(oks, errs)
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -176,6 +176,7 @@ where
             let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
             // We only want to arrange parts of the input that are not part of the actual output
             // such that `input.concat(&negated_output.negate())` yields the correct TopK
+            // TODO(#16549): Use explicit arrangement
             let negated_output = input.reduce_named("TopK", {
                 move |_key, source, target: &mut Vec<(Row, Diff)>| {
                     // Determine if we must actually shrink the result set.
@@ -241,7 +242,11 @@ where
                 }
             });
 
-            negated_output.negate().concat(&input).consolidate()
+            negated_output
+                .negate()
+                .concat(&input)
+                // TODO(#16549): Use explicit arrangement
+                .consolidate()
         }
 
         fn render_top1_monotonic<G>(
@@ -279,6 +284,7 @@ where
             // TODO: Could we use explode here? We'd lose the diff>0 assert and we'd have to impl Mul
             // for the monoid, unclear if it's worth it.
             let partial: Collection<G, Row, monoids::Top1Monoid> = collection
+                // TODO(#16549): Use explicit arrangement
                 .consolidate()
                 .inner
                 .map(move |((group_key, row), time, diff)| {
@@ -296,6 +302,7 @@ where
                 })
                 .as_collection();
             let result = partial
+                // TODO(#16549): Use explicit arrangement
                 .arrange_by_self()
                 .reduce_abelian::<_, OrdValSpine<_, _, _, _>>("Top1Monotonic", {
                     move |_key, input, output| {


### PR DESCRIPTION
Add TODOs where we implicitly create arrangements using the default structure. Fix some calls to `reduce_abelian` to create the correct arrangement.

This is related to #16549 