### PR TITLE
Doc: add smallint to data types table

### DIFF
--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -33,6 +33,7 @@ Type | Aliases | Use | Size (bytes) | Catalog name | Syntax
 [`oid`](oid) | | PostgreSQL object identifier | 4 | Named | `123`
 [`real`](float) | `float4` | Single precision floating-point number | 4 | Named | `1.23`
 [`record`](record) | | Tuple with arbitrary contents | Variable | Unnameable | `ROW($expr, ...)`
+[`smallint`](integer) | `int2` | Small signed integer | 2 | Named | `123`
 [`text`](text) | `string` | Unicode string | Variable | Named | `'foo'`
 [`time`](time) | | Time without date | 4 | Named | `TIME '01:23:45'`
 [`timestamp`](timestamp) | | Date and time | 8 | Named | `TIMESTAMP '2007-02-01 15:04:05'`


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Adding `smallint` to the data types table on the lts-docs branch as per MaterializeInc/database-issues#3774 

Closes MaterializeInc/database-issues#3774
