### PR TITLE
Remove `AS OF` from unsafe mode

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -815,33 +815,30 @@ pub fn plan_as_of(
 ) -> Result<QueryWhen, PlanError> {
     match as_of {
         None => Ok(QueryWhen::Immediately),
-        Some(mut as_of) => {
-            scx.require_unsafe_mode("AS OF")?;
-            match as_of {
-                AsOf::At(ref mut expr) | AsOf::AtLeast(ref mut expr) => {
-                    let scope = Scope::empty();
-                    let desc = RelationDesc::empty();
-                    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
-                    transform_ast::transform_expr(scx, expr)?;
-                    let ecx = &ExprContext {
-                        qcx: &qcx,
-                        name: "AS OF",
-                        scope: &scope,
-                        relation_type: desc.typ(),
-                        allow_aggregates: false,
-                        allow_subqueries: false,
-                        allow_windows: false,
-                    };
-                    let expr = plan_expr(ecx, expr)?
-                        .type_as_any(ecx)?
-                        .lower_uncorrelated()?;
-                    match as_of {
-                        AsOf::At(_) => Ok(QueryWhen::AtTimestamp(expr)),
-                        AsOf::AtLeast(_) => Ok(QueryWhen::AtLeastTimestamp(expr)),
-                    }
+        Some(mut as_of) => match as_of {
+            AsOf::At(ref mut expr) | AsOf::AtLeast(ref mut expr) => {
+                let scope = Scope::empty();
+                let desc = RelationDesc::empty();
+                let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
+                transform_ast::transform_expr(scx, expr)?;
+                let ecx = &ExprContext {
+                    qcx: &qcx,
+                    name: "AS OF",
+                    scope: &scope,
+                    relation_type: desc.typ(),
+                    allow_aggregates: false,
+                    allow_subqueries: false,
+                    allow_windows: false,
+                };
+                let expr = plan_expr(ecx, expr)?
+                    .type_as_any(ecx)?
+                    .lower_uncorrelated()?;
+                match as_of {
+                    AsOf::At(_) => Ok(QueryWhen::AtTimestamp(expr)),
+                    AsOf::AtLeast(_) => Ok(QueryWhen::AtLeastTimestamp(expr)),
                 }
             }
-        }
+        },
     }
 }
 


### PR DESCRIPTION
`SUBSCRIBE ... AS OF` is required for frontend observability work

### Motivation


  * This PR adds a known-desirable feature.

    [[Ensure issue is linked somewhere.]](https://github.com/MaterializeInc/materialize/issues/16356)

### Tips for reviewer

Outrageous diff due to `rustfmt` shenanigans. The only change was removing `scx.require_unsafe_mode("AS OF")?;`

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None (technically you can do historical queries on a few tables, not really in a way that's useful to the public yet)
