### PR TITLE
sql: function error handling improvements

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2497,9 +2497,6 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
             params!(TimestampTz) => AggregateFunc::MinTimestampTz, 2143;
             params!(Numeric) => AggregateFunc::MinNumeric, oid::FUNC_MIN_NUMERIC_OID;
         },
-        "json_agg" => Aggregate {
-            params!(Any) => Operation::unary(|_ecx, _e| bail_unsupported!("json_agg")) => Jsonb, 3175;
-        },
         "jsonb_agg" => Aggregate {
             params!(Any) => Operation::unary_ordered(|ecx, e, order_by| {
                 // TODO(#7572): remove this

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4358,15 +4358,19 @@ pub fn resolve_func(
         }
     };
 
-    let types: Vec<_> = cexprs
-        .iter()
-        .map(|e| match ecx.scalar_type(e) {
+    let arg_types: Vec<_> = cexprs
+        .into_iter()
+        .map(|ty| match ecx.scalar_type(&ty) {
             Some(ty) => ecx.humanize_scalar_type(&ty),
             None => "unknown".to_string(),
         })
         .collect();
 
-    sql_bail!("function {}({}) does not exist", name, types.join(", "))
+    Err(PlanError::UnknownFunction {
+        name: name.to_string(),
+        arg_types,
+        alternative_hint: None,
+    })
 }
 
 fn plan_is_expr<'a>(

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4366,10 +4366,24 @@ pub fn resolve_func(
         })
         .collect();
 
+    // Suggest using the `jsonb_` version of `json_` functions if they exist.
+    let alternative_hint = match name.0.split_last() {
+        Some((i, q)) if i.as_str().starts_with("json_") => {
+            let mut jsonb_version = q.to_vec();
+            jsonb_version.push(Ident::new(i.as_str().replace("json_", "jsonb_")));
+            let jsonb_version = UnresolvedObjectName(jsonb_version);
+            match resolve_func(ecx, &jsonb_version, args) {
+                Ok(_) => Some(format!("Try using {}", jsonb_version)),
+                Err(_) => None,
+            }
+        }
+        _ => None,
+    };
+
     Err(PlanError::UnknownFunction {
         name: name.to_string(),
         arg_types,
-        alternative_hint: None,
+        alternative_hint,
     })
 }
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -151,6 +151,26 @@ impl<'a> Outcome<'a> {
     fn success(&self) -> bool {
         matches!(self, Outcome::Success)
     }
+
+    /// Returns an error message that will match self. Appropriate for
+    /// rewriting error messages (i.e. not inserting error messages where we
+    /// currently expect success).
+    fn err_msg(&self) -> Option<String> {
+        match self {
+            Outcome::Unsupported { error, .. }
+            | Outcome::ParseFailure { error, .. }
+            | Outcome::PlanFailure { error, .. } => Some(
+                // This value gets fed back into regex to check that it matches
+                // `self`, so escape its meta characters.
+                regex::escape(
+                    // Take only first string in error message, which should be
+                    // sufficient for meaningfully matching error.
+                    error.to_string().split('\n').next().unwrap(),
+                ),
+            ),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for Outcome<'_> {
@@ -1250,92 +1270,111 @@ pub async fn rewrite_file(config: &RunConfig<'_>, filename: &Path) -> Result<(),
         let record = record;
         let outcome = state.run_record(&record).await?;
 
-        // If we see an output failure for a query, rewrite the expected output
-        // to match the observed output.
-        if let (
-            Record::Query {
-                output:
-                    Ok(QueryOutput {
-                        mode,
-                        output: Output::Values(_),
-                        output_str: expected_output,
-                        types,
-                        ..
-                    }),
-                ..
-            },
-            Outcome::OutputFailure {
-                actual_output: Output::Values(actual_output),
-                ..
-            },
-        ) = (&record, &outcome)
-        {
-            buf.append_header(&input, expected_output);
+        match (&record, &outcome) {
+            // If we see an output failure for a query, rewrite the expected output
+            // to match the observed output.
+            (
+                Record::Query {
+                    output:
+                        Ok(QueryOutput {
+                            mode,
+                            output: Output::Values(_),
+                            output_str: expected_output,
+                            types,
+                            ..
+                        }),
+                    ..
+                },
+                Outcome::OutputFailure {
+                    actual_output: Output::Values(actual_output),
+                    ..
+                },
+            ) => {
+                {
+                    buf.append_header(&input, expected_output);
 
-            for (i, row) in actual_output.chunks(types.len()).enumerate() {
-                match mode {
-                    // In Cockroach mode, output each row on its own line, with
-                    // two spaces between each column.
-                    Mode::Cockroach => {
-                        if i != 0 {
-                            buf.append("\n");
-                        }
-                        buf.append(&row.join("  "));
-                    }
-                    // In standard mode, output each value on its own line,
-                    // and ignore row boundaries.
-                    Mode::Standard => {
-                        for (j, col) in row.iter().enumerate() {
-                            if i != 0 || j != 0 {
-                                buf.append("\n");
+                    for (i, row) in actual_output.chunks(types.len()).enumerate() {
+                        match mode {
+                            // In Cockroach mode, output each row on its own line, with
+                            // two spaces between each column.
+                            Mode::Cockroach => {
+                                if i != 0 {
+                                    buf.append("\n");
+                                }
+                                buf.append(&row.join("  "));
                             }
-                            buf.append(col);
+                            // In standard mode, output each value on its own line,
+                            // and ignore row boundaries.
+                            Mode::Standard => {
+                                for (j, col) in row.iter().enumerate() {
+                                    if i != 0 || j != 0 {
+                                        buf.append("\n");
+                                    }
+                                    buf.append(col);
+                                }
+                            }
                         }
                     }
                 }
             }
-        } else if let (
-            Record::Query {
-                output:
-                    Ok(QueryOutput {
-                        output: Output::Hashed { .. },
-                        output_str: expected_output,
-                        ..
-                    }),
-                ..
-            },
-            Outcome::OutputFailure {
-                actual_output: Output::Hashed { num_values, md5 },
-                ..
-            },
-        ) = (&record, &outcome)
-        {
-            buf.append_header(&input, expected_output);
+            (
+                Record::Query {
+                    output:
+                        Ok(QueryOutput {
+                            output: Output::Hashed { .. },
+                            output_str: expected_output,
+                            ..
+                        }),
+                    ..
+                },
+                Outcome::OutputFailure {
+                    actual_output: Output::Hashed { num_values, md5 },
+                    ..
+                },
+            ) => {
+                buf.append_header(&input, expected_output);
 
-            buf.append(format!("{} values hashing to {}\n", num_values, md5).as_str())
-        } else if let (
-            Record::Simple {
-                output_str: expected_output,
-                ..
-            },
-            Outcome::OutputFailure {
-                actual_output: Output::Values(actual_output),
-                ..
-            },
-        ) = (&record, &outcome)
-        {
-            buf.append_header(&input, expected_output);
-
-            for (i, row) in actual_output.iter().enumerate() {
-                if i != 0 {
-                    buf.append("\n");
-                }
-                buf.append(row);
+                buf.append(format!("{} values hashing to {}\n", num_values, md5).as_str())
             }
-        } else if let Outcome::Success = outcome {
-            // Ok.
-        } else {
-            bail!("unexpected: {:?} {:?}", record, outcome);
+            (
+                Record::Simple {
+                    output_str: expected_output,
+                    ..
+                },
+                Outcome::OutputFailure {
+                    actual_output: Output::Values(actual_output),
+                    ..
+                },
+            ) => {
+                buf.append_header(&input, expected_output);
+
+                for (i, row) in actual_output.iter().enumerate() {
+                    if i != 0 {
+                        buf.append("\n");
+                    }
+                    buf.append(row);
+                }
+            }
+            (
+                Record::Query {
+                    sql,
+                    output: Err(err),
+                    ..
+                },
+                outcome,
+            )
+            | (
+                Record::Statement {
+                    expected_error: Some(err),
+                    sql,
+                    ..
+                },
+                outcome,
+            ) if outcome.err_msg().is_some() => {
+                buf.rewrite_expected_error(&input, err, &outcome.err_msg().unwrap(), sql)
+            }
+            (_, Outcome::Success) => {}
+            _ => bail!("unexpected: {:?} {:?}", record, outcome),
         }
     }
 
@@ -1346,6 +1385,15 @@ pub async fn rewrite_file(config: &RunConfig<'_>, filename: &Path) -> Result<(),
     Ok(())
 }
 
+/// Provides a means to rewrite the `.slt` file while iterating over it.
+///
+/// This struct takes the slt file as its `input`, tracks a cursor into it
+/// (`input_offset`), and provides a buffe (`output`) to store the rewritten
+/// results.
+///
+/// Functions that modify the file will lazily move `input` into `output` using
+/// `flush_to`. However, those calls should all be interior to other functions.
+#[derive(Debug)]
 struct RewriteBuffer<'a> {
     input: &'a str,
     input_offset: usize,
@@ -1390,6 +1438,22 @@ impl<'a> RewriteBuffer<'a> {
         } else if self.peek_last(6) != "\n----\n" {
             self.append("\n----\n");
         }
+    }
+
+    fn rewrite_expected_error(
+        &mut self,
+        input: &String,
+        old_err: &str,
+        new_err: &str,
+        query: &str,
+    ) {
+        // Output everything before this error message.
+        let err_offset = old_err.as_ptr() as usize - input.as_ptr() as usize;
+        self.flush_to(err_offset);
+        self.append(new_err);
+        self.append("\n");
+        self.append(query);
+        self.skip_to(query.as_ptr() as usize - input.as_ptr() as usize + query.len())
     }
 
     fn peek_last(&self, n: usize) -> &str {

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -223,7 +223,7 @@ SELECT avg(a) FROM t2
 
 # avg of an explicit NULL should return an error.
 
-query error unable to determine which implementation to use
+query error db error: ERROR: function pg_catalog\.sum\(unknown\) is not unique
 SELECT avg(NULL)
 
 statement error
@@ -324,7 +324,7 @@ select sum(distinct column1) from (values (1), (2), (1), (4)) _;
 query error count\(\*\) must be used to call a parameterless aggregate function
 SELECT count()
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function sum\(\) does not exist
 SELECT sum(*)
 
 # Ensure int2 has its own max implementation

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -466,13 +466,13 @@ SELECT round((SELECT * FROM nums));
 ----
 NULL
 
-query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, integer\) does not exist
 SELECT round((SELECT * FROM nums), 2)
 
-query error Cannot call function round\(double precision, double precision\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, double precision\) does not exist
 SELECT round((SELECT * FROM nums), (SELECT * FROM nums))
 
-query error Cannot call function round\(numeric, double precision\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(numeric, double precision\) does not exist
 SELECT round(5.0, (SELECT * FROM nums))
 
 query R
@@ -480,22 +480,22 @@ SELECT round(5.0, CAST ((SELECT * FROM nums) AS integer))
 ----
 NULL
 
-query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, integer\) does not exist
 SELECT round(CAST (5.0 AS double precision), 3)
 
-query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, integer\) does not exist
 SELECT round(CAST (5.0 AS float), 3)
 
-query error Cannot call function round\(boolean, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(boolean, integer\) does not exist
 SELECT round(true, 3)
 
 query error
 SELECT round(true)
 
-query error Cannot call function round\(double precision, numeric\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, numeric\) does not exist
 SELECT round(CAST (5.0 AS float), 3.0)
 
-query error Cannot call function round\(double precision, double precision\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, double precision\) does not exist
 SELECT round(CAST (5.0 AS float), CAST (3.0 AS float))
 
 query R
@@ -573,7 +573,7 @@ SELECT trunc(1.5678)
 statement ok
 DROP TABLE nums
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function trunc\(boolean\) does not exist
 SELECT trunc(true)
 
 query I

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -63,7 +63,7 @@ SELECT array_to_string(NULL::text[], ','), array_to_string(NULL::text[], 'foo', 
 ----
 NULL  NULL
 
-query error Cannot call function array_to_string\(unknown, unknown\): could not determine polymorphic type because input has type unknown
+query error db error: ERROR: could not determine polymorphic type because input has type unknown
 SELECT array_to_string(NULL, ','), array_to_string(NULL, 'foo', 'zerp')
 
 # Handle empty arrays as an input
@@ -89,7 +89,7 @@ SELECT 1 = ANY(ARRAY[2])
 ----
 false
 
-query error no overload for integer = text: arguments cannot be implicitly cast
+query error db error: ERROR: operator does not exist: integer = text
 SELECT 1 = ANY(ARRAY['1', '2'])
 
 query B
@@ -97,7 +97,7 @@ SELECT 3 = ANY(ARRAY[ARRAY[1, 2], ARRAY[3,4]])
 ----
 true
 
-query error no overload for integer = text: arguments cannot be implicitly cast
+query error db error: ERROR: operator does not exist: integer = text
 SELECT 1 = ANY(ARRAY['hi'::text])
 
 query error invalid input syntax for type integer: invalid digit found in string: "hi"
@@ -173,7 +173,7 @@ query T rowsort
 SELECT unnest::text FROM unnest(NULL::int[])
 ----
 
-query error Cannot call function unnest\(unknown\): unable to determine which implementation to use; try providing explicit casts to match parameter types
+query error db error: ERROR: function unnest\(unknown\) is not unique
 SELECT * FROM unnest(NULL)
 
 # array_agg
@@ -229,7 +229,7 @@ SELECT array_agg(a) FILTER (WHERE a IS NULL) FROM t1
 ----
 {NULL,NULL}
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function array_agg\(integer, integer\) does not exist
 SELECT array_agg(1, 2)
 
 statement ok
@@ -466,22 +466,22 @@ true true
 #----
 #false false
 
-query error no overload for integer\[\] = text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer\[\] = text\[\]
 SELECT ARRAY[1,2,3] = ARRAY['1','2','3']
 
-query error no overload for integer\[\] <> text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer\[\] <> text\[\]
 SELECT ARRAY[1,2,3] != ARRAY['1','2','3']
 
-query error no overload for integer\[\] < text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer\[\] < text\[\]
 SELECT ARRAY[1,2,3] < ARRAY['1','2','3']
 
-query error no overload for integer\[\] <= text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer\[\] <= text\[\]
 SELECT ARRAY[1,2,3] <= ARRAY['1','2','3']
 
-query error no overload for integer\[\] > text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer\[\] > text\[\]
 SELECT ARRAY[1,2,3] > ARRAY['1','2','3']
 
-query error no overload for integer\[\] >= text\[\]: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer\[\] >= text\[\]
 SELECT ARRAY[1,2,3] >= ARRAY['1','2','3']
 
 query T

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -123,5 +123,5 @@ SELECT date('2020-01-01'), date('2020-01-01'::timestamp), date('2020-01-01'::tim
 query error invalid input syntax for type date
 SELECT date('2000')
 
-query error Cannot call function date\(unknown, unknown\): arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function date\(unknown, unknown\) does not exist
 SELECT date('2000', 'a')

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -47,7 +47,7 @@ SELECT array_agg(1) FROM kv
 ----
 NULL
 
-statement error supported
+statement error db error: ERROR: function json_agg\(integer\) does not exist
 SELECT json_agg(1) FROM kv
 ----
 NULL
@@ -77,7 +77,7 @@ SELECT array_agg(v) FROM kv
 ----
 NULL
 
-statement error supported
+statement error db error: ERROR: function json_agg\(integer\) does not exist
 SELECT json_agg(v) FROM kv
 ----
 NULL
@@ -99,7 +99,7 @@ SELECT array_agg(1)
 ----
 {1}
 
-statement error supported
+statement error db error: ERROR: function json_agg\(integer\) does not exist
 SELECT json_agg(1)
 
 query T
@@ -114,7 +114,7 @@ SELECT count(NULL)
 ----
 0
 
-statement error supported
+statement error db error: ERROR: function json_agg\(unknown\) does not exist
 SELECT json_agg(NULL)
 
 query T
@@ -122,7 +122,7 @@ SELECT jsonb_agg(NULL)
 ----
 [null]
 
-query error unable to determine which implementation to use
+query error db error: ERROR: function array_agg\(unknown\) is not unique
 SELECT array_agg(NULL)
 
 # With an explicit cast, this works as expected.
@@ -186,7 +186,7 @@ SELECT array_agg(1) FROM kv
 ----
 {1,1,1,1,1,1}
 
-statement error supported
+statement error db error: ERROR: function json_agg\(integer\) does not exist
 SELECT json_agg(1) FROM kv
 
 query T
@@ -461,7 +461,7 @@ SELECT count(1) from kv
 ----
 6
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function count\(integer, integer\) does not exist
 SELECT count(k, v) FROM kv
 
 # Note: Result differs from Cockroach but matches Postgres.
@@ -588,7 +588,7 @@ SELECT array_agg(k), array_agg(s) FROM (SELECT k, s FROM kv ORDER BY k)
 ----
 {1,3,5,6,7,8} {NULL,A,a,a,b,b}
 
-query error arguments cannot be implicitly cast
+query error db error: ERROR: operator does not exist: integer\[\] \|\| integer
 SELECT array_agg(k) || 1 FROM (SELECT k FROM kv ORDER BY k)
 
 query T
@@ -596,7 +596,7 @@ SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
 {NULL}
 
-query error supported
+query error db error: ERROR: function json_agg\(text\) does not exist
 SELECT json_agg(s) FROM kv WHERE s IS NULL
 
 query T
@@ -693,22 +693,22 @@ SELECT avg(b), sum(b) FROM abc
 # ----
 # 3 years 5 mons 7 days 00:00:19
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function pg_catalog\.sum\(character varying\) does not exist
 SELECT avg(a) FROM abc
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function pg_catalog\.sum\(boolean\) does not exist
 SELECT avg(c) FROM abc
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function pg_catalog\.sum\(record\(f1: character varying,f2: boolean\?\)\) does not exist
 SELECT avg((a,c)) FROM abc
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function sum\(character varying\) does not exist
 SELECT sum(a) FROM abc
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function sum\(boolean\) does not exist
 SELECT sum(c) FROM abc
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function sum\(record\(f1: character varying,f2: boolean\?\)\) does not exist
 SELECT sum((a,c)) FROM abc
 
 statement ok
@@ -898,7 +898,7 @@ SELECT bool_and(b), bool_or(b) FROM bools
 query error concat_agg not yet supported
 SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 
-query error json_agg not yet supported
+query error db error: ERROR: function json_agg\(text\) does not exist
 SELECT json_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 
 # This is arguably wrong--we don't respect the inner ORDER BY--because we don't
@@ -1087,7 +1087,7 @@ SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1
 1
 
 # Regression test for distsql aggregator crash when using hash aggregation.
-query error unable to determine which implementation to use
+query error db error: ERROR: function array_agg\(unknown\) is not unique
 SELECT v, array_agg('a') FROM kv GROUP BY v
 
 query I

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -203,7 +203,7 @@ SELECT DATE '2000-01-01' - INTERVAL '1' YEAR
 ----
 1999-01-01 00:00:00
 
-query error no overload for interval - date
+query error db error: ERROR: operator does not exist: interval \- date
 SELECT INTERVAL '1' YEAR - DATE '2000-01-01'
 
 query T
@@ -268,7 +268,7 @@ SELECT TIMESTAMP '2000-01-01 00:00:00' - INTERVAL '1' YEAR
 ----
 1999-01-01 00:00:00
 
-query error no overload for interval - timestamp
+query error db error: ERROR: operator does not exist: interval \- timestamp
 SELECT INTERVAL '1' YEAR - TIMESTAMP '2000-01-01 00:00:00'
 
 # Date arithmetic with duration intervals.
@@ -548,7 +548,7 @@ SELECT TIMESTAMPTZ '2000-01-01 00:00:00-7' - INTERVAL '4' MONTH
 ----
 1999-09-01 07:00:00+00
 
-query error no overload for interval - timestamp with time zone
+query error db error: ERROR: operator does not exist: interval \- timestamp with time zone
 SELECT INTERVAL '1' YEAR - TIMESTAMPTZ '2000-01-01 00:00:00-4:00'
 
 # Timestamptz arithmetic with duration intervals.
@@ -573,19 +573,19 @@ SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' - INTERVAL '2' HOUR
 ----
 2000-01-01 02:00:00+00
 
-query error no overload for interval - timestamp with time zone
+query error db error: ERROR: operator does not exist: interval \- timestamp with time zone
 SELECT INTERVAL '2' HOUR - TIMESTAMPTZ '2000-01-01 00:00:00-04'
 
-query error no overload for timestamp with time zone \* interval
+query error db error: ERROR: operator does not exist: timestamp with time zone \* interval
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' * INTERVAL '2' HOUR
 
-query error no overload for timestamp with time zone / interval
+query error db error: ERROR: operator does not exist: timestamp with time zone / interval
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' / INTERVAL '2' HOUR
 
-query error no overload for timestamp with time zone \+ timestamp with time zone
+query error db error: ERROR: operator does not exist: timestamp with time zone \+ timestamp with time zone
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' + TIMESTAMPTZ '1999-01-01 00:00:00z'
 
-query error no overload for timestamp with time zone \+ timestamp
+query error db error: ERROR: operator does not exist: timestamp with time zone \+ timestamp
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' + TIMESTAMP '1999-01-01 00:00:00'
 
 # Tests with comparison operators and timestamptz

--- a/test/sqllogictest/extract.slt
+++ b/test/sqllogictest/extract.slt
@@ -38,8 +38,8 @@ input        column1  column2
 some,csv     some     csv
 testing,123  testing  123
 
-query error Cannot call function csv_extract\(integer, text\): csv_extract number of columns must be a positive integer literal
+query error db error: ERROR: csv_extract number of columns must be a positive integer literal
 SELECT * FROM data, (VALUES (2)) ncols, csv_extract(ncols.column1, data.input)
 
-query error Cannot call function csv_extract\(integer, text\): csv_extract number of columns must be a positive integer literal
+query error db error: ERROR: csv_extract number of columns must be a positive integer literal
 SELECT * FROM data, csv_extract((SELECT 2), data.input)

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -889,7 +889,7 @@ SELECT array_upper(NULL::text[], 1)
 NULL
 
 # TODO(fix)
-query error Cannot call function array_upper\(unknown, integer\): could not determine polymorphic type because input has type unknown
+query error db error: ERROR: could not determine polymorphic type because input has type unknown
 SELECT array_upper(NULL, 1)
 
 query I
@@ -957,7 +957,7 @@ SELECT upper('ALREADYUP')
 ----
 ALREADYUP
 
-query error Cannot call function upper\(numeric\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function upper\(numeric\) does not exist
 SELECT upper(2.2)
 
 query T
@@ -970,7 +970,7 @@ SELECT lower('alreadylow')
 ----
 alreadylow
 
-query error Cannot call function lower\(interval\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function lower\(interval\) does not exist
 SELECT lower('1ms'::interval)
 
 # Test trigonometric functions.

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1906,7 +1906,7 @@ SELECT jsonb_agg(a) FILTER (WHERE a IS NOT NULL) FROM t1
 ----
 [1,2,3]
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function jsonb_agg\(integer, integer\) does not exist
 SELECT jsonb_agg(1, 2)
 
 statement ok

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -663,10 +663,10 @@ SELECT list_append(NULL, NULL)::text
 query error invalid input syntax for type integer
 SELECT list_append(LIST[1], 'a')::text
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function list_append\(integer list, integer list\) does not exist
 SELECT list_append(LIST[1], LIST[2])
 
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function list_append\(integer, integer list\) does not exist
 SELECT list_append(1, LIST[1])
 
 # 🔬🔬 list_cat
@@ -1136,7 +1136,7 @@ query T
 SELECT unnest::text FROM unnest(NULL::int list)
 ----
 
-query error Cannot call function unnest\(unknown\): unable to determine which implementation to use; try providing explicit casts to match parameter types
+query error db error: ERROR: function unnest\(unknown\) is not unique
 SELECT * FROM unnest(NULL)
 
 # 🔬 List casts
@@ -1260,7 +1260,7 @@ SELECT length(LIST['1','2']::text)
 ----
 5
 
-query error Cannot call function length\(text list\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function length\(text list\) does not exist
 SELECT length(LIST['1','2'])
 
 # 🔬🔬 text to list
@@ -1945,24 +1945,24 @@ false
 
 # 🔬🔬🔬 errors
 
-query error no overload for integer list = text list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer list = text list
 SELECT LIST[1] = LIST['a']
 
-query error no overload for text list = integer list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: text list = integer list
 SELECT LIST[NULL] = LIST[1]
 
-query error no overload for text list list = integer list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: text list list = integer list
 SELECT LIST[[NULL]] = LIST[1]
 
-query error no overload for integer list list list = integer list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer list list list = integer list
 SELECT LIST[[[1]]] = LIST[2]
 
 # Literal text cannot be implicitly cast to list
-query error no overload for integer list = text: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: integer list = text
 SELECT LIST[1] = '{2}'::text
 
 # Two lists containing implicitly castable element types are not implicitly castable to one another
-query error no overload for real list = double precision list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: real list = double precision list
 SELECT '{1}'::float4 list = '{2}'::float8 list
 
 # 🔬 CREATE TYPE .. AS LIST
@@ -2340,7 +2340,7 @@ SELECT (list_agg(a) FILTER (WHERE a IS NULL))::text FROM t1
 ----
 {NULL,NULL}
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function list_agg\(integer, integer\) does not exist
 SELECT list_agg(1, 2)
 
 statement ok

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -164,7 +164,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] ? 'c'
 ----
 false
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>integer\] \? integer
 SELECT '{a=>1, b=>2}'::map[text=>int] ? 1
 
 query T
@@ -182,14 +182,14 @@ SELECT '{hello=>{world=>false}}'::map[text=>map[text=>bool]] -> 'hello'::text ? 
 ----
 true
 
-query error unable to determine which implementation to use
+query error db error: ERROR: operator is not unique: unknown \? unknown
 SELECT NULL ? 'a'
 
 ## ?&
 query error malformed array literal: missing opening left brace
 SELECT '{a=>1, b=>2}'::map[text=>int] ?& 'a'
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>integer\] \?\& integer\[\]
 SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY[1]
 
 query error cannot determine type of empty array
@@ -223,7 +223,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY['c', 'b']
 ----
 false
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>boolean\] \?\& integer\[\]
 SELECT '{1=>t, 2=>f}'::map[text=>bool] ?& ARRAY[1]
 
 query T
@@ -255,7 +255,7 @@ false
 query error malformed array literal: missing opening left brace
 SELECT '{a=>1, b=>2}'::map[text=>int] ?| 'a'
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>integer\] \?\| integer\[\]
 SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY[1]
 
 query error could not determine polymorphic type because input has type unknown
@@ -286,7 +286,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY['c', 'd', '1']
 ----
 false
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>boolean\] \?\| integer\[\]
 SELECT '{1=>t, 2=>f}'::map[text=>bool] ?| ARRAY[1]
 
 query T
@@ -308,13 +308,13 @@ false
 query error invalid input syntax for type map: expected '\{', found c: "c"
 SELECT '{a=>1, b=>2}'::map[text=>int] @> 'c'
 
-query error  arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>integer\] @> text
 SELECT '{a=>1, b=>2}'::map[text=>int] @> 'a'::text
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>integer\] @> integer\[\]
 SELECT '{a=>1, b=>2}'::map[text=>int] @> ARRAY[1]
 
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit cast
+query error db error: ERROR: operator does not exist: map\[text=>integer\] @> map\[text=>boolean\]
 SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>t}'::map[text=>bool]
 ----
 false
@@ -339,7 +339,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>1, b=>2, c=>3}'::map[text=>int]
 ----
 false
 
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: map\[text=>map\[text=>bytea\]\] @> map\[text=>text\]
 SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>bytea]] @> '{hello=>world}'::map[text=>text]
 ----
 false
@@ -355,7 +355,7 @@ SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>text]] @> '{hello=>{world
 false
 
 ## <@
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: operator does not exist: map\[text=>integer\] <@ map\[text=>boolean\]
 SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>t}'::map[text=>bool]
 ----
 false
@@ -416,7 +416,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] -> 'c'
 ----
 NULL
 
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: operator does not exist: map\[text=>integer\] \-> integer
 SELECT '{a=>1, b=>2}'::map[text=>int] -> 1
 
 query T
@@ -464,7 +464,7 @@ SELECT '{hello=>{world=>nested}, another=>{map=>here}}'::map[text=>map[text=>tex
 ----
 nested
 
-query error unable to determine which implementation to use
+query error db error: ERROR: operator is not unique: unknown \-> text
 SELECT NULL -> 'hello'::text
 
 query error could not determine polymorphic type because input has type unknown

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -722,7 +722,7 @@ SELECT '你' || '好'
 ----
 你好
 
-query error no overload for boolean \|\| boolean
+query error db error: ERROR: operator does not exist: boolean \|\| boolean
 SELECT true || false
 
 query T
@@ -753,13 +753,13 @@ SELECT split_part('', 'not', 1)
 query error field position must be greater than zero
 SELECT split_part('abc~@~def~@~ghi', '~@~', 0)
 
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function split_part\(\) does not exist
 SELECT split_part()
 
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function split_part\(unknown, unknown\) does not exist
 SELECT split_part('one', 'two')
 
-query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function split_part\(integer, integer, integer\) does not exist
 SELECT split_part(1, 2, 3)
 
 ### lpad ###
@@ -1002,10 +1002,10 @@ SELECT position(42)
 statement error Expected IN, found right parenthesis
 SELECT position('str')
 
-statement error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+statement error db error: ERROR: function position\(integer, unknown\) does not exist
 SELECT position(42 IN 'str')
 
-statement error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+statement error db error: ERROR: function position\(unknown, integer\) does not exist
 SELECT position('str' IN 42)
 
 statement error Expected right parenthesis, found comma
@@ -1169,7 +1169,7 @@ SELECT left('hello', -2147483647)
 (empty)
 
 # i64
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function left\(unknown, bigint\) does not exist
 SELECT left('hello', 2147483648)
 
 ### right ###
@@ -1291,7 +1291,7 @@ SELECT right('hello', -2147483647)
 (empty)
 
 # i64
-query error arguments cannot be implicitly cast to any implementation's parameters
+query error db error: ERROR: function right\(unknown, bigint\) does not exist
 SELECT right('hello', 2147483648)
 
 query T

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -72,7 +72,7 @@ query I
 SELECT generate_series FROM generate_series(1, null)
 ----
 
-query error unable to determine which implementation to use
+query error db error: ERROR: function generate_series\(unknown, unknown\) is not unique
 SELECT generate_series FROM generate_series(null, null)
 ----
 
@@ -82,7 +82,7 @@ SELECT generate_series FROM generate_series('foo', 2)
 statement error invalid input syntax for type integer: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series(1, 'foo')
 
-statement error arguments cannot be implicitly cast to any implementation's parameters
+statement error db error: ERROR: function generate_series\(integer\) does not exist
 SELECT generate_series FROM generate_series(2)
 
 query T multiline
@@ -469,10 +469,10 @@ EOF
 
 # information_schema._pg_expandarray
 
-query error arguments cannot be implicitly cast
+query error db error: ERROR: function information_schema\._pg_expandarray\(\) does not exist
 SELECT information_schema._pg_expandarray()
 
-query error arguments cannot be implicitly cast
+query error db error: ERROR: function information_schema\._pg_expandarray\(\) does not exist
 SELECT * FROM information_schema._pg_expandarray()
 
 query error cannot determine type of empty array

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -38,10 +38,10 @@ FROM t
 6.7  2.7  9.4  2.35  0.7000000000000002  false  false  true  true  false  true
 
 # Do not allow int4 text comparisons
-query error no overload for text < integer
+query error db error: ERROR: operator does not exist: text < integer
 SELECT 'foo'::text < 5::int;
 
-query error no overload for integer < text
+query error db error: ERROR: operator does not exist: integer < text
 SELECT 1 < ALL(VALUES(NULL))
 
 # But string *literals* can coerce to anything.
@@ -199,11 +199,11 @@ Map (floorf64(integer_to_double(1)))
 EOF
 
 # Cannot implicitly cast int4 to string
-query error Cannot call function char_length\(integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function char_length\(integer\) does not exist
 SELECT char_length(321);
 
 # Cannot implicitly cast double precision to numeric
-query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error db error: ERROR: function round\(double precision, integer\) does not exist
 SELECT round(1.23::float, 1);
 
 # Check that float8 is the most common type

--- a/test/testdrive/jsonb.td
+++ b/test/testdrive/jsonb.td
@@ -23,3 +23,17 @@
 "{\"c\":[\"d\"]}"
 "null"
 "<null>"
+
+# Show that we suggest using jsonb functions when presented with json functions
+! SELECT json_build_object('id', 1)
+contains:exist
+hint:Try using jsonb_build_object
+
+! SELECT json_agg(1)
+contains:exist
+hint:Try using jsonb_agg
+
+# This is the generic hint, showing we haven't populated it with the jsonb suggestion
+! SELECT json_without_corresponding_jsonb(1)
+contains:exist
+hint:No function matches the given name and argument type

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -124,7 +124,7 @@ inhseqno            false   integer
 inhdetachpending    false   boolean
 
 ! SELECT current_schemas()
-contains:Cannot call function current_schemas(): arguments cannot be implicitly cast to any implementation's parameters;
+contains:function current_schemas() does not exist
 
 > SELECT current_schemas(true)
 {mz_catalog,pg_catalog,public}

--- a/test/testdrive/temporal.td
+++ b/test/testdrive/temporal.td
@@ -260,13 +260,13 @@ ts
 contains:Unsupported binary temporal operation: NotEq
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_now() + 1 = ts;
-contains:no overload for mz_timestamp + integer
+contains:operator does not exist: mz_timestamp + integer
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE mz_now() > ts OR ts = 1;
 contains:Unsupported temporal predicate. Note: `mz_now()` must be directly compared to a non-temporal expression of mz_timestamp-castable type. Expression found: ((#0 = 1) OR (mz_now() > #0))
 
 !CREATE MATERIALIZED VIEW v1 AS SELECT * FROM first_ts WHERE ts BETWEEN mz_now() AND mz_now() + 1;
-contains:no overload for mz_timestamp + integer
+contains:operator does not exist: mz_timestamp + integer
 
 #
 # Numeric comparisons


### PR DESCRIPTION
@benesch This could be considered a breaking change, so wanted to see where we want to draw that line.

@philip-stoev Just wanted your blessing for the testdrive changes.

### Motivation

* This PR adds a feature that has not yet been specified.
  * @petrosagg suggested we let users know when a `jsonb` version of a function is available if they try to use the `json` version after getting bit by this sharp edge of our UX.
  * I have always wanted to be able to rewrite error messages in sqllogictest; this PR also introduces that functionality.

* This PR refactors existing code. Implementing Petros's suggestion required structuring our function selection error messages.

### Tips for reviewer

Some of the changes to [src/sqllogictest/src/runner.rs](https://github.com/MaterializeInc/materialize/compare/main...sploiselle:suggest-jsonb?expand=1#diff-752c178c80a6b2c15db434efa9354f37d8e42456d5e4d6f5404f767f69ec95d0) are moving a series of `else if` statements into a `match` statement. Glad to revert this but was having a hard time ensuring its matches were appropriately exhaustive in its prior form.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Align our error messages with Postgres when we fail to find or select functions and operators.