### PR TITLE
[sources] Thread a should_halt flag through the source pipeline

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -339,7 +339,7 @@ impl SourceReader for KafkaSourceReader {
                         "kafka error when polling consumer for source: {} topic: {} : {}",
                         self.source_name, self.topic_name, e
                     );
-                    next_message = NextMessage::Ready(SourceMessageType::SourceStatus(
+                    next_message = NextMessage::Ready(SourceMessageType::status(
                         HealthStatus::StalledWithError(message),
                     ))
                 }
@@ -370,7 +370,7 @@ impl SourceReader for KafkaSourceReader {
                     next_message = self.handle_message(Ok(message), ts);
                 }
                 Err(error) => {
-                    next_message = NextMessage::Ready(SourceMessageType::SourceStatus(
+                    next_message = NextMessage::Ready(SourceMessageType::status(
                         HealthStatus::StalledWithError(error),
                     ))
                 }
@@ -390,7 +390,7 @@ impl SourceReader for KafkaSourceReader {
             // are more messages in the queue; in that case, we'll rely on the client reporting that
             // error again in the future if the error condition persists.
             if let NextMessage::Pending = next_message {
-                next_message = NextMessage::Ready(SourceMessageType::SourceStatus(status))
+                next_message = NextMessage::Ready(SourceMessageType::status(status))
             }
         }
 

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -167,6 +167,12 @@ pub enum NextMessage<Key, Value, Diff> {
     Finished,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HealthStatusUpdate {
+    pub update: HealthStatus,
+    pub should_halt: bool,
+}
+
 /// A wrapper around [`SourceMessage`] that allows [`SourceReader`]'s to
 /// communicate additional "maintenance" messages.
 #[derive(Debug)]
@@ -186,7 +192,7 @@ pub enum SourceMessageType<Key, Value, Diff> {
         Diff,
     ),
     /// Information about the source status
-    SourceStatus(HealthStatus),
+    SourceStatus(HealthStatusUpdate),
     /// Signals that this [`SourceReader`] instance will never emit
     /// messages/updates for a given partition anymore. This is similar enough
     /// to a timely operator dropping a capability, hence the naming.
@@ -194,6 +200,15 @@ pub enum SourceMessageType<Key, Value, Diff> {
     /// We need these to compute a "global" source upper, when determining
     /// completeness of a timestamp.
     DropPartitionCapabilities(Vec<PartitionId>),
+}
+
+impl<Key, Value, Diff> SourceMessageType<Key, Value, Diff> {
+    pub fn status(update: HealthStatus) -> Self {
+        SourceMessageType::SourceStatus(HealthStatusUpdate {
+            update,
+            should_halt: false,
+        })
+    }
 }
 
 /// Source-agnostic wrapper for messages. Each source must implement a


### PR DESCRIPTION
This shifts the halt-on-snapshot error from the postgres source to the healthcheck operator, allowing us to ensure a stall is reported before shutdown.

This is objectively pretty sketchy, but it is:
- More reliable than sleeping in the source and hoping for the best.
- Much easier than inventing a graceful shutdown protocol for the source, which is an ongoing discussion point.

### Motivation

Known issue: https://github.com/MaterializeInc/materialize/issues/16581

### Tips for reviewer

I've also updated the tests to not avoid running during the snapshot, but of course it's a bit hard to ensure that they _do_ run during the snapshot. The tests hould at least verify that we're not breaking anything else in the source pipeline with this refactor.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
