### PR TITLE
sql-parser: use dedicated column def type for mut rec CTEs

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -387,12 +387,10 @@ impl<T: AstInfo> AstDisplay for Cte<T> {
 }
 impl_display_t!(Cte);
 
-use crate::ast::ColumnDef;
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CteMutRec<T: AstInfo> {
     pub name: Ident,
-    pub columns: Vec<ColumnDef<T>>,
+    pub columns: Vec<CteMutRecColumnDef<T>>,
     pub id: T::CteId,
     pub query: Query<T>,
 }
@@ -411,6 +409,22 @@ impl<T: AstInfo> AstDisplay for CteMutRec<T> {
     }
 }
 impl_display_t!(CteMutRec);
+
+/// A column definition in a [`CteMutRec`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CteMutRecColumnDef<T: AstInfo> {
+    pub name: Ident,
+    pub data_type: T::DataType,
+}
+
+impl<T: AstInfo> AstDisplay for CteMutRecColumnDef<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        f.write_str(" ");
+        f.write_node(&self.data_type);
+    }
+}
+impl_display_t!(CteMutRecColumnDef);
 
 /// One item of the comma-separated list following `SELECT`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4535,13 +4535,9 @@ impl<'a> Parser<'a> {
         let name = self.parse_identifier()?;
         self.expect_token(&Token::LParen)?;
         let columns = self.parse_comma_separated(|parser| {
-            let name = parser.parse_identifier()?;
-            let data_type = parser.parse_data_type()?;
-            Ok(ColumnDef {
-                name,
-                data_type,
-                collation: None,
-                options: Vec::new(),
+            Ok(CteMutRecColumnDef {
+                name: parser.parse_identifier()?,
+                data_type: parser.parse_data_type()?,
             })
         })?;
         self.expect_token(&Token::RParen)?;

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -858,7 +858,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     let columns = cte
                         .columns
                         .into_iter()
-                        .map(|column| self.fold_column_def(column))
+                        .map(|column| self.fold_cte_mut_rec_column_def(column))
                         .collect();
                     let query = self.fold_query(cte.query);
                     result_ctes.push(CteMutRec {


### PR DESCRIPTION
@frankmcsherry any objection to this? Wasn't sure if you were just tired of fighting with the code generator or if there is some future reason to want these fields around.

----

The column definitions for a mutually recursive CTE cannot contain collations nor options. Enforce that at the type level by introducing a dedicated AST node for a column definition in a mutually-recursive CTE block.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR minorly refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
