### PR TITLE
Correct `Get` types in `ProjectionPushdown`

### DIFF
--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -282,18 +282,15 @@ where
             // Push down the projection consisting of the entries of `columns`
             // in increasing order.
             projection_pushdown.action(view, &projection_pushed_down, demand)?;
-            applied_projection.insert(id, projection_pushed_down);
+            let new_type = view.typ();
+            applied_projection.insert(id, (projection_pushed_down, new_type));
         }
         view_refs.push(view);
     }
 
-    let typ_update = crate::normalize_lets::NormalizeLets::new(false);
     for view in view_refs {
-        // Update column references to views where projections were pushed down.
+        // Update `Get` nodes to reflect any columns that have been projected away.
         projection_pushdown.update_projection_around_get(view, &applied_projection)?;
-        // Types need to be updated after ProjectionPushdown
-        // because the width of each view may have changed.
-        typ_update.action(view)?;
     }
 
     Ok(())


### PR DESCRIPTION
The `ProjectionPushdown` transform pushes projections through `Let` bindings, and in `dataflow.rs` across view definitions. However, the transform does not correct the `Get` references to them if projections are applied. The `update_projection_around_get` method corrects projections around gets, but does not correct the type. In `dataflow.rs`, the `NormalizeLets` transform will correct types for `Let` bindings, but the types are not corrected for `Get` nodes that reference other views.

This PR updates `Get` nodes with modified types as part of the transform, by extending `update_projection_around_get` to require a new type. This also obliges `dataflow.rs` to provide that information, correcting the inter-view bug and removing the need for `NormalizeLets`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
