### PR TITLE
persist: add per-shard largest batch size metric

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -951,8 +951,8 @@ where
         self.collections.trace.num_updates()
     }
 
-    pub fn encoded_batch_size(&self) -> usize {
-        self.collections.trace.encoded_batch_size()
+    pub fn batch_size_metrics(&self) -> (usize, usize) {
+        self.collections.trace.batch_size_metrics()
     }
 
     pub fn latest_rollup(&self) -> (&SeqNo, &PartialRollupKey) {

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -242,7 +242,9 @@ impl StateVersions {
                 shard_metrics.set_upper(new_state.upper());
                 shard_metrics.set_batch_part_count(new_state.batch_part_count());
                 shard_metrics.set_update_count(new_state.num_updates());
-                shard_metrics.set_encoded_batch_size(new_state.encoded_batch_size());
+                let (largest_batch_size, encoded_batch_size) = new_state.batch_size_metrics();
+                shard_metrics.set_largest_batch_size(largest_batch_size);
+                shard_metrics.set_encoded_batch_size(encoded_batch_size);
                 shard_metrics.set_seqnos_held(new_state.seqnos_held());
                 shard_metrics.inc_encoded_diff_size(payload_len);
                 Ok(Ok(()))

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -163,14 +163,18 @@ impl<T> Trace<T> {
         ret
     }
 
-    pub fn encoded_batch_size(&self) -> usize {
-        let mut ret = 0;
+    pub fn batch_size_metrics(&self) -> (usize, usize) {
+        let mut largest_batch_size = 0;
+        let mut encoded_batch_size = 0;
         self.map_batches(|b| {
+            let mut this_batch_size = 0;
             for part in b.parts.iter() {
-                ret += part.encoded_size_bytes;
+                this_batch_size += part.encoded_size_bytes;
             }
+            largest_batch_size = std::cmp::max(largest_batch_size, this_batch_size);
+            encoded_batch_size += this_batch_size;
         });
-        ret
+        (largest_batch_size, encoded_batch_size)
     }
 }
 


### PR DESCRIPTION
Requested by Jan in the context of flow control and also might have come in useful in #16712.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
