### PR TITLE
metrics: add jemalloc stats

### DIFF
--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -98,6 +98,7 @@ use mz_ore::tracing::TracingHandle;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistConfig;
 use mz_pid_file::PidFile;
+use mz_prof::jemalloc_metrics;
 use mz_service::emit_boot_diagnostics;
 use mz_service::grpc::GrpcServer;
 use mz_service::secrets::SecretsReaderCliArgs;
@@ -225,6 +226,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         .context("loading secrets reader")?;
 
     let metrics_registry = MetricsRegistry::new();
+    jemalloc_metrics::register_into(&metrics_registry);
 
     mz_ore::task::spawn(|| "clusterd_internal_http_server", {
         let metrics_registry = metrics_registry.clone();

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -107,6 +107,7 @@ use mz_ore::now::NowFn;
 use mz_ore::task;
 use mz_ore::tracing::TracingHandle;
 use mz_persist_client::usage::StorageUsageClient;
+use mz_prof::jemalloc_metrics;
 use mz_secrets::SecretsController;
 use mz_sql::catalog::EnvironmentId;
 use mz_stash::Stash;
@@ -249,6 +250,8 @@ pub enum TlsMode {
 
 /// Start an `environmentd` server.
 pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
+    jemalloc_metrics::register_into(&config.metrics_registry);
+
     let tls = mz_postgres_util::make_tls(&tokio_postgres::config::Config::from_str(
         &config.adapter_stash_url,
     )?)?;

--- a/src/prof/src/jemalloc_metrics.rs
+++ b/src/prof/src/jemalloc_metrics.rs
@@ -1,0 +1,25 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// A thin wrapper around jemalloc::JemallocMetrics that can be used independent of jemalloc
+/// actually being used.
+
+#[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
+use crate::jemalloc;
+use mz_ore::metrics::MetricsRegistry;
+
+#[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
+pub fn register_into(registry: &MetricsRegistry) {
+    jemalloc::JemallocMetrics::register_into(registry);
+}
+
+#[cfg(not(all(not(target_os = "macos"), feature = "jemalloc")))]
+pub fn register_into(_registry: &MetricsRegistry) {
+    // No-op if we dont use jemalloc
+}

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -79,6 +79,7 @@ use std::{collections::BTreeMap, ffi::c_void, sync::atomic::AtomicBool, time::In
 pub mod http;
 #[cfg(all(not(target_os = "macos"), feature = "jemalloc"))]
 pub mod jemalloc;
+pub mod jemalloc_metrics;
 pub mod time;
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
Expose the jemalloc internal stats to `/metrics`

Fixes #16383

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
