### PR TITLE
ci: re-enable cargo test in CI

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -115,6 +115,8 @@ steps:
     label: Cargo test
     timeout_in_minutes: 30
     artifact_paths: target/nextest/ci/junit_cargo-test.xml
+    inputs:
+      - "*"
     env:
       AWS_DEFAULT_REGION: "us-east-2"
     plugins:


### PR DESCRIPTION
### Motivation

After changing to nexttext in 0275079d429fa669bb497b78405840eb59ac910a the CI no longer ran the `cargo test` job because it was using the default `glob` to detect if it should run it, which never matched any files.

The pipeline previously defined the `cargo test` step as a dependency of the `build-x86` step, which had a correct input definition and therefore was always triggered when the other job triggered.

This PR sets the `inputs` of the `cargo test` job to be the same as the build job so that the previous behaviour is maintained (tests run when the build runs.
