### PR TITLE
adapter: Implement MVP for real time recency

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5404,6 +5404,18 @@ impl<S: Append> Catalog<S> {
     pub fn set_most_recent_storage_usage_collection(&mut self, ts: EpochMillis) {
         self.state.most_recent_storage_usage_collection = ts;
     }
+
+    pub fn unsafe_mode(&self) -> bool {
+        self.config().unsafe_mode
+    }
+
+    pub fn require_unsafe_mode(&self, feature_name: &'static str) -> Result<(), AdapterError> {
+        if !self.unsafe_mode() {
+            Err(AdapterError::Unsupported(feature_name))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 pub fn is_reserved_name(name: &str) -> bool {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2207,6 +2207,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
+    // TODO(jkosh44) Once RTR is pulled off the main coord loop, we can remove async from this method.
     async fn plan_peek(
         &self,
         source: MirRelationExpr,
@@ -2399,6 +2400,8 @@ impl<S: Append + 'static> Coordinator<S> {
         })
     }
 
+    /// Checks to see if the session needs a real time recency timestamp and if so acquires and
+    /// returns one. This may wait for an unbounded amount for the timestamp.
     async fn recent_timestamp(
         &self,
         session: &Session,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -79,7 +79,9 @@ use crate::error::AdapterError;
 use crate::explain_new::optimizer_trace::OptimizerTrace;
 use crate::metrics;
 use crate::notice::AdapterNotice;
-use crate::session::vars::{IsolationLevel, CLUSTER_VAR_NAME, DATABASE_VAR_NAME};
+use crate::session::vars::{
+    IsolationLevel, CLUSTER_VAR_NAME, DATABASE_VAR_NAME, REAL_TIME_RECENCY_VAR_NAME,
+};
 use crate::session::{
     EndTransactionAction, PreparedStatement, Session, TransactionOps, TransactionStatus, Var,
     WriteOp,
@@ -297,7 +299,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 );
             }
             Plan::Explain(plan) => {
-                tx.send(self.sequence_explain(&session, plan), session);
+                tx.send(self.sequence_explain(&session, plan).await, session);
             }
             Plan::SendDiffs(plan) => {
                 tx.send(self.sequence_send_diffs(&mut session, plan), session);
@@ -1956,6 +1958,10 @@ impl<S: Append + 'static> Coordinator<S> {
             value => Some(value.to_string()), // or else use the AstDisplay for SetVariableValue
         };
 
+        if name.as_str() == REAL_TIME_RECENCY_VAR_NAME {
+            self.catalog.require_unsafe_mode("REAL TIME RECENCY")?;
+        }
+
         match &value {
             Some(v) => {
                 vars.set(&name, v, local)?;
@@ -2152,18 +2158,20 @@ impl<S: Append + 'static> Coordinator<S> {
         let in_immediate_multi_stmt_txn = session.transaction().is_in_multi_statement_transaction()
             && when == QueryWhen::Immediately;
 
-        let mut peek_plan = self.plan_peek(
-            source,
-            session,
-            &when,
-            compute_instance,
-            &mut target_replica,
-            view_id,
-            index_id,
-            timeline_context,
-            &source_ids,
-            in_immediate_multi_stmt_txn,
-        )?;
+        let mut peek_plan = self
+            .plan_peek(
+                source,
+                session,
+                &when,
+                compute_instance,
+                &mut target_replica,
+                view_id,
+                index_id,
+                timeline_context,
+                &source_ids,
+                in_immediate_multi_stmt_txn,
+            )
+            .await?;
 
         let compute_instance = compute_instance.id;
 
@@ -2199,7 +2207,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
-    fn plan_peek(
+    async fn plan_peek(
         &self,
         source: MirRelationExpr,
         session: &Session,
@@ -2232,6 +2240,9 @@ impl<S: Append + 'static> Coordinator<S> {
         // single-statement transaction (TransactionStatus::Started), we don't
         // need to worry about preventing compaction or choosing a valid
         // timestamp context for future queries.
+        let real_time_recency_ts = self
+            .recent_timestamp(session, source_ids.iter().cloned())
+            .await?;
         let timestamp_context = if in_immediate_multi_stmt_txn {
             match session.get_transaction_timestamp_context() {
                 Some(ts_context @ TimestampContext::TimelineTimestamp(_, _)) => ts_context,
@@ -2244,7 +2255,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         conn_id,
                         compute_instance,
                     )?;
-
                     // We want to prevent compaction of the indexes consulted by
                     // determine_timestamp, not the ones listed in the query.
                     let timestamp = self.determine_timestamp(
@@ -2253,6 +2263,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         &QueryWhen::Immediately,
                         compute_instance,
                         timeline_context,
+                        real_time_recency_ts,
                     )?;
                     // We only need read holds if the read depends on a timestamp.
                     if timestamp.timestamp_context.contains_timestamp() {
@@ -2268,6 +2279,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 when,
                 compute_instance,
                 timeline_context,
+                real_time_recency_ts,
             )?
             .timestamp_context
         };
@@ -2387,6 +2399,31 @@ impl<S: Append + 'static> Coordinator<S> {
         })
     }
 
+    async fn recent_timestamp(
+        &self,
+        session: &Session,
+        source_ids: impl Iterator<Item = GlobalId>,
+    ) -> Result<Option<Timestamp>, AdapterError> {
+        // Ideally this logic belongs inside of
+        // `mz-adapter::coord::timestamp_selection::determine_timestamp`. However, including the
+        // logic in there would make it extremely difficult and inconvenient to pull the waiting off
+        // of the main coord thread.
+        Ok(
+            if session.vars().real_time_recency()
+                && session.vars().transaction_isolation() == &IsolationLevel::StrictSerializable
+                && !session.contains_read_timestamp()
+            {
+                // We should have prevented anyone from turning on rtr outside of unsafe
+                // mode, but just incase check again.
+                // TODO(jkosh44) DO NOT remove unsafe until this waiting is removed from the main Coord loop.
+                self.catalog.require_unsafe_mode("REAL TIME RECENCY")?;
+                Some(self.controller.recent_timestamp(source_ids).await)
+            } else {
+                None
+            },
+        )
+    }
+
     async fn sequence_subscribe(
         &mut self,
         session: &mut Session,
@@ -2421,7 +2458,14 @@ impl<S: Append + 'static> Coordinator<S> {
             let timeline = coord.validate_timeline_context(id_bundle.iter())?;
             // If a timestamp was explicitly requested, use that.
             let frontier = coord
-                .determine_timestamp(session, &id_bundle, &when, compute_instance_id, timeline)?
+                .determine_timestamp(
+                    session,
+                    &id_bundle,
+                    &when,
+                    compute_instance_id,
+                    timeline,
+                    None,
+                )?
                 .timestamp_context
                 .antichain();
 
@@ -2515,13 +2559,13 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
-    fn sequence_explain(
+    async fn sequence_explain(
         &mut self,
         session: &Session,
         plan: ExplainPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         match plan.stage {
-            ExplainStage::Timestamp => self.sequence_explain_timestamp(session, plan),
+            ExplainStage::Timestamp => self.sequence_explain_timestamp(session, plan).await,
             _ => self.sequence_explain_plan(session, plan),
         }
     }
@@ -2705,7 +2749,7 @@ impl<S: Append + 'static> Coordinator<S> {
         Ok(send_immediate_rows(rows))
     }
 
-    fn sequence_explain_timestamp(
+    async fn sequence_explain_timestamp(
         &mut self,
         session: &Session,
         plan: ExplainPlan,
@@ -2730,15 +2774,16 @@ impl<S: Append + 'static> Coordinator<S> {
         let id_bundle = self
             .index_oracle(compute_instance)
             .sufficient_collections(&source_ids);
-        // TODO: determine_timestamp takes a mut self to modify the oracle
-        // timestamp, so explaining a plan involving tables has side effects.
-        // Removing those side effects would be good.
+        let real_time_recency_ts = self
+            .recent_timestamp(session, source_ids.iter().cloned())
+            .await?;
         let determination = self.determine_timestamp(
             session,
             &id_bundle,
             &QueryWhen::Immediately,
             compute_instance,
             timeline_context,
+            real_time_recency_ts,
         )?;
         let mut sources = Vec::new();
         {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -430,16 +430,16 @@ impl<T: TimestampManipulation> Session<T> {
 
     /// Whether this session has a timestamp for a read transaction.
     pub fn contains_read_timestamp(&self) -> bool {
-        match self.transaction.inner() {
+        matches!(
+            self.transaction.inner(),
             Some(Transaction {
                 pcx: _,
                 ops: TransactionOps::Peeks(TimestampContext::TimelineTimestamp(_, _)),
                 write_lock_guard: _,
                 access: _,
                 id: _,
-            }) => true,
-            _ => false,
-        }
+            })
+        )
     }
 
     /// Registers the prepared statement under `name`.

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -428,6 +428,20 @@ impl<T: TimestampManipulation> Session<T> {
         }
     }
 
+    /// Whether this session has a timestamp for a read transaction.
+    pub fn contains_read_timestamp(&self) -> bool {
+        match self.transaction.inner() {
+            Some(Transaction {
+                pcx: _,
+                ops: TransactionOps::Peeks(TimestampContext::TimelineTimestamp(_, _)),
+                write_lock_guard: _,
+                access: _,
+                id: _,
+            }) => true,
+            _ => false,
+        }
+    }
+
     /// Registers the prepared statement under `name`.
     pub fn set_prepared_statement(&mut self, name: String, statement: PreparedStatement) {
         self.prepared_statements.insert(name, statement);

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -330,6 +330,15 @@ pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+pub const REAL_TIME_RECENCY_VAR_NAME: &UncasedStr = UncasedStr::new("real_time_recency");
+/// Feature flag indicating whether real time recency is enabled.
+static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
+    name: REAL_TIME_RECENCY_VAR_NAME,
+    value: &false,
+    description: "Feature flag indicating whether real time recency is enabled (Materialize).",
+    internal: true,
+};
+
 /// Session variables.
 ///
 /// Materialize roughly follows the PostgreSQL configuration model, which works
@@ -381,6 +390,7 @@ pub struct SessionVars {
     idle_in_transaction_session_timeout: SessionVar<Duration>,
     timezone: SessionVar<TimeZone>,
     transaction_isolation: SessionVar<IsolationLevel>,
+    real_time_recency: SessionVar<bool>,
 }
 
 impl Default for SessionVars {
@@ -409,6 +419,7 @@ impl Default for SessionVars {
             ),
             timezone: SessionVar::new(&TIMEZONE),
             transaction_isolation: SessionVar::new(&TRANSACTION_ISOLATION),
+            real_time_recency: SessionVar::new(&REAL_TIME_RECENCY),
         }
     }
 }
@@ -449,6 +460,7 @@ impl SessionVars {
             &self.idle_in_transaction_session_timeout,
             &self.timezone,
             &self.transaction_isolation,
+            &self.real_time_recency,
         ]
         .into_iter()
     }
@@ -523,6 +535,8 @@ impl SessionVars {
             Ok(&self.timezone)
         } else if name == TRANSACTION_ISOLATION.name {
             Ok(&self.transaction_isolation)
+        } else if name == REAL_TIME_RECENCY.name {
+            Ok(&self.real_time_recency)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -659,6 +673,8 @@ impl SessionVars {
                     valid_values: Some(IsolationLevel::valid_values()),
                 });
             }
+        } else if name == REAL_TIME_RECENCY.name {
+            self.real_time_recency.set(value, local)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -701,6 +717,8 @@ impl SessionVars {
             self.timezone.reset(local);
         } else if name == TRANSACTION_ISOLATION.name {
             self.transaction_isolation.reset(local);
+        } else if name == REAL_TIME_RECENCY.name {
+            self.real_time_recency.reset(local);
         } else if name == CLIENT_ENCODING.name
             || name == DATE_STYLE.name
             || name == FAILPOINTS.name
@@ -744,6 +762,7 @@ impl SessionVars {
             idle_in_transaction_session_timeout,
             timezone,
             transaction_isolation,
+            real_time_recency,
         } = self;
         application_name.end_transaction(action);
         client_min_messages.end_transaction(action);
@@ -758,6 +777,7 @@ impl SessionVars {
         idle_in_transaction_session_timeout.end_transaction(action);
         timezone.end_transaction(action);
         transaction_isolation.end_transaction(action);
+        real_time_recency.end_transaction(action);
     }
 
     /// Returns the value of the `application_name` configuration parameter.
@@ -864,6 +884,11 @@ impl SessionVars {
     /// parameter.
     pub fn transaction_isolation(&self) -> &IsolationLevel {
         self.transaction_isolation.value()
+    }
+
+    /// Returns the value of `real_time_recency` configuration parameter.
+    pub fn real_time_recency(&self) -> bool {
+        *self.real_time_recency.value()
     }
 }
 

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -438,7 +438,7 @@ impl SessionVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values for this session.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        let vars: [&dyn Var; 21] = [
+        let vars: [&dyn Var; 22] = [
             &self.application_name,
             &self.client_encoding,
             &self.client_min_messages,

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -217,7 +217,8 @@ where
     /// `source_ids` at the time of the function call.
     #[allow(unused)]
     #[allow(clippy::unused_async)]
-    pub async fn recent_timestamp(&self, source_ids: &[GlobalId]) -> T {
+    pub async fn recent_timestamp(&self, source_ids: impl Iterator<Item = GlobalId>) -> T {
+        // Dummy implementation
         T::minimum()
     }
 }


### PR DESCRIPTION
This commit implements an MVP for real time recency on the adapter side, gated behind unsafe mode.

Currently, the Coordinator waits for a recent timestamp in the main coord loop, which can potentially block the Coordinator for an unbounded amount of time. Before unsafe mode is removed, this waiting will have to be removed from the main Coordinator loop.

Works towards resolving #11531

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
