### PR TITLE
compute: fix mz_message_counts_received field order

### DIFF
--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -404,7 +404,7 @@ pub fn construct<A: Allocate>(
                 Exchange::new(|((((_, w), _), ()), _, _)| u64::cast_from(*w)),
                 "PreArrange Timely messages received",
             )
-            .as_collection(move |((channel, source), target), ()| {
+            .as_collection(move |((channel, target), source), ()| {
                 Row::pack_slice(&[
                     Datum::UInt64(u64::cast_from(*channel)),
                     Datum::UInt64(u64::cast_from(*source)),


### PR DESCRIPTION
Counter-PR to https://github.com/MaterializeInc/materialize/pull/16755. Fixes the same issue but flips the fields later in the dataflow, making it (hopefully) more obviously correct.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/16754

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
