### PR TITLE
Support `EXPLAIN TIMESTAMP AS JSON`

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2851,7 +2851,7 @@ impl<S: Append + 'static> Coordinator<S> {
             sources,
         };
         let s = if is_json {
-            serde_json::to_string(&explanation).unwrap()
+            serde_json::to_string_pretty(&explanation).unwrap()
         } else {
             explanation.to_string()
         };

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -32,7 +32,7 @@ use mz_expr::{
     OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::task;
-use mz_repr::explain_new::Explainee;
+use mz_repr::explain_new::{ExplainFormat, Explainee};
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row, RowArena, Timestamp};
 use mz_sql::ast::{ExplainStage, IndexOptionName, ObjectType};
 use mz_sql::catalog::{
@@ -2763,9 +2763,17 @@ impl<S: Append + 'static> Coordinator<S> {
         let ExplainPlan {
             raw_plan,
             explainee,
+            format,
             ..
         } = plan;
 
+        let is_json = match format {
+            ExplainFormat::Text => false,
+            ExplainFormat::Json => true,
+            ExplainFormat::Dot => {
+                return Err(AdapterError::Unsupported("EXPLAIN TIMESTAMP AS DOT"));
+            }
+        };
         let compute_instance = self.catalog.active_compute_instance(session)?.id;
         let window_functions = self.catalog.system_config().window_functions();
 
@@ -2842,7 +2850,12 @@ impl<S: Append + 'static> Coordinator<S> {
             determination,
             sources,
         };
-        let rows = vec![Row::pack_slice(&[Datum::from(&*explanation.to_string())])];
+        let s = if is_json {
+            serde_json::to_string(&explanation).unwrap()
+        } else {
+            explanation.to_string()
+        };
+        let rows = vec![Row::pack_slice(&[Datum::from(s.as_str())])];
         Ok(send_immediate_rows(rows))
     }
 

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -13,6 +13,7 @@ use std::fmt;
 
 use chrono::NaiveDateTime;
 use differential_dataflow::lattice::Lattice;
+use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tracing::{event, Level};
 
@@ -32,7 +33,7 @@ use crate::session::{vars, Session};
 use crate::AdapterError;
 
 /// The timeline and timestamp context of a read.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum TimestampContext<T> {
     /// Read is executed in a specific timeline with a specific timestamp.
     TimelineTimestamp(Timeline, T),
@@ -396,6 +397,7 @@ impl<S: Append + 'static> Coordinator<S> {
 }
 
 /// Information used when determining the timestamp for a query.
+#[derive(Serialize, Deserialize)]
 pub struct TimestampDetermination<T> {
     /// The chosen timestamp context from `determine_timestamp`.
     pub timestamp_context: TimestampContext<T>,
@@ -419,6 +421,7 @@ impl<T: TimestampManipulation> TimestampDetermination<T> {
 }
 
 /// Information used when determining the timestamp for a query.
+#[derive(Serialize, Deserialize)]
 pub struct TimestampExplanation<T> {
     /// The chosen timestamp from `determine_timestamp`.
     pub determination: TimestampDetermination<T>,
@@ -426,6 +429,7 @@ pub struct TimestampExplanation<T> {
     pub sources: Vec<TimestampSource<T>>,
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct TimestampSource<T> {
     pub name: String,
     pub read_frontier: Vec<T>,

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -55,3 +55,5 @@ pub use crate::coord::peek::PeekResponseUnary;
 pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;
+
+pub use crate::coord::timestamp_selection::TimestampExplanation;


### PR DESCRIPTION
Title says it all

Adding @teskje as randomly-selected compute team reviewer

### Motivation

  * This PR fixes a previously unreported bug.

    `EXPLAIN TIMESTAMP AS JSON` silently did the same thing as `EXPLAIN TIMESTAMP`.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Support `EXPLAIN TIMESTAMP AS JSON`
