### PR TITLE
environmentd: improve telemetry reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4537,6 +4537,7 @@ dependencies = [
  "mz-ore",
  "mz-postgres-util",
  "mz-secrets",
+ "mz-sql",
  "mz-stash",
  "mz-storage-client",
  "once_cell",

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -108,6 +108,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 "--availability-zone=kind-worker",
                 "--availability-zone=kind-worker2",
                 "--availability-zone=kind-worker3",
+                "--environment-id=cloudtest-test-00000000-0000-0000-0000-000000000000-0",
                 f"--persist-blob-url=s3://minio:minio123@persist/persist?endpoint={s3_endpoint}&region=minio",
                 "--orchestrator=kubernetes",
                 "--orchestrator-kubernetes-image-pull-policy=if-not-present",

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -67,6 +67,7 @@ class Materialized(Service):
                 "MZ_SOFT_ASSERTIONS=1",
                 "MZ_UNSAFE_MODE=1",
                 "MZ_EXPERIMENTAL=1",
+                f"MZ_ENVIRONMENT_ID=mzcompose-test-00000000-0000-0000-0000-000000000000-0",
                 f"MZ_PERSIST_BLOB_URL={persist_blob_url}",
                 f"MZ_ORCHESTRATOR=process",
                 f"MZ_ORCHESTRATOR_PROCESS_SECRETS_DIRECTORY={data_directory}/secrets",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -50,8 +50,8 @@ use mz_sql::ast::Expr;
 use mz_sql::catalog::{
     CatalogComputeInstance, CatalogDatabase, CatalogError as SqlCatalogError,
     CatalogItem as SqlCatalogItem, CatalogItemType as SqlCatalogItemType, CatalogItemType,
-    CatalogSchema, CatalogType, CatalogTypeDetails, IdReference, NameReference, SessionCatalog,
-    TypeReference,
+    CatalogSchema, CatalogType, CatalogTypeDetails, EnvironmentId, IdReference, NameReference,
+    SessionCatalog, TypeReference,
 };
 use mz_sql::names::{
     Aug, DatabaseId, FullObjectName, ObjectQualifiers, PartialObjectName, QualifiedObjectName,
@@ -3113,7 +3113,7 @@ impl<S: Append> Catalog<S> {
             unsafe_mode: true,
             persisted_introspection: true,
             build_info: &DUMMY_BUILD_INFO,
-            environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
+            environment_id: EnvironmentId::for_tests(),
             now,
             skip_migrations: true,
             metrics_registry,

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -20,6 +20,7 @@ use mz_compute_client::controller::ComputeReplicaAllocation;
 use mz_ore::metrics::MetricsRegistry;
 use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
+use mz_sql::catalog::EnvironmentId;
 use mz_storage_client::types::hosts::StorageHostResourceAllocation;
 
 use crate::catalog::storage;
@@ -37,7 +38,7 @@ pub struct Config<'a, S> {
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// A persistent ID associated with the environment.
-    pub environment_id: String,
+    pub environment_id: EnvironmentId,
     /// Function to generate wall clock now; can be mocked.
     pub now: mz_ore::now::NowFn,
     /// Whether or not to skip catalog migrations.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -78,8 +78,6 @@ use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use futures::StreamExt;
 use itertools::Itertools;
-use mz_orchestrator::ServiceProcessMetrics;
-use mz_ore::task::spawn;
 use rand::seq::SliceRandom;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
@@ -90,10 +88,12 @@ use uuid::Uuid;
 use mz_build_info::BuildInfo;
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig};
 use mz_compute_client::controller::{ComputeInstanceEvent, ComputeInstanceId, ReplicaId};
+use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::retry::Retry;
+use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
@@ -102,6 +102,7 @@ use mz_persist_client::ShardId;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_secrets::SecretsController;
 use mz_sql::ast::{CreateSourceStatement, CreateSubsourceStatement, Raw, Statement};
+use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::Aug;
 use mz_sql::plan::{MutationKind, Params};
 use mz_stash::Append;
@@ -238,7 +239,7 @@ pub struct Config<S> {
     pub unsafe_mode: bool,
     pub persisted_introspection: bool,
     pub build_info: &'static BuildInfo,
-    pub environment_id: String,
+    pub environment_id: EnvironmentId,
     pub metrics_registry: MetricsRegistry,
     pub now: NowFn,
     pub secrets_controller: Arc<dyn SecretsController>,

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -658,7 +658,9 @@ fn eval_unmaterializable_func(
             pack(t)
         }
         UnmaterializableFunc::CurrentUser => pack(Datum::from(&*session.user().name)),
-        UnmaterializableFunc::MzEnvironmentId => pack(Datum::from(&*state.config().environment_id)),
+        UnmaterializableFunc::MzEnvironmentId => {
+            pack(Datum::from(&*state.config().environment_id.to_string()))
+        }
         UnmaterializableFunc::MzNow => match logical_time {
             None => coord_bail!("cannot call mz_now in this context"),
             Some(logical_time) => pack(Datum::MzTimestamp(logical_time)),

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -41,6 +41,7 @@ use crate::coord::appends::BuiltinTableUpdateSource;
 use crate::coord::Coordinator;
 use crate::session::vars::SystemVars;
 use crate::session::Session;
+use crate::telemetry::EnvironmentIdExt;
 use crate::util::ComputeSinkId;
 use crate::{catalog, AdapterError};
 
@@ -309,9 +310,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         "event_source": "environmentd",
                         "details": event.details.as_json(),
                     }),
-                    Some(json!({
-                        "groupId": user_metadata.group_id,
-                    })),
+                    Some(self.catalog.config().environment_id.as_segment_context()),
                 );
             }
         }

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -45,6 +45,7 @@ pub mod client;
 pub mod config;
 pub mod metrics;
 pub mod session;
+pub mod telemetry;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{

--- a/src/adapter/src/telemetry.rs
+++ b/src/adapter/src/telemetry.rs
@@ -1,0 +1,30 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Telemetry utilities.
+
+use serde_json::json;
+
+use mz_sql::catalog::EnvironmentId;
+
+/// Extension trait for [`EnvironmentId`].
+pub trait EnvironmentIdExt {
+    /// Returns the Segment context fields associated with this environment ID.
+    fn as_segment_context(&self) -> serde_json::Value;
+}
+
+impl EnvironmentIdExt for EnvironmentId {
+    fn as_segment_context(&self) -> serde_json::Value {
+        json!({
+            "group_id": self.organization_id(),
+            "cloud_provider": self.cloud_provider(),
+            "cloud_provider_region": self.cloud_provider_region(),
+        })
+    }
+}

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -31,7 +31,6 @@ use fail::FailScenario;
 use http::header::HeaderValue;
 use itertools::Itertools;
 use jsonwebtoken::DecodingKey;
-use mz_ore::metric;
 use once_cell::sync::Lazy;
 use prometheus::IntGauge;
 use sysinfo::{CpuExt, SystemExt};
@@ -54,11 +53,13 @@ use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
 use mz_orchestrator_tracing::{TracingCliArgs, TracingOrchestrator};
 use mz_ore::cgroup::{detect_memory_limit, MemoryLimit};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
+use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistConfig, PersistLocation};
 use mz_secrets::SecretsController;
+use mz_sql::catalog::EnvironmentId;
 use mz_stash::PostgresFactory;
 use mz_storage_client::types::connections::ConnectionContext;
 
@@ -345,10 +346,9 @@ pub struct Args {
     #[clap(
         long,
         env = "ENVIRONMENT_ID",
-        value_name = "ID",
-        default_value = "environment-00000000-0000-0000-0000-000000000000-0"
+        value_name = "<CLOUD>-<REGION>-<ORG-ID>-<ORDINAL>"
     )]
-    environment_id: String,
+    environment_id: EnvironmentId,
     /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
@@ -615,7 +615,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                         // binaries.
                         image_dir: env::current_exe()?.parent().unwrap().to_path_buf(),
                         suppress_output: false,
-                        environment_id: args.environment_id.clone(),
+                        environment_id: args.environment_id.to_string(),
                         secrets_dir: args
                             .orchestrator_process_secrets_directory
                             .expect("clap enforced"),

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -41,6 +41,7 @@ use mz_ore::task;
 use mz_ore::tracing::TracingTargetCallbacks;
 use mz_persist_client::usage::StorageUsageClient;
 use mz_secrets::SecretsController;
+use mz_sql::catalog::EnvironmentId;
 use mz_stash::Stash;
 use mz_storage_client::types::connections::ConnectionContext;
 
@@ -100,7 +101,7 @@ pub struct Config {
 
     // === Cloud options. ===
     /// The cloud ID of this environment.
-    pub environment_id: String,
+    pub environment_id: EnvironmentId,
     /// Availability zones in which storage and compute resources may be
     /// deployed.
     pub availability_zones: Vec<String>,
@@ -323,7 +324,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         unsafe_mode: config.unsafe_mode,
         persisted_introspection: config.persisted_introspection,
         build_info: &BUILD_INFO,
-        environment_id: config.environment_id,
+        environment_id: config.environment_id.clone(),
         metrics_registry: config.metrics_registry.clone(),
         now: config.now,
         secrets_controller: config.secrets_controller,
@@ -387,11 +388,11 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     });
 
     // Start telemetry reporting loop.
-    if let (Some(segment_client), Some(frontegg)) = (segment_client, config.frontegg) {
+    if let Some(segment_client) = segment_client {
         telemetry::start_reporting(telemetry::Config {
             segment_client,
             adapter_client: adapter_client.clone(),
-            organization_id: frontegg.tenant_id(),
+            environment_id: config.environment_id,
         });
     }
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -27,7 +27,6 @@ use tokio::sync::Mutex;
 use tokio_postgres::config::Host;
 use tokio_postgres::Client;
 use tower_http::cors::AllowOrigin;
-use uuid::Uuid;
 
 use mz_controller::ControllerConfig;
 use mz_environmentd::TlsMode;
@@ -41,6 +40,7 @@ use mz_ore::task;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistConfig, PersistLocation};
 use mz_secrets::SecretsController;
+use mz_sql::catalog::EnvironmentId;
 use mz_stash::PostgresFactory;
 use mz_storage_client::types::connections::ConnectionContext;
 
@@ -152,7 +152,7 @@ impl Config {
 
 pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
     let runtime = Arc::new(Runtime::new()?);
-    let environment_id = format!("environment-{}-0", Uuid::new_v4());
+    let environment_id = EnvironmentId::for_tests();
     let (data_directory, temp_dir) = match config.data_directory {
         None => {
             // If no data directory is provided, we create a temporary
@@ -190,7 +190,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
                 .unwrap()
                 .to_path_buf(),
             suppress_output: false,
-            environment_id: environment_id.clone(),
+            environment_id: environment_id.to_string(),
             secrets_dir: data_directory.join("secrets"),
             command_wrapper: vec![],
             propagate_crashes: config.propagate_crashes,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -448,7 +448,7 @@ pub fn plan_create_source(
                 topic,
                 start_offsets,
                 group_id_prefix,
-                environment_id: scx.catalog.config().environment_id.clone(),
+                environment_id: scx.catalog.config().environment_id.to_string(),
                 include_timestamp: None,
                 include_partition: None,
                 include_topic: None,

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -29,7 +29,8 @@ use mz_storage_client::types::sources::SourceDesc;
 use crate::ast::Expr;
 use crate::catalog::{
     CatalogComputeInstance, CatalogConfig, CatalogDatabase, CatalogError, CatalogItem,
-    CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, IdReference, SessionCatalog,
+    CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, EnvironmentId, IdReference,
+    SessionCatalog,
 };
 use crate::func::{Func, MZ_CATALOG_BUILTINS, MZ_INTERNAL_BUILTINS, PG_CATALOG_BUILTINS};
 use crate::names::{
@@ -43,7 +44,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     start_time: DateTime::<Utc>::MIN_UTC,
     start_instant: Instant::now(),
     nonce: 0,
-    environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
+    environment_id: EnvironmentId::for_tests(),
     session_id: Uuid::from_u128(0),
     unsafe_mode: false,
     persisted_introspection: false,

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -14,6 +14,7 @@ mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-secrets = { path = "../secrets" }
+mz-sql = { path = "../sql" }
 mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
 once_cell = "1.16.0"

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -37,6 +37,7 @@ use mz_ore::{
     now::SYSTEM_TIME,
 };
 use mz_secrets::InMemorySecretsController;
+use mz_sql::catalog::EnvironmentId;
 use mz_stash::{Append, PostgresFactory, Stash};
 use mz_storage_client::controller as storage;
 
@@ -328,7 +329,7 @@ impl Usage {
             unsafe_mode: true,
             persisted_introspection: true,
             build_info: &BUILD_INFO,
-            environment_id: "environment-stash-debug".to_string(),
+            environment_id: EnvironmentId::for_tests(),
             now,
             skip_migrations: false,
             metrics_registry,

--- a/test/testdrive/system-functions.td
+++ b/test/testdrive/system-functions.td
@@ -23,7 +23,7 @@ true
 true
 
 > SELECT length(cast(mz_environment_id() as text));
-50
+53
 
 > SELECT length(cast(mz_internal.mz_session_id() as text));
 36


### PR DESCRIPTION
See individual commits for details.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
