### PR TITLE
mz cli: Fix the app-password list command

### DIFF
--- a/src/mz/src/password.rs
+++ b/src/mz/src/password.rs
@@ -33,7 +33,7 @@ pub(crate) async fn list_passwords(
     body.insert("description", &"App password for the CLI");
 
     client
-        .get(valid_profile.profile.endpoint().api_token_auth_url())
+        .get(valid_profile.profile.endpoint().api_token_url())
         .headers(headers)
         .json(&body)
         .send()


### PR DESCRIPTION
The request was being sent to the wrong API endpoint.

Fixes: #16752

### Motivation

  * This PR fixes a recognized bug.