### PR TITLE
Replace `as` conversions with safe ones

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -589,9 +589,9 @@ where
         replica_id: ReplicaId,
         config: ComputeReplicaConfig,
     ) -> Result<(), ReplicaCreationError> {
-        let (enable_logging, interval_ns) = match config.logging.interval {
-            Some(interval) => (true, interval.as_nanos()),
-            None => (false, 1_000_000_000),
+        let (enable_logging, interval) = match config.logging.interval {
+            Some(interval) => (true, interval),
+            None => (false, Duration::from_secs(1)),
         };
 
         let mut sink_logs = BTreeMap::new();
@@ -606,7 +606,7 @@ where
         }
 
         let logging_config = LoggingConfig {
-            interval_ns,
+            interval,
             enable_logging,
             log_logging: config.logging.log_logging,
             index_logs: Default::default(),

--- a/src/compute-client/src/logging.proto
+++ b/src/compute-client/src/logging.proto
@@ -69,7 +69,7 @@ message ProtoLogVariant {
 }
 
 message ProtoLoggingConfig {
-    mz_proto.ProtoU128 interval_ns = 1;
+    mz_proto.ProtoDuration interval = 1;
     bool enable_logging = 2;
     bool log_logging = 3;
     repeated ProtoIndexLog index_logs = 4;

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -10,6 +10,7 @@
 //! Compute layer logging configuration.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
@@ -32,8 +33,8 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.logging.rs"));
 /// TODO(teskje): Clean this up once we remove the arranged introspection sources.
 #[derive(Arbitrary, Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggingConfig {
-    /// The logging interval in nanoseconds
-    pub interval_ns: u128,
+    /// The logging interval
+    pub interval: Duration,
     /// Whether logging is enabled
     pub enable_logging: bool,
     /// Whether we should report logs for the log-processing dataflows
@@ -56,7 +57,7 @@ impl LoggingConfig {
 impl RustType<ProtoLoggingConfig> for LoggingConfig {
     fn into_proto(&self) -> ProtoLoggingConfig {
         ProtoLoggingConfig {
-            interval_ns: Some(self.interval_ns.into_proto()),
+            interval: Some(self.interval.into_proto()),
             enable_logging: self.enable_logging,
             log_logging: self.log_logging,
             index_logs: self.index_logs.into_proto(),
@@ -66,9 +67,9 @@ impl RustType<ProtoLoggingConfig> for LoggingConfig {
 
     fn from_proto(proto: ProtoLoggingConfig) -> Result<Self, TryFromProtoError> {
         Ok(LoggingConfig {
-            interval_ns: proto
-                .interval_ns
-                .into_rust_if_some("ProtoLoggingConfig::interval_ns")?,
+            interval: proto
+                .interval
+                .into_rust_if_some("ProtoLoggingConfig::interval")?,
             enable_logging: proto.enable_logging,
             log_logging: proto.log_logging,
             index_logs: proto.index_logs.into_rust()?,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -307,7 +307,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         use crate::logging::BatchLogger;
         use timely::dataflow::operators::capture::event::link::EventLink;
 
-        let interval = std::cmp::max(1, logging.interval_ns / 1_000_000)
+        let interval = std::cmp::max(1, logging.interval.as_millis())
             .try_into()
             .expect("must fit");
 

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -52,17 +52,11 @@ pub fn construct<A: Allocate>(
     linked: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, DifferentialEvent)>>,
     activator: RcActivator,
 ) -> HashMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
-    let interval_ms = std::cmp::max(1, config.interval_ns / 1_000_000);
+    let interval_ms = std::cmp::max(1, config.interval.as_millis());
 
     let traces = worker.dataflow_named("Dataflow: differential logging", move |scope| {
-        // TODO(benesch): avoid dangerous `as` conversion.
-        #[allow(clippy::as_conversions)]
-        let (mut logs, token) = Some(linked).mz_replay(
-            scope,
-            "differential logs",
-            Duration::from_nanos(config.interval_ns as u64),
-            activator,
-        );
+        let (mut logs, token) =
+            Some(linked).mz_replay(scope, "differential logs", config.interval, activator);
 
         // If logging is disabled, we still need to install the indexes, but we can leave them
         // empty. We do so by immediately filtering all logs events.

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -269,7 +269,7 @@ where
         // Drop the encoded representation as soon as we can to reclaim memory.
         drop(value);
         read_metrics.part_goodbytes.inc_by(u64::cast_from(
-            part.updates.iter().map(|x| x.goodbytes()).sum(),
+            part.updates.iter().map(|x| x.goodbytes()).sum::<usize>(),
         ));
 
         EncodedPart::new(key, registered_desc.clone(), part)

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1483,7 +1483,7 @@ impl Consensus for MetricsConsensus {
                     .consensus
                     .cas_mismatch_versions_count
                     .inc_by(u64::cast_from(xs.len()));
-                let total_size = u64::cast_from(xs.iter().map(|x| x.data.len()).sum());
+                let total_size = u64::cast_from(xs.iter().map(|x| x.data.len()).sum::<usize>());
                 self.metrics
                     .consensus
                     .cas_mismatch_versions_bytes
@@ -1507,7 +1507,7 @@ impl Consensus for MetricsConsensus {
             .run_op(|| self.consensus.scan(key, from, limit), Self::on_err)
             .await;
         if let Ok(dataz) = res.as_ref() {
-            let bytes = dataz.iter().map(|x| x.data.len()).sum();
+            let bytes: usize = dataz.iter().map(|x| x.data.len()).sum();
             self.metrics
                 .consensus
                 .scan

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -315,7 +315,7 @@ impl<'a> CopyTextFormatParser<'a> {
         }
     }
 
-    pub fn iter_raw(self, num_columns: i32) -> RawIterator<'a> {
+    pub fn iter_raw(self, num_columns: usize) -> RawIterator<'a> {
         RawIterator {
             parser: self,
             current_column: 0,
@@ -326,8 +326,8 @@ impl<'a> CopyTextFormatParser<'a> {
 
 pub struct RawIterator<'a> {
     parser: CopyTextFormatParser<'a>,
-    current_column: i32,
-    num_columns: i32,
+    current_column: usize,
+    num_columns: usize,
 }
 
 impl<'a> RawIterator<'a> {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -498,18 +498,16 @@ fn read_value<'a, T>(type_: &PgType, buf: &mut &'a [u8]) -> Result<T, Box<dyn Er
 where
     T: FromSql<'a>,
 {
-    let len = read_be_i32(buf)?;
-    // TODO(benesch): rewrite to avoid `as`.
-    #[allow(clippy::as_conversions)]
-    let value = if len < 0 {
-        None
-    } else {
-        if len as usize > buf.len() {
-            return Err("invalid buffer size".into());
+    let value = match usize::try_from(read_be_i32(buf)?) {
+        Err(_) => None,
+        Ok(len) => {
+            if len > buf.len() {
+                return Err("invalid buffer size".into());
+            }
+            let (head, tail) = buf.split_at(len);
+            *buf = tail;
+            Some(head)
         }
-        let (head, tail) = buf.split_at(len as usize);
-        *buf = tail;
-        Some(head)
     };
     T::from_sql_nullable(type_, value)
 }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -29,6 +29,7 @@ use timely::PartialOrder;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
+use mz_ore::cast::CastFrom;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
@@ -335,7 +336,7 @@ impl Arbitrary for StorageResponse<mz_repr::Timestamp> {
 #[derive(Debug)]
 pub struct PartitionedStorageState<T> {
     /// Number of partitions the state machine represents.
-    parts: usize,
+    parts: u32,
     /// Upper frontiers for sources and sinks, both unioned across all partitions and from each
     /// individual partition.
     uppers: HashMap<GlobalId, (MutableAntichain<T>, Vec<Option<Antichain<T>>>)>,
@@ -350,7 +351,7 @@ where
 
     fn new(parts: usize) -> PartitionedStorageState<T> {
         PartitionedStorageState {
-            parts,
+            parts: parts.try_into().expect("more than 4 billion partitions"),
             uppers: HashMap::new(),
         }
     }
@@ -366,11 +367,11 @@ where
                 for ingestion in ingestions {
                     for &export_id in ingestion.description.source_exports.keys() {
                         let mut frontier = MutableAntichain::new();
-                        // TODO(benesch): fix this dangerous use of `as`.
-                        #[allow(clippy::as_conversions)]
-                        frontier.update_iter(iter::once((T::minimum(), self.parts as i64)));
-                        let part_frontiers =
-                            vec![Some(Antichain::from_elem(T::minimum())); self.parts];
+                        frontier.update_iter(iter::once((T::minimum(), i64::from(self.parts))));
+                        let part_frontiers = vec![
+                            Some(Antichain::from_elem(T::minimum()));
+                            usize::cast_from(self.parts)
+                        ];
                         let previous = self.uppers.insert(export_id, (frontier, part_frontiers));
                         assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", export_id, command);
                     }
@@ -379,10 +380,11 @@ where
             StorageCommand::CreateSinks(exports) => {
                 for export in exports {
                     let mut frontier = MutableAntichain::new();
-                    // TODO(benesch): fix this dangerous use of `as`.
-                    #[allow(clippy::as_conversions)]
-                    frontier.update_iter(iter::once((T::minimum(), self.parts as i64)));
-                    let part_frontiers = vec![Some(Antichain::from_elem(T::minimum())); self.parts];
+                    frontier.update_iter(iter::once((T::minimum(), i64::from(self.parts))));
+                    let part_frontiers = vec![
+                        Some(Antichain::from_elem(T::minimum()));
+                        usize::cast_from(self.parts)
+                    ];
                     let previous = self.uppers.insert(export.id, (frontier, part_frontiers));
                     assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", export.id, command);
                 }
@@ -401,7 +403,7 @@ where
     fn split_command(&mut self, command: StorageCommand<T>) -> Vec<Option<StorageCommand<T>>> {
         self.observe_command(&command);
 
-        vec![Some(command); self.parts]
+        vec![Some(command); usize::cast_from(self.parts)]
     }
 
     fn absorb_response(

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -682,14 +682,8 @@ fn to_metadata_row(
                     IncludedColumnSource::Timestamp => {
                         let ts =
                             upstream_time_millis.expect("kafka sources always have upstream_time");
-                        // TODO(benesch): rewrite to avoid `as`.
-                        #[allow(clippy::as_conversions)]
-                        let (secs, mut millis) = (ts / 1000, (ts.abs() % 1000) as u32);
-                        if secs < 0 {
-                            millis = 1000 - millis;
-                        }
 
-                        let d: Datum = NaiveDateTime::from_timestamp_opt(secs, millis * 1_000_000)
+                        let d: Datum = NaiveDateTime::from_timestamp_millis(ts)
                             .and_then(|dt| {
                                 let ct: Option<CheckedTimestamp<NaiveDateTime>> =
                                     dt.try_into().ok();

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -152,14 +152,7 @@ where
                 (Some(key), row)
             })
         } else {
-            // TODO(benesch): rewrite to avoid `as`.
-            #[allow(clippy::as_conversions)]
-            collection.map(|row| {
-                (
-                    Some(Row::pack(Some(Datum::Int64(row.hashed() as i64)))),
-                    row,
-                )
-            })
+            collection.map(|row| (Some(Row::pack(Some(Datum::UInt64(row.hashed())))), row))
         };
         keyed
     } else {

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1117,21 +1117,15 @@ where
                             continue;
                         }
 
-                        assert!(diff >= 0, "can't sink negative multiplicities");
                         if diff == 0 {
                             // Explicitly refuse to send no-op records
                             continue;
                         };
-                        // TODO(benesch): rewrite to avoid `as`.
-                        #[allow(clippy::as_conversions)]
-                        let diff = diff as usize;
+                        let count =
+                            usize::try_from(diff).expect("can't sink negative multiplicities");
 
                         let rows = s.pending_rows.entry(time).or_default();
-                        rows.push(EncodedRow {
-                            key,
-                            value,
-                            count: diff,
-                        });
+                        rows.push(EncodedRow { key, value, count });
                         s.metrics.rows_queued.inc();
                     }
                 }

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -664,9 +664,13 @@ mod tests {
         persist_clients: &Arc<Mutex<PersistClientCache>>,
     ) -> Healthchecker {
         let start = tokio::time::Instant::now();
-        // TODO(benesch): rewrite to avoid dangerous use of `as`.
-        #[allow(clippy::as_conversions)]
-        let now_fn = NowFn::from(move || start.elapsed().as_millis() as u64);
+        let now_fn = NowFn::from(move || {
+            start
+                .elapsed()
+                .as_millis()
+                .try_into()
+                .expect("materialize exists after 500M AD")
+        });
 
         let storage_metadata = CollectionMetadata {
             persist_location: (*PERSIST_LOCATION).clone(),

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -718,9 +718,7 @@ impl PostgresTaskInfo {
                 // and list of string-encoded values, e.g. Row{ 16391 , ["1", "2"] }
                 let parser = mz_pgcopy::CopyTextFormatParser::new(b.as_ref(), "\t", "\\N");
 
-                // TODO(benesch): rewrite to avoid `as`.
-                #[allow(clippy::as_conversions)]
-                let mut raw_values = parser.iter_raw(info.desc.columns.len() as i32);
+                let mut raw_values = parser.iter_raw(info.desc.columns.len());
                 while let Some(raw_value) = raw_values.next() {
                     match try_definite!(raw_value) {
                         Some(value) => {

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -474,14 +474,12 @@ impl SourceMetrics {
 
             metric.messages_ingested.inc_by(count);
 
-            // TODO(benesch): rewrite to avoid `as`.
-            #[allow(clippy::as_conversions)]
             metric.record_offset(
                 &self.source_name,
                 self.source_id,
                 &partition,
                 offset.offset,
-                u64::from(timestamp) as i64,
+                i64::try_from(timestamp).expect("materialize exists after 250M AD"),
             );
         }
     }

--- a/src/transform/src/cse/relation_cse.rs
+++ b/src/transform/src/cse/relation_cse.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 use mz_expr::visit::VisitChildren;
 use mz_expr::{Id, LocalId, MirRelationExpr, RECURSION_LIMIT};
+use mz_ore::cast::CastFrom;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
 use crate::normalize_lets::NormalizeLets;
@@ -155,9 +156,7 @@ impl Bindings {
                 // Do nothing, as the expression is already a local `Get` expression.
             } else {
                 // Either find an instance of `relation` or insert this one.
-                // TODO(benesch): fix this dangerous use of `as`.
-                #[allow(clippy::as_conversions)]
-                let bindings_len = this.bindings.len() as u64;
+                let bindings_len = u64::cast_from(this.bindings.len());
                 let id = this
                     .bindings
                     .entry(relation.take_dangerous())


### PR DESCRIPTION
### Motivation

Motivation here https://github.com/MaterializeInc/materialize/pull/16559

This PR removes all `as` conversions from storage crates (not including persist) and some from compute.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
