### PR TITLE
Support iterative dataflows

### DIFF
--- a/src/compute-client/src/types/dataflows.rs
+++ b/src/compute-client/src/types/dataflows.rs
@@ -247,7 +247,13 @@ where
     }
 
     /// Like `depends_on`, but appends to an existing `BTreeSet`.
+    ///
+    /// This method includes identifiers for e.g. intermediate views, and should be filtered
+    /// if one only wants sources and indexes.
+    ///
+    /// This method is safe for mutually recursive view defintions.
     pub fn depends_on_into(&self, collection_id: GlobalId, out: &mut BTreeSet<GlobalId>) {
+        out.insert(collection_id);
         if self.source_imports.contains_key(&collection_id) {
             // The collection is provided by an imported source. Report the
             // dependency on the source.
@@ -275,7 +281,9 @@ where
         // It must be a collection whose plan we have handy. Recurse.
         let build = self.build_desc(collection_id);
         for id in build.plan.depends_on() {
-            self.depends_on_into(id, out)
+            if !out.contains(&id) {
+                self.depends_on_into(id, out)
+            }
         }
     }
 }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -49,7 +49,6 @@ where
 {
     fn render_continuous_sink(
         &self,
-        scope: &G,
         compute_state: &mut ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
@@ -62,7 +61,7 @@ where
         let desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
 
         persist_sink(
-            scope,
+            &sinked_collection.scope(),
             sink_id,
             &self.storage_metadata,
             desired_collection,

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -34,7 +34,6 @@ where
 {
     fn render_continuous_sink(
         &self,
-        _scope: &G,
         compute_state: &mut crate::compute_state::ComputeState,
         sink: &ComputeSinkDesc<CollectionMetadata>,
         sink_id: GlobalId,


### PR DESCRIPTION
This is a revised version of #11178 for the current dataflow rendering.

It has the same issue, tbd, that one cannot correctly create a `Collection` for a `Bundle` at render time, as the necessary information has been secreted away. It may be possible to apply the same transformation from key to permutation and thinning, to determine a `MFP` to apply, but this needs some additional work to figure out. Perhaps instead the LIR layer should provide this arrangement, but .. it's all a bit undocumented and needs to be rediscovered.

Edit: upon further reading, the code is all set up so that one *cannot* create a `Collection` or new arrangements from a `Bundle`, as the bundle does not know its own arity. This makes translating between existing arrangements and collections impossible, as the required `(permutation, thinning)` needs to know the arity of the rows before it can be formed.

This is fine, it just means that anyone *producing* recursively defined bindings needs to ensure that all bindings end with at least a collection. In future work, we could be smarter and only require those collections that are referenced recursively need this, but for the moment it can be a requirement of all collections in all recursive dataflows.

### Motivation

  * This PR adds a known-desirable feature.

This is in support of `WITH MUTUALLY RECURSIVE`.

### Tips for reviewer

One discussion point is whether we could copy/paste less of dataflow rendering. In particular, source creation needs to happen outside of the iterative scope as several places have baked in the single dimensional time (this is fine, but involves a bit more data copying). One can imagine going forward that folks will update `render/mod.rs` and fail to remember to update `render/iterative.rs`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
