### PR TITLE
ci,test: Fortify the storage-usage mzcompose workflow

### DIFF
--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -87,10 +87,10 @@ database_objects = [
         testdrive=dedent(
             """
             > CREATE TABLE obj (f1 TEXT)
-            > INSERT INTO obj SELECT REPEAT('x', 1024) FROM generate_series(1, 1024)
+            > INSERT INTO obj SELECT REPEAT('x', 1024 * 1024) FROM generate_series(1, 1024)
             """
         ),
-        expected_size=4 * 1024,
+        expected_size=1024 * 1024,
     ),
     # Deleted/updated rows should be garbage-collected
     # https://github.com/MaterializeInc/materialize/issues/15093
@@ -224,6 +224,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ):
             continue
 
+        print(f"Running scenario {database_object.name} ...")
+
         c.testdrive(
             dedent(
                 """
@@ -232,8 +234,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 """
             )
         )
-
-        print(database_object.testdrive)
 
         c.testdrive(database_object.testdrive)
 


### PR DESCRIPTION
The reported storage usage for very small sources varies too much and causes the test to fail. Use a larger source while preserving the semantics of the test.
### Motivation

  * This PR fixes a previously unreported bug.
CI was failing.