### PR TITLE
ci/test: scope down the inputs to the cargo-test job

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -116,7 +116,11 @@ steps:
     timeout_in_minutes: 30
     artifact_paths: target/nextest/ci/junit_cargo-test.xml
     inputs:
-      - "*"
+      - Cargo.lock
+      - "**/Cargo.toml"
+      - "**/*.rs"
+      - "**/*.proto"
+      - "**/testdata/**/*"
     env:
       AWS_DEFAULT_REGION: "us-east-2"
     plugins:


### PR DESCRIPTION
Thanks again for catching the original bug, @petrosagg!

----

In 0275079 we switched to cargo-nextest, and in doing so accidentally disabled running tests on PR builds (though they still ran on main). 77c6a9c re-enabled running tests on PR builds, but erred on the side of caution, and always triggered the cargo test job if any file in the repository changed. This causes a large performance regression for docs only PRs, which we try to keep to less than one minute of CI time.

This commit uses a more precise filter for determining when to run the cargo test job: whenever a Rust file changes, a Cargo.toml changes, or a file in a "testdata" directory. There may be some edge cases that this misses (changing a file that is `include!`d, perhaps), but it will catch the vast majority of PRs that could cause a cargo test failure, while restorign the CI speed of docs-only PRs.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR speeds up CI for docs-only PRs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
