### PR TITLE
test: switch tests and dev env to use CockroachDB instead of Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,6 +4563,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tower-http",
+ "tracing",
  "uuid",
  "walkdir",
  "workspace-hack",

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -290,6 +290,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: restart
+          run: stash
     agents:
       queue: linux-x86_64
 

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -44,42 +44,26 @@ We recommend that you do _not_ install Rust via your system's package manager.
 We closely track the most recent version of Rust. The version of Rust in your
 package manager is likely too old to build Materialize.
 
-### PostgreSQL
+### CockroachDB
 
-Running Materialize locally requires a running PostgreSQL server.
+Running Materialize locally requires a running CockroachDB server.
 
-On macOS, when using Homebrew, Postgres can be installed and started via:
-
-```shell
-brew install postgresql
-brew services start postgresql
-```
-
-On Debian-based Linux variants:
+On macOS, when using Homebrew, CockroachDB can be installed and started via:
 
 ```shell
-apt install postgresql
+brew install cockroachdb/cockroach/cockroach
+brew services start cockroach
 ```
 
-If you can run `psql` without arguments and connect, you're all set. For the
-latter to work, you may need to create a new database with `createdb`. If you
-issue `createdb` without any arguments, a database with your username will be
-created.
+On Linux, we recommend using Docker:
 
-To also run `bin/cargo-test`, you'll need to add the following to your Postgres
-config. The location of your Postgres config file can be shown using `psql -c
-'SHOW config_file'` on macOS or using `sudo -u postgres psql -c 'SHOW
-config_file'` on Ubuntu. Common locations are:
-`/opt/homebrew/var/postgres/postgresql.conf` on macOS,
-`/etc/postgresql/13/main/postgresql.conf` on Ubuntu, and
-`/var/lib/postgres/data/postgresql.conf` on Arch Linux. Then, restart Postgres.
+```shell
+docker run --name=cockroach -d -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:v22.2.0 start-single-node --insecure
+```
 
-```
-wal_level=logical
-max_wal_senders=20
-max_replication_slots=20
-max_connections = 5000
-```
+If you can successfully connect to CockroachDB with either
+`psql postgres://root@localhost:26257` or `cockroach sql --insecure`, you're
+all set.
 
 ### Confluent Platform
 

--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -7,36 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# 22.1.2 community images with amd and arm variants. Used here so we can copy
-# the cockroach binary if this is an arm host. We are temporarily using this
-# image from the community until an official image is published.
-FROM juliuszaromskis/cockroachdb:22.1.2 AS crdb-arm
-
-# Create an image that determines the cockroach binary (so we don't have two
-# copies in the final image).
-MZFROM ubuntu-base AS crdb-bin
-
-RUN apt-get update \
-    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-        ca-certificates \
-        curl
-
-COPY --from=crdb-arm /cockroach/cockroach /cockroach-arm
-
-ARG COCKROACH_VERSION=22.1.5
-
-RUN set -eux; \
-	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
-	case "$arch" in \
-		'amd64') \
-		         curl https://binaries.cockroachdb.com/cockroach-v${COCKROACH_VERSION}.linux-amd64.tgz | tar -xz;  \
-		         cp cockroach-v${COCKROACH_VERSION}.linux-amd64/cockroach /cockroach; \
-			;; \
-		'arm64') \
-			mv /cockroach-arm /cockroach; \
-			;; \
-		*) echo >&2 "error: unsupported architecture '$arch'"; exit 1 ;; \
-	esac;
+FROM cockroachdb/cockroach:v22.2.0 AS crdb
 
 MZFROM ubuntu-base
 
@@ -53,7 +24,7 @@ RUN apt-get update \
     && mkdir /cockroach-data \
     && chown materialize /mzdata /cockroach-data
 
-COPY --from=crdb-bin /cockroach /usr/local/bin/cockroach
+COPY --from=crdb /cockroach/cockroach /usr/local/bin/cockroach
 
 COPY storaged computed environmentd entrypoint.sh /usr/local/bin/
 

--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -17,13 +17,13 @@ from pg8000.exceptions import InterfaceError
 
 from materialize import ROOT, mzbuild
 from materialize.cloudtest.k8s import K8sResource
+from materialize.cloudtest.k8s.cockroach import COCKROACH_RESOURCES
 from materialize.cloudtest.k8s.debezium import DEBEZIUM_RESOURCES
 from materialize.cloudtest.k8s.environmentd import (
     EnvironmentdService,
     EnvironmentdStatefulSet,
 )
 from materialize.cloudtest.k8s.minio import Minio
-from materialize.cloudtest.k8s.postgres import POSTGRES_RESOURCES
 from materialize.cloudtest.k8s.postgres_source import POSTGRES_SOURCE_RESOURCES
 from materialize.cloudtest.k8s.redpanda import REDPANDA_RESOURCES
 from materialize.cloudtest.k8s.role_binding import AdminRoleBinding
@@ -114,7 +114,7 @@ class MaterializeApplication(Application):
         )
 
         self.resources = [
-            *POSTGRES_RESOURCES,
+            *COCKROACH_RESOURCES,
             *POSTGRES_SOURCE_RESOURCES,
             *REDPANDA_RESOURCES,
             *DEBEZIUM_RESOURCES,

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -112,9 +112,9 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 f"--persist-blob-url=s3://minio:minio123@persist/persist?endpoint={s3_endpoint}&region=minio",
                 "--orchestrator=kubernetes",
                 "--orchestrator-kubernetes-image-pull-policy=if-not-present",
-                "--persist-consensus-url=postgres://postgres@postgres.default?options=--search_path=consensus",
-                "--adapter-stash-url=postgres://postgres@postgres.default?options=--search_path=catalog",
-                "--storage-stash-url=postgres://postgres@postgres.default?options=--search_path=storage",
+                "--persist-consensus-url=postgres://root@cockroach.default:26257?options=--search_path=consensus",
+                "--adapter-stash-url=postgres://root@cockroach.default:26257?options=--search_path=catalog",
+                "--storage-stash-url=postgres://root@cockroach.default:26257?options=--search_path=storage",
                 "--internal-sql-listen-addr=0.0.0.0:6877",
                 "--unsafe-mode",
                 # cloudtest may be called upon to spin up older versions of Mz too!

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -732,6 +732,34 @@ class Composition:
         )
 
     # TODO(benesch): replace with Docker health checks.
+    def wait_for_cockroach(
+        self,
+        *,
+        dbname: str = "defaultdb",
+        port: Optional[int] = None,
+        host: str = "localhost",
+        timeout_secs: int = 120,
+        query: str = "SELECT 1",
+        user: str = "root",
+        password: Optional[str] = None,
+        expected: Union[Iterable[Any], Literal["any"]] = [[1]],
+        print_result: bool = False,
+        service: str = "cockroach",
+    ) -> None:
+        """Wait for a CockroachDB service to start."""
+        _wait_for_pg(
+            dbname=dbname,
+            host=host,
+            port=self.port(service, port) if port else self.default_port(service),
+            timeout_secs=timeout_secs,
+            query=query,
+            user=user,
+            password=password,
+            expected=expected,
+            print_result=print_result,
+        )
+
+    # TODO(benesch): replace with Docker health checks.
     def wait_for_materialized(
         self,
         service: str = "materialized",
@@ -947,7 +975,7 @@ def _wait_for_pg(
     port: int,
     host: str,
     user: str,
-    password: str,
+    password: Optional[str],
     expected: Union[Iterable[Any], Literal["any"]],
     print_result: bool = False,
 ) -> None:

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -498,7 +498,7 @@ class Cockroach(Service):
         super().__init__(
             name="cockroach",
             config={
-                "image": "cockroachdb/cockroach:v22.1.2",
+                "image": "cockroachdb/cockroach:v22.2.0",
                 "ports": [26257],
                 "command": "start-single-node --insecure",
                 "volumes": ["/cockroach/cockroach-data"],
@@ -792,13 +792,13 @@ class TestCerts(Service):
 class SqlLogicTest(Service):
     def __init__(
         self,
-        name: str = "sqllogictest-svc",
+        name: str = "sqllogictest",
         mzbuild: str = "sqllogictest",
         environment: List[str] = [
             "MZ_SOFT_ASSERTIONS=1",
         ],
         volumes: List[str] = ["../..:/workdir"],
-        depends_on: List[str] = ["postgres"],
+        depends_on: List[str] = ["cockroach"],
     ) -> None:
         super().__init__(
             name=name,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -166,18 +166,18 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
     };
     let (consensus_uri, adapter_stash_url, storage_stash_url) = {
         let seed = config.seed;
-        let postgres_url = env::var("POSTGRES_URL")
-            .map_err(|_| anyhow!("POSTGRES_URL environment variable is not set"))?;
-        let mut conn = postgres::Client::connect(&postgres_url, NoTls)?;
+        let cockroach_url = env::var("COCKROACH_URL")
+            .map_err(|_| anyhow!("COCKROACH_URL environment variable is not set"))?;
+        let mut conn = postgres::Client::connect(&cockroach_url, NoTls)?;
         conn.batch_execute(&format!(
             "CREATE SCHEMA IF NOT EXISTS consensus_{seed};
              CREATE SCHEMA IF NOT EXISTS adapter_{seed};
              CREATE SCHEMA IF NOT EXISTS storage_{seed};",
         ))?;
         (
-            format!("{postgres_url}?options=--search_path=consensus_{seed}"),
-            format!("{postgres_url}?options=--search_path=adapter_{seed}"),
-            format!("{postgres_url}?options=--search_path=storage_{seed}"),
+            format!("{cockroach_url}?options=--search_path=consensus_{seed}"),
+            format!("{cockroach_url}?options=--search_path=adapter_{seed}"),
+            format!("{cockroach_url}?options=--search_path=storage_{seed}"),
         )
     };
     let metrics_registry = MetricsRegistry::new();

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -37,6 +37,7 @@ regex = "1.7.0"
 serde_json = "1.0.89"
 tempfile = "3.2.0"
 time = "0.3.17"
+tracing = "0.1.37"
 tokio = "1.23.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
 tower-http = { version = "0.3.5", features = ["cors"] }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -16,6 +16,7 @@ from pg8000.dbapi import ProgrammingError
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
+    Cockroach,
     Computed,
     Kafka,
     Localstack,
@@ -540,17 +541,15 @@ def workflow_test_remote_storaged(c: Composition) -> None:
 
     with c.override(
         Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True),
-        # Use a separate PostgreSQL service for persist rather than the one in
+        # Use a separate CockroachDB service for persist rather than the one in
         # the `Materialized` service, so that crashing `environmentd` does not
-        # also take down PostgreSQL.
-        Postgres(),
-        Materialized(
-            options="--persist-consensus-url=postgres://postgres:postgres@postgres"
-        ),
+        # also take down CockroachDB.
+        Cockroach(),
+        Materialized(options="--persist-consensus-url=postgres://root@cockroach:26257"),
     ):
         dependencies = [
             "materialized",
-            "postgres",
+            "cockroach",
             "storaged",
             "zookeeper",
             "kafka",

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -9,9 +9,9 @@
 
 from materialize import ROOT, ci_util
 from materialize.mzcompose import Composition
-from materialize.mzcompose.services import Postgres, SqlLogicTest
+from materialize.mzcompose.services import Cockroach, SqlLogicTest
 
-SERVICES = [Postgres(), SqlLogicTest()]
+SERVICES = [Cockroach(), SqlLogicTest()]
 
 
 def workflow_default(c: Composition) -> None:
@@ -25,15 +25,16 @@ def workflow_sqllogictest(c: Composition) -> None:
 
 
 def run_sqllogictest(c: Composition, command: str) -> None:
-    c.up("postgres")
-    c.wait_for_postgres(dbname="postgres")
+    c.up("cockroach")
+    c.wait_for_cockroach()
+
     try:
         junit_report = ci_util.junit_report_filename(c.name)
         c.run(
-            "sqllogictest-svc",
+            "sqllogictest",
             command,
             f"--junit-report={junit_report}",
-            "--postgres-url=postgres://postgres:postgres@postgres",
+            "--postgres-url=postgres://root@cockroach:26257",
         )
     finally:
         ci_util.upload_junit_report(c.name, ROOT / junit_report)

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -19,7 +19,6 @@ from semver import Version
 from materialize import util
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
-    Cockroach,
     Kafka,
     Materialized,
     Postgres,
@@ -32,13 +31,7 @@ from materialize.mzcompose.services import (
 # All released Materialize versions, in order from most to least recent.
 all_versions = util.released_materialize_versions()
 
-mz_options: Dict[Version, str] = {
-    Version.parse(
-        "0.27.0"
-    ): " --persist-consensus-url=postgres://root@cockroach:26257?options=--search_path=consensus"
-    " --adapter-stash-url=postgres://root@cockroach:26257?options=--search_path=adapter"
-    " --storage-stash-url=postgres://root@cockroach:26257?options=--search_path=storage "
-}
+mz_options: Dict[Version, str] = {}
 
 SERVICES = [
     TestCerts(),
@@ -56,16 +49,12 @@ SERVICES = [
         ],
     ),
     Postgres(),
-    Cockroach(),
     Materialized(
         options=" ".join(mz_options.values()),
         environment_extra=[
             "SSL_KEY_PASSWORD=mzmzmz",
         ],
-        volumes_extra=[
-            "/cockroach-data",
-            "secrets:/share/secrets",
-        ],
+        volumes_extra=["secrets:/share/secrets"],
     ),
     # N.B.: we need to use `validate_postgres_stash=False` because testdrive uses
     # HEAD to load the catalog from disk but does *not* run migrations. There
@@ -149,19 +138,7 @@ def test_upgrade_from_version(
 
     c.down(destroy_volumes=True)
     c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "postgres", "cockroach"]
-    )
-
-    # We use a CockroachDB instance *outside* of the `materialized` container
-    # so that we don't unnecessarily test CockroachDB upgrades in addition to
-    # Materialize updates.
-    c.sql(
-        """CREATE SCHEMA adapter;
-           CREATE SCHEMA storage;
-           CREATE SCHEMA consensus;
-        """,
-        service="cockroach",
-        user="root",
+        services=["zookeeper", "kafka", "schema-registry", "postgres"]
     )
 
     if from_version != "current_source":
@@ -216,10 +193,7 @@ def test_upgrade_from_version(
 
     with c.override(
         Testdrive(
-            entrypoint_extra=[
-                "--validate-postgres-stash=postgres://root@cockroach:26257?options=--search_path=adapter"
-            ],
-            volumes_extra=["secrets:/share/secrets"],
+            validate_postgres_stash=True, volumes_extra=["secrets:/share/secrets"]
         )
     ):
         c.run(


### PR DESCRIPTION
We run Materialize against CockroachDB in production for persist consensus state and stash state, but our development environments and many of our tests were still using PostgreSQL for this purpose. Switch everything over to CockroachDB, to better match production.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing tests.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
