### PR TITLE
repr: remove Serialize impls from Datum and friends

### DIFF
--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -15,8 +15,7 @@ use std::fmt;
 use std::mem;
 
 use proptest_derive::Arbitrary;
-use serde::ser::SerializeSeq;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_proto::{RustType, TryFromProtoError};
@@ -46,43 +45,6 @@ impl<'a> Array<'a> {
     /// Returns the elements of the array.
     pub fn elements(&self) -> DatumList<'a> {
         self.elements
-    }
-}
-
-impl<'a> Serialize for Array<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut dim_iter = self.dims().into_iter();
-        if let Some(dim1) = dim_iter.next() {
-            let mut seq = serializer.serialize_seq(Some(dim1.length))?;
-            let other_dims = dim_iter.collect::<Vec<_>>();
-            if other_dims.is_empty() {
-                let mut iter = self.elements.iter();
-                while let Some(datum) = iter.next() {
-                    seq.serialize_element(&datum)?;
-                }
-            } else {
-                let subarray_len = other_dims.iter().map(|dim| dim.length).product();
-                for i in 0..dim1.length {
-                    let mut row = crate::Row::with_capacity(subarray_len);
-                    row.packer()
-                        .push_array(
-                            &other_dims,
-                            self.elements
-                                .iter()
-                                .skip(i * subarray_len)
-                                .take(subarray_len),
-                        )
-                        .unwrap();
-                    seq.serialize_element(&row.unpack_first().unwrap_array())?;
-                }
-            }
-            seq.end()
-        } else {
-            serializer.serialize_unit()
-        }
     }
 }
 

--- a/src/repr/src/explain_new/mod.rs
+++ b/src/repr/src/explain_new/mod.rs
@@ -33,7 +33,6 @@
 use std::{collections::HashSet, fmt};
 
 use mz_ore::{stack::RecursionLimitError, str::Indent, str::IndentLike};
-use serde::{Serialize, Serializer};
 
 use crate::{ColumnType, GlobalId, Row, ScalarType};
 
@@ -566,27 +565,6 @@ impl<'a> AsRef<&'a dyn ExprHumanizer> for RenderingContext<'a> {
     }
 }
 
-#[derive(Debug)]
-/// A wrapper around [Row] so that [serde_json] can produce human-readable
-/// output without changing the default serialization for Row.
-pub struct JSONRow(Row);
-
-impl JSONRow {
-    pub fn new(row: Row) -> Self {
-        Self(row)
-    }
-}
-
-impl Serialize for JSONRow {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let row = self.0.unpack();
-        row.serialize(serializer)
-    }
-}
-
 /// A trait for humanizing components of an expression.
 ///
 /// This will be most often used as part of the rendering context
@@ -689,8 +667,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::adt::timestamp::CheckedTimestamp;
-
     use super::*;
 
     struct Environment {
@@ -806,120 +782,5 @@ mod tests {
 
         assert!(act.is_ok());
         assert_eq!(act.unwrap(), exp);
-    }
-
-    #[test]
-    fn test_json_row_serialization() {
-        use crate::adt::array::ArrayDimension;
-        use crate::Datum;
-        // a 2 x 3 array
-        let mut array = Row::default();
-        array
-            .packer()
-            .push_array(
-                &[
-                    ArrayDimension {
-                        lower_bound: 1,
-                        length: 2,
-                    },
-                    ArrayDimension {
-                        lower_bound: 1,
-                        length: 3,
-                    },
-                ],
-                [
-                    Datum::Int32(12),
-                    Datum::Int32(20),
-                    Datum::Int32(-312),
-                    Datum::Int32(0),
-                    Datum::Int32(-42),
-                    Datum::Int32(1231),
-                ]
-                .into_iter(),
-            )
-            .unwrap();
-        let mut list_datum = Row::default();
-        list_datum.packer().push_list_with(|row| {
-            row.push(Datum::UInt32(0));
-            row.push(Datum::Int64(10));
-        });
-        let mut map_datum = Row::default();
-        map_datum.packer().push_dict_with(|row| {
-            row.push(Datum::String("hello"));
-            row.push(Datum::Int16(-1));
-            row.push(Datum::String("world"));
-            row.push(Datum::Int16(1000));
-        });
-
-        // For ease of reading the expected output, construct a vec with
-        // type of datum + the expected output for that datm
-        let all_types_of_datum = vec![
-            (Datum::True, "true"),
-            (Datum::False, "false"),
-            (Datum::Null, "null"),
-            (Datum::Dummy, r#""Dummy""#),
-            (Datum::JsonNull, r#""JsonNull""#),
-            (Datum::UInt8(32), "32"),
-            (Datum::from(0.1_f32), "0.1"),
-            (Datum::from(-1.23), "-1.23"),
-            (
-                Datum::Date(
-                    crate::adt::date::Date::try_from(
-                        chrono::NaiveDate::from_ymd_opt(2022, 8, 3).unwrap(),
-                    )
-                    .unwrap(),
-                ),
-                r#""2022-08-03""#,
-            ),
-            (
-                Datum::Time(chrono::NaiveTime::from_hms_opt(12, 10, 22).unwrap()),
-                r#""12:10:22""#,
-            ),
-            (
-                Datum::Timestamp(
-                    CheckedTimestamp::from_timestamplike(
-                        chrono::NaiveDateTime::from_timestamp_opt(1023123, 234).unwrap(),
-                    )
-                    .unwrap(),
-                ),
-                r#""1970-01-12T20:12:03.000000234""#,
-            ),
-            (
-                Datum::TimestampTz(
-                    CheckedTimestamp::from_timestamplike(chrono::DateTime::from_utc(
-                        chrono::NaiveDateTime::from_timestamp_opt(90234242, 234).unwrap(),
-                        chrono::Utc,
-                    ))
-                    .unwrap(),
-                ),
-                r#""1972-11-10T09:04:02.000000234Z""#,
-            ),
-            (
-                Datum::Uuid(uuid::uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8")),
-                r#""67e55044-10b1-426f-9247-bb680e5fe0c8""#,
-            ),
-            (Datum::Bytes(&[127, 23, 4]), "[127,23,4]"),
-            (
-                Datum::Interval(crate::adt::interval::Interval {
-                    months: 1,
-                    days: 2,
-                    micros: 10,
-                }),
-                r#"{"months":1,"days":2,"micros":10}"#,
-            ),
-            (
-                Datum::from(crate::adt::numeric::Numeric::from(10.234)),
-                r#""10.234""#,
-            ),
-            (array.unpack_first(), "[[12,20,-312],[0,-42,1231]]"),
-            (list_datum.unpack_first(), "[0,10]"),
-            (map_datum.unpack_first(), r#"{"hello":-1,"world":1000}"#),
-        ];
-        let (data, strings): (Vec<_>, Vec<_>) = all_types_of_datum.into_iter().unzip();
-        let row = JSONRow(Row::pack(data.into_iter()));
-        let result = serde_json::to_string(&row);
-        assert!(result.is_ok());
-        let expected = format!("[{}]", strings.join(","));
-        assert_eq!(result.unwrap(), expected);
     }
 }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -23,8 +23,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Strategy};
-use serde::ser::{SerializeMap, SerializeSeq};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -305,39 +304,11 @@ impl PartialOrd for DatumList<'_> {
     }
 }
 
-impl<'a> Serialize for DatumList<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut seq = serializer.serialize_seq(None)?;
-        let mut iter = self.iter();
-        while let Some(datum) = iter.next() {
-            seq.serialize_element(&datum)?;
-        }
-        seq.end()
-    }
-}
-
 /// A mapping from string keys to Datums
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct DatumMap<'a> {
     /// Points at the serialized datums, which should be sorted in key order
     data: &'a [u8],
-}
-
-impl<'a> Serialize for DatumMap<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(None)?;
-        let mut iter = self.iter();
-        while let Some((key, val)) = iter.next() {
-            map.serialize_entry(&key, &val)?;
-        }
-        map.end()
-    }
 }
 
 /// Represents a single `Datum`, appropriate to be nested inside other
@@ -374,17 +345,6 @@ impl<'a> Ord for DatumNested<'a> {
 impl<'a> PartialOrd for DatumNested<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl<'a> Serialize for DatumNested<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut seq = serializer.serialize_seq(None)?;
-        seq.serialize_element(&self.datum())?;
-        seq.end()
     }
 }
 

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_lowertest::MzReflect;
@@ -151,48 +151,6 @@ pub enum Datum<'a> {
     Null,
     // A range of values, e.g. [-1, 1).
     Range(Range<'a>),
-}
-
-/// This implementation of serialize is designed to be able to print out Datums
-/// in a human-readable way in JSON. This implementation may not suit other
-/// serialization purposes.
-impl<'a> Serialize for Datum<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use Datum::*;
-        match self {
-            False => serializer.serialize_bool(false),
-            True => serializer.serialize_bool(true),
-            Int16(i) => serializer.serialize_i16(*i),
-            Int32(i) => serializer.serialize_i32(*i),
-            Int64(i) => serializer.serialize_i64(*i),
-            UInt8(u) => serializer.serialize_u8(*u),
-            UInt16(u) => serializer.serialize_u16(*u),
-            UInt32(u) => serializer.serialize_u32(*u),
-            UInt64(u) => serializer.serialize_u64(*u),
-            Float32(f) => serializer.serialize_f32(**f),
-            Float64(f) => serializer.serialize_f64(**f),
-            Date(d) => chrono::NaiveDate::from(d).serialize(serializer),
-            Time(t) => t.serialize(serializer),
-            Timestamp(ts) => ts.serialize(serializer),
-            TimestampTz(tstz) => tstz.serialize(serializer),
-            Interval(i) => i.serialize(serializer),
-            Bytes(b) => serializer.serialize_bytes(b),
-            String(s) => serializer.serialize_str(s),
-            Array(a) => a.serialize(serializer),
-            List(l) => l.serialize(serializer),
-            Map(m) => m.serialize(serializer),
-            Numeric(n) => serializer.serialize_str(&n.to_string()),
-            Uuid(u) => u.serialize(serializer),
-            MzTimestamp(t) => serializer.serialize_str(&t.to_string()),
-            Dummy => serializer.serialize_str("Dummy"),
-            JsonNull => serializer.serialize_str("JsonNull"),
-            Null => serializer.serialize_none(),
-            r @ Range { .. } => serializer.serialize_str(&r.to_string()),
-        }
-    }
 }
 
 impl TryFrom<Datum<'_>> for bool {


### PR DESCRIPTION
Remove the custom `Serialize` implementation from `Datum`, `DatumList`, `DatumMap`, and `Array`.  These ladder up into a disused `JSONRow` struct. Remove them. They are just confusing, particularly since `Row` `DatumList`, `DatumMap`, and `Array` already *are* serialized `Datum`s.

`git blame` suggests that these implementations were not added for particularly compelling reasons.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes dead code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
