### PR TITLE
Add `mz_cluster_replica_frontiers` table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,6 +3541,7 @@ dependencies = [
  "columnation",
  "differential-dataflow",
  "futures",
+ "itertools",
  "mz-build-info",
  "mz-expr",
  "mz-orchestrator",

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -172,6 +172,21 @@ Field        | Type       | Meaning
 `export_id ` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
 `time`       | [`mz_timestamp`] | The next timestamp at which the output may change.
 
+### `mz_cluster_replica_frontiers`
+
+The `mz_cluster_replica_frontiers` table describes the frontiers of each [dataflow] in the system.
+[`mz_compute_frontiers`](#mz_compute_frontiers) is similar to this table, but `mz_compute_frontiers`
+exposes the frontiers known to the compute replicas while `mz_cluster_replica_frontiers` contains
+the frontiers the coordinator is aware of.
+
+At this time, we do not make any guarantees about the freshness of these numbers.
+
+Field        | Type       | Meaning
+-------------|------------|--------
+`replica_id` | [`bigint`] | The ID of a cluster replica.
+`export_id ` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
+`time`       | [`mz_timestamp`] | The next timestamp at which the output may change.
+
 ### `mz_compute_import_frontiers`
 
 The `mz_compute_import_frontiers` view describes the frontiers for every

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1625,6 +1625,15 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
         .with_column("memory_bytes", ScalarType::UInt64.nullable(true)),
 });
 
+pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_cluster_replica_frontiers",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("replica_id", ScalarType::UInt64.nullable(false))
+        .with_column("export_id", ScalarType::String.nullable(false))
+        .with_column("time", ScalarType::MzTimestamp.nullable(false)),
+});
+
 pub static MZ_STORAGE_HOST_METRICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_storage_host_metrics",
     // TODO[btv] - make this public once we work out whether and how to fuse it with
@@ -2898,6 +2907,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_CONNECTIONS),
         Builtin::Table(&MZ_SSH_TUNNEL_CONNECTIONS),
         Builtin::Table(&MZ_CLUSTER_REPLICAS),
+        Builtin::Table(&MZ_CLUSTER_REPLICA_FRONTIERS),
         Builtin::Table(&MZ_CLUSTER_REPLICA_METRICS),
         Builtin::Table(&MZ_CLUSTER_REPLICA_SIZES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_STATUSES),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -34,11 +34,12 @@ use mz_storage_client::types::sinks::{KafkaSinkConnection, StorageSinkConnection
 
 use crate::catalog::builtin::{
     MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS,
-    MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_METRICS, MZ_CLUSTER_REPLICA_STATUSES,
-    MZ_COLUMNS, MZ_CONNECTIONS, MZ_DATABASES, MZ_EGRESS_IPS, MZ_FUNCTIONS, MZ_INDEXES,
-    MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS, MZ_LIST_TYPES, MZ_MAP_TYPES,
-    MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS, MZ_SECRETS, MZ_SINKS, MZ_SOURCES,
-    MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
+    MZ_CLUSTER_REPLICA_FRONTIERS, MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_METRICS,
+    MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS, MZ_DATABASES, MZ_EGRESS_IPS,
+    MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS,
+    MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS,
+    MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD,
+    MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
     CatalogItem, CatalogState, Connection, Database, Error, ErrorKind, Func, Index,
@@ -945,6 +946,26 @@ impl CatalogState {
                     BuiltinTableUpdate { id, row, diff: 1 }
                 },
             )
+            .collect();
+        updates
+    }
+
+    pub fn pack_replica_write_frontiers_updates(
+        &self,
+        replica_id: ReplicaId,
+        updates: &[(GlobalId, mz_repr::Timestamp)],
+        diff: Diff,
+    ) -> Vec<BuiltinTableUpdate> {
+        let id = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_FRONTIERS);
+        let rows = updates.into_iter().map(|(coll_id, time)| {
+            Row::pack_slice(&[
+                replica_id.into(),
+                Datum::String(&coll_id.to_string()),
+                Datum::MzTimestamp(*time),
+            ])
+        });
+        let updates = rows
+            .map(|row| BuiltinTableUpdate { id, row, diff })
             .collect();
         updates
     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -268,6 +268,8 @@ pub struct ReplicaMetadata {
     pub last_heartbeat: Option<DateTime<Utc>>,
     /// The last known CPU and memory metrics
     pub metrics: Option<Vec<ServiceProcessMetrics>>,
+    /// Write frontiers of that replica.
+    pub write_frontiers: Vec<(GlobalId, mz_repr::Timestamp)>,
 }
 
 /// Metadata about an active connection.

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -254,6 +254,10 @@ impl<S: Append + 'static> Coordinator<S> {
                         .await;
                 }
             }
+            ControllerResponse::ComputeReplicaWriteFrontiers(updates) => {
+                // TODO: implement this
+                tracing::info!("Received ComputeReplicaWriteFrontiers: {}", updates.len());
+            }
         }
     }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -255,8 +255,38 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
             }
             ControllerResponse::ComputeReplicaWriteFrontiers(updates) => {
-                // TODO: implement this
-                tracing::info!("Received ComputeReplicaWriteFrontiers: {}", updates.len());
+                let mut builtin_updates = vec![];
+                for (replica_id, new) in updates {
+                    let m = match self
+                        .transient_replica_metadata
+                        .entry(replica_id)
+                        .or_insert_with(|| Some(Default::default()))
+                    {
+                        // `None` is the tombstone for a removed replica
+                        None => continue,
+                        Some(md) => &mut md.write_frontiers,
+                    };
+                    let old = std::mem::replace(m, new.clone());
+                    if old != new {
+                        let retractions = self
+                            .catalog
+                            .state()
+                            .pack_replica_write_frontiers_updates(replica_id, &old, -1);
+                        builtin_updates.extend(retractions.into_iter());
+
+                        let insertions = self
+                            .catalog
+                            .state()
+                            .pack_replica_write_frontiers_updates(replica_id, &new, 1);
+                        builtin_updates.extend(insertions.into_iter());
+                    }
+                }
+
+                self.send_builtin_table_updates(
+                    builtin_updates,
+                    BuiltinTableUpdateSource::Background,
+                )
+                .await;
             }
         }
     }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1852,6 +1852,7 @@ impl<S: Append + 'static> Coordinator<S> {
         if let Some(Some(ReplicaMetadata {
             last_heartbeat,
             metrics,
+            write_frontiers,
         })) = self.transient_replica_metadata.insert(replica_id, None)
         {
             let mut updates = vec![];
@@ -1870,6 +1871,12 @@ impl<S: Append + 'static> Coordinator<S> {
                     .pack_replica_metric_updates(replica_id, &metrics, -1);
                 updates.extend(retraction.into_iter());
             }
+            let retraction = self.catalog.state().pack_replica_write_frontiers_updates(
+                replica_id,
+                &write_frontiers,
+                -1,
+            );
+            updates.extend(retraction.into_iter());
             self.send_builtin_table_updates(updates, BuiltinTableUpdateSource::Background)
                 .await;
         }

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -15,6 +15,7 @@ columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.25"
+itertools = "0.10.5"
 mz-build-info = { path = "../build-info" }
 mz-expr = { path = "../expr" }
 mz-orchestrator = { path = "../orchestrator" }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -127,6 +127,10 @@ impl<T> Instance<T> {
         self.collections.get_mut(&id).ok_or(CollectionMissing(id))
     }
 
+    pub fn collections_iter(&self) -> impl Iterator<Item = (&GlobalId, &CollectionState<T>)> {
+        self.collections.iter()
+    }
+
     /// Acquire an [`ActiveInstance`] by providing a storage controller.
     pub fn activate<'a>(
         &'a mut self,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -21,6 +21,7 @@
 //! Consult the `StorageController` and `ComputeController` documentation for more information
 //! about each of these interfaces.
 
+use std::collections::HashMap;
 use std::mem;
 use std::num::NonZeroI64;
 use std::sync::Arc;
@@ -96,6 +97,8 @@ pub enum ControllerResponse<T = mz_repr::Timestamp> {
     ComputeReplicaHeartbeat(ReplicaId, DateTime<Utc>),
     /// Notification that new resource usage metrics are available for a given replica.
     ComputeReplicaMetrics(ReplicaId, Vec<ServiceProcessMetrics>),
+    /// Notification that the write frontiers of the replicas have changed.
+    ComputeReplicaWriteFrontiers(HashMap<ReplicaId, Vec<(GlobalId, T)>>),
 }
 
 impl<T> From<ComputeControllerResponse<T>> for ControllerResponse<T> {
@@ -112,6 +115,9 @@ impl<T> From<ComputeControllerResponse<T>> for ControllerResponse<T> {
             }
             ComputeControllerResponse::ReplicaMetrics(id, metrics) => {
                 ControllerResponse::ComputeReplicaMetrics(id, metrics)
+            }
+            ComputeControllerResponse::ReplicaWriteFrontiers(frontiers) => {
+                ControllerResponse::ComputeReplicaWriteFrontiers(frontiers)
             }
         }
     }

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -265,6 +265,10 @@ mz_arrangement_sizes_3
 VIEW
 materialize
 mz_internal
+mz_cluster_replica_frontiers
+BASE TABLE
+materialize
+mz_internal
 mz_cluster_replica_heartbeats
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -527,6 +527,7 @@ mz_worker_compute_import_frontiers              log   <null>
 > SHOW TABLES FROM mz_internal
 name
 ----
+mz_cluster_replica_frontiers
 mz_cluster_replica_heartbeats
 mz_cluster_replica_metrics
 mz_cluster_replica_sizes
@@ -580,7 +581,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-36
+37
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/cluster_replica_frontiers.td
+++ b/test/testdrive/cluster_replica_frontiers.td
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test mz_internal.cluster_replica_frontiers
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+> CREATE TABLE t1 (a int)
+
+> INSERT INTO t1 VALUES (1)
+
+> CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM t1
+
+# Make sure compute controller has the frontier
+> SELECT * FROM mv1
+1
+
+> SELECT mz_clusters.name, mz_cluster_replicas.name FROM
+  mz_catalog.mz_objects AS obj, mz_internal.mz_cluster_replica_frontiers AS frontiers,
+  mz_cluster_replicas, mz_clusters
+  WHERE obj.name = 'mv1' AND frontiers.export_id = obj.id AND
+  replica_id = mz_cluster_replicas.id AND cluster_id = mz_clusters.id
+  ORDER BY mz_cluster_replicas.name;
+default r1
+
+> CREATE CLUSTER REPLICA default.r2 SIZE '2';
+
+> SELECT mz_clusters.name, mz_cluster_replicas.name, time > 0 FROM
+  mz_catalog.mz_objects AS obj, mz_internal.mz_cluster_replica_frontiers AS frontiers,
+  mz_cluster_replicas, mz_clusters
+  WHERE obj.name = 'mv1' AND frontiers.export_id = obj.id AND
+  replica_id = mz_cluster_replicas.id AND cluster_id = mz_clusters.id
+  ORDER BY mz_cluster_replicas.name;
+default r1 true
+default r2 true
+
+
+> DROP CLUSTER REPLICA default.r2;
+
+> SELECT mz_clusters.name, mz_cluster_replicas.name FROM
+  mz_catalog.mz_objects AS obj, mz_internal.mz_cluster_replica_frontiers AS frontiers,
+  mz_cluster_replicas, mz_clusters
+  WHERE obj.name = 'mv1' AND frontiers.export_id = obj.id AND
+  replica_id = mz_cluster_replicas.id AND cluster_id = mz_clusters.id
+  ORDER BY mz_cluster_replicas.name;
+default r1


### PR DESCRIPTION
Expose the write frontiers known to the compute controller as builtin table.

Fixes #15996

### Motivation
  * This PR fixes a recognized bug: #15996

### Tips for reviewer

The code follows closely the implementation of `mz_cluster_replica_metrics`, except for the trigger mechanism. This PR uses a periodical ticker to generate the corresponding ComputeResponse .

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add `mz_internal.mz_cluster_replica_frontiers` system table
