### PR TITLE
Unrevert "persist: read a bounded # of rows from CRDB when fetching l…

### DIFF
--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 
 use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData,
+    Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData, SCAN_ALL,
 };
 
 use crate::maelstrom::api::{ErrorCode, MaelstromError};
@@ -118,7 +118,7 @@ impl Consensus for MaelstromConsensus {
                 Ok(x) => Value::from(&MaelstromVersionedData::from(x)),
                 Err(_) => {
                     let from = expected.next();
-                    return Ok(Err(self.scan(key, from).await?));
+                    return Ok(Err(self.scan(key, from, SCAN_ALL).await?));
                 }
             },
             None => Value::Null,
@@ -147,14 +147,19 @@ impl Consensus for MaelstromConsensus {
                 ..
             }) => {
                 let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-                let current = self.scan(key, from).await?;
+                let current = self.scan(key, from, SCAN_ALL).await?;
                 Ok(Err(current))
             }
             Err(err) => Err(ExternalError::from(anyhow::Error::new(err))),
         }
     }
 
-    async fn scan(&self, _key: &str, _from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        _key: &str,
+        _from: SeqNo,
+        _limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         unimplemented!("TODO")
     }
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -629,6 +629,8 @@ impl Service for TransactorService {
         // to simplify some downstream logic (+ a bit more stress testing),
         // always downgrade the since of critical handles when asked
         config.critical_downgrade_interval = Duration::from_secs(0);
+        // set a live diff scan limit such that we'll explore both the fast and slow paths
+        config.state_versions_recent_live_diffs_limit = 5;
         let metrics = Arc::new(Metrics::new(&config, &MetricsRegistry::new()));
         let consensus = match &args.consensus_uri {
             Some(consensus_uri) => {

--- a/src/persist-client/src/admin.rs
+++ b/src/persist-client/src/admin.rs
@@ -57,12 +57,14 @@ pub async fn force_compaction(
     ));
 
     // Prime the K V codec magic
-    let versions = state_versions.fetch_live_diffs(&shard_id).await;
+    let versions = state_versions
+        .fetch_recent_live_diffs::<u64>(&shard_id)
+        .await;
     loop {
         let state_res = state_versions
             .fetch_current_state::<crate::inspect::K, crate::inspect::V, u64, i64>(
                 &shard_id,
-                versions.clone(),
+                versions.0.clone(),
             )
             .await;
         let state = match state_res {

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -55,10 +55,12 @@ pub async fn fetch_latest_state(
     let blob = blob.clone().open().await?;
 
     let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
-    let versions = state_versions.fetch_live_diffs(&shard_id).await;
+    let versions = state_versions
+        .fetch_recent_live_diffs::<u64>(&shard_id)
+        .await;
 
     let state = match state_versions
-        .fetch_current_state::<K, V, u64, D>(&shard_id, versions.clone())
+        .fetch_current_state::<K, V, u64, D>(&shard_id, versions.0.clone())
         .await
     {
         Ok(s) => s.into_proto(),
@@ -68,7 +70,7 @@ pub async fn fetch_latest_state(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_current_state::<K, V, u64, D>(&shard_id, versions)
+                .fetch_current_state::<K, V, u64, D>(&shard_id, versions.0)
                 .await
                 .expect("codecs match")
                 .into_proto()
@@ -132,7 +134,7 @@ pub async fn fetch_state_rollups(
     let state_versions =
         StateVersions::new(cfg, consensus, Arc::clone(&blob), Arc::clone(&metrics));
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(&shard_id)
+        .fetch_all_live_states::<K, V, u64, D>(&shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -142,7 +144,7 @@ pub async fn fetch_state_rollups(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(&shard_id)
+                .fetch_all_live_states::<K, V, u64, D>(&shard_id)
                 .await?
         }
     };
@@ -191,7 +193,7 @@ pub async fn fetch_state_diffs(
 
     let mut live_states = vec![];
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(&shard_id)
+        .fetch_all_live_states::<K, V, u64, D>(&shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -201,7 +203,7 @@ pub async fn fetch_state_diffs(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(&shard_id)
+                .fetch_all_live_states::<K, V, u64, D>(&shard_id)
                 .await?
         }
     };
@@ -292,7 +294,7 @@ pub async fn unreferenced_blobs(
 
     let state_versions = StateVersions::new(cfg, consensus, blob, Arc::clone(&metrics));
     let mut state_iter = match state_versions
-        .fetch_live_states::<K, V, u64, D>(shard_id)
+        .fetch_all_live_states::<K, V, u64, D>(shard_id)
         .await
     {
         Ok(state_iter) => state_iter,
@@ -302,7 +304,7 @@ pub async fn unreferenced_blobs(
                 *kvtd = codec.actual;
             }
             state_versions
-                .fetch_live_states::<K, V, u64, D>(shard_id)
+                .fetch_all_live_states::<K, V, u64, D>(shard_id)
                 .await?
         }
     };

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -196,7 +196,7 @@ where
 
         let mut states = machine
             .state_versions
-            .fetch_live_states::<K, V, T, D>(&req.shard_id)
+            .fetch_all_live_states::<K, V, T, D>(&req.shard_id)
             .await
             .expect("shard codecs should not change");
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1188,7 +1188,7 @@ pub mod datadriven {
 
         let mut states = datadriven
             .state_versions
-            .fetch_live_states::<String, (), u64, i64>(&datadriven.shard_id)
+            .fetch_all_live_states::<String, (), u64, i64>(&datadriven.shard_id)
             .await
             .expect("shard codecs should not change");
         let mut s = String::new();
@@ -1801,18 +1801,18 @@ pub mod tests {
         let live_diffs = write
             .machine
             .state_versions
-            .fetch_live_diffs(&write.machine.shard_id())
+            .fetch_all_live_diffs(&write.machine.shard_id())
             .await;
         // Make sure we constructed the key correctly.
-        assert!(live_diffs.len() > 0);
+        assert!(live_diffs.0.len() > 0);
         // Make sure the number of entries is bounded. (I think we could work
         // out a tighter bound than this, but the point is only that it's
         // bounded).
         let max_live_diffs = 2 * usize::cast_from(NUM_BATCHES.next_power_of_two().trailing_zeros());
         assert!(
-            live_diffs.len() < max_live_diffs,
+            live_diffs.0.len() < max_live_diffs,
             "{} vs {}",
-            live_diffs.len(),
+            live_diffs.0.len(),
             max_live_diffs
         );
     }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -900,6 +900,8 @@ pub struct StateMetrics {
     pub(crate) update_state_fast_path: IntCounter,
     pub(crate) update_state_slow_path: IntCounter,
     pub(crate) rollup_at_seqno_migration: IntCounter,
+    pub(crate) fetch_recent_live_diffs_fast_path: IntCounter,
+    pub(crate) fetch_recent_live_diffs_slow_path: IntCounter,
 }
 
 impl StateMetrics {
@@ -936,6 +938,14 @@ impl StateMetrics {
             rollup_at_seqno_migration: registry.register(metric!(
                 name: "mz_persist_state_rollup_at_seqno_migration",
                 help: "count of fetch_rollup_at_seqno calls that only worked because of the migration",
+            )),
+            fetch_recent_live_diffs_fast_path: registry.register(metric!(
+                name: "mz_persist_state_fetch_recent_live_diffs_fast_path",
+                help: "count of fetch_recent_live_diffs that hit the fast path",
+            )),
+            fetch_recent_live_diffs_slow_path: registry.register(metric!(
+                name: "mz_persist_state_fetch_recent_live_diffs_slow_path",
+                help: "count of fetch_recent_live_diffs that hit the slow path",
             )),
         }
     }
@@ -1486,12 +1496,17 @@ impl Consensus for MetricsConsensus {
         res
     }
 
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         let res = self
             .metrics
             .consensus
             .scan
-            .run_op(|| self.consensus.scan(key, from), Self::on_err)
+            .run_op(|| self.consensus.scan(key, from, limit), Self::on_err)
             .await;
         if let Ok(dataz) = res.as_ref() {
             let bytes = dataz.iter().map(|x| x.data.len()).sum();

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
+use mz_ore::cast::u64_to_usize;
 use mz_persist_types::Codec;
 use mz_proto::RustType;
 use serde::{Deserialize, Serialize};
@@ -326,6 +327,10 @@ impl<T: Codec> TryFrom<&VersionedData> for (SeqNo, T) {
     }
 }
 
+/// Helper constant to scan all states in [Consensus::scan].
+/// The maximum possible SeqNo is i64::MAX.
+pub const SCAN_ALL: usize = u64_to_usize(i64::MAX as u64);
+
 /// An abstraction for [VersionedData] held in a location in persistent storage
 /// where the data are conditionally updated by version.
 ///
@@ -338,8 +343,6 @@ impl<T: Codec> TryFrom<&VersionedData> for (SeqNo, T) {
 pub trait Consensus: std::fmt::Debug {
     /// Returns a recent version of `data`, and the corresponding sequence number, if
     /// one exists at this location.
-    ///
-    /// TODO: This is no longer used. Remove it?
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError>;
 
     /// Update the [VersionedData] stored at this location to `new`, iff the
@@ -361,12 +364,17 @@ pub trait Consensus: std::fmt::Debug {
         new: VersionedData,
     ) -> Result<Result<(), Vec<VersionedData>>, ExternalError>;
 
-    /// Return all versions of data stored for this `key` at sequence numbers
+    /// Return `limit` versions of data stored for this `key` at sequence numbers
     /// >= `from`, in ascending order of sequence number.
     ///
     /// Returns an empty vec if `from` is greater than the current sequence
     /// number or if there is no data at this key.
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError>;
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError>;
 
     /// Deletes all historical versions of the data stored at `key` that are <
     /// `seqno`, iff `seqno` <= the current sequence number.
@@ -616,7 +624,7 @@ pub mod tests {
         assert_eq!(consensus.head(&key).await, Ok(None));
 
         // Can scan a key that has no data.
-        assert_eq!(consensus.scan(&key, SeqNo(0)).await, Ok(vec![]));
+        assert_eq!(consensus.scan(&key, SeqNo(0), SCAN_ALL).await, Ok(vec![]));
 
         // Cannot truncate data from a key that doesn't have any data
         assert!(consensus.truncate(&key, SeqNo(0)).await.is_err(),);
@@ -645,19 +653,19 @@ pub mod tests {
 
         // Can scan a key that has data with a lower bound sequence number < head.
         assert_eq!(
-            consensus.scan(&key, SeqNo(0)).await,
+            consensus.scan(&key, SeqNo(0), SCAN_ALL).await,
             Ok(vec![state.clone()])
         );
 
         // Can scan a key that has data with a lower bound sequence number == head.
         assert_eq!(
-            consensus.scan(&key, SeqNo(5)).await,
+            consensus.scan(&key, SeqNo(5), SCAN_ALL).await,
             Ok(vec![state.clone()])
         );
 
         // Can scan a key that has data with a lower bound sequence number >
         // head.
-        assert_eq!(consensus.scan(&key, SeqNo(6)).await, Ok(vec![]));
+        assert_eq!(consensus.scan(&key, SeqNo(6), SCAN_ALL).await, Ok(vec![]));
 
         // Can truncate data with an upper bound <= head, even if there is no data in the
         // range [0, upper).
@@ -760,33 +768,55 @@ pub mod tests {
         // We can observe both states in the correct order with scan if pass
         // in a suitable lower bound.
         assert_eq!(
-            consensus.scan(&key, SeqNo(5)).await,
+            consensus.scan(&key, SeqNo(5), SCAN_ALL).await,
             Ok(vec![state.clone(), new_state.clone()])
         );
 
         // We can observe only the most recent state if the lower bound is higher
         // than the previous insertion's sequence number.
         assert_eq!(
-            consensus.scan(&key, SeqNo(6)).await,
+            consensus.scan(&key, SeqNo(6), SCAN_ALL).await,
             Ok(vec![new_state.clone()])
         );
 
         // We can still observe the most recent insert as long as the provided
         // lower bound == most recent 's sequence number.
         assert_eq!(
-            consensus.scan(&key, SeqNo(10)).await,
+            consensus.scan(&key, SeqNo(10), SCAN_ALL).await,
             Ok(vec![new_state.clone()])
         );
 
         // We can scan if the provided lower bound > head's sequence number.
-        assert_eq!(consensus.scan(&key, SeqNo(11)).await, Ok(vec![]));
+        assert_eq!(consensus.scan(&key, SeqNo(11), SCAN_ALL).await, Ok(vec![]));
+
+        // We can scan with limits that don't cover all states
+        assert_eq!(
+            consensus.scan(&key, SeqNo::minimum(), 1).await,
+            Ok(vec![state.clone()])
+        );
+        assert_eq!(
+            consensus.scan(&key, SeqNo(5), 1).await,
+            Ok(vec![state.clone()])
+        );
+
+        // We can scan with limits to cover exactly the number of states
+        assert_eq!(
+            consensus.scan(&key, SeqNo::minimum(), 2).await,
+            Ok(vec![state.clone(), new_state.clone()])
+        );
+
+        // We can scan with a limit larger than the number of states
+        assert_eq!(
+            consensus.scan(&key, SeqNo(4), 100).await,
+            Ok(vec![state.clone(), new_state.clone()])
+        );
 
         // Can remove the previous write with the appropriate truncation.
         assert_eq!(consensus.truncate(&key, SeqNo(6)).await, Ok(1));
 
         // Verify that the old write is indeed deleted.
         assert_eq!(
-            consensus.scan(&key, SeqNo(0)).await,
+            consensus.scan(&key, SeqNo(0), SCAN_ALL).await,
             Ok(vec![new_state.clone()])
         );
 

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -34,7 +34,7 @@ use std::time::{Duration, Instant};
 use tracing::debug;
 
 use crate::error::Error;
-use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
+use crate::location::{Consensus, ExternalError, SeqNo, VersionedData, SCAN_ALL};
 use crate::metrics::PostgresConsensusMetrics;
 
 const SCHEMA: &str = "
@@ -440,19 +440,29 @@ impl Consensus for PostgresConsensus {
             // 2. All operations that modify the (seqno, data) can only increase
             //    the sequence number.
             let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
-            let current = self.scan(key, from).await?;
+            let current = self.scan(key, from, SCAN_ALL).await?;
             Ok(Err(current))
         }
     }
 
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         let q = "SELECT sequence_number, data FROM consensus
              WHERE shard = $1 AND sequence_number >= $2
-             ORDER BY sequence_number";
+             ORDER BY sequence_number ASC LIMIT $3";
+        let Ok(limit) = i64::try_from(limit) else {
+            return Err(ExternalError::from(anyhow!(
+                    "limit must be [0, i64::MAX]. was: {:?}", limit
+                )));
+        };
         let rows = {
             let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
-            client.query(&statement, &[&key, &from]).await?
+            client.query(&statement, &[&key, &from, &limit]).await?
         };
         let mut results = Vec::with_capacity(rows.len());
 

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -201,9 +201,14 @@ impl Consensus for UnreliableConsensus {
             .await
     }
 
-    async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
         self.handle
-            .run_op("scan", || self.consensus.scan(key, from))
+            .run_op("scan", || self.consensus.scan(key, from, limit))
             .await
     }
 


### PR DESCRIPTION
…atest state (#16143)"

This reverts commit 6663bde24a5696680b34a0540d5f47c114c52575, which was a revert of #16143. It also fixes the issue that led to the revert, which was a race condition in the order of blob and consensus wipes involved in `./bin/environmentd --reset`. Concretely, if we wipe blob (files) first and then consensus (crdb/postgres) and are interrupted in between, then we could end up with consensus state pointing at no longer existing files. There's no race if we wipe them in the opposite order.

Closes #16385

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
