### PR TITLE
adapter/sql: Remove some usages of as

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -27,6 +27,7 @@ use mz_compute_client::response::PeekResponse;
 use mz_compute_client::types::dataflows::DataflowDescription;
 use mz_expr::explain::Indices;
 use mz_expr::{EvalError, Id, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
+use mz_ore::cast::CastFrom;
 use mz_ore::str::Indent;
 use mz_ore::str::StrExt;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -323,9 +324,9 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     )))?
                 };
                 if count > 0 {
-                    // TODO(benesch): rewrite to avoid `as`.
-                    #[allow(clippy::as_conversions)]
-                    results.push((row, NonZeroUsize::new(count as usize).unwrap()));
+                    let count =
+                        usize::cast_from(u64::try_from(count).expect("known to be positive"));
+                    results.push((row, NonZeroUsize::new(count).unwrap()));
                 }
             }
             let results = finishing.finish(results, self.catalog.system_config().max_result_size());

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2729,14 +2729,14 @@ impl<S: Append + 'static> Coordinator<S> {
             }
             // For the `Trace` stage, return the entire trace as (time, path, plan) triples.
             Trace => {
-                // TODO(benesch): remove this once this module no longer makes
-                // use of potentially dangerous `as` conversions.
-                #[allow(clippy::as_conversions)]
                 let rows = trace
                     .into_iter()
                     .map(|entry| {
                         Row::pack_slice(&[
-                            Datum::from(entry.duration.as_nanos() as u64),
+                            Datum::from(
+                                // The trace would have to take over 584 years to overflow a u64.
+                                u64::try_from(entry.duration.as_nanos()).unwrap_or(u64::MAX),
+                            ),
                             Datum::from(entry.path.as_str()),
                             Datum::from(entry.plan.as_str()),
                         ])

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -1301,7 +1301,7 @@ pub fn give_value<D: AvroDecode>(d: D, v: &Value) -> Result<D::Out, AvroError> {
         Value::Bytes(val) => d.bytes::<&[u8]>(V(val)),
         Value::String(val) => d.string::<&[u8]>(V(val)),
         Value::Fixed(_len, val) => d.fixed::<&[u8]>(V(val)),
-        Value::Enum(idx, symbol) => d.enum_variant(symbol, *idx as usize),
+        Value::Enum(idx, symbol) => d.enum_variant(symbol, *idx),
         Value::Union {
             index,
             inner,

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -401,10 +401,9 @@ impl Value {
             (&Value::String(_), SchemaPiece::String) => true,
             (&Value::Fixed(n, _), SchemaPiece::Fixed { size }) => n == *size,
             (&Value::String(ref s), SchemaPiece::Enum { symbols, .. }) => symbols.contains(s),
-            (&Value::Enum(i, ref s), SchemaPiece::Enum { symbols, .. }) => symbols
-                .get(i as usize)
-                .map(|symbol| symbol == s)
-                .unwrap_or(false),
+            (&Value::Enum(i, ref s), SchemaPiece::Enum { symbols, .. }) => {
+                symbols.get(i).map(|symbol| symbol == s).unwrap_or(false)
+            }
             (
                 &Value::Union {
                     index,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -149,7 +149,7 @@ pub enum Datum<'a> {
     // calling `<` on Datums (see `fn lt` in scalar/func.rs).
     /// An unknown value.
     Null,
-    // A range of values, e.g. [-1, 1).
+    /// A range of values, e.g. [-1, 1).
     Range(Range<'a>),
 }
 


### PR DESCRIPTION


### Motivation
This PR refactors existing code.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
