### PR TITLE
doc/user: document self-serve access to AWS PrivateLink principals

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -215,7 +215,10 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 );
 ```
 
-### Tunnels (AWS PrivateLink, SSH tunnel) {#kafka-tunnels}
+### Tunnels {#kafka-tunnels}
+
+You can tunnel a connection to a Kafka broker through an AWS PrivateLink service
+or an SSH bastion host.
 
 #### Syntax
 
@@ -231,7 +234,7 @@ The full syntax for the `BROKERS` option is:
 
 Field                                   | Value            | Required | Description
 ----------------------------------------|------------------|:--------:|-------------------------------
-`connection`                            | object name      | ✓        | The name of an [AWS PrivateLink connection](#aws-privatelink) through which network traffic for this broker should be routed.
+`aws_connection`                        | object name      | ✓        | The name of an [AWS PrivateLink connection](#aws-privatelink) through which network traffic for this broker should be routed.
 `PORT`                                  | `integer`        |          | The port of the AWS PrivateLink service to connect to. Defaults to the broker's port.
 `ssh_connection`                        | object name      | ✓        | The name of an [SSH tunnel connection](#ssh-tunnel) through which network traffic for this broker should be routed.
 

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -35,28 +35,34 @@ Field                       | Value            | Required | Description
 ### Permissions
 
 After you create the connection, you must configure your AWS PrivateLink service
-to accept connections from the following AWS principal:
+to accept connections from the AWS principal that Materialize will connect as.
+This principal has an Amazon Resource Name of the following form:
 
 ```
-arn:aws:iam::664411391173:role/mz_<EXTERNAL-ID>_<CONNECTION-ID>
+arn:aws:iam::664411391173:role/mz_<REGION-ID>_<CONNECTION-ID>
 ```
 
-Fill in the values as follows:
+Query the
+[`mz_aws_privatelink_connections`](/sql/system-catalog/mz_catalog/#mz_aws_privatelink_connections)
+table to determine the principals for the AWS PrivateLink connections in your
+region. For example:
 
-  * **`EXTERNAL-ID`**: A unique ID associated with your Materialize region.
-    You must [contact support](/support/) to determine this ID.
-  * **`CONNECTION-ID`**: The ID of the AWS PrivateLink connection in your
-    Materialize region. You can determine this ID by querying
-    [`mz_connections`].
-
-For example:
-
+```sql
+SELECT * FROM mz_aws_privatelink_connections;
 ```
-arn:aws:iam::664411391173:role/mz_20273b7c-2bbe-42b8-8c36-8cc179e9bbc3_u23
 ```
+   id   |                                 principal
+--------+---------------------------------------------------------------------------
+ u1     | arn:aws:iam::664411391173:role/mz_20273b7c-2bbe-42b8-8c36-8cc179e9bbc3_u1
+ u7     | arn:aws:iam::664411391173:role/mz_20273b7c-2bbe-42b8-8c36-8cc179e9bbc3_u7
+```
+
+Note that Materialize assigns a unique principal to each AWS PrivateLink
+connection in your region.
 
 See [Manage permissions](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permissions) in the AWS PrivateLink
-documentation for details.
+documentation for details about how to configure a trusted principal for your
+AWS PrivateLink service.
 
 {{< warning >}}
 Do **not** grant access to the root principal for the Materialize AWS account.
@@ -418,6 +424,7 @@ SELECT * FROM mz_ssh_tunnel_connections;
 [`CREATE SOURCE`]: /sql/create-source
 [`CREATE SINK`]: /sql/create-sink
 [`FORMAT`]: /sql/create-source/#formats
+[`mz_aws_privatelink_connections`]: /sql/system-catalog/mz_catalog/#mz_aws_privatelink_connections
 [`mz_connections`]: /sql/system-catalog/mz_catalog/#mz_connections
 [`mz_ssh_tunnel_connections`]: /sql/system-catalog/mz_catalog/#mz_ssh_tunnel_connections
 [Ed25519 algorithm]: https://ed25519.cr.yp.to

--- a/doc/user/layouts/partials/sql-grammar/create-connection-kafka-broker.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-connection-kafka-broker.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="815" height="199">
+<svg xmlns="http://www.w3.org/2000/svg" width="849" height="199">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="90" height="32" rx="10"/>
@@ -33,36 +33,36 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="231" y="107">PRIVATELINK</text>
-   <rect x="355" y="89" width="92" height="32"/>
-   <rect x="353" y="87" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="363" y="107">connection</text>
-   <rect x="487" y="121" width="26" height="32" rx="10"/>
-   <rect x="485"
+   <rect x="355" y="89" width="126" height="32"/>
+   <rect x="353" y="87" width="126" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="363" y="107">aws_connection</text>
+   <rect x="521" y="121" width="26" height="32" rx="10"/>
+   <rect x="519"
          y="119"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="495" y="139">(</text>
-   <rect x="533" y="121" width="58" height="32" rx="10"/>
-   <rect x="531"
+   <text class="terminal" x="529" y="139">(</text>
+   <rect x="567" y="121" width="58" height="32" rx="10"/>
+   <rect x="565"
          y="119"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="541" y="139">PORT</text>
-   <rect x="611" y="121" width="70" height="32"/>
-   <rect x="609" y="119" width="70" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="619" y="139">number</text>
-   <rect x="701" y="121" width="26" height="32" rx="10"/>
-   <rect x="699"
+   <text class="terminal" x="575" y="139">PORT</text>
+   <rect x="645" y="121" width="70" height="32"/>
+   <rect x="643" y="119" width="70" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="653" y="139">number</text>
+   <rect x="735" y="121" width="26" height="32" rx="10"/>
+   <rect x="733"
          y="119"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="709" y="139">)</text>
+   <text class="terminal" x="743" y="139">)</text>
    <rect x="149" y="165" width="48" height="32" rx="10"/>
    <rect x="147"
          y="163"
@@ -83,7 +83,7 @@
    <rect x="311" y="163" width="122" height="32" class="nonterminal"/>
    <text class="nonterminal" x="321" y="183">ssh_connection</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-142 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h732 m-762 0 h20 m742 0 h20 m-782 0 q10 0 10 10 m762 0 q0 -10 10 -10 m-772 10 v12 m762 0 v-12 m-762 12 q0 10 10 10 m742 0 q10 0 10 -10 m-752 10 h10 m64 0 h10 m20 0 h10 m54 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h250 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v12 m280 0 v-12 m-280 12 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m26 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m26 0 h10 m-618 -32 h20 m618 0 h20 m-658 0 q10 0 10 10 m638 0 q0 -10 10 -10 m-648 10 v56 m638 0 v-56 m-638 56 q0 10 10 10 m618 0 q10 0 10 -10 m-628 10 h10 m48 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m122 0 h10 m0 0 h312 m43 -108 h-3"/>
-   <polygon points="805 71 813 67 813 75"/>
-   <polygon points="805 71 797 67 797 75"/>
+         d="m19 17 h2 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-142 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h766 m-796 0 h20 m776 0 h20 m-816 0 q10 0 10 10 m796 0 q0 -10 10 -10 m-806 10 v12 m796 0 v-12 m-796 12 q0 10 10 10 m776 0 q10 0 10 -10 m-786 10 h10 m64 0 h10 m20 0 h10 m54 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m0 0 h250 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v12 m280 0 v-12 m-280 12 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m26 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m26 0 h10 m-652 -32 h20 m652 0 h20 m-692 0 q10 0 10 10 m672 0 q0 -10 10 -10 m-682 10 v56 m672 0 v-56 m-672 56 q0 10 10 10 m652 0 q10 0 10 -10 m-662 10 h10 m48 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m122 0 h10 m0 0 h346 m43 -108 h-3"/>
+   <polygon points="839 71 847 67 847 75"/>
+   <polygon points="839 71 831 67 831 75"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -44,7 +44,7 @@ create_connection ::=
   '(' field '='? val ( ',' field '='? val )* ')'
 create_connection_kafka_brokers ::= 'BROKERS' '(' kafka_broker (',' kafka_broker)* ')'
 create_connection_kafka_broker ::=
-  "'host:port'" ('USING' ('AWS' 'PRIVATELINK' connection ('(' 'PORT' number ')')? | 'SSH' 'TUNNEL' ssh_connection))?
+  "'host:port'" ('USING' ('AWS' 'PRIVATELINK' aws_connection ('(' 'PORT' number ')')? | 'SSH' 'TUNNEL' ssh_connection))?
 create_database ::=
     'CREATE' 'DATABASE' ('IF NOT EXISTS')? database_name
 create_index ::=


### PR DESCRIPTION
Update the AWS PrivateLink connection docs to mention that the principal
to trust is available in the system catalog in the
`mz_aws_privatelink_connections` table.

Follow up from #16140.

### Motivation

   * This PR refactors existing documentation.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
