### PR TITLE
[persist] Always perform routine maintenance

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -248,9 +248,12 @@ pub async fn force_compaction(
                     .sum::<usize>(),
                 start.elapsed(),
             );
-            let apply_res = machine
+            let (apply_res, maintenance) = machine
                 .merge_res(&FueledMergeRes { output: res.output })
                 .await;
+            if !maintenance.is_empty() {
+                info!("ignoring non-empty requested maintenance: {maintenance:?}")
+            }
             match apply_res {
                 ApplyMergeResult::AppliedExact | ApplyMergeResult::AppliedSubset => {
                     info!("attempt {} req {}: {:?}", attempt, idx, apply_res);

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -297,7 +297,8 @@ where
     /// Politely expires this reader, releasing its since capability.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn expire(mut self) {
-        self.machine.expire_critical_reader(&self.reader_id).await;
+        let (_, maintenance) = self.machine.expire_critical_reader(&self.reader_id).await;
+        maintenance.start_performing(&self.machine, &self.gc);
     }
 }
 

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -40,6 +40,7 @@ use tracing::{debug, debug_span, trace, Instrument, Span};
 use crate::async_runtime::CpuHeavyRuntime;
 use crate::batch::BatchParts;
 use crate::fetch::{fetch_batch_part, EncodedPart};
+use crate::internal::gc::GarbageCollector;
 use crate::internal::machine::{retry_external, Machine};
 use crate::internal::state::{HollowBatch, HollowBatchPart};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
@@ -102,13 +103,14 @@ where
     K: Debug + Codec,
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64 + Send,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     pub fn new(
         cfg: PersistConfig,
         metrics: Arc<Metrics>,
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
         writer_id: WriterId,
+        gc: GarbageCollector<K, V, T, D>,
     ) -> Self {
         let (compact_req_sender, mut compact_req_receiver) = mpsc::channel::<(
             Instant,
@@ -163,6 +165,7 @@ where
                 let compact_span =
                     debug_span!(parent: None, "compact::apply", shard_id=%machine.shard_id());
                 compact_span.follows_from(&Span::current());
+                let gc = gc.clone();
                 let _ = mz_ore::task::spawn(|| "PersistCompactionWorker", async move {
                     let res = Self::compact_and_apply(
                         cfg,
@@ -172,6 +175,7 @@ where
                         req,
                         writer_id,
                         &mut machine,
+                        &gc,
                     )
                     .instrument(compact_span)
                     .await;
@@ -249,6 +253,7 @@ where
         req: CompactReq<T>,
         writer_id: WriterId,
         machine: &mut Machine<K, V, T, D>,
+        gc: &GarbageCollector<K, V, T, D>,
     ) -> Result<ApplyMergeResult, anyhow::Error> {
         metrics.compaction.started.inc();
         let start = Instant::now();
@@ -312,7 +317,8 @@ where
         match res {
             Ok(Ok(res)) => {
                 let res = FueledMergeRes { output: res.output };
-                let apply_merge_result = machine.merge_res(&res).await;
+                let (apply_merge_result, maintenance) = machine.merge_res(&res).await;
+                maintenance.start_performing(machine, gc);
                 match &apply_merge_result {
                     ApplyMergeResult::AppliedExact => {
                         metrics.compaction.applied.inc();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -73,7 +73,7 @@ pub struct CompactRes<T> {
 /// This will possibly be called over RPC in the future. Physical compaction is
 /// merging adjacent batches. Logical compaction is advancing timestamps to a
 /// new since and consolidating the resulting updates.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Compactor<K, V, T, D> {
     cfg: PersistConfig,
     metrics: Arc<Metrics>,
@@ -84,6 +84,17 @@ pub struct Compactor<K, V, T, D> {
         oneshot::Sender<Result<ApplyMergeResult, anyhow::Error>>,
     )>,
     _phantom: PhantomData<fn() -> D>,
+}
+
+impl<K, V, T, D> Clone for Compactor<K, V, T, D> {
+    fn clone(&self) -> Self {
+        Compactor {
+            cfg: self.cfg.clone(),
+            metrics: Arc::clone(&self.metrics),
+            sender: self.sender.clone(),
+            _phantom: Default::default(),
+        }
+    }
 }
 
 impl<K, V, T, D> Compactor<K, V, T, D>

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -28,8 +28,7 @@ use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::paths::{PartialRollupKey, RollupId};
 use crate::ShardId;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GcReq {
     pub shard_id: ShardId,
     pub new_seqno_since: SeqNo,

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -304,7 +304,7 @@ where
             .state_versions
             .write_rollup_blob(&machine.shard_metrics, &state, &rollup_key)
             .await;
-        let applied = machine
+        let (applied, _maintenance) = machine
             .add_and_remove_rollups((rollup_seqno, &rollup_key), &deleteable_rollup_blobs)
             .await;
         // We raced with some other GC process to write this rollup out. Ours

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -10,6 +10,7 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::mem;
 use std::time::Instant;
 
 use differential_dataflow::difference::Semigroup;
@@ -23,6 +24,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, debug_span, warn, Instrument, Span};
 
 use crate::internal::machine::{retry_external, Machine};
+use crate::internal::maintenance::RoutineMaintenance;
 use crate::internal::paths::{PartialRollupKey, RollupId};
 use crate::ShardId;
 
@@ -35,7 +37,7 @@ pub struct GcReq {
 
 #[derive(Debug)]
 pub struct GarbageCollector<K, V, T, D> {
-    sender: UnboundedSender<(GcReq, oneshot::Sender<()>)>,
+    sender: UnboundedSender<(GcReq, oneshot::Sender<RoutineMaintenance>)>,
     _phantom: PhantomData<fn() -> (K, V, T, D)>,
 }
 
@@ -105,7 +107,7 @@ where
 {
     pub fn new(mut machine: Machine<K, V, T, D>) -> Self {
         let (gc_req_sender, mut gc_req_recv) =
-            mpsc::unbounded_channel::<(GcReq, oneshot::Sender<()>)>();
+            mpsc::unbounded_channel::<(GcReq, oneshot::Sender<RoutineMaintenance>)>();
 
         // spin off a single task responsible for executing GC requests.
         // work is enqueued into the task through a channel
@@ -141,7 +143,7 @@ where
 
                 let start = Instant::now();
                 machine.metrics.gc.started.inc();
-                Self::gc_and_truncate(&mut machine, consolidated_req)
+                let mut maintenance = Self::gc_and_truncate(&mut machine, consolidated_req)
                     .instrument(gc_span)
                     .await;
                 machine.metrics.gc.finished.inc();
@@ -155,8 +157,9 @@ where
                 // inform all callers who enqueued GC reqs that their work is complete
                 for sender in gc_completed_senders {
                     // we can safely ignore errors here, it's possible the caller
-                    // wasn't interested in waiting and dropped their receiver
-                    let _ = sender.send(());
+                    // wasn't interested in waiting and dropped their receiver.
+                    // maintenance will be somewhat-arbitrarily assigned to the first oneshot.
+                    let _ = sender.send(mem::take(&mut maintenance));
                 }
             }
         });
@@ -170,7 +173,10 @@ where
     /// Enqueues a [GcReq] to be consumed by the GC background task when available.
     ///
     /// Returns a future that indicates when GC has cleaned up to at least [GcReq::new_seqno_since]
-    pub fn gc_and_truncate_background(&self, req: GcReq) -> Option<oneshot::Receiver<()>> {
+    pub fn gc_and_truncate_background(
+        &self,
+        req: GcReq,
+    ) -> Option<oneshot::Receiver<RoutineMaintenance>> {
         let (gc_completed_sender, gc_completed_receiver) = oneshot::channel();
         let new_gc_sender = self.sender.clone();
         let send = new_gc_sender.send((req, gc_completed_sender));
@@ -188,7 +194,10 @@ where
         Some(gc_completed_receiver)
     }
 
-    pub async fn gc_and_truncate(machine: &mut Machine<K, V, T, D>, req: GcReq) {
+    pub async fn gc_and_truncate(
+        machine: &mut Machine<K, V, T, D>,
+        req: GcReq,
+    ) -> RoutineMaintenance {
         assert_eq!(req.shard_id, machine.shard_id());
         // NB: Because these requests can be processed concurrently (and in
         // arbitrary order), all of the logic below has to work even if we've
@@ -224,7 +233,7 @@ where
                 "gc {} early returning, already GC'd past {}",
                 req.shard_id, req.new_seqno_since,
             );
-            return;
+            return RoutineMaintenance::default();
         }
 
         let mut deleteable_batch_blobs = HashSet::new();
@@ -304,7 +313,7 @@ where
             .state_versions
             .write_rollup_blob(&machine.shard_metrics, &state, &rollup_key)
             .await;
-        let (applied, _maintenance) = machine
+        let (applied, maintenance) = machine
             .add_and_remove_rollups((rollup_seqno, &rollup_key), &deleteable_rollup_blobs)
             .await;
         // We raced with some other GC process to write this rollup out. Ours
@@ -351,5 +360,7 @@ where
             "gc {} truncated diffs through seqno {}",
             req.shard_id, req.new_seqno_since
         );
+
+        maintenance
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1572,7 +1572,8 @@ pub mod datadriven {
             shard_id: datadriven.shard_id,
             new_seqno_since,
         };
-        GarbageCollector::gc_and_truncate(&mut datadriven.machine, req).await;
+        let maintenance = GarbageCollector::gc_and_truncate(&mut datadriven.machine, req).await;
+        datadriven.routine.push(maintenance);
 
         Ok(format!("{} ok\n", datadriven.machine.seqno()))
     }

--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -25,7 +25,7 @@ use std::mem;
 use timely::progress::Timestamp;
 use tracing::info;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct LeaseExpiration {
     pub(crate) readers: Vec<LeasedReaderId>,
     pub(crate) writers: Vec<WriterId>,
@@ -42,7 +42,7 @@ pub struct LeaseExpiration {
 /// Operations that run regularly once a handle is registered, such
 /// as heartbeats, are expected to always perform maintenance.
 #[must_use]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct RoutineMaintenance {
     pub(crate) garbage_collection: Option<GcReq>,
     pub(crate) lease_expiration: LeaseExpiration,
@@ -51,10 +51,7 @@ pub struct RoutineMaintenance {
 
 impl RoutineMaintenance {
     pub(crate) fn is_empty(&self) -> bool {
-        self.garbage_collection.is_none()
-            && self.lease_expiration.readers.is_empty()
-            && self.lease_expiration.writers.is_empty()
-            && self.write_rollup.is_none()
+        self == &RoutineMaintenance::default()
     }
 
     /// Initiates any routine maintenance necessary in background tasks

--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -111,7 +111,7 @@ impl RoutineMaintenance {
             if let Some(recv) = gc.gc_and_truncate_background(gc_req) {
                 // it's safe to ignore errors on the receiver. in the
                 // case of shutdown, the sender may have been dropped
-                futures.push(recv.map(|_| RoutineMaintenance::default()).boxed());
+                futures.push(recv.map(Result::unwrap_or_default).boxed());
             }
         }
 

--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -146,8 +146,8 @@ impl RoutineMaintenance {
                         expired,
                         machine.shard_id()
                     );
-                    let _ = machine.expire_leased_reader(&expired).await;
-                    RoutineMaintenance::default()
+                    let (_, maintenance) = machine.expire_leased_reader(&expired).await;
+                    maintenance
                 })
                 .map(Result::unwrap_or_default)
                 .boxed(),
@@ -162,8 +162,8 @@ impl RoutineMaintenance {
                         expired,
                         machine.shard_id()
                     );
-                    machine.expire_writer(&expired).await;
-                    RoutineMaintenance::default()
+                    let (_, maintenance) = machine.expire_writer(&expired).await;
+                    maintenance
                 })
                 .map(Result::unwrap_or_default)
                 .boxed(),

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -721,6 +721,7 @@ impl PersistClient {
                 Arc::clone(&self.metrics),
                 Arc::clone(&self.cpu_heavy_runtime),
                 writer_id.clone(),
+                gc.clone(),
             )
         });
         let heartbeat_ts = (self.cfg.now)();

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -534,7 +534,7 @@ impl PersistClient {
 
         let reader_id = LeasedReaderId::new();
         let heartbeat_ts = (self.cfg.now)();
-        let reader_state = machine
+        let (reader_state, maintenance) = machine
             .register_leased_reader(
                 &reader_id,
                 purpose,
@@ -542,6 +542,7 @@ impl PersistClient {
                 heartbeat_ts,
             )
             .await;
+        maintenance.start_performing(&machine, &gc);
         let reader = ReadHandle::new(
             self.cfg.clone(),
             Arc::clone(&self.metrics),

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -707,7 +707,7 @@ where
         let new_reader_id = LeasedReaderId::new();
         let mut machine = self.machine.clone();
         let heartbeat_ts = (self.cfg.now)();
-        let reader_state = machine
+        let (reader_state, _maintenance) = machine
             .register_leased_reader(
                 &new_reader_id,
                 purpose,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -478,14 +478,14 @@ where
             cfg,
             metrics,
             machine: machine.clone(),
-            gc,
+            gc: gc.clone(),
             blob,
             reader_id: reader_id.clone(),
             since,
             last_heartbeat,
             explicitly_expired: false,
             leased_seqnos: BTreeMap::new(),
-            heartbeat_task: Some(machine.start_reader_heartbeat_task(reader_id).await),
+            heartbeat_task: Some(machine.start_reader_heartbeat_task(reader_id, gc).await),
         }
     }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -164,7 +164,7 @@ where
             cfg,
             metrics,
             machine: machine.clone(),
-            gc,
+            gc: gc.clone(),
             compact,
             blob,
             cpu_heavy_runtime,
@@ -172,7 +172,7 @@ where
             upper,
             last_heartbeat,
             explicitly_expired: false,
-            heartbeat_task: Some(machine.start_writer_heartbeat_task(writer_id).await),
+            heartbeat_task: Some(machine.start_writer_heartbeat_task(writer_id, gc).await),
         }
     }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -630,7 +630,8 @@ where
     /// happens.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn expire(mut self) {
-        self.machine.expire_writer(&self.writer_id).await;
+        let (_, maintenance) = self.machine.expire_writer(&self.writer_id).await;
+        maintenance.start_performing(&self.machine, &self.gc);
         self.explicitly_expired = true;
     }
 
@@ -732,6 +733,7 @@ where
             }
         };
         let mut machine = self.machine.clone();
+        let gc = self.gc.clone();
         let writer_id = self.writer_id.clone();
         // Spawn a best-effort task to expire this write handle. It's fine if
         // this doesn't run to completion, we'd just have to wait out the lease
@@ -742,7 +744,8 @@ where
         let _ = handle.spawn_named(
             || format!("WriteHandle::expire ({})", self.writer_id),
             async move {
-                machine.expire_writer(&writer_id).await;
+                let (_, maintenance) = machine.expire_writer(&writer_id).await;
+                maintenance.start_performing(&machine, &gc);
             }
             .instrument(expire_span),
         );

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -139,6 +139,8 @@ v21 ok
 v21 ok
 v21 ok
 v21 ok
+v21 ok
+v22 ok
 v22 ok
 v22 ok
 v22 ok

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -133,6 +133,7 @@ error: Since(Antichain { elements: [] })
 # maintenance it needs.
 perform-maintenance
 ----
+v20 ok
 v21 ok
 v21 ok
 v21 ok
@@ -140,6 +141,8 @@ v21 ok
 v21 ok
 v21 ok
 v21 ok
+v21 ok
+v22 ok
 v22 ok
 v22 ok
 v22 ok

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -151,6 +151,7 @@ v22 ok
 v22 ok
 v22 ok
 v22 ok
+v22 ok
 
 # Now compare_and_append to the empty antichain, closing the shard to writes as
 # well. Everything still works (for idempotence), but this replaces the shard

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -149,6 +149,8 @@ v22 ok
 v22 ok
 v22 ok
 v22 ok
+v22 ok
+v22 ok
 
 # Now compare_and_append to the empty antichain, closing the shard to writes as
 # well. Everything still works (for idempotence), but this replaces the shard

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -114,6 +114,7 @@ v15 ok
 v15 ok
 v15 ok
 v15 ok
+v15 ok
 v16 ok
 v16 ok
 v16 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -122,6 +122,7 @@ v16 ok
 v16 ok
 v16 ok
 v16 ok
+v16 ok
 
 # Now downgrade_since to empty antichain, closing the shard to reads as well.
 # Everything still works (for idempotence), but this replaces the shard with a

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -110,11 +110,14 @@ k2 2 1
 # maintenance it needs.
 perform-maintenance
 ----
+v14 ok
 v15 ok
 v15 ok
 v15 ok
 v15 ok
 v15 ok
+v15 ok
+v16 ok
 v16 ok
 v16 ok
 v16 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -121,6 +121,7 @@ v16 ok
 v16 ok
 v16 ok
 v16 ok
+v16 ok
 
 # Now downgrade_since to empty antichain, closing the shard to reads as well.
 # Everything still works (for idempotence), but this replaces the shard with a


### PR DESCRIPTION
Today, most operations ignore any maintenance passed up from the core CAS loop in persist. This PR takes all the places I could find where maintenance was dropped and passes it on to a layer where it can be handled. This is mostly 

### Motivation

Known-desirable; listed in #16557.

### Tips for reviewer

At time of posting this was very merge-conflicty thanks to a reverted PR, but I'm optimistic that most of the conflicts will go away once the unrevert lands.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
