### PR TITLE
Fix embarrassing query error in mz_cluster_replica_utilization

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2265,8 +2265,8 @@ pub const MZ_CLUSTER_REPLICA_UTILIZATION: BuiltinView = BuiltinView {
 SELECT
     r.id AS replica_id,
     m.process_id,
-    100 * m.cpu_nano_cores / s.cpu_nano_cores AS cpu_percent,
-    100 * m.memory_bytes / s.memory_bytes AS memory_percent
+    m.cpu_nano_cores::float8 / s.cpu_nano_cores AS cpu_percent,
+    m.memory_bytes::float8 / s.memory_bytes AS memory_percent
 FROM
     mz_cluster_replicas AS r
         JOIN mz_internal.mz_cluster_replica_sizes AS s ON r.size = s.size

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2265,8 +2265,8 @@ pub const MZ_CLUSTER_REPLICA_UTILIZATION: BuiltinView = BuiltinView {
 SELECT
     r.id AS replica_id,
     m.process_id,
-    m.cpu_nano_cores / s.cpu_nano_cores * 100 AS cpu_percent,
-    m.memory_bytes / s.memory_bytes * 100 AS memory_percent
+    100 * m.cpu_nano_cores / s.cpu_nano_cores AS cpu_percent,
+    100 * m.memory_bytes / s.memory_bytes AS memory_percent
 FROM
     mz_cluster_replicas AS r
         JOIN mz_internal.mz_cluster_replica_sizes AS s ON r.size = s.size

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2265,8 +2265,8 @@ pub const MZ_CLUSTER_REPLICA_UTILIZATION: BuiltinView = BuiltinView {
 SELECT
     r.id AS replica_id,
     m.process_id,
-    m.cpu_nano_cores::float8 / s.cpu_nano_cores AS cpu_percent,
-    m.memory_bytes::float8 / s.memory_bytes AS memory_percent
+    m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
+    m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent
 FROM
     mz_cluster_replicas AS r
         JOIN mz_internal.mz_cluster_replica_sizes AS s ON r.size = s.size

--- a/test/testdrive/metrics.td
+++ b/test/testdrive/metrics.td
@@ -17,11 +17,11 @@
   JOIN mz_internal.mz_cluster_replica_utilization u ON r.id = u.replica_id
   WHERE c.name IN ('foo', 'bar', 'xyzzy')
   ORDER BY c.name, r.name, process_id
-foo size_1 0 t t
-foo size_2_2 0 t t
-foo size_2_2 1 t t
-foo size_32 0 t t
-xyzzy size_4 0 t t
+foo size_1 0 true true
+foo size_2_2 0 true true
+foo size_2_2 1 true true
+foo size_32 0 true true
+xyzzy size_4 0 true true
 
 > DROP CLUSTER foo
 > DROP CLUSTER bar

--- a/test/testdrive/metrics.td
+++ b/test/testdrive/metrics.td
@@ -11,17 +11,17 @@
 > CREATE CLUSTER bar REPLICAS ()
 > CREATE CLUSTER xyzzy REPLICAS (size_4 (SIZE '4'))
 
-> SELECT c.name, r.name, u.process_id, u.cpu_percent, u.memory_percent
+> SELECT c.name, r.name, u.process_id, u.cpu_percent > 0.0, u.memory_percent > 0.0
   FROM mz_clusters c
   JOIN mz_cluster_replicas r ON r.cluster_id = c.id
   JOIN mz_internal.mz_cluster_replica_utilization u ON r.id = u.replica_id
   WHERE c.name IN ('foo', 'bar', 'xyzzy')
   ORDER BY c.name, r.name, process_id
-foo size_1 0 0 0
-foo size_2_2 0 0 0
-foo size_2_2 1 0 0
-foo size_32 0 0 0
-xyzzy size_4 0 0 0
+foo size_1 0 t t
+foo size_2_2 0 t t
+foo size_2_2 1 t t
+foo size_32 0 t t
+xyzzy size_4 0 t t
 
 > DROP CLUSTER foo
 > DROP CLUSTER bar


### PR DESCRIPTION
I somehow didn't realize `/` does integer division, so these will always be zero.
