### PR TITLE
tracing: fix the fast-path in the presence of an otel collector, and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,6 +3754,8 @@ dependencies = [
  "mz-ore",
  "prometheus",
  "serde",
+ "serde_json",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -203,6 +203,7 @@ impl InternalHttpServer {
                     .await
                 }),
             )
+            .route("/api/tracing", routing::get(mz_http_util::handle_tracing))
             .route(
                 "/api/catalog",
                 routing::get(catalog::handle_internal_catalog),

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -11,6 +11,8 @@ askama = { version = "0.11.1", default-features = false, features = ["config", "
 axum = { version = "0.5.17", features = ["headers"] }
 headers = "0.3.8"
 serde = "1.0.147"
+serde_json = { version = "1.0.89" }
+tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 include_dir = "0.7.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -10,14 +10,15 @@
 //! HTTP utilities.
 
 use askama::Template;
-use axum::extract::Json;
 use axum::http::status::StatusCode;
 use axum::response::{Html, IntoResponse};
+use axum::Json;
 use axum::TypedHeader;
 use headers::ContentType;
 use mz_ore::metrics::MetricsRegistry;
 use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tracing_subscriber::filter::Targets;
 
 /// Renders a template into an HTTP response.
@@ -127,4 +128,15 @@ pub async fn handle_modify_filter_target(
         },
         Err(e) => (StatusCode::BAD_REQUEST, e.to_string()),
     }
+}
+
+/// Returns information about the current status of tracing.
+#[allow(clippy::unused_async)]
+pub async fn handle_tracing() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(json!({
+            "current_level_filter": tracing::level_filters::LevelFilter::current().to_string()
+        })),
+    )
 }

--- a/src/ore/src/tracing/mod.rs
+++ b/src/ore/src/tracing/mod.rs
@@ -252,11 +252,11 @@ where
         }
         StderrLogFormat::Json => Box::new(fmt::layer().with_writer(io::stderr).json()),
     };
-    let (stderr_log_layer, stderr_reloader) =
-        reload::Layer::new(stderr_log_layer.with_filter(config.stderr_log.filter));
+    let (stderr_filter, stderr_filter_reloader) = reload::Layer::new(config.stderr_log.filter);
+    let stderr_log_layer = stderr_log_layer.with_filter(stderr_filter);
     let stderr_callback = DynamicTargetsCallback {
         callback: Arc::new(move |targets| {
-            stderr_reloader.modify(|layer| *layer.filter_mut() = targets)?;
+            stderr_filter_reloader.reload(targets)?;
             Ok(())
         }),
     };
@@ -316,7 +316,7 @@ where
             .with_filter(filter);
         let reloader = DynamicTargetsCallback {
             callback: Arc::new(move |targets| {
-                filter_handle.modify(|filter| *filter = targets)?;
+                filter_handle.reload(targets)?;
                 Ok(())
             }),
         };

--- a/src/ore/src/tracing/mod.rs
+++ b/src/ore/src/tracing/mod.rs
@@ -223,7 +223,8 @@ pub async fn configure<C, F>(
     config: C,
     // _Effectively_ unused if `sentry_config` is not set in the `config`,
     // as its not dynamically configured and is likely a closure with
-    // an opaque type.
+    // an opaque type. Note that the sentry layer is statically configured
+    // to never receive events more verbose than `INFO`.
     sentry_event_filter: F,
     (build_version, build_sha, build_time): (&str, &str, &str),
 ) -> Result<(TracingTargetCallbacks, Option<sentry::ClientInitGuard>), anyhow::Error>
@@ -374,7 +375,35 @@ where
     let stack = stack.with(otel_layer);
     #[cfg(feature = "tokio-console")]
     let stack = stack.with(tokio_console_layer);
-    let stack = stack.with(sentry_tracing::layer().event_filter(sentry_event_filter));
+    let stack = stack.with(
+        sentry_tracing::layer()
+            .event_filter(sentry_event_filter)
+            // WARNING, ENTERING THE SPOOKY ZONE
+            //
+            // While sentry provides an event filter above that maps events to types of sentry events, its `Layer`
+            // implementation does not participate in `tracing`'s level-fast-path implementation, which depends on
+            // a hidden api (<https://github.com/tokio-rs/tracing/blob/b28c9351dd4f34ed3c7d5df88bb5c2e694d9c951/tracing-subscriber/src/layer/mod.rs#L861-L867>)
+            // which is primarily manged by filters (like below). The fast path skips verbose log
+            // (and span) levels that no layer is interested by reading a single atomic. Usually, not implementing this
+            // api means "give me everything, including `trace`, unless you attach a filter to me.
+            //
+            // The curious thing here (and a bug in tracing) is that _some configurations of our layer stack above_,
+            // if you don't have this filter can cause the fast-path to trigger, despite the fact
+            // that the sentry layer would specifically communicating that it wants to see
+            // everything. This bug appears to be related to the presence of a `reload::Layer`
+            // _around a filter, not a layer_, and guswynn is tracking investigating it here:
+            // <https://github.com/MaterializeInc/materialize/issues/16556>. Because we don't
+            // enable a reload-able filter in CI/locally, but DO in production (the otel layer), it
+            // was once possible to trigger and rely on the fast path in CI, but not notice that it
+            // was disabled in production.
+            //
+            // The behavior of this optimization is now tested in various scenarios (in
+            // `test/tracing`). Regardless, when the upstream bug is fixed/resolved,
+            // we will continue to place this here, as the sentry layer only cares about
+            // events <= INFO, so we want to use the fast-path if no other layer
+            // is interested in high-fidelity events.
+            .with_filter(tracing::level_filters::LevelFilter::INFO),
+    );
     stack.init();
 
     #[cfg(feature = "tokio-console")]

--- a/test/tracing/mzcompose
+++ b/test/tracing/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -1,0 +1,99 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# TODO(guswynn): test that the setup forwards to compute and storage correctly
+
+import requests
+
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import Materialized
+
+SERVICES = [
+    Materialized(
+        options=[
+            "--opentelemetry-endpoint=whatever:7777",
+            "--opentelemetry-enabled=false",
+            "--opentelemetry-filter=trace",
+        ]
+    ),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    """Tests the dynamic tracing setup on environmentd"""
+
+    c.workflow("with-otel")
+    c.workflow("without-otel")
+
+
+def workflow_with_otel(c: Composition) -> None:
+    c.start_and_wait_for_tcp(services=["materialized"])
+    port = c.port("materialized", 6878)
+
+    # Start with fastpath
+    info = requests.get(f"http://localhost:{port}/api/tracing").json()
+    assert info["current_level_filter"] == "info"
+
+    # update the stderr config
+    requests.put(
+        f"http://localhost:{port}/api/stderr/config",
+        json={"targets": "debug"},
+    )
+    info = requests.get(f"http://localhost:{port}/api/tracing").json()
+    assert info["current_level_filter"] == "debug"
+
+    # update the otel config
+    requests.put(
+        f"http://localhost:{port}/api/opentelemetry/config",
+        json={"targets": "trace"},
+    )
+    info = requests.get(f"http://localhost:{port}/api/tracing").json()
+    assert info["current_level_filter"] == "trace"
+
+    # revert the otel config and make sure we go back
+    requests.put(
+        f"http://localhost:{port}/api/opentelemetry/config",
+        json={"targets": "off"},
+    )
+    info = requests.get(f"http://localhost:{port}/api/tracing").json()
+    assert info["current_level_filter"] == "debug"
+
+    # make sure we can go allll the way back
+    requests.put(
+        f"http://localhost:{port}/api/stderr/config",
+        json={"targets": "info"},
+    )
+    info = requests.get(f"http://localhost:{port}/api/tracing").json()
+    assert info["current_level_filter"] == "info"
+
+
+def workflow_without_otel(c: Composition) -> None:
+    with c.override(Materialized()):
+        c.start_and_wait_for_tcp(services=["materialized"])
+        port = c.port("materialized", 6878)
+
+        # Start with fastpath
+        info = requests.get(f"http://localhost:{port}/api/tracing").json()
+        assert info["current_level_filter"] == "info"
+
+        # update the stderr config
+        requests.put(
+            f"http://localhost:{port}/api/stderr/config",
+            json={"targets": "debug"},
+        )
+        info = requests.get(f"http://localhost:{port}/api/tracing").json()
+        assert info["current_level_filter"] == "debug"
+
+        # make sure we can go back to normal
+        requests.put(
+            f"http://localhost:{port}/api/stderr/config",
+            json={"targets": "info"},
+        )
+        info = requests.get(f"http://localhost:{port}/api/tracing").json()
+        assert info["current_level_filter"] == "info"


### PR DESCRIPTION
The fast path has been broken in production for a LONG time, but a bug in tracing (tracked internally here https://github.com/MaterializeInc/materialize/issues/16556) meant that the code as laid out by https://github.com/MaterializeInc/materialize/pull/16443 worked _in ci_. This pr works around the regression that erroneously-only-somtimes-exists by correctly filtering the sentry-layer. Note I also add an endpoint to check the current fast-path, and also revert https://github.com/MaterializeInc/materialize/pull/16443, as its no longer broken. I feel comfortable with this because of the added tests.

The behavior I noticed that inspired this pr was that the sentry layer would be starved of events more verbose than `DEBUG`/`TRACE`, but only if the otel layer was `None`. We never noticed because it only cares about `INFO` and above. 

In practice, when @jpepin enables the otel layer in production, we will see a perf hit as it will eliminate the fast path this pr adds back.

Also, i added tests to ensure our ci and prod situation dont regress. I chose an mzcompose because, and I think @benesch will agree with this, i dont trust any test setup that doesnt literally mirror production exactly.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
