### PR TITLE
environmentd: try bumping expiry again?

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -512,8 +512,8 @@ fn test_auth_expiry() {
     let encoding_key =
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
 
-    const EXPIRES_IN_SECS: u64 = 10;
-    const REFRESH_BEFORE_SECS: u64 = 9;
+    const EXPIRES_IN_SECS: u64 = 20;
+    const REFRESH_BEFORE_SECS: u64 = 10;
     let frontegg_server = start_mzcloud(
         encoding_key,
         tenant_id,


### PR DESCRIPTION
I have no ideas about what's going on here besides sometimes things are quite slow?

See #15718

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a