### PR TITLE
bump to rust 1.66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.66.0"
 
 [profile.dev]
 # TODO(gusywnn|benesch): remove this when incremental ice's are improved

--- a/bin/check
+++ b/bin/check
@@ -51,6 +51,10 @@ disabled_lints=(
     # This lint has false positives where the pattern cannot be avoided without cloning
     # the key used in the map.
     clippy::map_entry
+
+    ## Its unclear if the performance gain here is worth it
+    ## TODO(guswynn): figure out if this should be enabled
+    clippy::box_default
 )
 
 extra_lints=(

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -13,9 +13,9 @@
 //! Format details:
 //!
 //!   * Sources that have [`MapFilterProject`]s come first.
-//!     The format is "Source <name> (<id>):" followed by the [`MapFilterProject`].
+//!     The format is `"Source <name> (<id>):"` followed by the [`MapFilterProject`].
 //!   * Intermediate views in the dataflow come next.
-//!     The format is "View <name> (<id>):" followed by the output of
+//!     The format is `"View <name> (<id>):"` followed by the output of
 //!     [`mz_expr::explain::ViewExplanation`].
 //!   * Last is the view or query being explained. The format is "Query:"
 //!     followed by the output of [`mz_expr::explain::ViewExplanation`].

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -99,7 +99,7 @@ impl Ca {
             )?;
             builder.build()
         };
-        fs::write(dir.path().join("ca.crt"), &cert.to_pem()?)?;
+        fs::write(dir.path().join("ca.crt"), cert.to_pem()?)?;
         Ok(Ca {
             dir,
             name,
@@ -164,8 +164,8 @@ impl Ca {
         };
         let cert_path = self.dir.path().join(Path::new(name).with_extension("crt"));
         let key_path = self.dir.path().join(Path::new(name).with_extension("key"));
-        fs::write(&cert_path, &cert.to_pem()?)?;
-        fs::write(&key_path, &pkey.private_key_to_pem_pkcs8()?)?;
+        fs::write(&cert_path, cert.to_pem()?)?;
+        fs::write(&key_path, pkey.private_key_to_pem_pkcs8()?)?;
         Ok((cert_path, key_path))
     }
 }
@@ -553,7 +553,7 @@ fn test_auth_expiry() {
     };
 
     let config = util::Config::default()
-        .with_tls(TlsMode::Require, &server_cert, &server_key)
+        .with_tls(TlsMode::Require, server_cert, server_key)
         .with_frontegg(&frontegg_auth);
     let server = util::start_server(config).unwrap();
 
@@ -1635,8 +1635,7 @@ fn test_auth_intermediate_ca() {
     // When the server is configured to present the entire certificate chain,
     // the client should be able to verify the chain even though it only knows
     // about the root CA.
-    let config =
-        util::Config::default().with_tls(TlsMode::Require, &server_cert_chain, &server_key);
+    let config = util::Config::default().with_tls(TlsMode::Require, server_cert_chain, &server_key);
     let server = util::start_server(config).unwrap();
     run_tests(
         "TlsMode::Require",

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -201,7 +201,7 @@ fn test_http_sql() {
             server.inner.http_local_addr()
         ))
         .unwrap();
-        let (mut ws, _resp) = tungstenite::connect(&ws_url).unwrap();
+        let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
 
         f.run(|tc| {
             let msg = match tc.directive.as_str() {

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -207,7 +207,7 @@ impl ExprHumanizer for TestCatalog {
 ///
 /// The following variants of `MirScalarExpr` have non-standard syntax:
 /// Literal -> the syntax is `(ok <literal> <scalar type>)`, `<literal>`
-/// or (err <eval error> <scalar type>). Note that `ok` token can be omitted.
+/// or `(err <eval error> <scalar type>)`. Note that `ok` token can be omitted.
 /// If `<scalar type>` is not specified, then literals will be assigned
 /// default types:
 /// * true/false become Bool

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2471,7 +2471,7 @@ pub enum JoinImplementation {
     /// This gets translated to a Differential join during MIR -> LIR lowering, but we still want
     /// to represent it in MIR, because the fast path detection wants to match on this.
     ///
-    /// Consists of (<view id>, <keys of index>, <constants>)
+    /// Consists of (`<view id>`, `<keys of index>`, `<constants>`)
     IndexedFilter(GlobalId, Vec<MirScalarExpr>, #[mzreflect(ignore)] Vec<Row>),
     /// No implementation yet selected.
     Unimplemented,

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -428,12 +428,12 @@ impl MirScalarExpr {
     /// `<literal> = <expr>`, it tries to simplify the equality by applying the inverse function of
     /// the outermost function call of `<expr>` (if exists):
     ///
-    /// <literal> = func(<inner_expr>), where f is invertible
+    /// `<literal> = func(<inner_expr>)`, where f is invertible
     ///  -->
-    /// <func^-1(literal)> = <inner_expr>
+    /// `<func^-1(literal)> = <inner_expr>`
     /// (if func^-1(literal) doesn't error out)
     ///
-    /// The return value is the <inner_expr> and the literal value that we get by applying the
+    /// The return value is the `<inner_expr>` and the literal value that we get by applying the
     /// inverse function.
     fn invert_casts_on_expr_eq_literal_inner(
         expr: &MirScalarExpr,

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -186,7 +186,7 @@ fn get_type_as_string(t: &syn::Type) -> String {
 ///
 /// Supported types are:
 /// A plain path type A -> extracts A
-/// Box<A>, Vec<A>, Option<A> -> extracts A
+/// `Box<A>`, `Vec<A>`, `Option<A>` -> extracts A
 /// Tuple (A, (B, C)) -> extracts A, B, C.
 /// Remove A, B, C from expected results if they are primitive types or listed
 /// in [EXTERNAL_TYPES].

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -328,7 +328,7 @@ pub trait TestDeserializeContext {
         I: Iterator<Item = TokenTree>;
 
     /// Converts `json` back to the extended syntax specified by
-    /// [TestDeserializeContext::override_syntax<I>].
+    /// [TestDeserializeContext::override_syntax].
     ///
     /// Returns `Some(value)` if `json` has been resolved.
     /// Returns `None` is `json` should be resolved in the default manner.

--- a/src/npm/src/lib.rs
+++ b/src/npm/src/lib.rs
@@ -156,15 +156,15 @@ const JS_DEV_VENDOR: &str = "src/http/static-dev/js/vendor";
 
 impl NpmPackage {
     fn css_path(&self) -> PathBuf {
-        Path::new(CSS_VENDOR).join(&format!("{}.css", self.name))
+        Path::new(CSS_VENDOR).join(format!("{}.css", self.name))
     }
 
     fn js_prod_path(&self) -> PathBuf {
-        Path::new(JS_PROD_VENDOR).join(&format!("{}.js", self.name))
+        Path::new(JS_PROD_VENDOR).join(format!("{}.js", self.name))
     }
 
     fn js_dev_path(&self) -> PathBuf {
-        Path::new(JS_DEV_VENDOR).join(&format!("{}.js", self.name))
+        Path::new(JS_DEV_VENDOR).join(format!("{}.js", self.name))
     }
 
     fn extra_path(&self) -> PathBuf {
@@ -186,10 +186,10 @@ impl NpmPackage {
             vec![]
         };
         Ok(Sha256::new()
-            .chain_update(Sha256::digest(&css_data))
-            .chain_update(Sha256::digest(&js_prod_data))
-            .chain_update(Sha256::digest(&js_dev_data))
-            .chain_update(Sha256::digest(&extra_data))
+            .chain_update(Sha256::digest(css_data))
+            .chain_update(Sha256::digest(js_prod_data))
+            .chain_update(Sha256::digest(js_dev_data))
+            .chain_update(Sha256::digest(extra_data))
             .finalize()
             .as_slice()
             .into())
@@ -215,7 +215,7 @@ pub fn ensure() -> Result<(), anyhow::Error> {
             pkg.version,
         );
         let res = client
-            .get(&url)
+            .get(url)
             .send()
             .and_then(|res| res.error_for_status())
             .with_context(|| format!("downloading {}", pkg.name))?;

--- a/src/ore/src/cgroup.rs
+++ b/src/ore/src/cgroup.rs
@@ -39,7 +39,7 @@ impl CgroupEntry {
     }
 }
 
-/// Parses /proc/self/cgroup into a Vec<CgroupEntry>, if the file exists.
+/// Parses /proc/self/cgroup into a `Vec<CgroupEntry>`, if the file exists.
 pub fn parse_proc_self_cgroup() -> Option<Vec<CgroupEntry>> {
     let file = File::open("/proc/self/cgroup").ok()?;
     let file = BufReader::new(file);

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -575,7 +575,7 @@ where
 ///
 /// For more details see documentation and comments on:
 /// - [`LeasedBatchPart`]
-/// - From<SerdeLeasedBatchPart> for LeasedBatchPart<T>
+/// - `From<SerdeLeasedBatchPart>` for `LeasedBatchPart<T>`
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SerdeLeasedBatchPart {
     shard_id: ShardId,

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -518,13 +518,13 @@ impl ColumnarRecordsBuilder {
     }
 }
 
-/// A new-type so we can impl FromIterator for Vec<ColumnarRecords>.
+/// A new-type so we can impl FromIterator for `Vec<ColumnarRecords>`.
 #[derive(Debug)]
 pub struct ColumnarRecordsVec(pub Vec<ColumnarRecords>);
 
 impl ColumnarRecordsVec {
     /// Unwraps this ColumnarRecordsVec, returning the underlying
-    /// Vec<ColumnarRecords>.
+    /// `Vec<ColumnarRecords>`.
     pub fn into_inner(self) -> Vec<ColumnarRecords> {
         self.0
     }
@@ -614,7 +614,7 @@ impl ColumnarRecordsVecBuilder {
         }
     }
 
-    /// Finalize constructing a [Vec<ColumnarRecords>].
+    /// Finalize constructing a `Vec<ColumnarRecords>`.
     pub fn finish(self) -> Vec<ColumnarRecords> {
         let mut ret = self.filled;
         if self.current.len > 0 {

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -1802,7 +1802,7 @@ impl std::fmt::Display for TimeStrToken {
 }
 
 /// Convert a string from a time-like datatype (INTERVAL, TIMESTAMP/TZ, DATE, and TIME)
-/// into Vec<TimeStrToken>.
+/// into `Vec<TimeStrToken>`.
 ///
 /// # Warning
 /// - Any sequence of numeric characters following a decimal that exceeds 9 characters

--- a/src/service/src/grpc.rs
+++ b/src/service/src/grpc.rs
@@ -53,7 +53,7 @@ pub type ClientTransport = InterceptedService<Channel, VersionAttachInterceptor>
 /// protobuf RPC sets up two streams that persist after the RPC has returned: A
 /// Request (Command) stream (for us, backed by a unbounded mpsc queue) going
 /// from this instance to the server and a response stream coming back
-/// (represented directly as a Streaming<Response> instance). The recv and send
+/// (represented directly as a `Streaming<Response>` instance). The recv and send
 /// functions interact with the two mpsc channels or the streaming instance
 /// respectively.
 #[derive(Debug)]

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -112,7 +112,7 @@ pub enum Expr<T: AstInfo> {
         expr: Box<Expr<T>>,
         collation: UnresolvedObjectName,
     },
-    /// COALESCE(<expr>, ...) or GREATEST(<expr>, ...) or LEAST(<expr>, ...)
+    /// `COALESCE(<expr>, ...)` or `GREATEST(<expr>, ...)` or `LEAST(<expr>`, ...)
     ///
     /// While COALESCE/GREATEST/LEAST have the same syntax as a function call,
     /// their semantics are extremely unusual, and are better captured with a

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1191,9 +1191,9 @@ pub enum ReplicaOptionName {
     Workers,
     /// The `COMPUTE [<host> [, <host> ...]]` option.
     Compute,
-    /// The `INTROSPECTION INTERVAL [[=] <interval>] option.
+    /// The `INTROSPECTION INTERVAL [[=] <interval>]` option.
     IntrospectionInterval,
-    /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
+    /// The `INTROSPECTION DEBUGGING [[=] <enabled>]` option.
     IntrospectionDebugging,
 }
 

--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -35,7 +35,7 @@ use crate::ast::{
 /// trait), but later on, we replace them with both the name along with the ID
 /// that it gets resolved to.
 ///
-/// Currently this process brings an Ast<Raw> to Ast<Aug>, and lives in
+/// Currently this process brings an `Ast<Raw>` to `Ast<Aug>`, and lives in
 /// sql/src/names.rs:resolve.
 pub trait AstInfo: Clone {
     /// The type used for nested statements.

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1498,7 +1498,7 @@ impl<'a> Parser<'a> {
         } else {
             self.expected(
                 self.peek_pos(),
-                &format!("one of {}", keywords.iter().join(" or ")),
+                format!("one of {}", keywords.iter().join(" or ")),
                 self.peek_token(),
             )
         }
@@ -1552,7 +1552,7 @@ impl<'a> Parser<'a> {
             }
             _ => self.expected(
                 self.peek_pos(),
-                &format!("one of {}", tokens.iter().join(" or ")),
+                format!("one of {}", tokens.iter().join(" or ")),
                 self.peek_token(),
             ),
         }

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -143,6 +143,7 @@ pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
 /// when the inputs to the comparison are non-nullable. This function is careful
 /// to only apply the transformation when it is valid to do so.
 ///
+/// ```ignore
 /// WHERE (SELECT any(<pred>) FROM <rel>)
 /// =>
 /// WHERE EXISTS(SELECT * FROM <rel> WHERE <pred>)
@@ -150,6 +151,7 @@ pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
 /// WHERE (SELECT all(<pred>) FROM <rel>)
 /// =>
 /// WHERE NOT EXISTS(SELECT * FROM <rel> WHERE (NOT <pred>) OR <pred> IS NULL)
+/// ```
 ///
 /// See Section 3.5 of "Execution Strategies for SQL Subqueries" by
 /// M. Elhemali, et al.

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -217,8 +217,8 @@ pub enum UpsertError {
     /// with the value.
     ///
     /// It is necessary to distinguish them because the necessary record to retract them is different.
-    /// (K, <errored V>) is retracted by (K, null), whereas (<errored K>, anything) is retracted by
-    /// ("bytes", null), where "bytes" is the string that failed to correctly decode as a key.
+    /// `(K, <errored V>)` is retracted by `(K, null)`, whereas `(<errored K>, anything)` is retracted by
+    /// `("bytes", null)`, where "bytes" is the string that failed to correctly decode as a key.
     KeyDecode(DecodeError),
     /// Wrapper around an error related to the value.
     Value(UpsertValueError),

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -712,7 +712,7 @@ impl PredicatePushdown {
         *inputs = new_inputs;
     }
 
-    /// Returns (<predicates to retain>, <predicates to push at each input>).
+    /// Returns `(<predicates to retain>, <predicates to push at each input>)`.
     pub fn push_filters_through_join(
         input_mapper: &JoinInputMapper,
         equivalences: &Vec<Vec<MirScalarExpr>>,

--- a/src/walkabout/src/parse.rs
+++ b/src/walkabout/src/parse.rs
@@ -52,8 +52,8 @@ where
         match item {
             Item::Mod(item) if item.content.is_none() => {
                 let path = match stem {
-                    "mod" | "lib" => dir.join(&format!("{}.rs", item.ident)),
-                    _ => dir.join(&format!("{}/{}.rs", stem, item.ident)),
+                    "mod" | "lib" => dir.join(format!("{}.rs", item.ident)),
+                    _ => dir.join(format!("{}/{}.rs", stem, item.ident)),
                 };
                 collect_items(path, out)?;
             }


### PR DESCRIPTION
All the non-`Cargo.toml` changes are just clippy changes. The ones to `transform` look weird, but apparently its a (small) perf win: https://rust-lang.github.io/rust-clippy/master/index.html#box_default
