### PR TITLE
ci: Fix the cleanup pipeline

### DIFF
--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -22,7 +22,6 @@ steps:
     plugins:
        - ./ci/plugins/scratch-aws-access
 
-steps:
   - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.launchdarkly
     timeout_in_minutes: 10
     agents:


### PR DESCRIPTION
An extra 'step' directive in the Yaml meant that only the launcharkly cleanup was run and not the AWS one.

### Motivation

  * This PR fixes a previously unreported bug.


AWS cleanup was not running.