### PR TITLE
Revert "Merge pull request #16288 from teskje/simplify-peek-tracking"

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -10,7 +10,6 @@
 import re
 import time
 from textwrap import dedent
-from threading import Thread
 from typing import Tuple
 
 from pg8000.dbapi import ProgrammingError
@@ -70,7 +69,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-builtin-migration",
         "pg-snapshot-resumption",
         "test-system-table-indexes",
-        "test-replica-targeted-select-drop",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -853,46 +851,3 @@ def workflow_test_system_table_indexes(c: Composition) -> None:
     """
             )
         )
-
-
-def workflow_test_replica_targeted_select_drop(c: Composition) -> None:
-    """
-    Test that a replica-targeted SELECT is aborted then the target
-    replica is dropped.
-    """
-
-    c.down(destroy_volumes=True)
-    c.up("materialized")
-    c.up("computed_1")
-    c.wait_for_materialized()
-
-    c.sql(
-        """
-        DROP CLUSTER IF EXISTS cluster1 CASCADE;
-        CREATE CLUSTER cluster1 REPLICAS (
-            replica1 (REMOTE ['computed_1:2100'], COMPUTE ['computed_1:2102'], WORKERS 2)
-        );
-        """
-    )
-
-    def drop_replica_with_delay() -> None:
-        time.sleep(2)
-        c.sql("DROP CLUSTER REPLICA cluster1.replica1")
-
-    dropper = Thread(target=drop_replica_with_delay)
-    dropper.start()
-
-    try:
-        c.sql(
-            """
-            SET cluster = cluster1;
-            SET cluster_replica = replica1;
-            SELECT * FROM mz_views AS OF 18446744073709551615
-            """
-        )
-    except ProgrammingError as e:
-        assert "target replica was dropped" in e.args[0]["M"], e
-    else:
-        assert False, "SELECT was unexpectedly successful"
-
-    dropper.join()


### PR DESCRIPTION
This PR reverts https://github.com/MaterializeInc/materialize/pull/16288.

We do this to stop the crash reported in #16615 from happening. The verdict is still out on whether the peek tracking simplification itself is invalid or whether it just unearthed a different bug we have in frontier tracking.

### Motivation

  * This PR fixes a recognized bug.

Stops the crash reported in #16615.

### Tips for reviewer

My plan is to merge this now for the release, and then keep debugging the crash in #16615. Once that is understood, we will see if there is a bug in peek tracking that we should fix, and then revert this revert.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
