### PR TITLE
plan: Update stale comment for plan_view_select

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1576,7 +1576,7 @@ struct SelectPlan {
 
 generate_extracted_config!(SelectOption, (ExpectedGroupSize, u64));
 
-/// Plans a SELECT query with an intrusive ORDER BY clause.
+/// Plans a SELECT query. The SELECT query may contain an intrusive ORDER BY clause.
 ///
 /// Normally, the ORDER BY clause occurs after the columns specified in the
 /// SELECT list have been projected. In a query like
@@ -1593,9 +1593,6 @@ generate_extracted_config!(SelectOption, (ExpectedGroupSize, u64));
 ///
 /// where expressions in the ORDER BY clause can refer to *both* input columns
 /// and output columns.
-///
-/// This function handles queries of the latter class. For queries of the
-/// former class, see `plan_view_select`.
 fn plan_view_select(
     qcx: &QueryContext,
     mut s: Select<Aug>,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1576,7 +1576,7 @@ struct SelectPlan {
 
 generate_extracted_config!(SelectOption, (ExpectedGroupSize, u64));
 
-/// Plans a SELECT query. The SELECT query may contain an intrusive ORDER BY clause.
+/// Plans a SELECT query. The SELECT query may contain a intrusive ORDER BY clause.
 ///
 /// Normally, the ORDER BY clause occurs after the columns specified in the
 /// SELECT list have been projected. In a query like

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1576,7 +1576,7 @@ struct SelectPlan {
 
 generate_extracted_config!(SelectOption, (ExpectedGroupSize, u64));
 
-/// Plans a SELECT query. The SELECT query may contain a intrusive ORDER BY clause.
+/// Plans a SELECT query. The SELECT query may contain an intrusive ORDER BY clause.
 ///
 /// Normally, the ORDER BY clause occurs after the columns specified in the
 /// SELECT list have been projected. In a query like

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2223,7 +2223,7 @@ fn plan_table_factor(
             Ok((expr, scope))
         }
 
-        TableFactor::Fsssssssssunction {
+        TableFactor::Function {
             function,
             alias,
             with_ordinality,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2223,7 +2223,7 @@ fn plan_table_factor(
             Ok((expr, scope))
         }
 
-        TableFactor::Function {
+        TableFactor::Fsssssssssunction {
             function,
             alias,
             with_ordinality,


### PR DESCRIPTION
In a previous iteration of Materialize there were two separate functions, `plan_view_select` and `plan_view_select_intrusive`. At some point these functions were merged into a single `plan_view_select`. However, the function comment was never updated to reflect this.

### Motivation
 This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
