### PR TITLE
Revert "misc: bump cockroach to 22.2"

### DIFF
--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -7,7 +7,36 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM cockroachdb/cockroach:v22.2.0 AS crdb
+# 22.1.2 community images with amd and arm variants. Used here so we can copy
+# the cockroach binary if this is an arm host. We are temporarily using this
+# image from the community until an official image is published.
+FROM juliuszaromskis/cockroachdb:22.1.2 AS crdb-arm
+
+# Create an image that determines the cockroach binary (so we don't have two
+# copies in the final image).
+MZFROM ubuntu-base AS crdb-bin
+
+RUN apt-get update \
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        ca-certificates \
+        curl
+
+COPY --from=crdb-arm /cockroach/cockroach /cockroach-arm
+
+ARG COCKROACH_VERSION=22.1.5
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	case "$arch" in \
+		'amd64') \
+		         curl https://binaries.cockroachdb.com/cockroach-v${COCKROACH_VERSION}.linux-amd64.tgz | tar -xz;  \
+		         cp cockroach-v${COCKROACH_VERSION}.linux-amd64/cockroach /cockroach; \
+			;; \
+		'arm64') \
+			mv /cockroach-arm /cockroach; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch'"; exit 1 ;; \
+	esac;
 
 MZFROM ubuntu-base
 
@@ -24,7 +53,7 @@ RUN apt-get update \
     && mkdir /cockroach-data \
     && chown materialize /mzdata /cockroach-data
 
-COPY --from=crdb /cockroach/cockroach /usr/local/bin/cockroach
+COPY --from=crdb-bin /cockroach /usr/local/bin/cockroach
 
 COPY storaged computed environmentd entrypoint.sh /usr/local/bin/
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -489,6 +489,22 @@ class MySql(Service):
         self.mysql_root_password = mysql_root_password
 
 
+class Cockroach(Service):
+    def __init__(
+        self,
+        name: str = "cockroach",
+    ):
+        super().__init__(
+            name="cockroach",
+            config={
+                "image": "cockroachdb/cockroach:v22.1.2",
+                "ports": [26257],
+                "command": "start-single-node --insecure",
+                "volumes": ["/cockroach/cockroach-data"],
+            },
+        )
+
+
 class Postgres(Service):
     def __init__(
         self,


### PR DESCRIPTION
We're seeing issues in CI due to [a CockroachDB v22.2 issue](https://github.com/cockroachdb/cockroach/issues/93892). Revert MaterializeInc/materialize#16594 until this gets resolved upstream.