### PR TITLE
bump kubernetes version

### DIFF
--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.59"
-k8s-openapi = { version = "0.16.0", features = ["v1_22"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_23"] }
 kube = { version = "0.76.0", features = ["derive", "openssl-tls", "ws"] }
 mz-repr = { path = "../repr" }
 schemars = { version = "0.8", features = ["uuid1"] }

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -18,7 +18,7 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
-k8s-openapi = { version = "0.16.0", features = ["v1_22"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_23"] }
 kube = { version = "0.76.0", features = ["runtime", "ws"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/cloud/issues/4724, following up on https://github.com/MaterializeInc/cloud/pull/4755

### Tips for reviewer

i think this is everything that matters

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - no user facing changes