### PR TITLE
persist: tag each version of state with a strictly increasing walltime

### DIFF
--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -202,6 +202,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
             applier_version,
             seqno_from,
             seqno_to,
+            walltime_ms,
             latest_rollup_key,
             rollups,
             hostname,
@@ -275,6 +276,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
             applier_version: applier_version.to_string(),
             seqno_from: seqno_from.into_proto(),
             seqno_to: seqno_to.into_proto(),
+            walltime_ms: walltime_ms.into_proto(),
             latest_rollup_key: latest_rollup_key.into_proto(),
             field_diffs: Some(field_diffs),
         }
@@ -298,6 +300,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
             applier_version,
             proto.seqno_from.into_rust()?,
             proto.seqno_to.into_rust()?,
+            proto.walltime_ms,
             proto.latest_rollup_key.into_rust()?,
         );
         if let Some(field_diffs) = proto.field_diffs {
@@ -502,6 +505,7 @@ where
             applier_version: self.applier_version.to_string(),
             shard_id: self.shard_id.into_proto(),
             seqno: self.seqno.into_proto(),
+            walltime_ms: self.walltime_ms.into_proto(),
             hostname: self.hostname.into_proto(),
             key_codec: K::codec_name(),
             val_codec: V::codec_name(),
@@ -611,6 +615,7 @@ where
             applier_version,
             shard_id: x.shard_id.into_rust()?,
             seqno: x.seqno.into_rust()?,
+            walltime_ms: x.walltime_ms,
             hostname: x.hostname,
             collections,
             _phantom: PhantomData,
@@ -911,7 +916,7 @@ mod tests {
         let v3 = semver::Version::new(3, 0, 0);
 
         // Code version v2 evaluates and writes out some State.
-        let state = State::<(), (), u64, i64>::new(v2.clone(), "".to_owned(), ShardId::new());
+        let state = State::<(), (), u64, i64>::new(v2.clone(), ShardId::new(), "".to_owned(), 0);
         let mut buf = Vec::new();
         state.encode(&mut buf);
 
@@ -938,6 +943,7 @@ mod tests {
             v2.clone(),
             SeqNo(0),
             SeqNo(1),
+            2,
             PartialRollupKey("rollup".into()),
         );
         let mut buf = Vec::new();

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -77,6 +77,7 @@ message ProtoStateRollup {
     string ts_codec = 4;
     string diff_codec = 5;
     uint64 seqno = 6;
+    uint64 walltime_ms = 15;
     string hostname = 14;
     uint64 last_gc_req = 10;
     map<uint64, string> rollups = 12;
@@ -129,6 +130,7 @@ message ProtoStateDiff {
 
     uint64 seqno_from = 2;
     uint64 seqno_to = 3;
+    uint64 walltime_ms = 6;
     string latest_rollup_key = 4;
 
     ProtoStateFieldDiffs field_diffs = 5;

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -555,8 +555,9 @@ impl StateVersions {
     {
         let empty_state = State::new(
             self.cfg.build_version.clone(),
-            self.cfg.hostname.clone(),
             shard_metrics.shard_id,
+            self.cfg.hostname.clone(),
+            (self.cfg.now)(),
         );
         let rollup_seqno = empty_state.seqno.next();
         let rollup_key = PartialRollupKey::new(rollup_seqno, &RollupId::new());


### PR DESCRIPTION
For debugging.

Also, persist state is a definite collection. This makes it a _reclocked_ definite collection.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Split into a new PR, as promised in #16201

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
