### PR TITLE
Make storage controller metrics warning less verbose

### DIFF
--- a/src/storage-client/src/controller/metrics_scraper.rs
+++ b/src/storage-client/src/controller/metrics_scraper.rs
@@ -93,10 +93,7 @@ pub(super) fn spawn_metrics_scraper(
                                 }
                             }
                             Err(err) => {
-                                tracing::warn!(
-                                    "error fetching metrics for {service_id}: {:?}",
-                                    err
-                                );
+                                tracing::warn!("error fetching metrics for {service_id}: {err}");
                             }
                         }
                     }


### PR DESCRIPTION
This should cause the backtrace not to be printed.

### Motivation

  * This PR fixes a previously unreported bug.

    Reported by Philip on Slack: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1671450572711719

### Tips for reviewer

I haven't tested this, but I'm 99.999% sure it does the right thing :) 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- None