### PR TITLE
Switch to HEAD of Chrono 0.4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,8 +996,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "chrono"
 version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+source = "git+https://github.com/chronotope/chrono.git?branch=0.4.x#a1591e91f3a6af50e3d642039bbed1042f300d5b"
 dependencies = [
  "iana-time-zone",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ debug = 1
 # The reasons for each of these overrides are listed in deny.toml.
 [patch.crates-io]
 axum = { git = "https://github.com/tokio-rs/axum.git" }
+chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x" }
 csv = { git = "https://github.com/BurntSushi/rust-csv.git" }
 csv-core = { git = "https://github.com/BurntSushi/rust-csv.git" }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }

--- a/deny.toml
+++ b/deny.toml
@@ -158,6 +158,10 @@ allow-git = [
     # See: https://github.com/BurntSushi/rust-csv/issues/271
     "https://github.com/BurntSushi/rust-csv.git",
 
+    # Waiting for https://github.com/chronotope/chrono/pull/906
+    # to be released in the v0.4.x series.
+    "https://github.com/chronotope/chrono.git",
+
     # Waiting on v0.18.
     # See: https://github.com/open-telemetry/opentelemetry-rust/pull/779
     "https://github.com/MaterializeInc/opentelemetry-rust.git",

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -21,7 +21,7 @@
 // The original source code is subject to the terms of the MIT license, a copy
 // of which can be found in the LICENSE file at the root of this repository.
 
-use std::cmp::{self, Ordering};
+use std::cmp;
 use std::fmt::{self, Display};
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
@@ -121,12 +121,6 @@ mod tests {
 
     #[test]
     fn test_negative_timestamps() {
-        // TODO[btv] The currently released `from_timestamp_millis` is buggy,
-        // so we use `from_timestamp_opt` everywhere here.
-        //
-        // See discussion at https://github.com/chronotope/chrono/issues/903 .
-        // We should update to the new version of Chrono whenever that
-        // goes to master.
         assert_eq!(
             build_ts_value(-1, TsUnit::Millis).unwrap(),
             Value::Timestamp(NaiveDateTime::from_timestamp_opt(-1, 999_000_000).unwrap())
@@ -153,70 +147,9 @@ mod tests {
 }
 
 fn build_ts_value(value: i64, unit: TsUnit) -> Result<Value, AvroError> {
-    // The algorithm here is taken from NaiveDateTime::from_timestamp_millis
-    // on the unreleased 0.4.x branch,
-    // made general to work with either millis or micros.
-    //
-    // That function is reproduced below for clarity.
-    //
-    // pub fn from_timestamp_millis(millis: i64) -> Option<NaiveDateTime> {
-    //     let (secs, subsec_millis) = (millis / 1000, millis % 1000);
-
-    //     match subsec_millis.cmp(&0) {
-    //         Ordering::Less => {
-    //             // in the case where our subsec part is negative, then we are actually in the earlier second
-    //             // hence we subtract one from the seconds part, and we then add a whole second worth of nanos
-    //             // to our nanos part. Due to the use of u32 datatype, it is more convenient to subtract
-    //             // the absolute value of the subsec nanos from a whole second worth of nanos
-    //             let nsecs = u32::try_from(subsec_millis.abs()).ok()? * NANOS_IN_MILLISECOND;
-    //             NaiveDateTime::from_timestamp_opt(
-    //                 secs.checked_sub(1)?,
-    //                 NANOS_IN_SECOND.checked_sub(nsecs)?,
-    //             )
-    //         }
-    //         Ordering::Equal => NaiveDateTime::from_timestamp_opt(secs, 0),
-    //         Ordering::Greater => {
-    //             // convert the subsec millis into nanosecond scale so they can be supplied
-    //             // as the nanoseconds parameter
-    //             let nsecs = u32::try_from(subsec_millis).ok()? * NANOS_IN_MILLISECOND;
-    //             NaiveDateTime::from_timestamp_opt(secs, nsecs)
-    //         }
-    //     }
-    // }
-    const NANOS_PER_SECOND: u32 = 1_000_000_000;
-    let units_per_second = match unit {
-        TsUnit::Millis => 1_000,
-        TsUnit::Micros => 1_000_000,
-    };
-    let nanos_per_unit = NANOS_PER_SECOND / units_per_second as u32;
-
-    let (secs, subsec_units) = (value / units_per_second, value % units_per_second);
-    // See comment in copied Chrono code above for explanation of what's
-    // going on in this match statement.
-    //
-    // TODO[btv] - The expects below should never fail and are just here to document assumptions.
-    // Since they're potentially being called in a tight loop,
-    // we can optimize with `as` or unsafe code, if this ever proves to
-    // be a bottleneck.
-    let result = match subsec_units.cmp(&0) {
-        Ordering::Less => {
-            let nsecs = u32::try_from(subsec_units.abs())
-                .expect("abs(subsec_units) can't be greater than 1M")
-                * nanos_per_unit;
-            NaiveDateTime::from_timestamp_opt(
-                secs.checked_sub(1)
-                    .expect("secs is the result of a division by at least 1000"),
-                NANOS_PER_SECOND
-                    .checked_sub(nsecs)
-                    .expect("abs(nsecs) can't be greater than 1B"),
-            )
-        }
-        Ordering::Equal => NaiveDateTime::from_timestamp_opt(secs, 0),
-        Ordering::Greater => {
-            let nsecs = u32::try_from(subsec_units).expect("subsec_units can't be greater than 1M")
-                * nanos_per_unit;
-            NaiveDateTime::from_timestamp_opt(secs, nsecs)
-        }
+    let result = match unit {
+        TsUnit::Millis => NaiveDateTime::from_timestamp_millis(value),
+        TsUnit::Micros => NaiveDateTime::from_timestamp_micros(value),
     };
     let ndt = result.ok_or(AvroError::Decode(DecodeError::BadTimestamp { unit, value }))?;
     Ok(Value::Timestamp(ndt))

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -25,7 +25,7 @@ base64 = { version = "0.13.1", features = ["alloc", "std"] }
 bstr = { version = "0.2.14", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1.4.3", features = ["std"] }
 bytes = { version = "1.3.0", features = ["std"] }
-chrono = { version = "0.4.23", default-features = false, features = ["alloc", "clock", "iana-time-zone", "serde", "std", "winapi"] }
+chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "iana-time-zone", "serde", "std", "winapi"] }
 clap = { version = "3.2.20", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor", "terminal_size", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async", "async_tokio", "cargo_bench_support", "futures", "html_reports", "plotters", "rayon", "tokio"] }
 crossbeam-channel = { version = "0.5.6", features = ["crossbeam-utils", "std"] }
@@ -125,7 +125,7 @@ bstr = { version = "0.2.14", features = ["lazy_static", "regex-automata", "serde
 byteorder = { version = "1.4.3", features = ["std"] }
 bytes = { version = "1.3.0", features = ["std"] }
 cc = { version = "1.0.77", default-features = false, features = ["jobserver", "parallel"] }
-chrono = { version = "0.4.23", default-features = false, features = ["alloc", "clock", "iana-time-zone", "serde", "std", "winapi"] }
+chrono = { git = "https://github.com/chronotope/chrono.git", branch = "0.4.x", default-features = false, features = ["alloc", "clock", "iana-time-zone", "serde", "std", "winapi"] }
 clap = { version = "3.2.20", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor", "terminal_size", "wrap_help"] }
 criterion = { version = "0.4.0", features = ["async", "async_tokio", "cargo_bench_support", "futures", "html_reports", "plotters", "rayon", "tokio"] }
 crossbeam-channel = { version = "0.5.6", features = ["crossbeam-utils", "std"] }


### PR DESCRIPTION
This has two benefits:

1. We will no longer risk calling the old, buggy `from_timestamp_millis` function (which had the property that `NaiveDateTime::from_timestamp_millis(-1000)` did not compare equal to `NaiveDateTime::from_timestamp_opt(-1, 0)`. It has been fixed in the latest Chrono.
2. We will be able to use the `from_timestamp_micros` function introduced in https://github.com/chronotope/chrono/pull/906 , rather than duplicating this error-prone logic in our own codebase.

Once Chrono does another release of 0.4.x, we can stop depending on HEAD.  

### Motivation

See initial section

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- None
