### PR TITLE
Set up metrics stream on replica creation

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -38,7 +38,7 @@ use crate::types::sources::SourceInstanceDesc;
 
 use super::error::CollectionMissing;
 use super::orchestrator::ComputeOrchestrator;
-use super::replica::Replica;
+use super::replica::{Replica, ReplicaResponse};
 use super::{
     CollectionState, ComputeControllerResponse, ComputeInstanceId, ComputeReplicaLocation,
     ReplicaId,
@@ -241,7 +241,7 @@ where
     /// rehydration.
     ///
     /// This method is cancellation safe.
-    pub async fn recv(&mut self) -> Result<(ReplicaId, ComputeResponse<T>), ReplicaId> {
+    pub async fn recv(&mut self) -> Result<(ReplicaId, ReplicaResponse<T>), ReplicaId> {
         // Receive responses from any of the replicas, and take appropriate
         // action.
         let response = self


### PR DESCRIPTION
In the previous code, `ensure_service` might not have been called by the time we start polling the metrics stream, which causes the orchestrator to get confused. 

This PR changes the logic to not poll the metrics stream until we have installed the service with the orchestrator.

@aalexandrov added as randomly-selected compute team reviewer

### Motivation

  * This PR fixes a recognized bug.

   Fixes https://github.com/MaterializeInc/materialize/issues/16378



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None