### PR TITLE
*: use ReinterpretCast everywhere it applies

### DIFF
--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
+use mz_ore::cast::ReinterpretCast;
 use mz_repr::adt::numeric::{self, Numeric, NumericMaxScale};
 use mz_repr::adt::system::{Oid, PgLegacyChar};
 use mz_repr::{strconv, ColumnType, ScalarType};
@@ -176,7 +177,7 @@ sqlfunc!(
         // Do not use this as a model for behavior in other contexts. OIDs
         // should not in general be thought of as freely convertible from
         // `i32`s.
-        Oid(u32::from_ne_bytes(a.to_ne_bytes()))
+        Oid(u32::reinterpret_cast(a))
     }
 );
 
@@ -189,7 +190,7 @@ sqlfunc!(
         // `PgLegacyChar` is signed.
         // See: https://github.com/postgres/postgres/blob/791b1b71da35d9d4264f72a87e4078b85a2fcfb4/src/backend/utils/adt/char.c#L91-L96
         let a = i8::try_from(a).map_err(|_| EvalError::CharOutOfRange)?;
-        Ok(PgLegacyChar(u8::from_ne_bytes(a.to_ne_bytes())))
+        Ok(PgLegacyChar(u8::reinterpret_cast(a)))
     }
 );
 

--- a/src/expr/src/scalar/func/impls/oid.rs
+++ b/src/expr/src/scalar/func/impls/oid.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use mz_ore::cast::ReinterpretCast;
 use mz_pgrepr::Type;
 use mz_repr::adt::system::{Oid, RegClass, RegProc, RegType};
 use mz_repr::strconv;
@@ -33,7 +34,7 @@ sqlfunc!(
         //
         // Do not use this as a model for behavior in other contexts. OIDs
         // should not in general be thought of as freely convertible to `i32`s.
-        i32::from_ne_bytes(a.0.to_ne_bytes())
+        i32::reinterpret_cast(a.0)
     }
 );
 

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -39,7 +39,7 @@ use mz_orchestrator::{
     NamespacedOrchestrator, Orchestrator, Service, ServiceConfig, ServiceEvent, ServicePort,
     ServiceProcessMetrics, ServiceStatus,
 };
-use mz_ore::cast::CastFrom;
+use mz_ore::cast::{CastFrom, ReinterpretCast};
 use mz_ore::netio::UnixSocketAddr;
 use mz_ore::result::ResultExt;
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
@@ -406,7 +406,7 @@ async fn supervise_existing_process(state_updater: &ProcessStateUpdater, pid_fil
         return;
     };
 
-    let pid = Pid::from_u32(u32::from_ne_bytes(pid.to_ne_bytes()));
+    let pid = Pid::from_u32(u32::reinterpret_cast(pid));
     let mut system = System::new();
     system.refresh_process_specifics(pid, ProcessRefreshKind::new());
     let Some(process) = system.process(pid) else {

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -110,10 +110,14 @@ macro_rules! reinterpret_cast {
     };
 }
 
-reinterpret_cast!(u64, i64);
-reinterpret_cast!(i64, u64);
+reinterpret_cast!(u8, i8);
+reinterpret_cast!(i8, u8);
+reinterpret_cast!(u16, i16);
+reinterpret_cast!(i16, u16);
 reinterpret_cast!(u32, i32);
 reinterpret_cast!(i32, u32);
+reinterpret_cast!(u64, i64);
+reinterpret_cast!(i64, u64);
 
 /// Returns `Some` if `f` can losslessly be converted to an i64.
 #[allow(clippy::as_conversions)]

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -16,9 +16,6 @@ use std::mem::{size_of, transmute};
 use std::str;
 
 use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, Timelike, Utc};
-use mz_ore::soft_assert;
-use mz_ore::vec::Vector;
-use mz_persist_types::Codec64;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
@@ -27,7 +24,10 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use uuid::Uuid;
 
-use mz_ore::cast::CastFrom;
+use mz_ore::cast::{CastFrom, ReinterpretCast};
+use mz_ore::soft_assert;
+use mz_ore::vec::Vector;
+use mz_persist_types::Codec64;
 
 use crate::adt::array::{
     Array, ArrayDimension, ArrayDimensions, InvalidArrayError, MAX_ARRAY_DIMENSIONS,
@@ -577,7 +577,7 @@ unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
         Tag::Dummy => Datum::Dummy,
         Tag::Numeric => {
             let digits = read_byte(data, offset).into();
-            let exponent = i8::from_ne_bytes(read_byte(data, offset).to_ne_bytes());
+            let exponent = i8::reinterpret_cast(read_byte(data, offset));
             let bits = read_byte(data, offset);
 
             let lsu_u16_len = Numeric::digits_to_lsu_elements_len(digits);

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -44,6 +44,7 @@ use ryu::Float as RyuFloat;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use mz_ore::cast::ReinterpretCast;
 use mz_ore::fmt::FormatBuffer;
 use mz_ore::lex::LexBuf;
 use mz_ore::str::StrExt;
@@ -241,7 +242,7 @@ pub fn parse_oid(s: &str) -> Result<u32, ParseError> {
         .trim()
         .parse()
         .map_err(|e| ParseError::invalid_input_syntax("oid", s).with_details(e))?;
-    Ok(u32::from_ne_bytes(oid.to_ne_bytes()))
+    Ok(u32::reinterpret_cast(oid))
 }
 
 fn parse_float<Fl>(type_name: &'static str, s: &str) -> Result<Fl, ParseError>

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -60,6 +60,7 @@ use uuid::Uuid;
 
 use mz_controller::ControllerConfig;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
+use mz_ore::cast::ReinterpretCast;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task;
@@ -368,7 +369,7 @@ impl<'a> FromSql<'a> for Slt {
                 let num_fields = read_be_i32(&mut raw)?;
                 let mut tuple = vec![];
                 for _ in 0..num_fields {
-                    let oid = u32::from_ne_bytes(read_be_i32(&mut raw)?.to_ne_bytes());
+                    let oid = u32::reinterpret_cast(read_be_i32(&mut raw)?);
                     let typ = match PgType::from_oid(oid) {
                         Some(typ) => typ,
                         None => return Err("unknown oid".into()),


### PR DESCRIPTION
Convert all uses of the confusing `from_ne_bytes(to_ne_bytes())` idiom into the purpose-built `ReinterpretCast` trait added in #16695.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
