### PR TITLE
zippy: Extend the execution time of the Release Qualification tests

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -49,7 +49,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaSourcesLarge, --actions=50000]
+          args: [--scenario=KafkaSourcesLarge, --actions=100000]
 
   - id: zippy-dataflows-large
     label: "Long running Zippy with complex dataflows"
@@ -60,7 +60,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=DataflowsLarge, --actions=50000]
+          args: [--scenario=DataflowsLarge, --actions=100000]
 
   - id: zippy-pg-cdc-large
     label: "Longer Zippy PogresCdc test"
@@ -70,4 +70,4 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=PostgresCdc, --actions=50000]
+          args: [--scenario=PostgresCdc, --actions=100000]


### PR DESCRIPTION
Have the Release Qualification zippy tests run 100K actions each, which will translate into 16-27h execution time for each Scenario.

### Motivation

  * This PR adds a feature that has not yet been specified.

Our target with the Release Qualification tests is 48h, but the current setup is running for 7 to 14h.