### PR TITLE
compute: fix `mz_message_counts` introspection view

### DIFF
--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -279,7 +279,7 @@ pub fn construct<A: Allocate>(
                                     messages_received_data
                                         .entry((event.channel, event.target))
                                         .or_insert_with(|| vec![0; peers])[event.source] += length;
-                                    let d = ((event.channel, event.target), event.source);
+                                    let d = ((event.channel, event.source), event.target);
                                     messages_received_session.give(&cap, (d, time_ms, length));
                                 }
                             }


### PR DESCRIPTION
Fixes #16754

We fix it by fixing `mz_message_counts_received_internal`, which had source and target swapped compare to what the rest of the logging dataflow was expecting.

Before the fix:

```sql
materialize=> select * from mz_internal.mz_message_counts_sent_internal where channel_id = 193;
 channel_id | from_worker_id | to_worker_id
------------+----------------+--------------
 193        | 0              | 0
 193        | 0              | 1
 193        | 0              | 1
 193        | 0              | 1
(4 rows)

materialize=> select * from mz_internal.mz_message_counts_received_internal where channel_id = 193;
 channel_id | from_worker_id | to_worker_id
------------+----------------+--------------
 193        | 0              | 0
 193        | 1              | 0
 193        | 1              | 0
 193        | 1              | 0
(4 rows)

materialize=> select * from mz_internal.mz_message_counts where channel_id = 193;
 channel_id | from_worker_id | to_worker_id | sent | received
------------+----------------+--------------+------+----------
 193        | 0              | 0            |    1 |        1
(1 row)
```

After the fix:

```sql

materialize=> select * from mz_internal.mz_message_counts_sent_internal where channel_id = 193;
 channel_id | from_worker_id | to_worker_id
------------+----------------+--------------
 193        | 0              | 0
 193        | 0              | 1
 193        | 0              | 1
 193        | 0              | 1
(4 rows)

materialize=> select * from mz_internal.mz_message_counts_received_internal where channel_id = 193;
 channel_id | from_worker_id | to_worker_id
------------+----------------+--------------
 193        | 0              | 0
 193        | 0              | 1
 193        | 0              | 1
 193        | 0              | 1
(4 rows)

materialize=> select * from mz_internal.mz_message_counts where channel_id = 193;
 channel_id | from_worker_id | to_worker_id | sent | received
------------+----------------+--------------+------+----------
 193        | 0              | 0            |    1 |        1
 193        | 0              | 1            |    3 |        3
(2 row)
```

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
