### PR TITLE
adapter: add session var to emit timestamp notices

### DIFF
--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -58,6 +58,9 @@ pub enum AdapterNotice {
     DroppedActiveCluster {
         name: String,
     },
+    QueryTimestamp {
+        timestamp: mz_repr::Timestamp,
+    },
 }
 
 impl AdapterNotice {
@@ -132,6 +135,9 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::DroppedActiveCluster { name } => {
                 write!(f, "active cluster {} has been dropped", name.quoted())
+            }
+            AdapterNotice::QueryTimestamp { timestamp } => {
+                write!(f, "query timestamp: {}", timestamp)
             }
         }
     }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -433,6 +433,7 @@ impl ErrorResponse {
             AdapterNotice::ClusterReplicaStatusChanged { .. } => SqlState::WARNING,
             AdapterNotice::DroppedActiveDatabase { .. } => SqlState::WARNING,
             AdapterNotice::DroppedActiveCluster { .. } => SqlState::WARNING,
+            AdapterNotice::QueryTimestamp { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -584,6 +585,7 @@ impl Severity {
             AdapterNotice::ClusterReplicaStatusChanged { .. } => Severity::Notice,
             AdapterNotice::DroppedActiveDatabase { .. } => Severity::Notice,
             AdapterNotice::DroppedActiveCluster { .. } => Severity::Notice,
+            AdapterNotice::QueryTimestamp { .. } => Severity::Notice,
         }
     }
 }

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -18,6 +18,7 @@ cluster                                 <CLUSTER_NAME>         "Sets the current
 cluster_replica                         ""                     "Sets a target cluster replica for SELECT queries (Materialize)."
 database                                materialize            "Sets the current database (CockroachDB)."
 DateStyle                               "ISO, MDY"             "Sets the display format for date and time values (PostgreSQL)."
+emit_timestamp_notice               off                 "Boolean flag indicating whether to send a NOTICE specifying query timestamps (Materialize)."
 extra_float_digits                      3                      "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                              ""                     "Allows failpoints to be dynamically activated."
 idle_in_transaction_session_timeout     "2 min"                "Sets the maximum allowed duration that a session can sit idle in a transaction before being terminated. A value of zero disables the timeout (PostgreSQL)."


### PR DESCRIPTION
Internal feature request to enable repeatedly running the same query to verify the timestamp is increasing.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a