### PR TITLE
zippy,ci: Add a longer ClusterReplicas Zippy test to the Release Qual…

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -20,6 +20,7 @@ steps:
           - { value: zippy-kafka-sources-large }
           - { value: zippy-dataflows-large }
           - { value: zippy-pg-cdc-large }
+          - { value: zippy-cluster-replicas-large }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -71,3 +72,13 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=PostgresCdc, --actions=100000]
+
+  - id: zippy-cluster-replicas-large
+    label: "Longer Zippy ClusterReplicas test"
+    timeout_in_minutes: 2880
+    agents:
+      queue: linux-x86_64-large
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=ClusterReplicas, --actions=100000]


### PR DESCRIPTION
…ification pipeline

### Motivation

  * This PR adds a feature that has not yet been specified.

We are getting some rare crashes that are only seen in the ClusterReplicas test. Run it for longer in order to avoid regressions in that direction.