### PR TITLE
release: bump to version v0.38.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "mz-compute"
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 dependencies = [
  "anyhow",
  "askama",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "mz-persist-client"
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "mz-storage"
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-compute"
 description = "Materialize's compute layer."
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition.workspace = true

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-storage"
 description = "Materialize's storage layer."
-version = "0.37.0-dev"
+version = "0.38.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
### Motivation

Bump version

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
