### PR TITLE
Add notifications for `release-blocker` issues to Slack

### DIFF
--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -48,3 +48,12 @@ jobs:
           channel: github-bugs
           color: red
           verbose: false
+      - uses: actions-ecosystem/action-slack-notifier@v1
+        if: ${{ github.event.label.name == 'release-blocker' }}
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          message: |
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
+          channel: release
+          color: red
+          verbose: false


### PR DESCRIPTION
Notifications will be sent to the #release Slack channel.