### PR TITLE
mzcompose: Update Redpanda to v22.3.8

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -365,7 +365,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v22.2.3",
+        version: str = "v22.3.8",
         auto_create_topics: bool = False,
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Redpanda [v22.3.8](https://github.com/redpanda-data/redpanda/releases/tag/v22.3.8) has been released.

Signed-off-by: Ben Pope <ben@redpanda.com>

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Successfully ran the tests locally.
```sh
./mzcompose run default --redpanda
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
