### PR TITLE
Normalize `LetRec` in expressions

### DIFF
--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -130,6 +130,21 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, Plan> {
                     Ok(())
                 })?;
             }
+            LetRec { ids, values, body } => {
+                let bindings = ids.iter().zip(values).collect::<Vec<_>>();
+                let head = body.as_ref();
+
+                writeln!(f, "{}Return", ctx.indent)?;
+                ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
+                writeln!(f, "{}Where Mutually Recursive", ctx.indent)?;
+                ctx.indented(|ctx| {
+                    for (id, value) in bindings.iter().rev() {
+                        writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                        ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                    }
+                    Ok(())
+                })?;
+            }
             Mfp {
                 input,
                 mfp,

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -125,8 +125,35 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                     })?;
                 }
             }
-            MirRelationExpr::LetRec { .. } => {
-                unimplemented!("unclear how to format");
+            LetRec { ids, values, body } => {
+                let bindings = ids.iter().zip(values.iter()).collect::<Vec<_>>();
+                let head = body.as_ref();
+
+                if ctx.config.linear_chains {
+                    writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
+                    ctx.indented(|ctx| {
+                        for (id, value) in bindings.iter() {
+                            writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                        }
+                        Ok(())
+                    })?;
+                    write!(f, "{}Return", ctx.indent)?;
+                    self.fmt_attributes(f, ctx)?;
+                    ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
+                } else {
+                    write!(f, "{}Return", ctx.indent)?;
+                    self.fmt_attributes(f, ctx)?;
+                    ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
+                    writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
+                    ctx.indented(|ctx| {
+                        for (id, value) in bindings.iter().rev() {
+                            writeln!(f, "{}cte {} =", ctx.indent, *id)?;
+                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                        }
+                        Ok(())
+                    })?;
+                }
             }
             Get { id, .. } => {
                 match id {

--- a/src/compute-client/src/plan.proto
+++ b/src/compute-client/src/plan.proto
@@ -73,6 +73,12 @@ message ProtoPlan {
         ProtoPlan body  = 3;
    }
 
+   message ProtoPlanLetRec {
+        repeated mz_expr.id.ProtoLocalId ids = 1;
+        repeated ProtoPlan values = 2;
+        ProtoPlan body  = 3;
+   }
+
    message ProtoPlanInputKeyVal {
         repeated mz_expr.scalar.ProtoMirScalarExpr key = 1;
         mz_repr.row.ProtoRow val = 2;
@@ -142,5 +148,6 @@ message ProtoPlan {
         ProtoPlanThreshold threshold = 10;
         ProtoPlanUnion union = 11;
         ProtoPlanArrangeBy arrange_by = 12;
+        ProtoPlanLetRec let_rec = 13;
    }
 }

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -212,6 +212,21 @@ pub enum Plan<T = mz_repr::Timestamp> {
         /// that reference `Id::Local(id)`.
         body: Box<Plan<T>>,
     },
+    /// Binds `values` to `ids`, evaluates them potentially recursively, and returns `body`.
+    ///
+    /// All bindings are available to all bindings, and to `body`.
+    /// The contents of each binding are initially empty, and then updated through a sequence
+    /// of iterations in which each binding is updated in sequence, from the most recent values
+    /// of all bindings.
+    LetRec {
+        /// The local identifiers to be used, available to `body` as `Id::Local(id)`.
+        ids: Vec<LocalId>,
+        /// The collection that should be bound to `id`.
+        values: Vec<Plan<T>>,
+        /// The collection that results, which is allowed to contain `Get` stages
+        /// that reference `Id::Local(id)`.
+        body: Box<Plan<T>>,
+    },
     /// Map, Filter, and Project operators.
     ///
     /// This stage contains work that we would ideally like to fuse to other plan
@@ -349,6 +364,7 @@ impl<T> Plan<T> {
         let mut first = None;
         let mut second = None;
         let mut rest = None;
+        let mut last = None;
 
         use Plan::*;
         match self {
@@ -356,6 +372,10 @@ impl<T> Plan<T> {
             Let { value, body, .. } => {
                 first = Some(&mut **value);
                 second = Some(&mut **body);
+            }
+            LetRec { values, body, .. } => {
+                rest = Some(values);
+                last = Some(&mut **body);
             }
             Mfp { input, .. }
             | FlatMap { input, .. }
@@ -375,6 +395,7 @@ impl<T> Plan<T> {
             .into_iter()
             .chain(second)
             .chain(rest.into_iter().flatten())
+            .chain(last)
     }
 }
 
@@ -562,6 +583,14 @@ impl RustType<ProtoPlan> for Plan {
                     body: Some(body.into_proto()),
                 }
                 .into()),
+                Plan::LetRec { ids, values, body } => LetRec(
+                    ProtoPlanLetRec {
+                        ids: ids.into_proto(),
+                        values: values.into_proto(),
+                        body: Some(body.into_proto()),
+                    }
+                    .into(),
+                ),
                 Plan::Mfp {
                     input,
                     mfp,
@@ -691,6 +720,11 @@ impl RustType<ProtoPlan> for Plan {
             Let(proto) => Plan::Let {
                 id: proto.id.into_rust_if_some("ProtoPlanLet::id")?,
                 value: proto.value.into_rust_if_some("ProtoPlanLet::value")?,
+                body: proto.body.into_rust_if_some("ProtoPlanLet::body")?,
+            },
+            LetRec(proto) => Plan::LetRec {
+                ids: proto.ids.into_rust()?,
+                values: proto.values.into_rust()?,
                 body: proto.body.into_rust_if_some("ProtoPlanLet::body")?,
             },
             Mfp(proto) => Plan::Mfp {
@@ -911,14 +945,9 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         arrangements: &mut BTreeMap<Id, AvailableCollections>,
         debug_info: LirDebugInfo<'_>,
     ) -> Result<(Self, AvailableCollections), ()> {
-        // TODO: This block should be removed once we can lower `MirRelationExpr::LetRec`.
-        let mut non_recursive = expr.clone();
-        non_recursive.make_nonrecursive();
-        assert!(!non_recursive.is_recursive());
-
         // We don't want to trace recursive calls, which is why the public `from_mir`
         // is annotated and delecates the work to a private (recursive) from_mir_inner.
-        Plan::from_mir_inner(&non_recursive, arrangements, debug_info)
+        Plan::from_mir_inner(expr, arrangements, debug_info)
     }
 
     fn from_mir_inner(
@@ -962,11 +991,6 @@ impl<T: timely::progress::Timestamp> Plan<T> {
             }
             MirRelationExpr::Project { .. } => {
                 panic!("This operator should have been extracted");
-            }
-            MirRelationExpr::LetRec { .. } => {
-                panic!(
-                    "We must extract potentially recursive objects into dataflow objects to build"
-                );
             }
             // These operators may not have been extracted, and need to result in a `Plan`.
             MirRelationExpr::Constant { rows, typ: _ } => {
@@ -1059,6 +1083,32 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                     Plan::Let {
                         id: id.clone(),
                         value: Box::new(value),
+                        body: Box::new(body),
+                    },
+                    b_keys,
+                )
+            }
+            MirRelationExpr::LetRec { ids, values, body } => {
+                // Plan the value using only the initial arrangements, but
+                // introduce any resulting arrangements bound to `id`.
+                let mut lir_values = Vec::with_capacity(values.len());
+                for (id, value) in ids.iter().zip(values) {
+                    let (value, v_keys) = Plan::from_mir_inner(value, arrangements, debug_info)?;
+                    let pre_existing = arrangements.insert(Id::Local(*id), v_keys);
+                    assert!(pre_existing.is_none());
+                    lir_values.push(value);
+                }
+                // Plan the body using initial and `value` arrangements,
+                // and then remove reference to the value arrangements.
+                let (body, b_keys) = Plan::from_mir_inner(body, arrangements, debug_info)?;
+                for id in ids.iter() {
+                    arrangements.remove(&Id::Local(*id));
+                }
+                // Return the plan, and any `body` arrangements.
+                (
+                    Plan::LetRec {
+                        ids: ids.clone(),
+                        values: lir_values,
                         body: Box::new(body),
                     },
                     b_keys,
@@ -1673,6 +1723,24 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         })
                         .collect()
                 }
+                Plan::LetRec { ids, values, body } => {
+                    let mut values_parts: Vec<Vec<Self>> = Vec::with_capacity(parts);
+                    for value in values.into_iter() {
+                        for (index, part) in value.partition_among(parts).into_iter().enumerate() {
+                            values_parts[index].push(part);
+                        }
+                    }
+                    let body_parts = body.partition_among(parts);
+                    values_parts
+                        .into_iter()
+                        .zip(body_parts)
+                        .map(|(values, body)| Plan::LetRec {
+                            values,
+                            body: Box::new(body),
+                            ids: ids.clone(),
+                        })
+                        .collect()
+                }
                 Plan::Mfp {
                     input,
                     input_key_val,
@@ -1811,6 +1879,16 @@ impl<T> CollectionPlan for Plan<T> {
             },
             Plan::Let { id: _, value, body } => {
                 value.depends_on_into(out);
+                body.depends_on_into(out);
+            }
+            Plan::LetRec {
+                ids: _,
+                values,
+                body,
+            } => {
+                for value in values.iter() {
+                    value.depends_on_into(out);
+                }
                 body.depends_on_into(out);
             }
             Plan::Join { inputs, plan: _ } | Plan::Union { inputs } => {

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -696,6 +696,9 @@ where
                 self.remove_id(Id::Local(id));
                 body
             }
+            Plan::LetRec { .. } => {
+                unimplemented!("Not yet implemented; sorry!");
+            }
             Plan::Mfp {
                 input,
                 mfp,

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -295,21 +295,38 @@ impl MirRelationExpr {
         #[allow(deprecated)]
         self.visit_pre_post_nolimit(
             &mut |e: &MirRelationExpr| -> Option<Vec<&MirRelationExpr>> {
-                if let MirRelationExpr::Let { body, .. } = &e {
-                    // Do not traverse the value sub-graph, since it's not relevant for
-                    // determining the relation type of Let operators.
-                    Some(vec![&*body])
-                } else {
-                    None
+                match &e {
+                    MirRelationExpr::Let { body, .. } => {
+                        // Do not traverse the value sub-graph, since it's not relevant for
+                        // determining the relation type of Let operators.
+                        Some(vec![&*body])
+                    }
+                    MirRelationExpr::LetRec { body, .. } => {
+                        // Do not traverse the value sub-graph, since it's not relevant for
+                        // determining the relation type of Let operators.
+                        Some(vec![&*body])
+                    }
+                    _ => None,
                 }
             },
             &mut |e: &MirRelationExpr| {
-                if let MirRelationExpr::Let { .. } = &e {
-                    let body_typ = type_stack.pop().unwrap();
-                    // Insert a dummy relation type for the value, since `typ_with_input_types`
-                    // won't look at it, but expects the relation type of the body to be second.
-                    type_stack.push(RelationType::empty());
-                    type_stack.push(body_typ);
+                match e {
+                    MirRelationExpr::Let { .. } => {
+                        let body_typ = type_stack.pop().unwrap();
+                        // Insert a dummy relation type for the value, since `typ_with_input_types`
+                        // won't look at it, but expects the relation type of the body to be second.
+                        type_stack.push(RelationType::empty());
+                        type_stack.push(body_typ);
+                    }
+                    MirRelationExpr::LetRec { values, .. } => {
+                        let body_typ = type_stack.pop().unwrap();
+                        // Insert dummy relation types for the values, since `typ_with_input_types`
+                        // won't look at them, but expects the relation type of the body to be last.
+                        type_stack
+                            .extend(std::iter::repeat(RelationType::empty()).take(values.len()));
+                        type_stack.push(body_typ);
+                    }
+                    _ => {}
                 }
                 let num_inputs = e.num_inputs();
                 let relation_type =
@@ -431,14 +448,11 @@ impl MirRelationExpr {
             }
             Let { .. } => {
                 // skip over the unique keys for value
-                input_types.next();
-                input_types.next().unwrap().clone()
+                input_types.nth(1).unwrap().clone()
             }
             LetRec { values, .. } => {
-                for _ in 0..values.len() {
-                    input_types.next();
-                }
-                input_types.next().unwrap().clone()
+                // skip over the unique keys for value
+                input_types.nth(values.len()).unwrap().clone()
             }
             Union { .. } => {
                 let mut result = input_types.next().unwrap().clone();
@@ -520,14 +534,11 @@ impl MirRelationExpr {
             Threshold { .. } | ArrangeBy { .. } => input_keys.next().unwrap().clone(),
             Let { .. } => {
                 // skip over the unique keys for value
-                input_keys.next();
-                input_keys.next().unwrap().clone()
+                input_keys.nth(1).unwrap().clone()
             }
             LetRec { values, .. } => {
-                for _ in 0..values.len() {
-                    input_keys.next();
-                }
-                input_keys.next().unwrap().clone()
+                // skip over the unique keys for value
+                input_keys.nth(values.len()).unwrap().clone()
             }
             Project { outputs, .. } => {
                 let input = input_keys.next().unwrap();
@@ -836,19 +847,33 @@ impl MirRelationExpr {
         #[allow(deprecated)]
         self.visit_pre_post_nolimit(
             &mut |e: &MirRelationExpr| -> Option<Vec<&MirRelationExpr>> {
-                if let MirRelationExpr::Let { body, .. } = &e {
-                    // Do not traverse the value sub-graph, since it's not relevant for
-                    // determining the arity of Let operators.
-                    Some(vec![&*body])
-                } else {
-                    None
+                match &e {
+                    MirRelationExpr::Let { body, .. } => {
+                        // Do not traverse the value sub-graph, since it's not relevant for
+                        // determining the arity of Let operators.
+                        Some(vec![&*body])
+                    }
+                    MirRelationExpr::LetRec { body, .. } => {
+                        // Do not traverse the value sub-graph, since it's not relevant for
+                        // determining the arity of Let operators.
+                        Some(vec![&*body])
+                    }
+                    _ => None,
                 }
             },
             &mut |e: &MirRelationExpr| {
-                if let MirRelationExpr::Let { .. } = &e {
-                    let body_arity = arity_stack.pop().unwrap();
-                    arity_stack.push(0);
-                    arity_stack.push(body_arity);
+                match &e {
+                    MirRelationExpr::Let { .. } => {
+                        let body_arity = arity_stack.pop().unwrap();
+                        arity_stack.push(0);
+                        arity_stack.push(body_arity);
+                    }
+                    MirRelationExpr::LetRec { values, .. } => {
+                        let body_arity = arity_stack.pop().unwrap();
+                        arity_stack.extend(std::iter::repeat(0).take(values.len()));
+                        arity_stack.push(body_arity);
+                    }
+                    _ => {}
                 }
                 let num_inputs = e.num_inputs();
                 let arity = e

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -447,11 +447,11 @@ impl MirRelationExpr {
                 input_types.next().unwrap().clone()
             }
             Let { .. } => {
-                // skip over the unique keys for value
+                // skip over the input types for `value`.
                 input_types.nth(1).unwrap().clone()
             }
             LetRec { values, .. } => {
-                // skip over the unique keys for value
+                // skip over the input types for `values`.
                 input_types.nth(values.len()).unwrap().clone()
             }
             Union { .. } => {

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -21,7 +21,7 @@ use std::ops::AddAssign;
 use std::sync::Mutex;
 
 /// Manages the allocation of unique IDs.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Gen<Id: From<u64> + Default> {
     id: u64,
     phantom: PhantomData<Id>,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -100,6 +100,8 @@ pub enum TransformError {
     Internal(String),
     /// An ideally temporary error indicating transforms that do not support the `MirRelationExpr::LetRec` variant.
     LetRecUnsupported,
+    /// A reference to an apparently unbound identifier.
+    IdentifierMissing(mz_expr::LocalId),
 }
 
 impl fmt::Display for TransformError {
@@ -107,6 +109,9 @@ impl fmt::Display for TransformError {
         match self {
             TransformError::Internal(msg) => write!(f, "internal transform error: {}", msg),
             TransformError::LetRecUnsupported => write!(f, "LetRec AST node not supported"),
+            TransformError::IdentifierMissing(i) => {
+                write!(f, "apparently unbound identifier: {:?}", i)
+            }
         }
     }
 }

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -7,34 +7,32 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Normalize the structure of `Let` operators in expressions.
+//! Normalize the structure of `Let` and `LetRec` operators in expressions.
 //!
-//! Let operators are hoisted to the root of the expression, and given
-//! consecutive identifiers from zero. Each bound `value` is `Let`-free,
-//! and both is more complex than a `Get` or a `Constant` and occurs at
-//! least twice in the `body` of its binding.
+//! Normalization happens in the context of "scopes", corresponding to
+//! 1. the expression's root and 2. each instance of a `LetRec` AST node.
 //!
-//! No effort is yet made to choose among the topological orders of the
-//! bindings in some canonical way; this could be future work if we are
-//! excited about it (I think we don't expect CSE to discover matches
-//! involving `Let` operator as they are all at the roots).
-//!
+//! Within each scope,
+//! 1. Each expression is normalized to have all `Let` nodes at the root
+//! of the expression, in order of identifier.
+//! 2. Each expression assigns a contiguous block of identifiers.
+
 //! The transform may remove some `Let` and `Get` operators, and does not
 //! introduce any new operators. It is idempotent.
 //!
 //! The module also publishes the function `renumber_bindings` which can
 //! be used to renumber bindings in an expression starting from a provided
 //! `IdGen`, which is used to prepare distinct expressions for inlining.
-use std::collections::BTreeMap;
 
-use mz_expr::RECURSION_LIMIT;
-use mz_expr::{Id, LocalId, MirRelationExpr};
-use mz_ore::cast::CastFrom;
+use mz_expr::MirRelationExpr;
 use mz_ore::id_gen::IdGen;
-use mz_ore::stack::RecursionGuard;
-use mz_repr::RelationType;
 
 use crate::TransformArgs;
+
+/// Normalize `Let` and `LetRec` structure.
+pub fn normalize_lets(expr: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
+    NormalizeLets { inline_mfp: false }.action(expr)
+}
 
 /// Install replace certain `Get` operators with their `Let` value.
 #[derive(Debug)]
@@ -59,6 +57,10 @@ impl NormalizeLets {
 }
 
 impl crate::Transform for NormalizeLets {
+    fn recursion_safe(&self) -> bool {
+        true
+    }
+
     #[tracing::instrument(
         target = "optimizer"
         level = "trace",
@@ -88,143 +90,58 @@ impl NormalizeLets {
 
     /// Normalize `Let` bindings in `relation`.
     ///
-    /// Mechanically, `action` first renumbers all bindings to remove shadowing and ensure
-    /// each `LocalId` is bound at most once. It then destructures the bindings into a map
-    /// from `LocalId` to `Let`-free `MirRelationExpr`, and determines which to inline and
-    /// then does so. Finally, it refreshes the types of each `Get` operator, and performs
-    /// a final renumbering if the numbers are not contiguous from zero.
+    /// Mechanically, `action` first renumbers all bindings, erroring if any shadowing is encountered.
+    /// It then promotes all `LetRec` expressions to the root, and considers inlining bindings.
+    /// Finally, it refreshes the types of each `Get` operator, and performs a final renumbering.
     ///
-    /// The method takes time linear in the size of `relation`.
+    /// The method takes time linear in the size of `relation` for each `LetRec`.
     pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
-        // Rename all bindings to be distinct.
+        // Rename all bindings to be distinct. Start at zero.
         let mut id_gen = IdGen::default();
-        renumber_bindings(relation, &mut id_gen)?;
+        renumbering::renumber_bindings(relation, &mut id_gen)?;
 
-        // Extract all let bindings into let-free expressions.
-        // `relation` is the `Let`-free body, and `let_bindings` maps from each `LocalId`
-        // to a `Let`-free value.
-        let let_bindings = support::digest_lets(relation);
+        // Promote all `Let` and `LetRec` AST nodes to the roots.
+        // After this, all non-`LetRec` nodes contain no further `Let` or `LetRec` nodes,
+        // placing all `LetRec` nodes around the root, if not always in a single AST node.
+        let_motion::promote_let_rec(relation);
 
-        // Count the number of uses of each local id across all expressions.
-        let mut counts = BTreeMap::new();
-        support::count_local_id_uses(relation, &mut counts);
-        for expr in let_bindings.values() {
-            support::count_local_id_uses(expr, &mut counts);
-        }
+        inlining::inline_lets(relation, self.inline_mfp)?;
 
-        // Each binding can be uniquely swapped in for a `Get`, cloned to replace a `Get`,
-        // or stacked atop the body as a `Let` binding.
-        let mut to_take = BTreeMap::new();
-        let mut to_clone = BTreeMap::new();
-        let mut to_emit = BTreeMap::new();
+        support::refresh_types(relation)?;
 
-        // For each binding, inline `Get`s and then determine if *it* should be inlined.
-        // It is important that we do the substitution in-order and before reasoning
-        // about the inlineability of each binding, to ensure that our conclusion about
-        // the inlineability of a binding stays put. Specifically,
-        //   1. by going in order no substitution will increase the `Get`-count of an
-        //      identifier beyond one, as all in values with strictly greater identifiers.
-        //   2. by performing the substitution before reasoning, the structure of the value
-        //      as it would be substituted is fixed.
-        for (id, mut expr) in let_bindings {
-            // Substitute any appropriate prior let bindings.
-            support::inline_gets(&mut expr, &mut to_take, &to_clone)?;
-            // Gets for `id` only occur in later expressions, so this should still be correct.
-            let num_gets = counts.get(&id).map(|x| *x).unwrap_or(0);
-            // Counts of zero or one lead to substitution; other wise certain simple structures
-            // are cloned in to `Get` operators, and all others emitted as `Let` bindings.
-            if num_gets == 0 {
-            } else if num_gets == 1 {
-                to_take.insert(id, Some(expr));
-            } else {
-                let clone_binding = {
-                    let stripped_value = if self.inline_mfp {
-                        mz_expr::MapFilterProject::extract_non_errors_from_expr(&expr).1
-                    } else {
-                        &expr
-                    };
-                    match stripped_value {
-                        MirRelationExpr::Get { .. } | MirRelationExpr::Constant { .. } => true,
-                        _ => false,
-                    }
+        // Renumber bindings for good measure.
+        // Ideally we could skip when `action` is a no-op, but hard to thread that through at the moment.
+        let mut id_gen = IdGen::default();
+        renumbering::renumber_bindings(relation, &mut id_gen)?;
+
+        // Disassemble `LetRec` into `Let` stack if possible.
+        // If a `LetRec` remains, return the would-be `Let` bindings to it.
+        let mut bindings = let_motion::harvest_non_recursive(relation);
+        if let MirRelationExpr::LetRec {
+            ids,
+            values,
+            body: _,
+        } = relation
+        {
+            bindings.extend(ids.drain(..).zip(values.drain(..)));
+            let (new_ids, new_values) = bindings.into_iter().unzip();
+            *ids = new_ids;
+            *values = new_values;
+        } else {
+            for (id, value) in bindings.into_iter().rev() {
+                *relation = MirRelationExpr::Let {
+                    id,
+                    value: Box::new(value),
+                    body: Box::new(relation.take_dangerous()),
                 };
-
-                if clone_binding {
-                    to_clone.insert(id, expr);
-                } else {
-                    to_emit.insert(id, expr);
-                }
             }
-        }
-        // Complete the inlining in the base relation.
-        support::inline_gets(relation, &mut to_take, &to_clone)?;
-
-        // We should have removed all single-reference bindings.
-        // The code is just to confirm this intended invariant.
-        to_take.retain(|_key, val| val.is_some());
-        if !to_take.is_empty() {
-            Err(crate::TransformError::Internal(format!(
-                "Untaken bindings: {:?}",
-                to_take
-            )))?;
-        }
-
-        // Refresh type information at `Get` operators.
-        let mut types: BTreeMap<LocalId, RelationType> = BTreeMap::new();
-        for (id, expr) in to_emit.iter_mut() {
-            expr.visit_pre_mut(|expr| {
-                if let MirRelationExpr::Get { id, typ } = expr {
-                    if let Id::Local(i) = id {
-                        typ.clone_from(&types[i]);
-                    }
-                }
-            });
-            types.insert(*id, expr.typ());
-        }
-        relation.visit_pre_mut(|expr| {
-            if let MirRelationExpr::Get { id, typ } = expr {
-                if let Id::Local(i) = id {
-                    typ.clone_from(&types[i]);
-                }
-            }
-        });
-
-        // We may need to perform renumbering again if we inlined bindings.
-        // We do this on a full `MirRelationExpr` once we have reintroduced
-        // the `Let` operators from `to_emit`.
-        let renumber = to_emit
-            .keys()
-            .enumerate()
-            .any(|(i, b)| LocalId::new(u64::cast_from(i)) != *b);
-
-        // Reconstitute the stack of let bindings from `to_emit`.
-        for (id, value) in to_emit.into_iter().rev() {
-            *relation = MirRelationExpr::Let {
-                id,
-                value: Box::new(value),
-                body: Box::new(relation.take_dangerous()),
-            };
-        }
-
-        // Do a final pass if we inlined anything, in order to count from zero.
-        if renumber {
-            let mut id_gen = IdGen::default();
-            renumber_bindings(relation, &mut id_gen)?;
         }
 
         Ok(())
     }
 }
 
-/// Re-assign an identifier to each `Let`.
-pub fn renumber_bindings(
-    relation: &mut MirRelationExpr,
-    id_gen: &mut IdGen,
-) -> Result<(), crate::TransformError> {
-    let mut renaming = BTreeMap::new();
-    let recursion_guard = RecursionGuard::with_limit(RECURSION_LIMIT);
-    support::renumber_bindings_helper(&recursion_guard, relation, &mut renaming, id_gen)
-}
+pub use renumbering::renumber_bindings;
 
 // Support methods that are unlikely to be useful to other modules.
 mod support {
@@ -232,11 +149,23 @@ mod support {
     use std::collections::BTreeMap;
 
     use mz_expr::{Id, LocalId, MirRelationExpr};
-    use mz_ore::id_gen::IdGen;
-    use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
-    // This is pretty simple, but it is used in two locations and seemed clearer named.
-    /// Populates `counts` with the number of uses of each local identifier.
+    pub(super) fn for_local_id<F>(expr: &MirRelationExpr, mut logic: F)
+    where
+        F: FnMut(LocalId),
+    {
+        expr.visit_pre(|expr| {
+            if let MirRelationExpr::Get {
+                id: Id::Local(i), ..
+            } = expr
+            {
+                logic(*i);
+            }
+        });
+    }
+
+    // This is pretty simple, but it is used in multiple locations and seemed clearer as a named method.
+    /// Populates `counts` with the number of uses of each local identifier in `expr`.
     pub(super) fn count_local_id_uses(
         expr: &MirRelationExpr,
         counts: &mut std::collections::BTreeMap<LocalId, usize>,
@@ -251,46 +180,337 @@ mod support {
         });
     }
 
-    /// Extract all `Let` bindings from an expression, into a map from `LocalId` to `Let`-free expressions.
+    /// Visit `LetRec` stages and determine and update type information for `Get` nodes.
     ///
-    /// An equivalent expression can be reconstructed by introducing the bindings atop the resulting `expr`.
-    pub(super) fn digest_lets(expr: &mut MirRelationExpr) -> BTreeMap<LocalId, MirRelationExpr> {
-        let mut lets = BTreeMap::new();
-        let mut worklist = Vec::new();
-        digest_lets_helper(expr, &mut worklist);
-        while let Some((id, mut expr)) = worklist.pop() {
-            digest_lets_helper(&mut expr, &mut worklist);
-            lets.insert(id, expr);
+    /// This method errors if the scalar type information has changed (number of columns, or types).
+    /// It only refreshes the nullability and unique key information. As this information can regress,
+    /// we do not error if the type weakens, even though that may be something we want to look into.
+    pub(super) fn refresh_types(expr: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
+        // TODO: This is not as complete as a post-order traversal would be, refreshing as it goes.
+        let mut types = BTreeMap::new();
+        let mut worklist = vec![&mut *expr];
+        while let Some(expr) = worklist.pop() {
+            if let MirRelationExpr::LetRec {
+                ids,
+                values,
+                body: _,
+            } = expr
+            {
+                for (id, value) in ids.iter().zip(values.iter()) {
+                    types.insert(*id, value.typ());
+                }
+            }
+            worklist.extend(expr.children_mut().rev());
         }
-        lets
+        let mut worklist = vec![&mut *expr];
+        while let Some(expr) = worklist.pop() {
+            if let MirRelationExpr::Get {
+                id: Id::Local(id),
+                typ,
+            } = expr
+            {
+                if let Some(new_type) = types.get(id) {
+                    // Something bad has happened if the type *weakens*.
+                    assert!(
+                        new_type.column_types.len() == typ.column_types.len(),
+                        "column lengths do not match: {:?} v {:?}",
+                        new_type.column_types,
+                        typ.column_types
+                    );
+                    assert!(
+                        new_type
+                            .column_types
+                            .iter()
+                            .zip(typ.column_types.iter())
+                            .all(|(t1, t2)| t1.scalar_type == t2.scalar_type),
+                        "scalar types do not match: {:?} v {:?}",
+                        new_type.column_types,
+                        typ.column_types
+                    );
+                    // assert!(new_type.subtypes(typ), "{:?} does not subtype {:?}", new_type, typ);
+                    typ.clone_from(new_type);
+                }
+            }
+            worklist.extend(expr.children_mut().rev());
+        }
+
+        Ok(())
+    }
+}
+
+mod let_motion {
+
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use mz_expr::{LocalId, MirRelationExpr};
+
+    /// Normalizes the `LetRec` structure in an expression by promoting and potentially fusing all `LetRec` nodes.
+    pub(crate) fn promote_let_rec(expr: &mut MirRelationExpr) {
+        // First, promote all `LetRec` nodes above all other nodes.
+        let mut worklist = vec![&mut *expr];
+        while let Some(expr) = worklist.pop() {
+            digest_lets(expr);
+            if let MirRelationExpr::LetRec {
+                ids: _,
+                values,
+                body,
+            } = expr
+            {
+                // The order may not be important, but let's not risk it.
+                worklist.push(body);
+                worklist.extend(values.iter_mut().rev());
+            }
+        }
+
+        // Second, attempt to fuse non-recursive `LetRec` bindings.
+        // Ideally do a post-order traversal of only `LetRec` nodes, but for now just once.
+        if let MirRelationExpr::LetRec { ids, values, body } = expr {
+            let mut bindings = BTreeMap::new();
+            for (id, mut value) in ids.drain(..).zip(values.drain(..)) {
+                bindings.extend(harvest_non_recursive(&mut value));
+                bindings.insert(id, value);
+            }
+            bindings.extend(harvest_non_recursive(body));
+            let (new_ids, new_values) = bindings.into_iter().unzip();
+            *ids = new_ids;
+            *values = new_values;
+        }
     }
 
-    /// Extract all `Let` bindings from `expr`, into `(id, value)` pairs.
+    /// Promotes all available let bindings to the root of the expression.
     ///
-    /// Importantly, the `value` pairs may not be `Let`-free, and must be further processed.
+    /// The method only extracts bindings that can be placed in the same `LetRec` scope, so in particular
+    /// it does not continue recursively through `LetRec` nodes and stops once it arrives at the first one
+    /// along each path from the root. Each of `values` and `body` may need further processing to promote
+    /// all bindings to their respective roots.
+    ///
+    /// If `expr` is anything but a `LetRec` node, then it contains no further `Let` or `LetRec` nodes.
+    ///
+    /// This method is idempotent.
+    fn digest_lets(expr: &mut MirRelationExpr) {
+        let mut worklist = Vec::new();
+        let mut bindings = BTreeMap::new();
+        digest_lets_helper(expr, &mut worklist);
+        while let Some((id, mut value)) = worklist.pop() {
+            digest_lets_helper(&mut value, &mut worklist);
+            bindings.insert(id, value);
+        }
+        if !bindings.is_empty() {
+            let (ids, values) = bindings.into_iter().unzip();
+            *expr = MirRelationExpr::LetRec {
+                ids,
+                values,
+                body: Box::new(expr.take_dangerous()),
+            }
+        }
+    }
+
+    /// Extracts all `Let` and `LetRec` bindings from `expr` through its first `LetRec`.
+    ///
+    /// The bindings themselves may not be `Let`-free, and should be further processed to ensure this.
+    /// We stop at the first `LetRec` as we cannot be certain that subsequent bindings can be lifted
+    /// to a shared `LetRec` scope atop `expr`.
     fn digest_lets_helper(
         expr: &mut MirRelationExpr,
         bindings: &mut Vec<(LocalId, MirRelationExpr)>,
     ) {
         let mut to_visit = vec![expr];
         while let Some(expr) = to_visit.pop() {
-            if let MirRelationExpr::Let { id, value, body } = expr {
-                bindings.push((*id, value.take_dangerous()));
-                *expr = body.take_dangerous();
-                to_visit.push(expr);
-            } else {
-                to_visit.extend(expr.children_mut());
+            match expr {
+                MirRelationExpr::Let { id, value, body } => {
+                    bindings.push((*id, value.take_dangerous()));
+                    *expr = body.take_dangerous();
+                    // Continue through `Let` nodes as they are certainly non-recursive.
+                    to_visit.push(expr);
+                }
+                MirRelationExpr::LetRec { ids, values, body } => {
+                    bindings.extend(ids.drain(..).zip(values.drain(..)));
+                    *expr = body.take_dangerous();
+                    // Stop at `LetRec` nodes as we cannot always lift `Let` nodes out of them.
+                }
+                _ => {
+                    to_visit.extend(expr.children_mut());
+                }
             }
         }
+    }
+
+    /// Harvest any safe-to-lift non-recursive bindings from a `LetRec` expression.
+    ///
+    /// A binding is safe to lift if it
+    /// 1. references no other non-lifted binding here, and
+    /// 2. is referenced by no prior non-lifted binding here.
+    pub(crate) fn harvest_non_recursive(
+        expr: &mut MirRelationExpr,
+    ) -> BTreeMap<LocalId, MirRelationExpr> {
+        let mut peeled = BTreeMap::new();
+        if let MirRelationExpr::LetRec { ids, values, body } = expr {
+            let mut id_set: BTreeSet<_> = ids.iter().cloned().collect();
+            let mut cannot = BTreeSet::new();
+            let mut retain = BTreeMap::new();
+            let mut counts = BTreeMap::new();
+            for (id, value) in ids.iter().zip(values.drain(..)) {
+                counts.clear();
+                super::support::count_local_id_uses(&value, &mut counts);
+                cannot.extend(counts.keys().cloned());
+                if !cannot.contains(id) && counts.keys().all(|i| !id_set.contains(i)) {
+                    peeled.insert(*id, value);
+                    id_set.remove(id);
+                } else {
+                    retain.insert(*id, value);
+                }
+            }
+
+            let (new_ids, new_values) = retain.into_iter().unzip();
+            *ids = new_ids;
+            *values = new_values;
+            if values.is_empty() {
+                *expr = body.take_dangerous();
+            }
+        }
+        peeled
+    }
+}
+
+mod inlining {
+
+    use std::collections::BTreeMap;
+
+    use mz_expr::{Id, LocalId, MirRelationExpr};
+
+    /// Considers inlining actions to perform for a sequence of bindings and a following body.
+    ///
+    /// A let binding may be inlined only in subsequent bindings or in the body; other bindings should
+    /// not "immediately" osberve the binding, and it would be a change to the semantics of `LetRec`.
+    /// For example, it would not be correct to replace `C` with `A` in the definition of `B` here:
+    /// ```ignore
+    /// let A = ...;
+    /// let B = A - C;
+    /// let C = a;
+    ///```
+    /// The explanation is that `B` should always be the difference between the current and previous `A`,
+    /// and that the substitution of `C` would instead make it always zero, changing its definition.
+    ///
+    /// Here a let binding is proposed for inlining if any of the following:
+    ///  1. It has a single reference across all bindings and the body.
+    ///  2. It is a "sufficient simple" `Get`, determined in part by the `inline_mfp` argument.
+    /// The case of `Constant` binding could also apply, but is better handled by `FoldConstants`. Although
+    /// a bit weird, constants should also not be inlined into prior bindings as this does change the bemavion
+    /// from one where the collection is initially empty to one where it is always the contant.
+    ///
+    /// Having inlined bindings, many of them may now be dead (with no transitive references from `body`).
+    /// These can now be removed. They may not be exactly those bindings that were inlineable, as we may not always
+    /// be able to apply inlining due to ordering (we cannot inline a binding into one that is not strictly later).
+    pub(super) fn inline_lets(
+        expr: &mut MirRelationExpr,
+        inline_mfp: bool,
+    ) -> Result<(), crate::TransformError> {
+        if let MirRelationExpr::LetRec { ids, values, body } = expr {
+            // Count the number of uses of each local id across all expressions.
+            let mut counts = BTreeMap::new();
+            for value in values.iter() {
+                super::support::count_local_id_uses(value, &mut counts);
+            }
+            super::support::count_local_id_uses(body, &mut counts);
+
+            // Each binding can reach one of three positions on its inlineability:
+            //  1. The binding is used once and is available to be directly taken.
+            //  2. The binding is simple enough that it can just be cloned.
+            //  3. The binding is not available for inlining.
+            let mut inline_offer = BTreeMap::new();
+
+            // For each binding, inline `Get`s and then determine if *it* should be inlined.
+            // It is important that we do the substitution in-order and before reasoning
+            // about the inlineability of each binding, to ensure that our conclusion about
+            // the inlineability of a binding stays put. Specifically,
+            //   1. by going in order no substitition will increase the `Get`-count of an
+            //      identifier beyond one, as all in values with strictly greater identifiers.
+            //   2. by performing the substitution before reasoning, the structure of the value
+            //      as it would be substituted is fixed.
+            for (id, mut expr) in ids.drain(..).zip(values.drain(..)) {
+                // Substitute any appropriate prior let bindings.
+                inline_lets_helper(&mut expr, &mut inline_offer)?;
+                // Gets for `id` only occur in later expressions, so this should still be correct.
+                let num_gets = counts.get(&id).map(|x| *x).unwrap_or(0);
+                // Counts of zero or one lead to substitution; other wise certain simple structures
+                // are cloned in to `Get` operators, and all others emitted as `Let` bindings.
+                if num_gets == 0 {
+                } else if num_gets == 1 {
+                    inline_offer.insert(id, InlineOffer::Take(Some(expr)));
+                } else {
+                    let clone_binding = {
+                        let stripped_value = if inline_mfp {
+                            mz_expr::MapFilterProject::extract_non_errors_from_expr(&expr).1
+                        } else {
+                            &expr
+                        };
+                        match stripped_value {
+                            MirRelationExpr::Get { .. } | MirRelationExpr::Constant { .. } => true,
+                            _ => false,
+                        }
+                    };
+
+                    if clone_binding {
+                        inline_offer.insert(id, InlineOffer::Clone(expr));
+                    } else {
+                        inline_offer.insert(id, InlineOffer::Unavailable(expr));
+                    }
+                }
+            }
+            // Complete the inlining in the base relation.
+            inline_lets_helper(body, &mut inline_offer)?;
+
+            // We may now be able to discard some of `inline_offer` based on the remaning pattern of `Get` expressions.
+            // Storting from `body` and working backwards, we can activate bindings that are still required because we
+            // observe `Get` expressions referencing them. Any bindings not so identified can be dropped (including any
+            // that may be part of a cycle not reachable from `body`).
+            let mut let_bindings = BTreeMap::new();
+            let mut todo = Vec::new();
+            super::support::for_local_id(body, |id| todo.push(id));
+            while let Some(id) = todo.pop() {
+                if let Some(offer) = inline_offer.remove(&id) {
+                    let value = match offer {
+                        InlineOffer::Take(value) => value.ok_or_else(|| {
+                            crate::TransformError::Internal(
+                                "Needed value already taken".to_string(),
+                            )
+                        })?,
+                        InlineOffer::Clone(value) => value,
+                        InlineOffer::Unavailable(value) => value,
+                    };
+                    super::support::for_local_id(&value, |id| todo.push(id));
+                    let_bindings.insert(id, value);
+                }
+            }
+
+            // If bindings remain we update the `LetRec`, otherwise we remove it.
+            if !let_bindings.is_empty() {
+                let (new_ids, new_values) = let_bindings.into_iter().unzip();
+                *ids = new_ids;
+                *values = new_values;
+            } else {
+                *expr = body.take_dangerous();
+            }
+        }
+        Ok(())
+    }
+
+    /// Possible states of let binding inlineability.
+    enum InlineOffer {
+        /// There is a unique reference to this value and given the option it should take this expression.
+        Take(Option<MirRelationExpr>),
+        /// Any reference to this value should clone this expression.
+        Clone(MirRelationExpr),
+        /// Any reference to this value should do no inlining of it.
+        Unavailable(MirRelationExpr),
     }
 
     /// Substitute `Get{id}` expressions for any proposed expressions.
     ///
     /// The proposed expressions can be proposed either to be taken or cloned.
-    pub(super) fn inline_gets(
+    fn inline_lets_helper(
         expr: &mut MirRelationExpr,
-        to_take: &mut BTreeMap<LocalId, Option<MirRelationExpr>>,
-        to_clone: &BTreeMap<LocalId, MirRelationExpr>,
+        inline_offer: &mut BTreeMap<LocalId, InlineOffer>,
     ) -> Result<(), crate::TransformError> {
         let mut worklist = vec![expr];
         while let Some(expr) = worklist.pop() {
@@ -298,69 +518,131 @@ mod support {
                 id: Id::Local(id), ..
             } = expr
             {
-                if let Some(value) = to_take.get_mut(id) {
-                    if let Some(value) = value.take() {
-                        *expr = value;
-                        worklist.push(expr);
-                    } else {
-                        Err(crate::TransformError::Internal(format!(
-                            "Value already taken for {:?}",
-                            id
-                        )))?;
+                if let Some(offer) = inline_offer.get_mut(id) {
+                    match offer {
+                        InlineOffer::Take(value) => {
+                            *expr = value.take().ok_or_else(|| {
+                                crate::TransformError::Internal(format!(
+                                    "Value already taken for {:?}",
+                                    id
+                                ))
+                            })?;
+                            worklist.push(expr);
+                        }
+                        InlineOffer::Clone(value) => {
+                            *expr = value.clone();
+                            worklist.push(expr);
+                        }
+                        InlineOffer::Unavailable(_) => {
+                            // Do nothing.
+                        }
                     }
-                } else if let Some(value) = to_clone.get(id) {
-                    *expr = value.clone();
-                    worklist.push(expr);
+                } else {
+                    // Presumably a reference to an outer scope.
                 }
             } else {
-                worklist.extend(expr.children_mut());
+                worklist.extend(expr.children_mut().rev());
+            }
+        }
+        Ok(())
+    }
+}
+
+mod renumbering {
+
+    use std::collections::BTreeMap;
+
+    use mz_expr::{Id, LocalId, MirRelationExpr};
+    use mz_ore::id_gen::IdGen;
+
+    /// Re-assign an identifier to each `Let`.
+    pub fn renumber_bindings(
+        relation: &mut MirRelationExpr,
+        id_gen: &mut IdGen,
+    ) -> Result<(), crate::TransformError> {
+        let mut renaming = BTreeMap::new();
+        determine(&*relation, &mut renaming, id_gen)?;
+        implement(relation, &renaming)?;
+        Ok(())
+    }
+
+    /// Performs an in-order traversal of the AST, assigning identifiers as it goes.
+    fn determine(
+        relation: &MirRelationExpr,
+        remap: &mut BTreeMap<LocalId, LocalId>,
+        id_gen: &mut IdGen,
+    ) -> Result<(), crate::TransformError> {
+        // The stack contains pending work as `Result<LocalId, &MirRelationExpr>`, where
+        // 1. 'Ok(id)` means the identifier `id` is ready for renumbering,
+        // 2. `Err(expr)` means that the expression `expr` needs to be further processed.
+        let mut stack: Vec<Result<LocalId, _>> = vec![Err(relation)];
+        while let Some(action) = stack.pop() {
+            match action {
+                Ok(id) => {
+                    if remap.contains_key(&id) {
+                        Err(crate::TransformError::Internal(format!(
+                            "Shadowing of let binding for {:?}",
+                            id
+                        )))?;
+                    } else {
+                        remap.insert(id, LocalId::new(id_gen.allocate_id()));
+                    }
+                }
+                Err(expr) => match expr {
+                    MirRelationExpr::Let { id, value, body } => {
+                        stack.push(Err(body));
+                        stack.push(Ok(*id));
+                        stack.push(Err(value));
+                    }
+                    MirRelationExpr::LetRec { ids, values, body } => {
+                        stack.push(Err(body));
+                        for (id, value) in ids.iter().rev().zip(values.iter().rev()) {
+                            stack.push(Ok(*id));
+                            stack.push(Err(value));
+                        }
+                    }
+                    _ => {
+                        stack.extend(expr.children().rev().map(Err));
+                    }
+                },
             }
         }
         Ok(())
     }
 
-    pub(super) fn renumber_bindings_helper(
-        guard: &RecursionGuard,
+    fn implement(
         relation: &mut MirRelationExpr,
-        remap: &mut BTreeMap<LocalId, LocalId>,
-        id_gen: &mut IdGen,
+        remap: &BTreeMap<LocalId, LocalId>,
     ) -> Result<(), crate::TransformError> {
-        guard.checked_recur(|_| {
-            match relation {
-                MirRelationExpr::Let { id, value, body } => {
-                    renumber_bindings_helper(guard, value, remap, id_gen)?;
-                    // If a local id, assign a new identifier and refresh the type.
-                    let new_id = LocalId::new(id_gen.allocate_id());
-                    let prev = remap.insert(id.clone(), new_id);
-                    renumber_bindings_helper(guard, body, remap, id_gen)?;
-                    remap.remove(id);
-                    if let Some(prev_stuff) = prev {
-                        remap.insert(id.clone(), prev_stuff);
-                        tracing::warn!("Shadowing of let binding for {:?}", id);
-                    }
-                    *id = new_id;
-                    Ok(())
+        let mut worklist = vec![relation];
+        while let Some(expr) = worklist.pop() {
+            match expr {
+                MirRelationExpr::Let { id, .. } => {
+                    *id = *remap
+                        .get(id)
+                        .ok_or(crate::TransformError::IdentifierMissing(*id))?;
                 }
-                MirRelationExpr::Get { id, .. } => {
-                    if let Id::Local(local_id) = id {
-                        if let Some(new_id) = remap.get(local_id) {
-                            *local_id = new_id.clone();
-                        } else {
-                            Err(crate::TransformError::Internal(format!(
-                                "Remap not found for {:?}",
-                                local_id
-                            )))?;
-                        }
+                MirRelationExpr::LetRec { ids, .. } => {
+                    for id in ids.iter_mut() {
+                        *id = *remap
+                            .get(id)
+                            .ok_or(crate::TransformError::IdentifierMissing(*id))?;
                     }
-                    Ok(())
+                }
+                MirRelationExpr::Get {
+                    id: Id::Local(id), ..
+                } => {
+                    *id = *remap
+                        .get(id)
+                        .ok_or(crate::TransformError::IdentifierMissing(*id))?;
                 }
                 _ => {
-                    use mz_expr::visit::VisitChildren;
-                    relation.try_visit_mut_children(|e| {
-                        renumber_bindings_helper(guard, e, remap, id_gen)
-                    })
+                    // Remapped identifiers not used in these patterns.
                 }
             }
-        })
+            // The order is not critical, but behave as a stack for clarity.
+            worklist.extend(expr.children_mut().rev());
+        }
+        Ok(())
     }
 }

--- a/src/transform/src/normalize_lets.rs
+++ b/src/transform/src/normalize_lets.rs
@@ -16,9 +16,9 @@
 //! 1. Each expression is normalized to have all `Let` nodes at the root
 //! of the expression, in order of identifier.
 //! 2. Each expression assigns a contiguous block of identifiers.
-
+//!
 //! The transform may remove some `Let` and `Get` operators, and does not
-//! introduce any new operators. It is idempotent.
+//! introduce any new operators.
 //!
 //! The module also publishes the function `renumber_bindings` which can
 //! be used to renumber bindings in an expression starting from a provided
@@ -88,13 +88,16 @@ impl NormalizeLets {
         Ok(())
     }
 
-    /// Normalize `Let` bindings in `relation`.
+    /// Normalize `Let` and `LetRec` bindings in `relation`.
     ///
     /// Mechanically, `action` first renumbers all bindings, erroring if any shadowing is encountered.
-    /// It then promotes all `LetRec` expressions to the root, and considers inlining bindings.
-    /// Finally, it refreshes the types of each `Get` operator, and performs a final renumbering.
+    /// It then promotes all `Let` and `LetRec` expressions to the roots of their expressions, fusing
+    /// `Let` bindings into containing `LetRec` bindings, but leaving `LetRec` bindings unfused to each
+    /// other (for reasons of correctness). It then considers potential inlining in each `LetRec` scope.
+    /// Lastly, it refreshes the types of each `Get` operator, erroring if any scalar types have changed
+    /// but updating nullability and keys.
     ///
-    /// The method takes time linear in the size of `relation` for each `LetRec`.
+    /// We then perform a final renumbering.
     pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
         // Rename all bindings to be distinct. Start at zero.
         let mut id_gen = IdGen::default();
@@ -114,8 +117,9 @@ impl NormalizeLets {
         let mut id_gen = IdGen::default();
         renumbering::renumber_bindings(relation, &mut id_gen)?;
 
-        // Disassemble `LetRec` into `Let` stack if possible.
+        // Disassemble `LetRec` into a `Let` stack if possible.
         // If a `LetRec` remains, return the would-be `Let` bindings to it.
+        // This is to maintain `LetRec`-freedom for `LetRec`-free expressions.
         let mut bindings = let_motion::harvest_non_recursive(relation);
         if let MirRelationExpr::LetRec {
             ids,
@@ -150,6 +154,7 @@ mod support {
 
     use mz_expr::{Id, LocalId, MirRelationExpr};
 
+    /// Logic mapped across each use of a `LocalId`.
     pub(super) fn for_local_id<F>(expr: &MirRelationExpr, mut logic: F)
     where
         F: FnMut(LocalId),
@@ -164,20 +169,12 @@ mod support {
         });
     }
 
-    // This is pretty simple, but it is used in multiple locations and seemed clearer as a named method.
     /// Populates `counts` with the number of uses of each local identifier in `expr`.
     pub(super) fn count_local_id_uses(
         expr: &MirRelationExpr,
         counts: &mut std::collections::BTreeMap<LocalId, usize>,
     ) {
-        expr.visit_pre(|expr| {
-            if let MirRelationExpr::Get {
-                id: Id::Local(i), ..
-            } = expr
-            {
-                *counts.entry(*i).or_insert(0) += 1;
-            }
-        });
+        for_local_id(expr, |i| *counts.entry(i).or_insert(0) += 1)
     }
 
     /// Visit `LetRec` stages and determine and update type information for `Get` nodes.
@@ -186,7 +183,7 @@ mod support {
     /// It only refreshes the nullability and unique key information. As this information can regress,
     /// we do not error if the type weakens, even though that may be something we want to look into.
     pub(super) fn refresh_types(expr: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
-        // TODO: This is not as complete as a post-order traversal would be, refreshing as it goes.
+        // TODO: consider a different visitation order, or iterating, to propagate types further.
         let mut types = BTreeMap::new();
         let mut worklist = vec![&mut *expr];
         while let Some(expr) = worklist.pop() {
@@ -210,7 +207,7 @@ mod support {
             } = expr
             {
                 if let Some(new_type) = types.get(id) {
-                    // Something bad has happened if the type *weakens*.
+                    // Assert that the column length and types have not changed.
                     assert!(
                         new_type.column_types.len() == typ.column_types.len(),
                         "column lengths do not match: {:?} v {:?}",
@@ -227,7 +224,6 @@ mod support {
                         new_type.column_types,
                         typ.column_types
                     );
-                    // assert!(new_type.subtypes(typ), "{:?} does not subtype {:?}", new_type, typ);
                     typ.clone_from(new_type);
                 }
             }
@@ -244,7 +240,10 @@ mod let_motion {
 
     use mz_expr::{LocalId, MirRelationExpr};
 
-    /// Normalizes the `LetRec` structure in an expression by promoting and potentially fusing all `LetRec` nodes.
+    /// Promotes all `Let` and `LetRec` nodes to the roots of their expressions.
+    ///
+    /// We cannot (without further reasoning) fuse stacked `LetRec` stages, and instead we just promote
+    /// `LetRec` to the roots of their expressions (e.g. as children of another `LetRec` stage).
     pub(crate) fn promote_let_rec(expr: &mut MirRelationExpr) {
         // First, promote all `LetRec` nodes above all other nodes.
         let mut worklist = vec![&mut *expr];
@@ -261,10 +260,22 @@ mod let_motion {
                 worklist.extend(values.iter_mut().rev());
             }
         }
+        // Harvest any potential `Let` nodes, via a post-order traversal.
+        post_order_harvest_lets(expr);
+    }
 
+    /// Performs a post-order traversal of the `LetRec` nodes at the root of an expression.
+    ///
+    /// The traversal is only of the `LetRec` nodes, for which fear of stack exhaustion is nominal.
+    fn post_order_harvest_lets(expr: &mut MirRelationExpr) {
         // Second, attempt to fuse non-recursive `LetRec` bindings.
-        // Ideally do a post-order traversal of only `LetRec` nodes, but for now just once.
+        // TODO: Ideally do a post-order traversal of only `LetRec` nodes, but for now just once.
         if let MirRelationExpr::LetRec { ids, values, body } = expr {
+            // Only recursively descend through `LetRec` stages.
+            for value in values.iter_mut() {
+                post_order_harvest_lets(value);
+            }
+
             let mut bindings = BTreeMap::new();
             for (id, mut value) in ids.drain(..).zip(values.drain(..)) {
                 bindings.extend(harvest_non_recursive(&mut value));
@@ -284,15 +295,13 @@ mod let_motion {
     /// along each path from the root. Each of `values` and `body` may need further processing to promote
     /// all bindings to their respective roots.
     ///
-    /// If `expr` is anything but a `LetRec` node, then it contains no further `Let` or `LetRec` nodes.
-    ///
-    /// This method is idempotent.
+    /// If the resulting `expr` is not a `LetRec` node, then it contains no further `Let` or `LetRec` nodes.
     fn digest_lets(expr: &mut MirRelationExpr) {
         let mut worklist = Vec::new();
         let mut bindings = BTreeMap::new();
-        digest_lets_helper(expr, &mut worklist);
+        digest_lets_helper(expr, &mut worklist, &mut bindings);
         while let Some((id, mut value)) = worklist.pop() {
-            digest_lets_helper(&mut value, &mut worklist);
+            digest_lets_helper(&mut value, &mut worklist, &mut bindings);
             bindings.insert(id, value);
         }
         if !bindings.is_empty() {
@@ -308,22 +317,25 @@ mod let_motion {
     /// Extracts all `Let` and `LetRec` bindings from `expr` through its first `LetRec`.
     ///
     /// The bindings themselves may not be `Let`-free, and should be further processed to ensure this.
-    /// We stop at the first `LetRec` as we cannot be certain that subsequent bindings can be lifted
-    /// to a shared `LetRec` scope atop `expr`.
+    /// Bindings are extracted either into `worklist` if they should be further processed (e.g. from a `Let`),
+    /// or into `bindings` if they should not be further processed (e.g. from a `LetRec`).
     fn digest_lets_helper(
         expr: &mut MirRelationExpr,
-        bindings: &mut Vec<(LocalId, MirRelationExpr)>,
+        worklist: &mut Vec<(LocalId, MirRelationExpr)>,
+        bindings: &mut BTreeMap<LocalId, MirRelationExpr>,
     ) {
         let mut to_visit = vec![expr];
         while let Some(expr) = to_visit.pop() {
             match expr {
                 MirRelationExpr::Let { id, value, body } => {
-                    bindings.push((*id, value.take_dangerous()));
+                    // push binding into `worklist` as it can be further processed.
+                    worklist.push((*id, value.take_dangerous()));
                     *expr = body.take_dangerous();
                     // Continue through `Let` nodes as they are certainly non-recursive.
                     to_visit.push(expr);
                 }
                 MirRelationExpr::LetRec { ids, values, body } => {
+                    // push bindings into `bindings` as they should not be further processed.
                     bindings.extend(ids.drain(..).zip(values.drain(..)));
                     *expr = body.take_dangerous();
                     // Stop at `LetRec` nodes as we cannot always lift `Let` nodes out of them.
@@ -337,9 +349,12 @@ mod let_motion {
 
     /// Harvest any safe-to-lift non-recursive bindings from a `LetRec` expression.
     ///
-    /// A binding is safe to lift if it
-    /// 1. references no other non-lifted binding here, and
-    /// 2. is referenced by no prior non-lifted binding here.
+    /// At the moment, we reason that a binding can be lifted without changing the output if both
+    /// 1. it references no other non-lifted binding here, and
+    /// 2. it is referenced by no prior non-lifted binding here.
+    /// The rationale is that (1.) ensures that the binding's value does not change across iterations,
+    /// and that (2.) ensures that all observations of the binding are after it assumes its first value,
+    /// rather than when it could be empty.
     pub(crate) fn harvest_non_recursive(
         expr: &mut MirRelationExpr,
     ) -> BTreeMap<LocalId, MirRelationExpr> {

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -122,9 +122,15 @@ impl ProjectionPushdown {
                 )?;
                 desired_projection.clone()
             }
-            MirRelationExpr::LetRec { .. } => {
+            MirRelationExpr::LetRec { values, body, .. } => {
                 // TODO: Implement a more thoughtful projection pushdown.
-                (0..relation.arity()).collect()
+                let desired_projection = (0..body.arity()).collect();
+                self.action(body, &desired_projection, gets)?;
+                for value in values.iter_mut() {
+                    let desired_projection = (0..value.arity()).collect();
+                    self.action(value, &desired_projection, gets)?;
+                }
+                desired_projection
             }
             MirRelationExpr::Join {
                 inputs,

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -65,22 +65,18 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 ----
 Return // { arity: 1 }
   Project (#0) // { arity: 1 }
-    Get l2 // { arity: 2 }
-With
-  cte l2 =
     Filter (true AND (#0 = #1)) // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
         CrossJoin // { arity: 2 }
-          Get l1 // { arity: 1 }
-          Get l1 // { arity: 1 }
-  cte l1 =
+          Get l0 // { arity: 1 }
+          Get l0 // { arity: 1 }
+With
+  cte l0 =
     Filter (#0 < 3) // { arity: 1 }
       CrossJoin // { arity: 1 }
-        Get l0 // { arity: 0 }
+        Constant // { arity: 0 }
+          - ()
         Get materialize.public.y // { arity: 1 }
-  cte l0 =
-    Constant // { arity: 0 }
-      - ()
 
 EOF
 
@@ -96,40 +92,36 @@ Return // { arity: 2 }
   Filter true // { arity: 2 }
     Project (#0, #2) // { arity: 2 }
       Join on=(#0 = #1) // { arity: 3 }
-        Get l1 // { arity: 1 }
-        Get l4 // { arity: 2 }
+        Get l0 // { arity: 1 }
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          CrossJoin // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct group_by=[#0] // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 1 }
+              - (null)
 With
-  cte l4 =
-    Union // { arity: 2 }
-      Get l3 // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
-                  Get l3 // { arity: 2 }
-              Distinct group_by=[#0] // { arity: 1 }
-                Get l2 // { arity: 1 }
-            Get l2 // { arity: 1 }
-        Constant // { arity: 1 }
-          - (null)
-  cte l3 =
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin // { arity: 2 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l1 // { arity: 1 }
   cte l1 =
-    CrossJoin // { arity: 1 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.x // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
 
 EOF
 
@@ -158,84 +150,80 @@ Return // { arity: 2 }
   Filter true // { arity: 2 }
     Project (#0, #2) // { arity: 2 }
       Join on=(#0 = #1) // { arity: 3 }
-        Get l1 // { arity: 1 }
+        Get l0 // { arity: 1 }
         Project (#0, #2) // { arity: 2 }
           Project (#0, #1, #5) // { arity: 3 }
             Map (#4) // { arity: 6 }
               Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
-                Get l5 // { arity: 2 }
+                Get l3 // { arity: 2 }
                 Project (#0, #1, #3) // { arity: 3 }
                   Join on=(#0 = #2) // { arity: 4 }
-                    Get l6 // { arity: 2 }
+                    Get l4 // { arity: 2 }
                     Union // { arity: 2 }
-                      Get l9 // { arity: 2 }
+                      Get l7 // { arity: 2 }
                       CrossJoin // { arity: 2 }
                         Project (#0) // { arity: 1 }
                           Join on=(#0 = #1) // { arity: 2 }
                             Union // { arity: 1 }
                               Negate // { arity: 1 }
                                 Distinct group_by=[#0] // { arity: 1 }
-                                  Get l9 // { arity: 2 }
+                                  Get l7 // { arity: 2 }
                               Distinct group_by=[#0] // { arity: 1 }
-                                Get l7 // { arity: 1 }
-                            Get l7 // { arity: 1 }
+                                Get l5 // { arity: 1 }
+                            Get l5 // { arity: 1 }
                         Constant // { arity: 1 }
                           - (null)
 With
-  cte l9 =
+  cte l7 =
     Union // { arity: 2 }
-      Get l8 // { arity: 2 }
+      Get l6 // { arity: 2 }
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
             Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l8 // { arity: 2 }
-  cte l8 =
+              Get l6 // { arity: 2 }
+  cte l6 =
     Project (#0, #2) // { arity: 2 }
       Join on=(#0 = #1) // { arity: 3 }
-        Get l7 // { arity: 1 }
-        Get l4 // { arity: 2 }
-  cte l7 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l6 // { arity: 2 }
-  cte l6 =
-    Distinct group_by=[#0, #1] // { arity: 2 }
-      Get l5 // { arity: 2 }
+        Get l5 // { arity: 1 }
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          CrossJoin // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct group_by=[#0] // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 1 }
+              - (null)
   cte l5 =
-    CrossJoin // { arity: 2 }
-      Get l2 // { arity: 1 }
-      Get materialize.public.y // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l4 // { arity: 2 }
   cte l4 =
-    Union // { arity: 2 }
+    Distinct group_by=[#0, #1] // { arity: 2 }
       Get l3 // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
-                  Get l3 // { arity: 2 }
-              Distinct group_by=[#0] // { arity: 1 }
-                Get l2 // { arity: 1 }
-            Get l2 // { arity: 1 }
-        Constant // { arity: 1 }
-          - (null)
   cte l3 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin // { arity: 2 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l1 // { arity: 1 }
   cte l1 =
-    CrossJoin // { arity: 1 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.x // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
 
 EOF
 
@@ -252,46 +240,42 @@ Return // { arity: 3 }
   Filter true // { arity: 3 }
     Project (#0, #2, #3) // { arity: 3 }
       Join on=(#0 = #1) // { arity: 4 }
-        Get l1 // { arity: 1 }
-        Get l5 // { arity: 3 }
+        Get l0 // { arity: 1 }
+        Filter (#1 = #2) // { arity: 3 }
+          Project (#0, #1, #3) // { arity: 3 }
+            Join on=(#0 = #2) // { arity: 4 }
+              Get l3 // { arity: 2 }
+              Get l3 // { arity: 2 }
 With
-  cte l5 =
-    Filter (#1 = #2) // { arity: 3 }
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) // { arity: 4 }
-          Get l4 // { arity: 2 }
-          Get l4 // { arity: 2 }
-  cte l4 =
+  cte l3 =
     Union // { arity: 2 }
-      Get l3 // { arity: 2 }
+      Get l2 // { arity: 2 }
       CrossJoin // { arity: 2 }
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Distinct group_by=[#0] // { arity: 1 }
-                  Get l3 // { arity: 2 }
+                  Get l2 // { arity: 2 }
               Distinct group_by=[#0] // { arity: 1 }
-                Get l2 // { arity: 1 }
-            Get l2 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Get l1 // { arity: 1 }
         Constant // { arity: 1 }
           - (null)
-  cte l3 =
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin // { arity: 2 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l1 // { arity: 1 }
   cte l1 =
-    CrossJoin // { arity: 1 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.x // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
 
 EOF
 
@@ -326,91 +310,85 @@ Return // { arity: 3 }
   Filter true // { arity: 3 }
     Project (#0, #2, #3) // { arity: 3 }
       Join on=(#0 = #1) // { arity: 4 }
-        Get l1 // { arity: 1 }
-        Get l11 // { arity: 3 }
-With
-  cte l11 =
-    Filter true // { arity: 3 }
-      Project (#0, #1, #3) // { arity: 3 }
-        Join on=(#0 = #2) // { arity: 4 }
-          Get l4 // { arity: 2 }
-          Get l10 // { arity: 2 }
-  cte l10 =
-    Project (#0, #5) // { arity: 2 }
-      Map (#4) // { arity: 6 }
-        Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
-          Get l5 // { arity: 2 }
+        Get l0 // { arity: 1 }
+        Filter true // { arity: 3 }
           Project (#0, #1, #3) // { arity: 3 }
             Join on=(#0 = #2) // { arity: 4 }
-              Get l6 // { arity: 2 }
-              Union // { arity: 2 }
-                Get l9 // { arity: 2 }
-                CrossJoin // { arity: 2 }
-                  Project (#0) // { arity: 1 }
-                    Join on=(#0 = #1) // { arity: 2 }
-                      Union // { arity: 1 }
-                        Negate // { arity: 1 }
-                          Distinct group_by=[#0] // { arity: 1 }
-                            Get l9 // { arity: 2 }
-                        Distinct group_by=[#0] // { arity: 1 }
-                          Get l7 // { arity: 1 }
-                      Get l7 // { arity: 1 }
-                  Constant // { arity: 1 }
-                    - (null)
-  cte l9 =
+              Get l3 // { arity: 2 }
+              Project (#0, #5) // { arity: 2 }
+                Map (#4) // { arity: 6 }
+                  Join on=(#0 = #2 AND #1 = #3) // { arity: 5 }
+                    Get l4 // { arity: 2 }
+                    Project (#0, #1, #3) // { arity: 3 }
+                      Join on=(#0 = #2) // { arity: 4 }
+                        Get l5 // { arity: 2 }
+                        Union // { arity: 2 }
+                          Get l8 // { arity: 2 }
+                          CrossJoin // { arity: 2 }
+                            Project (#0) // { arity: 1 }
+                              Join on=(#0 = #1) // { arity: 2 }
+                                Union // { arity: 1 }
+                                  Negate // { arity: 1 }
+                                    Distinct group_by=[#0] // { arity: 1 }
+                                      Get l8 // { arity: 2 }
+                                  Distinct group_by=[#0] // { arity: 1 }
+                                    Get l6 // { arity: 1 }
+                                Get l6 // { arity: 1 }
+                            Constant // { arity: 1 }
+                              - (null)
+With
+  cte l8 =
     Union // { arity: 2 }
-      Get l8 // { arity: 2 }
+      Get l7 // { arity: 2 }
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
             Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l8 // { arity: 2 }
-  cte l8 =
+              Get l7 // { arity: 2 }
+  cte l7 =
     Project (#0, #2) // { arity: 2 }
       Join on=(#0 = #1) // { arity: 3 }
-        Get l7 // { arity: 1 }
-        Get l4 // { arity: 2 }
-  cte l7 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l6 // { arity: 2 }
+        Get l6 // { arity: 1 }
+        Get l3 // { arity: 2 }
   cte l6 =
-    Distinct group_by=[#0, #1] // { arity: 2 }
+    Distinct group_by=[#0] // { arity: 1 }
       Get l5 // { arity: 2 }
   cte l5 =
-    CrossJoin // { arity: 2 }
-      Get l2 // { arity: 1 }
-      Get materialize.public.y // { arity: 1 }
+    Distinct group_by=[#0, #1] // { arity: 2 }
+      Get l4 // { arity: 2 }
   cte l4 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l3 =
     Union // { arity: 2 }
-      Get l3 // { arity: 2 }
+      Get l2 // { arity: 2 }
       CrossJoin // { arity: 2 }
         Project (#0) // { arity: 1 }
           Join on=(#0 = #1) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Distinct group_by=[#0] // { arity: 1 }
-                  Get l3 // { arity: 2 }
+                  Get l2 // { arity: 2 }
               Distinct group_by=[#0] // { arity: 1 }
-                Get l2 // { arity: 1 }
-            Get l2 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Get l1 // { arity: 1 }
         Constant // { arity: 1 }
           - (null)
-  cte l3 =
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin // { arity: 2 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l1 // { arity: 1 }
   cte l1 =
-    CrossJoin // { arity: 1 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.x // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
 
 EOF
 
@@ -443,94 +421,86 @@ Return // { arity: 3 }
   Filter true // { arity: 3 }
     Project (#0, #2, #3) // { arity: 3 }
       Join on=(#0 = #1) // { arity: 4 }
-        Get l1 // { arity: 1 }
+        Get l0 // { arity: 1 }
         Filter true // { arity: 3 }
           Project (#0, #1, #3) // { arity: 3 }
             Join on=(#1 = #2) // { arity: 4 }
-              Get l5 // { arity: 2 }
+              Get l3 // { arity: 2 }
               Project (#0, #2) // { arity: 2 }
                 Map (#0) // { arity: 3 }
-                  Get l11 // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (#2 > 0) // { arity: 3 }
+                      Project (#0, #1, #3) // { arity: 3 }
+                        Join on=(#0 = #2) // { arity: 4 }
+                          Get l4 // { arity: 2 }
+                          Union // { arity: 2 }
+                            Get l7 // { arity: 2 }
+                            CrossJoin // { arity: 2 }
+                              Project (#0) // { arity: 1 }
+                                Join on=(#0 = #1) // { arity: 2 }
+                                  Union // { arity: 1 }
+                                    Negate // { arity: 1 }
+                                      Distinct group_by=[#0] // { arity: 1 }
+                                        Get l7 // { arity: 2 }
+                                    Distinct group_by=[#0] // { arity: 1 }
+                                      Get l5 // { arity: 1 }
+                                  Get l5 // { arity: 1 }
+                              Constant // { arity: 1 }
+                                - (null)
 With
-  cte l11 =
-    Project (#0, #1) // { arity: 2 }
-      Filter (#2 > 0) // { arity: 3 }
-        Project (#0, #1, #3) // { arity: 3 }
-          Join on=(#0 = #2) // { arity: 4 }
-            Get l7 // { arity: 2 }
-            Union // { arity: 2 }
-              Get l10 // { arity: 2 }
-              CrossJoin // { arity: 2 }
-                Project (#0) // { arity: 1 }
-                  Join on=(#0 = #1) // { arity: 2 }
-                    Union // { arity: 1 }
-                      Negate // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
-                          Get l10 // { arity: 2 }
-                      Distinct group_by=[#0] // { arity: 1 }
-                        Get l8 // { arity: 1 }
-                    Get l8 // { arity: 1 }
-                Constant // { arity: 1 }
-                  - (null)
-  cte l10 =
+  cte l7 =
     Union // { arity: 2 }
-      Get l9 // { arity: 2 }
+      Get l6 // { arity: 2 }
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
             Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-              Get l9 // { arity: 2 }
-  cte l9 =
+              Get l6 // { arity: 2 }
+  cte l6 =
     Project (#0, #2) // { arity: 2 }
       Join on=(#0 = #1) // { arity: 3 }
-        Get l8 // { arity: 1 }
-        Get l4 // { arity: 2 }
-  cte l8 =
+        Get l5 // { arity: 1 }
+        Union // { arity: 2 }
+          Get l2 // { arity: 2 }
+          CrossJoin // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Join on=(#0 = #1) // { arity: 2 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Distinct group_by=[#0] // { arity: 1 }
+                      Get l2 // { arity: 2 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Get l1 // { arity: 1 }
+                Get l1 // { arity: 1 }
+            Constant // { arity: 1 }
+              - (null)
+  cte l5 =
     Distinct group_by=[#0] // { arity: 1 }
-      Get l7 // { arity: 2 }
-  cte l7 =
+      Get l4 // { arity: 2 }
+  cte l4 =
     Filter true // { arity: 2 }
       CrossJoin // { arity: 2 }
-        Get l6 // { arity: 1 }
+        Distinct group_by=[#1] // { arity: 1 }
+          Get l3 // { arity: 2 }
         Get materialize.public.x // { arity: 1 }
-  cte l6 =
-    Distinct group_by=[#1] // { arity: 1 }
-      Get l5 // { arity: 2 }
-  cte l5 =
-    CrossJoin // { arity: 2 }
-      Get l2 // { arity: 1 }
-      Get materialize.public.y // { arity: 1 }
-  cte l4 =
-    Union // { arity: 2 }
-      Get l3 // { arity: 2 }
-      CrossJoin // { arity: 2 }
-        Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
-                  Get l3 // { arity: 2 }
-              Distinct group_by=[#0] // { arity: 1 }
-                Get l2 // { arity: 1 }
-            Get l2 // { arity: 1 }
-        Constant // { arity: 1 }
-          - (null)
   cte l3 =
+    CrossJoin // { arity: 2 }
+      Get l1 // { arity: 1 }
+      Get materialize.public.y // { arity: 1 }
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
       Filter (#1 < #0) // { arity: 2 }
         CrossJoin // { arity: 2 }
-          Get l2 // { arity: 1 }
+          Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
-  cte l2 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l1 // { arity: 1 }
   cte l1 =
-    CrossJoin // { arity: 1 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.x // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l0 // { arity: 1 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.x // { arity: 1 }
 
 EOF
 

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -34,12 +34,8 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT 1 / 0
 ----
-Return
-  Project (#0)
-    Map ((1 / 0))
-      Get l0
-With
-  cte l0 =
+Project (#0)
+  Map ((1 / 0))
     Constant
       - ()
 
@@ -50,38 +46,28 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
-Return
-  Union
-    Project (#2, #3)
-      Map (#0, #1)
-        Get l3
-    Project (#2, #3)
-      Map (#0, #1)
-        Get l4
-With
-  cte l4 =
-    Project (#0, #1)
-      Map (3, 4)
-        Get l0
-  cte l3 =
-    Union
-      Project (#2, #3)
-        Map (#0, #1)
-          Get l1
-      Project (#2, #3)
-        Map (#0, #1)
-          Get l2
-  cte l2 =
-    Project (#0, #1)
-      Map (1, 2)
-        Get l0
-  cte l1 =
-    Project (#0, #1)
-      Map (1, 2)
-        Get l0
-  cte l0 =
-    Constant
-      - ()
+Union
+  Project (#2, #3)
+    Map (#0, #1)
+      Union
+        Project (#2, #3)
+          Map (#0, #1)
+            Project (#0, #1)
+              Map (1, 2)
+                Constant
+                  - ()
+        Project (#2, #3)
+          Map (#0, #1)
+            Project (#0, #1)
+              Map (1, 2)
+                Constant
+                  - ()
+  Project (#2, #3)
+    Map (#0, #1)
+      Project (#0, #1)
+        Map (3, 4)
+          Constant
+            - ()
 
 EOF
 
@@ -90,19 +76,13 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
 ----
-Return
-  Project (#2, #3)
-    Map (1, (#0 + #1))
-      Get l1
-With
-  cte l1 =
+Project (#2, #3)
+  Map (1, (#0 + #1))
     Filter (((#0 > 0) AND (#1 < 0)) AND ((#0 + #1) > 0))
       CrossJoin
-        Get l0
+        Constant
+          - ()
         Get materialize.public.mv
-  cte l0 =
-    Constant
-      - ()
 
 EOF
 
@@ -111,19 +91,13 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT generate_series(a, b) from t
 ----
-Return
-  Project (#2)
-    Filter true
-      FlatMap generate_series(#0, #1, 1)
-        Get l1
-With
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+Project (#2)
+  Filter true
+    FlatMap generate_series(#0, #1, 1)
+      CrossJoin
+        Constant
+          - ()
+        Get materialize.public.t
 
 EOF
 
@@ -132,32 +106,25 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
-Return
-  Threshold
-    Union
+Threshold
+  Union
+    Distinct group_by=[#0]
+      Project (#1)
+        Map (#0)
+          Project (#0)
+            CrossJoin
+              Constant
+                - ()
+              Get materialize.public.t
+    Negate
       Distinct group_by=[#0]
         Project (#1)
           Map (#0)
-            Get l1
-      Negate
-        Distinct group_by=[#0]
-          Project (#1)
-            Map (#0)
-              Get l2
-With
-  cte l2 =
-    Project (#1)
-      CrossJoin
-        Get l0
-        Get materialize.public.mv
-  cte l1 =
-    Project (#0)
-      CrossJoin
-        Get l0
-        Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+            Project (#1)
+              CrossJoin
+                Constant
+                  - ()
+                Get materialize.public.mv
 
 EOF
 
@@ -166,30 +133,23 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
-Return
-  Threshold
-    Union
+Threshold
+  Union
+    Project (#1)
+      Map (#0)
+        Project (#0)
+          CrossJoin
+            Constant
+              - ()
+            Get materialize.public.t
+    Negate
       Project (#1)
         Map (#0)
-          Get l1
-      Negate
-        Project (#1)
-          Map (#0)
-            Get l2
-With
-  cte l2 =
-    Project (#1)
-      CrossJoin
-        Get l0
-        Get materialize.public.mv
-  cte l1 =
-    Project (#0)
-      CrossJoin
-        Get l0
-        Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+          Project (#1)
+            CrossJoin
+              Constant
+                - ()
+              Get materialize.public.mv
 
 EOF
 
@@ -198,16 +158,12 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 VIEW ov
 ----
-Return
-  Project (#0, #1)
-    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
-      CrossJoin
-        Get l0
-        Get materialize.public.t
-With
-  cte l0 =
-    Constant
-      - ()
+Project (#0, #1)
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 
@@ -217,14 +173,10 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
-  Return
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  With
-    cte l0 =
-      Constant
-        - ()
+  CrossJoin
+    Constant
+      - ()
+    Get materialize.public.t
 
 EOF
 
@@ -236,31 +188,29 @@ SELECT abs(min(a) - max(a)) FROM t
 Return
   Project (#2)
     Map (abs((#0 - #1)))
-      Get l2
-With
-  cte l2 =
-    Union
-      Get l1
-      CrossJoin
-        Project ()
-          CrossJoin
-            Union
-              Negate
+      Union
+        Get l0
+        CrossJoin
+          Project ()
+            CrossJoin
+              Union
+                Negate
+                  Distinct
+                    Get l0
                 Distinct
-                  Get l1
-              Distinct
-                Get l0
-            Get l0
-        Constant
-          - (null, null)
-  cte l1 =
+                  Constant
+                    - ()
+              Constant
+                - ()
+          Constant
+            - (null, null)
+With
+  cte l0 =
     Reduce aggregates=[min(#0), max(#0)]
       CrossJoin
-        Get l0
+        Constant
+          - ()
         Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
 
 EOF
 
@@ -269,23 +219,15 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
-Return
-  Project (#3)
-    Map (abs((#1 - #2)))
-      Get l2
-With
-  cte l2 =
+Project (#3)
+  Map (abs((#1 - #2)))
     Reduce group_by=[#2] aggregates=[min(#0), max(#0)]
       Project (#0..=#2)
         Map (#1)
-          Get l1
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+          CrossJoin
+            Constant
+              - ()
+            Get materialize.public.t
 
 EOF
 
@@ -299,74 +241,72 @@ Return
     Filter #2
       Project (#0, #1, #3)
         Join on=(#1 = #2)
-          Get l4
+          Get l3
           Union
-            Get l6
+            Get l5
             CrossJoin
               Project (#0)
                 Join on=(#0 = #1)
                   Union
                     Negate
                       Distinct group_by=[#0]
-                        Get l6
+                        Get l5
                     Distinct group_by=[#0]
-                      Get l5
-                  Get l5
+                      Get l4
+                  Get l4
               Constant
                 - (false)
 With
-  cte l6 =
+  cte l5 =
     CrossJoin
       Distinct group_by=[#0]
         Filter (#0 > #2)
           CrossJoin
-            Get l5
+            Get l4
             Get materialize.public.mv
       Constant
         - (true)
-  cte l5 =
-    Distinct group_by=[#1]
-      Get l4
   cte l4 =
+    Distinct group_by=[#1]
+      Get l3
+  cte l3 =
     Project (#0, #1)
       Filter #2
         Project (#0, #1, #3)
           Join on=(#0 = #2)
-            Get l1
+            Get l0
             Union
-              Get l3
+              Get l2
               CrossJoin
                 Project (#0)
                   Join on=(#0 = #1)
                     Union
                       Negate
                         Distinct group_by=[#0]
-                          Get l3
+                          Get l2
                       Distinct group_by=[#0]
-                        Get l2
-                    Get l2
+                        Get l1
+                    Get l1
                 Constant
                   - (false)
-  cte l3 =
+  cte l2 =
     CrossJoin
       Distinct group_by=[#0]
         Filter (#0 < #1)
           CrossJoin
-            Get l2
+            Get l1
             Get materialize.public.mv
       Constant
         - (true)
-  cte l2 =
-    Distinct group_by=[#0]
-      Get l1
   cte l1 =
+    Distinct group_by=[#0]
+      Get l0
+  cte l0 =
     Filter (true AND true)
       CrossJoin
-        Get l0
+        Constant
+          - ()
         Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
 
 EOF
 
@@ -379,91 +319,89 @@ Return
   Project (#8, #9)
     Map (#4, #7)
       Join on=(eq(#0, #2, #5) AND eq(#1, #3, #6))
-        Get l1
+        Get l0
         Project (#0, #1, #3)
           Join on=(#1 = #2)
-            Get l2
+            Get l1
             Union
-              Get l5
+              Get l4
               CrossJoin
                 Project (#0)
                   Join on=(#0 = #1)
                     Union
                       Negate
                         Distinct group_by=[#0]
-                          Get l5
+                          Get l4
                       Distinct group_by=[#0]
-                        Get l3
-                    Get l3
+                        Get l2
+                    Get l2
                 Constant
                   - (null)
         Project (#0, #1, #3)
           Join on=(#1 = #2)
-            Get l6
+            Get l5
             Union
-              Get l9
+              Get l8
               CrossJoin
                 Project (#0)
                   Join on=(#0 = #1)
                     Union
                       Negate
                         Distinct group_by=[#0]
-                          Get l9
+                          Get l8
                       Distinct group_by=[#0]
-                        Get l7
-                    Get l7
+                        Get l6
+                    Get l6
                 Constant
                   - (null)
 With
-  cte l9 =
-    Union
-      Get l8
-      Map (error("more than one record produced in subquery"))
-        Project (#0)
-          Filter (#1 > 1)
-            Reduce group_by=[#0] aggregates=[count(*)]
-              Get l8
   cte l8 =
-    Project (#0, #1)
-      TopK group_by=[#0] limit=1 monotonic=false
-        Filter (#2 = #0)
-          CrossJoin
-            Get l7
-            Get materialize.public.mv
-  cte l7 =
-    Distinct group_by=[#1]
-      Get l6
-  cte l6 =
-    Distinct group_by=[#0, #1]
-      Get l1
-  cte l5 =
     Union
-      Get l4
+      Get l7
       Map (error("more than one record produced in subquery"))
         Project (#0)
           Filter (#1 > 1)
             Reduce group_by=[#0] aggregates=[count(*)]
-              Get l4
-  cte l4 =
+              Get l7
+  cte l7 =
     Project (#0, #1)
       TopK group_by=[#0] limit=1 monotonic=false
         Filter (#2 = #0)
           CrossJoin
-            Get l3
-            Get materialize.public.v
-  cte l3 =
+            Get l6
+            Get materialize.public.mv
+  cte l6 =
     Distinct group_by=[#1]
-      Get l2
-  cte l2 =
+      Get l5
+  cte l5 =
     Distinct group_by=[#0, #1]
+      Get l0
+  cte l4 =
+    Union
+      Get l3
+      Map (error("more than one record produced in subquery"))
+        Project (#0)
+          Filter (#1 > 1)
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Get l3
+  cte l3 =
+    Project (#0, #1)
+      TopK group_by=[#0] limit=1 monotonic=false
+        Filter (#2 = #0)
+          CrossJoin
+            Get l2
+            Get materialize.public.v
+  cte l2 =
+    Distinct group_by=[#1]
       Get l1
   cte l1 =
-    CrossJoin
+    Distinct group_by=[#0, #1]
       Get l0
-      Get materialize.public.t
   cte l0 =
-    Constant
-      - ()
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 
@@ -472,27 +410,18 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
-Return
-  Project (#0, #2)
-    Get l3
-With
-  cte l3 =
-    Filter true
-      Project (#0..=#3)
+Project (#0, #2)
+  Filter true
+    Project (#0..=#3)
+      CrossJoin
         CrossJoin
-          Get l1
-          Get l2
-  cte l2 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+          Constant
+            - ()
+          Get materialize.public.t
+        CrossJoin
+          Constant
+            - ()
+          Get materialize.public.t
 
 EOF
 
@@ -501,27 +430,18 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
 ----
-Return
-  Project (#0, #2)
-    Get l3
-With
-  cte l3 =
-    Filter true
-      Project (#0..=#3)
+Project (#0, #2)
+  Filter true
+    Project (#0..=#3)
+      CrossJoin
         CrossJoin
-          Get l1
-          Get l2
-  cte l2 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+          Constant
+            - ()
+          Get materialize.public.t
+        CrossJoin
+          Constant
+            - ()
+          Get materialize.public.t
 
 EOF
 
@@ -535,40 +455,26 @@ FROM
   t as t3
 WHERE t1.b = t2.b AND t2.b = t3.b
 ----
-Return
-  Project (#0, #2)
-    Filter ((#1 = #3) AND (#3 = #5))
-      Get l6
-With
-  cte l6 =
+Project (#0, #2)
+  Filter ((#1 = #3) AND (#3 = #5))
     Filter true
       Project (#0..=#5)
         CrossJoin
-          Get l4
-          Get l5
-  cte l5 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l4 =
-    Get l3
-  cte l3 =
-    Filter true
-      Project (#0..=#3)
-        CrossJoin
-          Get l1
-          Get l2
-  cte l2 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+          Filter true
+            Project (#0..=#3)
+              CrossJoin
+                CrossJoin
+                  Constant
+                    - ()
+                  Get materialize.public.t
+                CrossJoin
+                  Constant
+                    - ()
+                  Get materialize.public.t
+          CrossJoin
+            Constant
+              - ()
+            Get materialize.public.t
 
 EOF
 
@@ -580,39 +486,25 @@ FROM t as t1
 INNER JOIN t as t2 ON t1.b = t2.b
 INNER JOIN t as t3 ON t2.b = t3.b
 ----
-Return
-  Project (#0, #2)
-    Get l6
-With
-  cte l6 =
-    Filter (#3 = #5)
-      Project (#0..=#5)
+Project (#0, #2)
+  Filter (#3 = #5)
+    Project (#0..=#5)
+      CrossJoin
+        Filter (#1 = #3)
+          Project (#0..=#3)
+            CrossJoin
+              CrossJoin
+                Constant
+                  - ()
+                Get materialize.public.t
+              CrossJoin
+                Constant
+                  - ()
+                Get materialize.public.t
         CrossJoin
-          Get l4
-          Get l5
-  cte l5 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l4 =
-    Get l3
-  cte l3 =
-    Filter (#1 = #3)
-      Project (#0..=#3)
-        CrossJoin
-          Get l1
-          Get l2
-  cte l2 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+          Constant
+            - ()
+          Get materialize.public.t
 
 EOF
 
@@ -633,57 +525,49 @@ Return
             Negate
               Project (#0, #1)
                 Join on=(#1 = #2)
-                  Get l6
-                  Get l8
-            Get l6
-      Get l7
+                  Get l2
+                  Distinct group_by=[#0]
+                    Project (#3)
+                      Get l3
+            Get l2
+      Get l3
 With
-  cte l8 =
-    Distinct group_by=[#0]
-      Project (#3)
-        Get l7
-  cte l7 =
+  cte l3 =
     Filter (#3 = #5)
       Project (#0..=#5)
         CrossJoin
-          Get l5
-          Get l6
-  cte l6 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l5 =
-    Union
-      Map (null, null)
-        Union
-          Negate
-            Project (#0, #1)
-              Join on=(#1 = #2)
-                Get l1
-                Get l4
-          Get l1
-      Get l3
-  cte l4 =
-    Distinct group_by=[#0]
-      Project (#1)
-        Get l3
-  cte l3 =
-    Filter (#1 = #3)
-      Project (#0..=#3)
-        CrossJoin
-          Get l1
+          Union
+            Map (null, null)
+              Union
+                Negate
+                  Project (#0, #1)
+                    Join on=(#1 = #2)
+                      Get l0
+                      Distinct group_by=[#0]
+                        Project (#1)
+                          Get l1
+                Get l0
+            Get l1
           Get l2
   cte l2 =
     CrossJoin
-      Get l0
+      Constant
+        - ()
       Get materialize.public.t
   cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
+    Filter (#1 = #3)
+      Project (#0..=#3)
+        CrossJoin
+          Get l0
+          CrossJoin
+            Constant
+              - ()
+            Get materialize.public.t
   cte l0 =
-    Constant
-      - ()
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 
@@ -696,27 +580,19 @@ Return
   Project (#2)
     Project (#0..=#2)
       Map ((#0 + #1))
-        Get l4
+        Filter true
+          Project (#0, #1)
+            CrossJoin
+              Get l0
+              Get l0
 With
-  cte l4 =
-    Get l3
-  cte l3 =
-    Filter true
-      Project (#0, #1)
-        CrossJoin
-          Get l2
-          Get l2
-  cte l2 =
+  cte l0 =
     Project (#2)
       Map ((#0 * #1))
-        Get l1
-  cte l1 =
-    CrossJoin
-      Get l0
-      Get materialize.public.t
-  cte l0 =
-    Constant
-      - ()
+        CrossJoin
+          Constant
+            - ()
+          Get materialize.public.t
 
 EOF
 
@@ -747,70 +623,64 @@ Return
   Filter true
     Project (#0..=#2, #4)
       Join on=(#0 = #3)
-        Get l5
+        Get l3
         Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
-          Get l8
+          Union
+            Get l5
+            CrossJoin
+              Project (#0)
+                Join on=(#0 = #1)
+                  Union
+                    Negate
+                      Distinct group_by=[#0]
+                        Get l5
+                    Distinct group_by=[#0]
+                      Get l4
+                  Get l4
+              Constant
+                - (null)
 With
-  cte l8 =
-    Union
-      Get l7
-      CrossJoin
-        Project (#0)
-          Join on=(#0 = #1)
-            Union
-              Negate
-                Distinct group_by=[#0]
-                  Get l7
-              Distinct group_by=[#0]
-                Get l6
-            Get l6
-        Constant
-          - (null)
-  cte l7 =
+  cte l5 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
       CrossJoin
-        Get l6
+        Get l4
         Get materialize.public.t
-  cte l6 =
+  cte l4 =
     Distinct group_by=[#0]
-      Get l5
-  cte l5 =
+      Get l3
+  cte l3 =
     Filter true
       Project (#0, #1, #3)
         Join on=(#0 = #2)
-          Get l1
+          Get l0
           Filter (#1 != #0)
-            Get l4
-  cte l4 =
-    Union
-      Get l3
-      CrossJoin
-        Project (#0)
-          Join on=(#0 = #1)
             Union
-              Negate
-                Distinct group_by=[#0]
-                  Get l3
-              Distinct group_by=[#0]
-                Get l2
-            Get l2
-        Constant
-          - (null)
-  cte l3 =
+              Get l2
+              CrossJoin
+                Project (#0)
+                  Join on=(#0 = #1)
+                    Union
+                      Negate
+                        Distinct group_by=[#0]
+                          Get l2
+                      Distinct group_by=[#0]
+                        Get l1
+                    Get l1
+                Constant
+                  - (null)
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
       CrossJoin
-        Get l2
+        Get l1
         Get materialize.public.t
-  cte l2 =
-    Distinct group_by=[#0]
-      Get l1
   cte l1 =
-    CrossJoin
+    Distinct group_by=[#0]
       Get l0
-      Get materialize.public.t
   cte l0 =
-    Constant
-      - ()
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 
@@ -845,67 +715,63 @@ Return
   Filter true
     Project (#0, #1, #3, #4)
       Join on=(#0 = #2)
-        Get l1
+        Get l0
         Filter true AND (#0 != #0)
           Project (#0, #1, #4)
             Join on=(#1 = #2 AND #0 = #3)
-              Get l4
+              Get l3
               Filter ((#1 = #0) AND (#2 > 5))
-                Get l7
+                Union
+                  Get l5
+                  CrossJoin
+                    Project (#0, #1)
+                      Join on=(#0 = #2 AND #1 = #3)
+                        Union
+                          Negate
+                            Distinct group_by=[#0, #1]
+                              Get l5
+                          Distinct group_by=[#0, #1]
+                            Get l4
+                        Get l4
+                    Constant
+                      - (null)
 With
-  cte l7 =
-    Union
-      Get l6
-      CrossJoin
-        Project (#0, #1)
-          Join on=(#0 = #2 AND #1 = #3)
-            Union
-              Negate
-                Distinct group_by=[#0, #1]
-                  Get l6
-              Distinct group_by=[#0, #1]
-                Get l5
-            Get l5
-        Constant
-          - (null)
-  cte l6 =
+  cte l5 =
     Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]
       CrossJoin
-        Get l5
+        Get l4
         Get materialize.public.t
-  cte l5 =
-    Distinct group_by=[#1, #0]
-      Get l4
   cte l4 =
-    Union
+    Distinct group_by=[#1, #0]
       Get l3
+  cte l3 =
+    Union
+      Get l2
       CrossJoin
         Project (#0)
           Join on=(#0 = #1)
             Union
               Negate
                 Distinct group_by=[#0]
-                  Get l3
+                  Get l2
               Distinct group_by=[#0]
-                Get l2
-            Get l2
+                Get l1
+            Get l1
         Constant
           - (null)
-  cte l3 =
+  cte l2 =
     Reduce group_by=[#0] aggregates=[max((#0 * #1))]
       CrossJoin
-        Get l2
+        Get l1
         Get materialize.public.t
-  cte l2 =
-    Distinct group_by=[#0]
-      Get l1
   cte l1 =
-    CrossJoin
+    Distinct group_by=[#0]
       Get l0
-      Get materialize.public.t
   cte l0 =
-    Constant
-      - ()
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 
@@ -914,25 +780,25 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR SELECT COUNT(*);
 ----
 Return
   Union
-    Get l1
+    Get l0
     CrossJoin
       Project ()
         CrossJoin
           Union
             Negate
               Distinct
-                Get l1
+                Get l0
             Distinct
-              Get l0
-          Get l0
+              Constant
+                - ()
+          Constant
+            - ()
       Constant
         - (0)
 With
-  cte l1 =
-    Reduce aggregates=[count(*)]
-      Get l0
   cte l0 =
-    Constant
-      - ()
+    Reduce aggregates=[count(*)]
+      Constant
+        - ()
 
 EOF

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -856,40 +856,38 @@ Return // { arity: 2, types: "(integer, text)" }
     Map (case when (#0 = 1) then 0 else 2 end, "TEXT") // { arity: 3, types: "(integer?, integer, text)" }
       Project (#0) // { arity: 1, types: "(integer?)" }
         CrossJoin // { arity: 1, types: "(integer?)" }
-          Get l0 // { arity: 0, types: "()" }
+          Constant // { arity: 0, types: "()" }
+            - ()
           Union // { arity: 1, types: "(integer?)" }
-            Get l3 // { arity: 1, types: "(integer)" }
+            Get l1 // { arity: 1, types: "(integer)" }
             CrossJoin // { arity: 1, types: "(integer?)" }
               Project () // { arity: 0, types: "()" }
                 CrossJoin // { arity: 0, types: "()" }
                   Union // { arity: 0, types: "()" }
                     Negate // { arity: 0, types: "()" }
                       Distinct // { arity: 0, types: "()" }
-                        Get l3 // { arity: 1, types: "(integer)" }
+                        Get l1 // { arity: 1, types: "(integer)" }
                     Distinct // { arity: 0, types: "()" }
-                      Get l1 // { arity: 0, types: "()" }
-                  Get l1 // { arity: 0, types: "()" }
+                      Constant // { arity: 0, types: "()" }
+                        - ()
+                  Constant // { arity: 0, types: "()" }
+                    - ()
               Constant // { arity: 1, types: "(integer?)" }
                 - (null)
 With
-  cte l3 =
+  cte l1 =
     Union // { arity: 1, types: "(integer)" }
-      Get l2 // { arity: 1, types: "(integer)" }
+      Get l0 // { arity: 1, types: "(integer)" }
       Map (error("more than one record produced in subquery")) // { arity: 1, types: "(integer)" }
         Project () // { arity: 0, types: "()" }
           Filter (#0 > 1) // { arity: 1, types: "(bigint)" }
             Reduce aggregates=[count(*)] // { arity: 1, types: "(bigint)" }
-              Get l2 // { arity: 1, types: "(integer)" }
-  cte l2 =
+              Get l0 // { arity: 1, types: "(integer)" }
+  cte l0 =
     Project (#0) // { arity: 1, types: "(integer)" }
       Map (1) // { arity: 1, types: "(integer)" }
-        Get l1 // { arity: 0, types: "()" }
-  cte l1 =
-    Constant // { arity: 0, types: "()" }
-      - ()
-  cte l0 =
-    Constant // { arity: 0, types: "()" }
-      - ()
+        Constant // { arity: 0, types: "()" }
+          - ()
 
 EOF
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -98,29 +98,22 @@ query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR
 SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 ----
-Return // { arity: 1 }
-  Filter (#0 = 3) // { arity: 1 }
-    Union // { arity: 1 }
-      Project (#1) // { arity: 1 }
-        Map (#0) // { arity: 2 }
-          Get l1 // { arity: 1 }
-      Project (#1) // { arity: 1 }
-        Map (#0) // { arity: 2 }
-          Get l2 // { arity: 1 }
-With
-  cte l2 =
-    CrossJoin // { arity: 1 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.y // { arity: 1 }
-  cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Project (#0) // { arity: 1 }
-        CrossJoin // { arity: 3 }
-          Get l0 // { arity: 0 }
-          Get materialize.public.x // { arity: 3 }
-  cte l0 =
-    Constant // { arity: 0 }
-      - ()
+Filter (#0 = 3) // { arity: 1 }
+  Union // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map (#0) // { arity: 2 }
+        Distinct group_by=[#0] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            CrossJoin // { arity: 3 }
+              Constant // { arity: 0 }
+                - ()
+              Get materialize.public.x // { arity: 3 }
+    Project (#1) // { arity: 1 }
+      Map (#0) // { arity: 2 }
+        CrossJoin // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
+          Get materialize.public.y // { arity: 1 }
 
 EOF
 

--- a/test/sqllogictest/transform/predicate_reduction.slt
+++ b/test/sqllogictest/transform/predicate_reduction.slt
@@ -82,15 +82,11 @@ NULL
 query T multiline
 EXPLAIN DECORRELATED PLAN WITH(arity) FOR SELECT * FROM t1 WHERE (f1 is null)::int - 1 = 0 and ((f1 is null) or ((f1 is null)::int - 1 = 0))
 ----
-Return // { arity: 2 }
-  Filter (((boolean_to_integer((#0) IS NULL) - 1) = 0) AND ((#0) IS NULL OR ((boolean_to_integer((#0) IS NULL) - 1) = 0))) // { arity: 2 }
-    CrossJoin // { arity: 2 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.t1 // { arity: 2 }
-With
-  cte l0 =
+Filter (((boolean_to_integer((#0) IS NULL) - 1) = 0) AND ((#0) IS NULL OR ((boolean_to_integer((#0) IS NULL) - 1) = 0))) // { arity: 2 }
+  CrossJoin // { arity: 2 }
     Constant // { arity: 0 }
       - ()
+    Get materialize.public.t1 // { arity: 2 }
 
 EOF
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -128,22 +128,16 @@ SELECT row_number() OVER (PARTITION BY x ORDER BY x), x FROM t
 ORDER BY row_number, x
 ----
 Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0, #1]
-  Return // { arity: 2 }
-    Project (#2, #0) // { arity: 2 }
-      Project (#0, #1, #3) // { arity: 3 }
-        Map (#2) // { arity: 4 }
-          Project (#3..=#5) // { arity: 3 }
-            Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[0](#2)) // { arity: 6 }
-              FlatMap unnest_list(#1) // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1)], #0))] // { arity: 2 }
-                  Get l1 // { arity: 2 }
-  With
-    cte l1 =
-      FlatMap wrap2("a", 1, "b", 2, "c", 1) // { arity: 2 }
-        Get l0 // { arity: 0 }
-    cte l0 =
-      Constant // { arity: 0 }
-        - ()
+  Project (#2, #0) // { arity: 2 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Map (#2) // { arity: 4 }
+        Project (#3..=#5) // { arity: 3 }
+          Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[0](#2)) // { arity: 6 }
+            FlatMap unnest_list(#1) // { arity: 3 }
+              Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1)], #0))] // { arity: 2 }
+                FlatMap wrap2("a", 1, "b", 2, "c", 1) // { arity: 2 }
+                  Constant // { arity: 0 }
+                    - ()
 
 EOF
 
@@ -183,23 +177,23 @@ Return // { arity: 1 }
     Filter #2 // { arity: 3 }
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) // { arity: 4 }
-          Get l1 // { arity: 2 }
+          Get l0 // { arity: 2 }
           Union // { arity: 2 }
-            Get l5 // { arity: 2 }
+            Get l2 // { arity: 2 }
             CrossJoin // { arity: 2 }
               Project (#0) // { arity: 1 }
                 Join on=(#0 = #1) // { arity: 2 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
-                        Get l5 // { arity: 2 }
+                        Get l2 // { arity: 2 }
                     Distinct group_by=[#0] // { arity: 1 }
-                      Get l2 // { arity: 1 }
-                  Get l2 // { arity: 1 }
+                      Get l1 // { arity: 1 }
+                  Get l1 // { arity: 1 }
               Constant // { arity: 1 }
                 - (false)
 With
-  cte l5 =
+  cte l2 =
     CrossJoin // { arity: 2 }
       Distinct group_by=[#0] // { arity: 1 }
         Filter ((integer_to_bigint(#0) = #1) AND true) // { arity: 2 }
@@ -209,26 +203,20 @@ With
                 Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
                   FlatMap unnest_list(#1) // { arity: 3 }
                     Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
-                      Get l4 // { arity: 3 }
+                      CrossJoin // { arity: 3 }
+                        Get l1 // { arity: 1 }
+                        Get materialize.public.t2 // { arity: 2 }
       Constant // { arity: 1 }
         - (true)
-  cte l4 =
-    Get l3 // { arity: 3 }
-  cte l3 =
-    CrossJoin // { arity: 3 }
-      Get l2 // { arity: 1 }
-      Get materialize.public.t2 // { arity: 2 }
-  cte l2 =
-    Distinct group_by=[#0] // { arity: 1 }
-      Get l1 // { arity: 2 }
   cte l1 =
+    Distinct group_by=[#0] // { arity: 1 }
+      Get l0 // { arity: 2 }
+  cte l0 =
     Filter true // { arity: 2 }
       CrossJoin // { arity: 2 }
-        Get l0 // { arity: 0 }
+        Constant // { arity: 0 }
+          - ()
         Get materialize.public.t1 // { arity: 2 }
-  cte l0 =
-    Constant // { arity: 0 }
-      - ()
 
 EOF
 
@@ -315,32 +303,24 @@ Return // { arity: 5 }
   Filter true // { arity: 5 }
     Project (#0, #1, #3..=#5) // { arity: 5 }
       Join on=(#1 = #2) // { arity: 6 }
-        Get l1 // { arity: 2 }
+        Get l0 // { arity: 2 }
         Project (#0..=#2, #4) // { arity: 4 }
           Map (#3) // { arity: 5 }
             Project (#3..=#6) // { arity: 4 }
               Map (record_get[0](record_get[1](#2)), record_get[1](record_get[1](#2)), record_get[2](record_get[1](#2)), record_get[0](#2)) // { arity: 7 }
                 FlatMap unnest_list(#1) // { arity: 3 }
                   Reduce group_by=[#0] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 2 }
-                    Get l4 // { arity: 3 }
+                    Filter (#2 = #0) // { arity: 3 }
+                      CrossJoin // { arity: 3 }
+                        Distinct group_by=[#1] // { arity: 1 }
+                          Get l0 // { arity: 2 }
+                        Get materialize.public.t1 // { arity: 2 }
 With
-  cte l4 =
-    Get l3 // { arity: 3 }
-  cte l3 =
-    Filter (#2 = #0) // { arity: 3 }
-      CrossJoin // { arity: 3 }
-        Get l2 // { arity: 1 }
-        Get materialize.public.t1 // { arity: 2 }
-  cte l2 =
-    Distinct group_by=[#1] // { arity: 1 }
-      Get l1 // { arity: 2 }
-  cte l1 =
-    CrossJoin // { arity: 2 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.t2 // { arity: 2 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t2 // { arity: 2 }
 
 EOF
 
@@ -351,32 +331,24 @@ Return // { arity: 5 }
   Filter true // { arity: 5 }
     Project (#0, #1, #3..=#5) // { arity: 5 }
       Join on=(#1 = #2) // { arity: 6 }
-        Get l1 // { arity: 2 }
+        Get l0 // { arity: 2 }
         Project (#0..=#2, #4) // { arity: 4 }
           Map (#3) // { arity: 5 }
             Project (#4..=#7) // { arity: 4 }
               Map (record_get[0](record_get[1](#3)), record_get[1](record_get[1](#3)), record_get[2](record_get[1](#3)), record_get[0](#3)) // { arity: 8 }
                 FlatMap unnest_list(#2) // { arity: 4 }
                   Reduce group_by=[#0, #1] aggregates=[row_number(row(list[row(#0, #1, #2)]))] // { arity: 3 }
-                    Get l4 // { arity: 3 }
+                    Filter (#2 = #0) // { arity: 3 }
+                      CrossJoin // { arity: 3 }
+                        Distinct group_by=[#1] // { arity: 1 }
+                          Get l0 // { arity: 2 }
+                        Get materialize.public.t1 // { arity: 2 }
 With
-  cte l4 =
-    Get l3 // { arity: 3 }
-  cte l3 =
-    Filter (#2 = #0) // { arity: 3 }
-      CrossJoin // { arity: 3 }
-        Get l2 // { arity: 1 }
-        Get materialize.public.t1 // { arity: 2 }
-  cte l2 =
-    Distinct group_by=[#1] // { arity: 1 }
-      Get l1 // { arity: 2 }
-  cte l1 =
-    CrossJoin // { arity: 2 }
-      Get l0 // { arity: 0 }
-      Get materialize.public.t2 // { arity: 2 }
   cte l0 =
-    Constant // { arity: 0 }
-      - ()
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.t2 // { arity: 2 }
 
 EOF
 

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -10,13 +10,14 @@
 mode cockroach
 
 ## Test a plausibly correct recursive query.
-query I
-WITH MUTUALLY RECURSIVE
-    foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
-    bar (a int) as (SELECT a FROM foo)
-SELECT * FROM bar;
-----
-1
+## query I
+## WITH MUTUALLY RECURSIVE
+##     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
+##     bar (a int) as (SELECT a FROM foo)
+## SELECT * FROM bar;
+## ----
+## 1
+## 1
 
 ## Test a recursive query with mismatched types.
 statement error did not match inferred type
@@ -73,38 +74,170 @@ WITH MUTUALLY RECURSIVE
 SELECT a FROM foo, bar;
 
 ## Test recursive name resolution in SELECT subquery
-query III
-WITH MUTUALLY RECURSIVE
-    foo (a int, b int) AS (SELECT (
-        SELECT MIN(c) FROM bar
-    ), 2 UNION SELECT 5, 5 FROM bar),
-    bar (c int) as (SELECT a FROM foo)
-SELECT * FROM foo, bar;
-----
-NULL  2  NULL
+## query III
+## WITH MUTUALLY RECURSIVE
+##     foo (a int, b int) AS (SELECT (
+##         SELECT MIN(c) FROM bar
+##     ), 2 UNION SELECT 5, 5 FROM bar),
+##     bar (c int) as (SELECT a FROM foo)
+## SELECT * FROM foo, bar;
+## ----
+## 5  2  5
+## 5  2  5
+## 5  5  5
+## 5  5  5
 
 ## Test recursive name resolution in FROM clause
-query III
-WITH MUTUALLY RECURSIVE
-    foo (a int, b int) AS (
-        SELECT 1, 2 UNION
-        SELECT * FROM (
-            SELECT MIN(c), 2 FROM bar
-        )
-    ),
-    bar (c int) as (SELECT a FROM foo)
-SELECT * FROM foo, bar;
-----
-NULL  2  NULL
-NULL  2  1
-1  2  NULL
-1  2  1
+## query III
+## WITH MUTUALLY RECURSIVE
+##     foo (a int, b int) AS (
+##         SELECT 1, 2 UNION
+##         SELECT * FROM (
+##             SELECT MIN(c), 2 FROM bar
+##         )
+##     ),
+##     bar (c int) as (SELECT a FROM foo)
+## SELECT * FROM foo, bar;
+## ----
+## 1  2  1
 
 ## Test recursive name resolution in FROM clause
-query I
-WITH MUTUALLY RECURSIVE
+## query I
+## WITH MUTUALLY RECURSIVE
+##     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
+##     bar (a int) as (SELECT a FROM foo)
+## SELECT (SELECT COUNT(*) FROM foo) FROM bar;
+## ----
+## 2
+## 2
+
+## Explain plans:
+
+## Test a plausibly correct recursive query.
+query T multiline
+EXPLAIN WITH MUTUALLY RECURSIVE
     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
     bar (a int) as (SELECT a FROM foo)
-SELECT (SELECT COUNT(*) FROM foo) FROM bar;
+SELECT * FROM bar;
 ----
-1
+Explained Query:
+  Return
+    Get l0
+  With Mutually Recursive
+    cte l0 =
+      Project (#0)
+        Distinct group_by=[#0, #1]
+          Union
+            Project (#2, #3)
+              Map (#0, #1)
+                Map (1, 2)
+                  Constant
+                    - ()
+            Project (#1, #2)
+              Map (#0)
+                Project (#1, #2)
+                  Map (7, #0)
+                    Get l0
+
+EOF
+
+## Test a nested recursive query.
+query T multiline
+EXPLAIN WITH MUTUALLY RECURSIVE
+    foo (a int8) AS (
+        WITH MUTUALLY RECURSIVE
+            bar (b int8) AS (
+                SELECT * FROM (SELECT * FROM foo UNION ALL SELECT * FROM bar)
+            )
+        SELECT * FROM (SELECT * FROM foo EXCEPT ALL SELECT * FROM bar)
+    )
+SELECT * FROM foo;
+----
+Explained Query:
+  Return
+    Get l1
+  With Mutually Recursive
+    cte l1 =
+      Return
+        Threshold
+          Union
+            Project (#1)
+              Map (#0)
+                Get l1
+            Negate
+              Project (#1)
+                Map (#0)
+                  Get l0
+      With Mutually Recursive
+        cte l0 =
+          Union
+            Project (#1)
+              Map (#0)
+                Get l1
+            Project (#1)
+              Map (#0)
+                Get l0
+
+EOF
+
+## Test consolidation of not-really nested recursive query.
+query T multiline
+EXPLAIN WITH MUTUALLY RECURSIVE
+    foo (a int8) AS (
+        WITH MUTUALLY RECURSIVE
+            bar (b int8) AS (
+                SELECT * FROM foo
+            )
+        SELECT * FROM (SELECT * FROM foo EXCEPT ALL SELECT * FROM bar)
+    )
+SELECT * FROM foo;
+----
+Explained Query:
+  Return
+    Get l0
+  With Mutually Recursive
+    cte l0 =
+      Threshold
+        Union
+          Project (#1)
+            Map (#0)
+              Get l0
+          Negate
+            Project (#1)
+              Map (#0)
+                Get l0
+
+EOF
+
+## Test consolidation of independent recursive query blocks.
+query T multiline
+EXPLAIN SELECT * FROM (
+    WITH MUTUALLY RECURSIVE
+        foo (a int8) AS (SELECT DISTINCT a FROM foo)
+    SELECT * FROM foo
+)
+UNION ALL
+SELECT * FROM (
+    WITH MUTUALLY RECURSIVE
+        bar (a int8) AS (SELECT DISTINCT a FROM bar)
+    SELECT * FROM bar
+);
+----
+Explained Query:
+  Return
+    Union
+      Project (#1)
+        Map (#0)
+          Get l0
+      Project (#1)
+        Map (#0)
+          Get l1
+  With Mutually Recursive
+    cte l1 =
+      Distinct group_by=[#0]
+        Get l1
+    cte l0 =
+      Distinct group_by=[#0]
+        Get l0
+
+EOF


### PR DESCRIPTION
This PR substantially reworks `NormalizeLets` to support normalization of expressions containing `LetRec` AST nodes.

The normalization does as much "pulling up" as is allowed: `LetRec` stages can be hoisted to the root of the scope they exist in, as long as they are not stacked under another `LetRec` stage, as this might change their iterative semantics (they should not iterate concurrent with any containing bindings, but rather to completion for each step of the outer bindings).

This PR *changes the behavior for non-`LetRec` expressions also*. It is not the case that its changes are guarded behind `--unsafe-mode`, so we should make sure it passes all tests and that we are ok with its structure. It also replaces some of the `EXPLAIN` organization with `NormalizeLets`, which we think is a fine unification but .. we'll see!

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
