### PR TITLE
environmentd: enable server-side TCP keepalives after 60s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3671,6 +3671,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
+ "socket2",
  "sysctl",
  "sysinfo",
  "tempfile",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -68,6 +68,7 @@ sentry = { version = "0.29.1", optional = true }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 shell-words = "1.1.0"
+socket2 = "0.4.7"
 sysctl = "0.5.2"
 sysinfo = "0.27.0"
 tempfile = "3.2.0"

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -46,12 +46,13 @@ use mz_stash::Stash;
 use mz_storage_client::types::connections::ConnectionContext;
 
 use crate::http::{HttpConfig, HttpServer, InternalHttpConfig, InternalHttpServer};
-pub use crate::http::{SqlResponse, WebSocketResponse};
 use crate::server::ListenerHandle;
 
 mod http;
 mod server;
 mod telemetry;
+
+pub use crate::http::{SqlResponse, WebSocketResponse};
 
 pub const BUILD_INFO: BuildInfo = build_info!();
 


### PR DESCRIPTION
Teach environmentd to enable TCP keepalives after the connection is idle for 60s. This avoids idle timeouts in common networking layers between Materialize and its clients. E.g., AWS NAT gateways have a hardcoded idle timeout of 350s [0]. None of our cloud infrastructure currently enables an idle timeout, but it is common for our users to connect to Materialize from behind a NAT gateway.

Idle SQL connections are an important use case for Materialize. Imagine a `SUBSCRIBE` to a view that contains critical alerts. You'd hope that subscription produces no data most of the time.

[0]: https://aws.amazon.com/blogs/networking-and-content-delivery/implementing-long-running-tcp-connections-within-vpc-networking/

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported issue: long-running `SUBSCRIBE`s executed from behind an AWS NAT gateway get closed.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Enable server-side TCP keepalives to avoid idle timeouts in networking devices between Materialize and its clients (e.g., AWS NAT gateways).