### PR TITLE
mzcompose: clear stale process metadata via tmpfs

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -571,16 +571,6 @@ class Composition:
                 service["command"] = []
             self._write_compose()
 
-        if "materialized" in services:
-            # Work around https://github.com/MaterializeInc/materialize/issues/15725
-            # by cleaning up Process Orchestrator metadata on restart
-            self.run(
-                "materialized",
-                "-c",
-                "rm -rf /mzdata/*.pid /mzdata/*.ports",
-                entrypoint="bash",
-            )
-
         self.invoke("up", *(["--detach"] if detach else []), *services)
 
         if persistent:
@@ -862,6 +852,9 @@ class ServiceConfig(TypedDict, total=False):
 
     depends_on: List[str]
     """The list of other services that must be started before this one."""
+
+    tmpfs: List[str]
+    """Paths at which to mount temporary file systems inside the container."""
 
     volumes: List[str]
     """Volumes to attach to the service."""

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -167,6 +167,7 @@ class Materialized(Service):
                 "environment": environment,
                 "volumes": volumes,
                 "allow_host_ports": allow_host_ports,
+                "tmpfs": ["/tmp"],
             }
         )
 


### PR DESCRIPTION
The process orchestrator stores per-incarnation state in /tmp (e.g., process IDs). After a restart, the orchestrator expects that /tmp has been cleared by the OS, as the metadata is no longer valid. This is not true with Docker containers, however; the /tmp directory survives a container stop and start.

We were previously working around this by manually deleting the metadata on a restart, with `rm -rf`. Per #16746, this approach was blowing away some important log files. Change to a different approach, which installs a temporary filesystem ("tmpfs") on /tmp. This temporary filesystem does *not* survive a container restart, as desired.

Fix #16746.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
