### PR TITLE
feature-benchmark: Use a fully-formed environment_id

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -11,6 +11,7 @@ import argparse
 import os
 import sys
 import time
+import uuid
 from textwrap import dedent
 from typing import List, Type
 
@@ -117,7 +118,7 @@ def run_one_scenario(
             image=f"materialize/materialized:{tag}" if tag else None,
             default_size=size,
             # Avoid clashes with the Kafka sink progress topic across restarts
-            environment_id=str(time.time()),
+            environment_id=f"local-az1-{uuid.uuid4()}-0",
         )
 
         with c.override(mz):


### PR DESCRIPTION
The feature benchmark uses a unique environment ID for each run in order to avoid clashes in the Kafka progress topic.

Mz now enforces a specific format for the environment ID, so the feature benchmark must comply.

### Motivation


  * This PR fixes a previously unreported bug.
Nightly CI was failing.