### PR TITLE
Remove the legacy-named status tables

### DIFF
--- a/doc/user/content/releases/v0.33.md
+++ b/doc/user/content/releases/v0.33.md
@@ -20,7 +20,7 @@ CREATE CONNECTION kafka_connection TO KAFKA (
 );
 ```
 
-* Add [`mz_internal.mz_source_status`](/sql/system-catalog/mz_internal/#mz_source_status) and
+* Add [`mz_internal.mz_source_status`](/sql/system-catalog/mz_internal/#mz_source_statuses) and
   [`mz_internal.mz_source_status_history`](/sql/system-catalog/mz_internal/#mz_source_status_history)
   to the system catalog. These objects respectively expose the current
   and historical state for each source in the system, including potential

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -471,9 +471,9 @@ them for any kind of capacity planning.
 | `cpu_nano_cores` | [`uint8`] | The CPU allocation per process, in billionths of a vCPU core. |
 | `memory_bytes`   | [`uint8`] | The RAM allocation per process, in billionths of a vCPU core. |
 
-### `mz_source_status`
+### `mz_source_statuses`
 
-The `mz_source_status` view provides the current state for each source in the
+The `mz_source_statuses` view provides the current state for each source in the
 system, including potential error messages and additional metadata helpful for
 debugging.
 
@@ -501,9 +501,9 @@ Field         | Type                          | Meaning
 `error`       | [`text`]                      | If the source is in an error state, the error message.
 `details`     | [`jsonb`]                     | Additional metadata provided by the source.
 
-### `mz_sink_status`
+### `mz_sink_statuses`
 
-The `mz_sink_status` view provides the current state for each sink in the
+The `mz_sink_statuses` view provides the current state for each sink in the
 system, including potential error messages and additional metadata helpful for
 debugging.
 

--- a/misc/python/materialize/checks/source_errors.py
+++ b/misc/python/materialize/checks/source_errors.py
@@ -89,7 +89,7 @@ class SourceErrors(Check):
             dedent(
                 """
                 > SELECT status, error ~* 'publication .+ does not exist'
-                  FROM mz_internal.mz_source_status
+                  FROM mz_internal.mz_source_statuses
                   WHERE name LIKE 'source_errors_source%'
                 stalled true
                 stalled true

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1482,48 +1482,6 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     is_retained_metrics_relation: false,
 });
 
-pub const MZ_SOURCE_STATUS: BuiltinView = BuiltinView {
-    name: "mz_source_status",
-    schema: MZ_INTERNAL_SCHEMA,
-    sql: "CREATE VIEW mz_internal.mz_source_status AS
-WITH ordered_events AS (
-    SELECT
-        source_id,
-        occurred_at,
-        status,
-        error,
-        details,
-        row_number() over (partition by source_id order by occurred_at desc) as row_number
-    FROM
-        mz_internal.mz_source_status_history
-),
-latest_events AS (
-    SELECT
-        source_id,
-        occurred_at,
-        status,
-        error,
-        details
-    FROM
-        ordered_events
-    WHERE
-        row_number = 1
-)
-SELECT
-    mz_sources.id,
-    name,
-    mz_sources.type,
-    occurred_at as last_status_change_at,
-    coalesce(status, 'created') as status,
-    error,
-    details
-FROM mz_sources
-LEFT JOIN latest_events ON mz_sources.id = latest_events.source_id
-WHERE
-    -- This is a convenient way to filter out system sources, like the status_history table itself.
-    mz_sources.size IS NOT NULL",
-};
-
 pub const MZ_SOURCE_STATUSES: BuiltinView = BuiltinView {
     name: "mz_source_statuses",
     schema: MZ_INTERNAL_SCHEMA,
@@ -1560,48 +1518,6 @@ pub static MZ_SINK_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSou
         .with_column("details", ScalarType::Jsonb.nullable(true)),
     is_retained_metrics_relation: false,
 });
-
-pub const MZ_SINK_STATUS: BuiltinView = BuiltinView {
-    name: "mz_sink_status",
-    schema: MZ_INTERNAL_SCHEMA,
-    sql: "CREATE VIEW mz_internal.mz_sink_status AS
-WITH ordered_events AS (
-    SELECT
-        sink_id,
-        occurred_at,
-        status,
-        error,
-        details,
-        row_number() over (partition by sink_id order by occurred_at desc) as row_number
-    FROM
-        mz_internal.mz_sink_status_history
-),
-latest_events AS (
-    SELECT
-        sink_id,
-        occurred_at,
-        status,
-        error,
-        details
-    FROM
-        ordered_events
-    WHERE
-        row_number = 1
-)
-SELECT
-    mz_sinks.id,
-    name,
-    mz_sinks.type,
-    occurred_at as last_status_change_at,
-    coalesce(status, 'created') as status,
-    error,
-    details
-FROM mz_sinks
-LEFT JOIN latest_events ON mz_sinks.id = latest_events.sink_id
-WHERE
-    -- This is a convenient way to filter out system sinks, like the status_history table itself.
-    mz_sinks.size IS NOT NULL",
-};
 
 pub const MZ_SINK_STATUSES: BuiltinView = BuiltinView {
     name: "mz_sink_statuses",
@@ -3012,10 +2928,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
         Builtin::Source(&MZ_SINK_STATUS_HISTORY),
-        Builtin::View(&MZ_SINK_STATUS),
         Builtin::View(&MZ_SINK_STATUSES),
         Builtin::Source(&MZ_SOURCE_STATUS_HISTORY),
-        Builtin::View(&MZ_SOURCE_STATUS),
         Builtin::View(&MZ_SOURCE_STATUSES),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::Source(&MZ_STORAGE_HOST_METRICS),

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -32,7 +32,7 @@ SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1' AND
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name LIKE '%_1');
 ----
-37
+35
 
 
 # The default and system clusters also have log sources, thus we should have 3 set active at boot.

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -717,10 +717,6 @@ mz_show_materialized_views
 VIEW
 materialize
 mz_internal
-mz_sink_status
-VIEW
-materialize
-mz_internal
 mz_sink_status_history
 SOURCE
 materialize
@@ -730,10 +726,6 @@ VIEW
 materialize
 mz_internal
 mz_sink_utilization
-VIEW
-materialize
-mz_internal
-mz_source_status
 VIEW
 materialize
 mz_internal

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -557,10 +557,8 @@ mz_records_per_dataflow_global
 mz_records_per_dataflow_operator
 mz_scheduling_elapsed
 mz_scheduling_parks
-mz_sink_status
 mz_sink_statuses
 mz_sink_utilization
-mz_source_status
 mz_source_statuses
 mz_source_utilization
 mz_worker_compute_delays


### PR DESCRIPTION
This is part two of a two-part rename of the status tables, `_status` to `statuses`. It removes the old definitions and cleans up a few lingering references.

### Motivation

Fixes #16550.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Rename `mz_internal.mz_source_status` to `mz_internal.mz_source_statuses`, and `mz_internal.mz_sink_status` to `mz_internal.mz_sink_statuses`.
