### PR TITLE
zippy: Improve log output

### DIFF
--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -81,6 +81,8 @@ class CreateDebeziumSource(Action):
         else:
             assert False
 
+        super().__init__(capabilities)
+
     def run(self, c: Composition) -> None:
         if self.new_debezium_source:
             c.testdrive(

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -81,9 +81,13 @@ class Capabilities:
 class Action:
     """Base class for an action that a Zippy test can take."""
 
+    current_seqno: int = 0
+
     def __init__(self, capabilities: Capabilities) -> None:
         """Construct a new action, possibly conditioning on the available
         capabilities."""
+        Action.current_seqno = Action.current_seqno + 1
+        self.seqno = Action.current_seqno
         pass
 
     @classmethod
@@ -107,6 +111,9 @@ class Action:
     def require_explicit_mention(self) -> bool:
         """Only use if explicitly mentioned by name in a Scenario."""
         return False
+
+    def __str__(self) -> str:
+        return f"--- #{self.seqno}: {self.__class__.__name__}"
 
 
 class ActionFactory:

--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -83,11 +83,12 @@ class CreateTopicParameterized(ActionFactory):
         if new_topic_name:
             return [
                 CreateTopic(
+                    capabilities=capabilities,
                     topic=TopicExists(
                         name=new_topic_name,
                         envelope=random.choice(self.envelopes),
                         partitions=random.randint(1, 10),
-                    )
+                    ),
                 )
             ]
         else:
@@ -95,8 +96,9 @@ class CreateTopicParameterized(ActionFactory):
 
 
 class CreateTopic(Action):
-    def __init__(self, topic: TopicExists) -> None:
+    def __init__(self, capabilities: Capabilities, topic: TopicExists) -> None:
         self.topic = topic
+        super().__init__(capabilities)
 
     def provides(self) -> List[Capability]:
         return [self.topic]
@@ -124,6 +126,10 @@ class Ingest(Action):
     def __init__(self, capabilities: Capabilities) -> None:
         self.topic = random.choice(capabilities.get(TopicExists))
         self.delta = random.randint(1, 100000)
+        super().__init__(capabilities)
+
+    def __str__(self) -> str:
+        return f"{Action.__str__(self)} {self.topic.name}"
 
 
 class KafkaInsert(Ingest):

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -34,6 +34,7 @@ class MzStart(Action):
                 f"ALTER SYSTEM SET {config_param} TO 1000",
                 user="mz_system",
                 port=6877,
+                print_statement=False,
             )
 
     def provides(self) -> List[Capability]:

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -49,6 +49,8 @@ class CreatePostgresCdcTable(Action):
         else:
             assert False
 
+        super().__init__(capabilities)
+
     def run(self, c: Composition) -> None:
         if self.new_postgres_cdc_table:
             assert self.postgres_cdc_table is not None

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -81,6 +81,8 @@ class CreatePostgresTable(Action):
         else:
             assert False
 
+        super().__init__(capabilities)
+
     def run(self, c: Composition) -> None:
         if self.new_postgres_table:
             primary_key = f"PRIMARY KEY" if self.postgres_table.has_pk else ""
@@ -112,6 +114,11 @@ class PostgresDML(Action):
     def __init__(self, capabilities: Capabilities) -> None:
         self.postgres_table = random.choice(capabilities.get(PostgresTableExists))
         self.delta = random.randint(1, PostgresDML.MAX_BATCH_SIZE)
+
+        super().__init__(capabilities)
+
+    def __str__(self) -> str:
+        return f"{Action.__str__(self)} {self.postgres_table.name}"
 
 
 class PostgresInsert(PostgresDML):

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -71,6 +71,8 @@ class CreateReplica(Action):
         else:
             assert False
 
+        super().__init__(capabilities)
+
     def run(self, c: Composition) -> None:
         if self.new_replica:
             c.testdrive(
@@ -98,6 +100,8 @@ class DropReplica(Action):
             capabilities.remove_capability_instance(self.replica)
         else:
             self.replica = None
+
+        super().__init__(capabilities)
 
     def run(self, c: Composition) -> None:
         if self.replica is not None:

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -36,10 +36,11 @@ class CreateSourceParameterized(ActionFactory):
         if new_source_name:
             return [
                 CreateSource(
+                    capabilities=capabilities,
                     source=SourceExists(
                         name=new_source_name,
                         topic=random.choice(capabilities.get(TopicExists)),
-                    )
+                    ),
                 )
             ]
         else:
@@ -47,8 +48,9 @@ class CreateSourceParameterized(ActionFactory):
 
 
 class CreateSource(Action):
-    def __init__(self, source: SourceExists) -> None:
+    def __init__(self, capabilities: Capabilities, source: SourceExists) -> None:
         self.source = source
+        super().__init__(capabilities)
 
     def run(self, c: Composition) -> None:
         envelope = str(self.source.topic.envelope).split(".")[1]

--- a/misc/python/materialize/zippy/table_actions.py
+++ b/misc/python/materialize/zippy/table_actions.py
@@ -58,6 +58,7 @@ class CreateTable(Action):
             table is not None
         ), "CreateTable Action can not be referenced directly, it is produced by CreateTableParameterized factory"
         self.table = table
+        super().__init__(capabilities)
 
     def run(self, c: Composition) -> None:
         index = (
@@ -88,6 +89,7 @@ class ValidateTable(Action):
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.table = random.choice(capabilities.get(TableExists))
+        super().__init__(capabilities)
 
     def run(self, c: Composition) -> None:
         c.testdrive(
@@ -110,6 +112,10 @@ class DML(Action):
     def __init__(self, capabilities: Capabilities) -> None:
         self.table = random.choice(capabilities.get(TableExists))
         self.delta = random.randint(1, self.table.max_rows_per_action)
+        super().__init__(capabilities)
+
+    def __str__(self) -> str:
+        return f"{Action.__str__(self)} {self.table.name}"
 
 
 class Insert(DML):

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -296,8 +296,8 @@ pub async fn run_ingest(
 
     let topic_name = &format!("{}-{}", topic_prefix, state.seed);
     println!(
-        "Ingesting data into Kafka topic {} with repeat {}",
-        topic_name, repeat
+        "Ingesting data into Kafka topic {} with start_iteration = {}, repeat = {}",
+        topic_name, start_iteration, repeat
     );
 
     let set_schema_id_var = |state: &mut State, schema_id_var, transcoder| match transcoder {

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -442,10 +442,8 @@ async fn main() {
         }
     }
 
-    eprint!("+++ ");
-    if error_count == 0 {
-        eprintln!("testdrive completed successfully.");
-    } else {
+    if error_count > 0 {
+        eprint!("+++ ");
         eprintln!("!!! Error Report");
         eprintln!("{} errors were encountered during execution", error_count);
         if !error_files.is_empty() {

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn run_file(config: &Config, filename: &Path) -> Result<(), Error> {
     let mut contents = String::new();
     file.read_to_string(&mut contents)
         .with_context(|| format!("reading {}", filename.display()))?;
-    run_string(config, filename, &contents).await
+    run_string(config, Some(filename), &contents).await
 }
 
 /// Runs a testdrive script from the standard input.
@@ -51,7 +51,7 @@ pub async fn run_stdin(config: &Config) -> Result<(), Error> {
     io::stdin()
         .read_to_string(&mut contents)
         .context("reading <stdin>")?;
-    run_string(config, Path::new("<stdin>"), &contents).await
+    run_string(config, None, &contents).await
 }
 
 /// Runs a testdrive script stored in a string.
@@ -59,8 +59,14 @@ pub async fn run_stdin(config: &Config) -> Result<(), Error> {
 /// The script in `contents` is used verbatim. The provided `filename` is used
 /// only as output in error messages and such. No attempt is made to read
 /// `filename`.
-pub async fn run_string(config: &Config, filename: &Path, contents: &str) -> Result<(), Error> {
-    println!("--- {}", filename.display());
+pub async fn run_string(
+    config: &Config,
+    filename: Option<&Path>,
+    contents: &str,
+) -> Result<(), Error> {
+    if let Some(f) = filename {
+        println!("--- {}", f.display());
+    }
 
     let mut line_reader = LineReader::new(contents);
     run_line_reader(config, &mut line_reader)


### PR DESCRIPTION
In testdrive:
 - do not print "testdrive successfully completed"
 - do not print "<stdin>" if td commands are passed via STDIN

In mzcompose:
 - do not repeatedly print the error while wait_for_mz() is looping

In Zippy:
 - label each Action with its sequence number
 - show which table or topic a given DML action applies to
 - Label each column in CREATE VIEW and SELECT for better visibility as to exactly what is being calculated in views, what is being checked and the expected result
 - make the output more Buildkite-friendly by using "---"
 - hide ALTER SYSTEM queries that are being run against Mz

### Motivation

  * This PR fixes a previously unreported bug.

The call center received a customer complaint about Zippy output not being user-friendly.