### PR TITLE
persist: monitor rtt latency to blob and consensus in metrics

### DIFF
--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -304,6 +304,9 @@ pub struct VersionedData {
 #[allow(clippy::as_conversions)]
 pub const SCAN_ALL: usize = u64_to_usize(i64::MAX as u64);
 
+/// A key usable for liveness checks via [Consensus::head].
+pub const CONSENSUS_HEAD_LIVENESS_KEY: &str = "LIVENESS";
+
 /// An abstraction for [VersionedData] held in a location in persistent storage
 /// where the data are conditionally updated by version.
 ///
@@ -366,6 +369,9 @@ pub struct BlobMetadata<'a> {
     /// Size of the blob
     pub size_in_bytes: u64,
 }
+
+/// A key usable for liveness checks via [Blob::get].
+pub const BLOB_GET_LIVENESS_KEY: &str = "LIVENESS";
 
 /// An abstraction over read-write access to a `bytes key`->`bytes value` store.
 ///


### PR DESCRIPTION
In particular, this measures the latency to blob and consensus as _this process sees them_, which should help narrow down suspected network performance issues when debugging prod.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
