### PR TITLE
adapter,storage: add `envelope` column to `mz_sources`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -321,6 +321,7 @@ Field            | Type       | Meaning
 `type`           | [`text`]   | The type of the source: `kafka`, `postgres`, `load-generator`, or `subsource`.
 `connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
 `size`           | [`text`]   | The [size](/sql/create-source/#sizing-a-source) of the source.
+`envelope_type`  | [`text`]   | The [envelope](/sql/create-source/#envelopes) of the source.
 
 ### `mz_storage_usage`
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -321,7 +321,7 @@ Field            | Type       | Meaning
 `type`           | [`text`]   | The type of the source: `kafka`, `postgres`, `load-generator`, or `subsource`.
 `connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
 `size`           | [`text`]   | The [size](/sql/create-source/#sizing-a-source) of the source.
-`envelope_type`  | [`text`]   | The [envelope](/sql/create-source/#envelopes) of the source.
+`envelope_type`  | [`text`]   | The [envelope](/sql/create-source/#envelopes) of the source: `none`, `upsert`, or `debezium`.
 
 ### `mz_storage_usage`
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1249,7 +1249,8 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("type", ScalarType::String.nullable(false))
         .with_column("connection_id", ScalarType::String.nullable(true))
-        .with_column("size", ScalarType::String.nullable(true)),
+        .with_column("size", ScalarType::String.nullable(true))
+        .with_column("envelope_type", ScalarType::String.nullable(true)),
 });
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sinks",

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -199,12 +199,14 @@ impl CatalogState {
         let name = &entry.name().item;
         let mut updates = match entry.item() {
             CatalogItem::Log(_) => {
-                self.pack_source_update(id, oid, schema_id, name, "log", None, None, diff)
+                self.pack_source_update(id, oid, schema_id, name, "log", None, None, None, diff)
             }
             CatalogItem::Index(index) => self.pack_index_update(id, oid, name, index, diff),
             CatalogItem::Table(_) => self.pack_table_update(id, oid, schema_id, name, diff),
             CatalogItem::Source(source) => {
-                let (source_type, connection_id) = (source.source_type(), source.connection_id());
+                let source_type = source.source_type();
+                let connection_id = source.connection_id();
+                let envelope = source.envelope();
 
                 self.pack_source_update(
                     id,
@@ -220,6 +222,7 @@ impl CatalogState {
                         }) => Some(size.as_str()),
                         _ => None,
                     },
+                    envelope,
                     diff,
                 )
             }
@@ -296,6 +299,7 @@ impl CatalogState {
         source_desc_name: &str,
         connection_id: Option<GlobalId>,
         size: Option<&str>,
+        envelope: Option<&str>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
@@ -308,6 +312,7 @@ impl CatalogState {
                 Datum::String(source_desc_name),
                 Datum::from(connection_id.map(|id| id.to_string()).as_deref()),
                 Datum::from(size),
+                Datum::from(envelope),
             ]),
             diff,
         }]

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -1450,6 +1450,10 @@ impl SourceDesc {
     pub fn name(&self) -> &'static str {
         self.connection.name()
     }
+
+    pub fn envelope(&self) -> &SourceEnvelope {
+        &self.envelope
+    }
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/test/testdrive/mz-sources.td
+++ b/test/testdrive/mz-sources.td
@@ -1,0 +1,147 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify that envelope types are correctly reported in mz_sources
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+$ kafka-create-topic topic=none-topic partitions=1
+
+> CREATE SOURCE none_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-none-topic-${testdrive.seed}')
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  INCLUDE KEY
+  ENVELOPE NONE
+
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "id", "type": "long"}
+    ]
+  }
+
+$ set schema={
+    "type" : "record",
+    "name" : "envelope",
+    "fields" : [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                  "name": "id",
+                  "type": "long"
+              },
+              {
+                "name": "creature",
+                "type": "string"
+              }]
+           },
+           "null"
+         ]
+      },
+      { "name": "op", "type": "string" },
+      {
+        "name": "after",
+        "type": ["row", "null"]
+      },
+      {
+        "name": "source",
+        "type": {
+          "type": "record",
+          "name": "Source",
+          "namespace": "io.debezium.connector.mysql",
+          "fields": [
+            {
+              "name": "file",
+              "type": "string"
+            },
+            {
+              "name": "pos",
+              "type": "long"
+            },
+            {
+              "name": "row",
+              "type": "int"
+            },
+            {
+              "name": "snapshot",
+              "type": [
+                {
+                  "type": "boolean",
+                  "connect.default": false
+                },
+                "null"
+              ],
+              "default": false
+            }
+          ],
+          "connect.name": "io.debezium.connector.mysql.Source"
+        }
+      }
+    ]
+  }
+
+
+$ kafka-create-topic topic=dbzupsert partitions=1
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
+{"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "u", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
+
+> CREATE SOURCE debezium_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+$ kafka-create-topic topic=upsert-topic
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-ingest format=avro topic=upsert-topic key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1000}
+
+> CREATE SOURCE upsert_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-topic-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT
+
+> SELECT envelope_type FROM mz_sources WHERE name = 'none_source'
+none
+
+> SELECT envelope_type FROM mz_sources WHERE name = 'debezium_source'
+debezium
+
+> SELECT envelope_type FROM mz_sources WHERE name = 'upsert_source'
+upsert


### PR DESCRIPTION
### Motivation

Known-desired feature: https://github.com/MaterializeInc/cloud/issues/4245.

### Tips for reviewer

We might want to think about what strings we use for the envelopes. @ggnall may or may not have opinions about that.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
