### PR TITLE
Implement `SUBSCRIBE ... UP TO`

### DIFF
--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -127,6 +127,8 @@ The `UP TO` clause allows specifying a timestamp at which the `SUBSCRIBE` will c
 
 The lower timestamp bound specified by `AS OF` is inclusive, whereas the upper bound specified by `UP TO` is exclusive. Thus, a `SUBSCRIBE` query whose `AS OF` is equal to its `UP TO` will terminate after returning zero rows.
 
+A `SUBSCRIBE` whose `UP TO` is less than its "as of" timestamp (whether that timestamp was specified in an `AS OF` clause or chosen by the system) will signal an error.
+
 ### Duration
 
 `SUBSCRIBE` will continue to run until canceled, session ends, the `UP TO` timestamp is reached, or all updates have been presented. The latter case typically occurs when

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -113,9 +113,13 @@ with several additional columns that describe the nature of the update:
 </tbody>
 </table>
 
+### `UP TO`
+
+The `UP TO` clause allows specifying a timestamp at which the `SUBSCRIBE` will cease running. If `UP TO` is specified, no rows whose timestamp is greater than or equal to the specified timestamp will be returned.
+
 ### Duration
 
-`SUBSCRIBE` will continue to run until canceled, session ends, or until all updates have been presented. The latter case typically occurs when
+`SUBSCRIBE` will continue to run until canceled, session ends, the `UP TO` timestamp is reached, or all updates have been presented. The latter case typically occurs when
 tailing constant views (e.g. `CREATE VIEW v AS SELECT 1`).
 
 {{< warning >}}

--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -113,9 +113,19 @@ with several additional columns that describe the nature of the update:
 </tbody>
 </table>
 
+### `AS OF`
+
+The `AS OF` clause allows specifying a timestamp at which the `SUBSCRIBE` should begin returning results, in order to inspect the historical state of a relation. If `AS OF` is specified, no rows whose timestamp is less than the specified timestamp will be returned. If the timestamp specified is earlier than the earliest historical state retained by the source relations, an error will be signaled.
+
+Currently, all user-defined sources and tables have a retention window of one second, so `AS OF` is of limited usefulness except when subscribing to queries over certain internal relations.
+
 ### `UP TO`
 
 The `UP TO` clause allows specifying a timestamp at which the `SUBSCRIBE` will cease running. If `UP TO` is specified, no rows whose timestamp is greater than or equal to the specified timestamp will be returned.
+
+### Interaction of `AS OF` and `UP TO`
+
+The lower timestamp bound specified by `AS OF` is inclusive, whereas the upper bound specified by `UP TO` is exclusive. Thus, a `SUBSCRIBE` query whose `AS OF` is equal to its `UP TO` will terminate after returning zero rows.
 
 ### Duration
 
@@ -129,7 +139,8 @@ results. Since `SUBSCRIBE` can run forever, naively executing a `SUBSCRIBE` usin
 driver's standard query API may never return.
 
 Either use an API in your driver that does not buffer rows or use the
-[`FETCH`](/sql/fetch) statement to fetch rows from `SUBSCRIBE` in batches.
+[`FETCH`](/sql/fetch) statement or `AS OF` and `UP TO` bounds
+to fetch rows from `SUBSCRIBE` in batches.
 See the [examples](#examples) for details.
 
 {{< /warning >}}

--- a/doc/user/layouts/partials/sql-grammar/subscribe-stmt.svg
+++ b/doc/user/layouts/partials/sql-grammar/subscribe-stmt.svg
@@ -1,44 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="657" height="239">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="100" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="651" height="439">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="100" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="100"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">SUBSCRIBE</text>
-   <rect x="173" y="35" width="40" height="32" rx="10"/>
-   <rect x="171"
+   <text class="terminal" x="39" y="21">SUBSCRIBE</text>
+   <rect x="171" y="35" width="40" height="32" rx="10"/>
+   <rect x="169"
          y="33"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="181" y="53">TO</text>
-   <rect x="273" y="3" width="104" height="32"/>
-   <rect x="271" y="1" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="281" y="21">object_name</text>
-   <rect x="273" y="47" width="26" height="32" rx="10"/>
-   <rect x="271"
+   <text class="terminal" x="179" y="53">TO</text>
+   <rect x="271" y="3" width="104" height="32"/>
+   <rect x="269" y="1" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="279" y="21">object_name</text>
+   <rect x="271" y="47" width="26" height="32" rx="10"/>
+   <rect x="269"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="65">(</text>
-   <rect x="319" y="47" width="96" height="32"/>
-   <rect x="317" y="45" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="65">select_stmt</text>
-   <rect x="435" y="47" width="26" height="32" rx="10"/>
-   <rect x="433"
+   <text class="terminal" x="279" y="65">(</text>
+   <rect x="317" y="47" width="96" height="32"/>
+   <rect x="315" y="45" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="65">select_stmt</text>
+   <rect x="433" y="47" width="26" height="32" rx="10"/>
+   <rect x="431"
          y="45"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="443" y="65">)</text>
+   <text class="terminal" x="441" y="65">)</text>
    <rect x="65" y="189" width="58" height="32" rx="10"/>
    <rect x="63"
          y="187"
@@ -85,8 +85,62 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="591" y="175">)</text>
+   <rect x="91" y="287" width="40" height="32" rx="10"/>
+   <rect x="89"
+         y="285"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="99" y="305">AS</text>
+   <rect x="151" y="287" width="38" height="32" rx="10"/>
+   <rect x="149"
+         y="285"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="305">OF</text>
+   <rect x="229" y="319" width="40" height="32" rx="10"/>
+   <rect x="227"
+         y="317"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="237" y="337">AT</text>
+   <rect x="289" y="319" width="66" height="32" rx="10"/>
+   <rect x="287"
+         y="317"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="297" y="337">LEAST</text>
+   <rect x="395" y="287" width="168" height="32"/>
+   <rect x="393" y="285" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="403" y="305">timestamp_expression</text>
+   <rect x="317" y="405" width="38" height="32" rx="10"/>
+   <rect x="315"
+         y="403"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="423">UP</text>
+   <rect x="375" y="405" width="40" height="32" rx="10"/>
+   <rect x="373"
+         y="403"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="423">TO</text>
+   <rect x="435" y="405" width="168" height="32"/>
+   <rect x="433" y="403" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="443" y="423">timestamp_expression</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m40 -32 h10 m104 0 h10 m0 0 h84 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m26 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-500 154 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-604 0 h20 m584 0 h20 m-624 0 q10 0 10 10 m604 0 q0 -10 10 -10 m-614 10 v46 m604 0 v-46 m-604 46 q0 10 10 10 m584 0 q10 0 10 -10 m-594 10 h10 m0 0 h574 m23 -66 h-3"/>
-   <polygon points="647 171 655 167 655 175"/>
-   <polygon points="647 171 639 167 639 175"/>
+         d="m17 17 h2 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m40 -32 h10 m104 0 h10 m0 0 h84 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m26 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-498 154 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m28 0 h10 m0 0 h10 m102 0 h10 m-334 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m334 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-334 0 h10 m24 0 h10 m0 0 h290 m20 44 h10 m26 0 h10 m-604 0 h20 m584 0 h20 m-624 0 q10 0 10 10 m604 0 q0 -10 10 -10 m-614 10 v46 m604 0 v-46 m-604 46 q0 10 10 10 m584 0 q10 0 10 -10 m-594 10 h10 m0 0 h574 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-602 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h482 m-512 0 h20 m492 0 h20 m-532 0 q10 0 10 10 m512 0 q0 -10 10 -10 m-522 10 v12 m512 0 v-12 m-512 12 q0 10 10 10 m492 0 q10 0 10 -10 m-502 10 h10 m40 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h136 m-166 0 h20 m146 0 h20 m-186 0 q10 0 10 10 m166 0 q0 -10 10 -10 m-176 10 v12 m166 0 v-12 m-166 12 q0 10 10 10 m146 0 q10 0 10 -10 m-156 10 h10 m40 0 h10 m0 0 h10 m66 0 h10 m20 -32 h10 m168 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-330 118 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h296 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v12 m326 0 v-12 m-326 12 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m38 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m168 0 h10 m23 -32 h-3"/>
+   <polygon points="641 387 649 383 649 391"/>
+   <polygon points="641 387 633 383 633 391"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -360,6 +360,7 @@ subscribe_stmt ::=
     'SUBSCRIBE' 'TO'?
     ( object_name | '(' select_stmt ')' )
     ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
+    ('AS' 'OF' ( 'AT' 'LEAST' )? timestamp_expression)?
     ( 'UP' 'TO' timestamp_expression )?
 table_ref ::=
   (

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -360,6 +360,7 @@ subscribe_stmt ::=
     'SUBSCRIBE' 'TO'?
     ( object_name | '(' select_stmt ')' )
     ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
+    ( 'UP' 'TO' timestamp_expression )?
 table_ref ::=
   (
     table_name

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -68,8 +68,8 @@ pub enum ExprPrepStyle<'a> {
         logical_time: Option<mz_repr::Timestamp>,
         session: &'a Session,
     },
-    /// The expression is being prepared for evaluation in an AS OF or UNTIL clause.
-    AsOfUntil,
+    /// The expression is being prepared for evaluation in an AS OF or UP TO clause.
+    AsOfUpTo,
 }
 
 impl<S: Append + 'static> Coordinator<S> {
@@ -109,7 +109,7 @@ impl<S: Append + 'static> Coordinator<S> {
             if plan.index_exports.is_empty() {
                 plan.until = Antichain::from_elem(Timestamp::MIN);
                 for (_, sink) in &plan.sink_exports {
-                    plan.until.join_assign(&sink.until);
+                    plan.until.join_assign(&sink.up_to);
                 }
             }
             dataflow_plans.push(plan);
@@ -421,7 +421,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                 frontier: as_of,
                 strict: false,
             },
-            until: Antichain::default(),
+            up_to: Antichain::default(),
         };
         self.build_sink_dataflow_into(&mut dataflow, id, sink_description)?;
 
@@ -553,7 +553,7 @@ pub fn prep_relation_expr(
                 }
             })
         }
-        ExprPrepStyle::OneShot { .. } | ExprPrepStyle::AsOfUntil => expr
+        ExprPrepStyle::OneShot { .. } | ExprPrepStyle::AsOfUpTo => expr
             .0
             .try_visit_scalars_mut(&mut |s| prep_scalar_expr(catalog, s, style)),
     }
@@ -584,7 +584,7 @@ pub fn prep_scalar_expr(
         }),
 
         // Reject the query if it contains any unmaterializable function calls.
-        ExprPrepStyle::Index | ExprPrepStyle::AsOfUntil => {
+        ExprPrepStyle::Index | ExprPrepStyle::AsOfUpTo => {
             let mut last_observed_unmaterializable_func = None;
             expr.visit_mut_post(&mut |e| {
                 if let MirScalarExpr::CallUnmaterializable(f) = e {
@@ -595,9 +595,9 @@ pub fn prep_scalar_expr(
             if let Some(f) = last_observed_unmaterializable_func {
                 let err = match style {
                     ExprPrepStyle::Index => AdapterError::UnmaterializableFunction(f),
-                    ExprPrepStyle::AsOfUntil => AdapterError::UncallableFunction {
+                    ExprPrepStyle::AsOfUpTo => AdapterError::UncallableFunction {
                         func: f,
-                        context: "AS OF or UNTIL",
+                        context: "AS OF or UP TO",
                     },
                     _ => unreachable!(),
                 };

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2458,6 +2458,7 @@ impl<S: Append + 'static> Coordinator<S> {
             when,
             copy_to,
             emit_progress,
+            until,
         } = plan;
 
         let compute_instance = self.catalog.active_compute_instance(session)?;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2492,6 +2492,11 @@ impl<S: Append + 'static> Coordinator<S> {
                 .timestamp_context
                 .antichain();
 
+            let until = until
+                .map(|expr| coord.evaluate_when(expr, session))
+                .transpose()?
+                .map(Antichain::from_elem)
+                .unwrap_or(Antichain::default());
             Ok::<_, AdapterError>(ComputeSinkDesc {
                 from,
                 from_desc,
@@ -2500,6 +2505,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     frontier,
                     strict: !with_snapshot,
                 },
+                until,
             })
         };
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2496,7 +2496,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .map(|expr| coord.evaluate_when(expr, session))
                 .transpose()?
                 .map(Antichain::from_elem)
-                .unwrap_or(Antichain::default());
+                .unwrap_or_default();
             Ok::<_, AdapterError>(ComputeSinkDesc {
                 from,
                 from_desc,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2500,8 +2500,10 @@ impl<S: Append + 'static> Coordinator<S> {
                 .map(|expr| coord.evaluate_when(expr, session))
                 .transpose()?;
             if let Some(up_to) = up_to {
-                if frontier_ts >= up_to {
-                    session.add_notice(AdapterNotice::EmptySubscribe {
+                if frontier_ts == up_to {
+                    session.add_notice(AdapterNotice::EqualSubscribeBounds { bound: up_to });
+                } else if frontier_ts > up_to {
+                    return Err(AdapterError::AbsurdSubscribeBounds {
                         as_of: frontier_ts,
                         up_to,
                     });

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2472,7 +2472,11 @@ impl<S: Append + 'static> Coordinator<S> {
             session.add_transaction_ops(TransactionOps::Subscribe)?;
         }
 
-        let make_sink_desc = |coord: &mut Coordinator<S>, session: &mut Session, from, from_desc, uses| {
+        let make_sink_desc = |coord: &mut Coordinator<S>,
+                              session: &mut Session,
+                              from,
+                              from_desc,
+                              uses| {
             // Determine the frontier of updates to subscribe *from*.
             // Updates greater or equal to this frontier will be produced.
             let id_bundle = coord

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2472,7 +2472,7 @@ impl<S: Append + 'static> Coordinator<S> {
             session.add_transaction_ops(TransactionOps::Subscribe)?;
         }
 
-        let make_sink_desc = |coord: &mut Coordinator<S>, from, from_desc, uses| {
+        let make_sink_desc = |coord: &mut Coordinator<S>, session: &mut Session, from, from_desc, uses| {
             // Determine the frontier of updates to subscribe *from*.
             // Updates greater or equal to this frontier will be produced.
             let id_bundle = coord
@@ -2489,14 +2489,22 @@ impl<S: Append + 'static> Coordinator<S> {
                     timeline,
                     None,
                 )?
-                .timestamp_context
-                .antichain();
+                .timestamp_context;
+            let frontier_ts = frontier.timestamp_or_default();
 
             let up_to = up_to
                 .map(|expr| coord.evaluate_when(expr, session))
-                .transpose()?
-                .map(Antichain::from_elem)
-                .unwrap_or_default();
+                .transpose()?;
+            if let Some(up_to) = up_to {
+                if frontier_ts >= up_to {
+                    session.add_notice(AdapterNotice::EmptySubscribe {
+                        as_of: frontier_ts,
+                        up_to,
+                    });
+                }
+            }
+            let frontier = frontier.antichain();
+            let up_to = up_to.map(Antichain::from_elem).unwrap_or_default();
             Ok::<_, AdapterError>(ComputeSinkDesc {
                 from,
                 from_desc,
@@ -2527,7 +2535,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .unwrap()
                     .into_owned();
                 let sink_id = self.catalog.allocate_user_id().await?;
-                let sink_desc = make_sink_desc(self, from_id, from_desc, &[from_id][..])?;
+                let sink_desc = make_sink_desc(self, session, from_id, from_desc, &[from_id][..])?;
                 let sink_name = format!("subscribe-{}", sink_id);
                 self.dataflow_builder(compute_instance_id)
                     .build_sink_dataflow(sink_name, sink_id, sink_desc)?
@@ -2542,7 +2550,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 let id = self.allocate_transient_id()?;
                 let expr = self.view_optimizer.optimize(expr)?;
                 let desc = RelationDesc::new(expr.typ(), desc.iter_names());
-                let sink_desc = make_sink_desc(self, id, desc, &depends_on)?;
+                let sink_desc = make_sink_desc(self, session, id, desc, &depends_on)?;
                 let mut dataflow = DataflowDesc::new(format!("subscribe-{}", id));
                 let mut dataflow_builder = self.dataflow_builder(compute_instance_id);
                 dataflow_builder.import_view_into_dataflow(&id, &expr, &mut dataflow)?;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2458,7 +2458,7 @@ impl<S: Append + 'static> Coordinator<S> {
             when,
             copy_to,
             emit_progress,
-            until,
+            up_to,
         } = plan;
 
         let compute_instance = self.catalog.active_compute_instance(session)?;
@@ -2492,7 +2492,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .timestamp_context
                 .antichain();
 
-            let until = until
+            let up_to = up_to
                 .map(|expr| coord.evaluate_when(expr, session))
                 .transpose()?
                 .map(Antichain::from_elem)
@@ -2505,7 +2505,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     frontier,
                     strict: !with_snapshot,
                 },
-                until,
+                up_to,
             })
         };
 

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -331,7 +331,11 @@ impl<S: Append + 'static> Coordinator<S> {
         session: &Session,
     ) -> Result<mz_repr::Timestamp, AdapterError> {
         let temp_storage = RowArena::new();
-        prep_scalar_expr(self.catalog.state(), &mut timestamp, ExprPrepStyle::AsOfUntil)?;
+        prep_scalar_expr(
+            self.catalog.state(),
+            &mut timestamp,
+            ExprPrepStyle::AsOfUntil,
+        )?;
         let evaled = timestamp.eval(&[], &temp_storage)?;
         if evaled.is_null() {
             coord_bail!("can't use {} as a mz_timestamp for AS OF or UNTIL", evaled);

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -334,11 +334,11 @@ impl<S: Append + 'static> Coordinator<S> {
         prep_scalar_expr(
             self.catalog.state(),
             &mut timestamp,
-            ExprPrepStyle::AsOfUntil,
+            ExprPrepStyle::AsOfUpTo,
         )?;
         let evaled = timestamp.eval(&[], &temp_storage)?;
         if evaled.is_null() {
-            coord_bail!("can't use {} as a mz_timestamp for AS OF or UNTIL", evaled);
+            coord_bail!("can't use {} as a mz_timestamp for AS OF or UP TO", evaled);
         }
         let ty = timestamp.typ(&[]);
         Ok(match ty.scalar_type {
@@ -356,7 +356,7 @@ impl<S: Append + 'static> Coordinator<S> {
             ScalarType::TimestampTz => evaled.unwrap_timestamptz().timestamp_millis().try_into()?,
             ScalarType::Timestamp => evaled.unwrap_timestamp().timestamp_millis().try_into()?,
             _ => coord_bail!(
-                "can't use {} as a mz_timestamp for AS OF or UNTIL",
+                "can't use {} as a mz_timestamp for AS OF or UP TO",
                 self.catalog.for_session(session).humanize_column_type(&ty)
             ),
         })

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -325,16 +325,16 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
-    fn evaluate_when(
+    pub(crate) fn evaluate_when(
         &self,
         mut timestamp: MirScalarExpr,
         session: &Session,
     ) -> Result<mz_repr::Timestamp, AdapterError> {
         let temp_storage = RowArena::new();
-        prep_scalar_expr(self.catalog.state(), &mut timestamp, ExprPrepStyle::AsOf)?;
+        prep_scalar_expr(self.catalog.state(), &mut timestamp, ExprPrepStyle::AsOfUntil)?;
         let evaled = timestamp.eval(&[], &temp_storage)?;
         if evaled.is_null() {
-            coord_bail!("can't use {} as a mz_timestamp for AS OF", evaled);
+            coord_bail!("can't use {} as a mz_timestamp for AS OF or UNTIL", evaled);
         }
         let ty = timestamp.typ(&[]);
         Ok(match ty.scalar_type {
@@ -352,7 +352,7 @@ impl<S: Append + 'static> Coordinator<S> {
             ScalarType::TimestampTz => evaled.unwrap_timestamptz().timestamp_millis().try_into()?,
             ScalarType::Timestamp => evaled.unwrap_timestamp().timestamp_millis().try_into()?,
             _ => coord_bail!(
-                "can't use {} as a mz_timestamp for AS OF",
+                "can't use {} as a mz_timestamp for AS OF or UNTIL",
                 self.catalog.for_session(session).humanize_column_type(&ty)
             ),
         })

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -61,9 +61,8 @@ pub enum AdapterNotice {
     QueryTimestamp {
         timestamp: mz_repr::Timestamp,
     },
-    EmptySubscribe {
-        as_of: mz_repr::Timestamp,
-        up_to: mz_repr::Timestamp,
+    EqualSubscribeBounds {
+        bound: mz_repr::Timestamp,
     },
 }
 
@@ -143,8 +142,8 @@ impl fmt::Display for AdapterNotice {
             AdapterNotice::QueryTimestamp { timestamp } => {
                 write!(f, "query timestamp: {}", timestamp)
             }
-            AdapterNotice::EmptySubscribe { as_of, up_to } => {
-                write!(f, "subscribe as of {as_of} (inclusive) up to {up_to} (exclusive) is guaranteed to be empty")
+            AdapterNotice::EqualSubscribeBounds { bound } => {
+                write!(f, "subscribe as of {bound} (inclusive) up to the same bound {bound} (exclusive) is guaranteed to be empty")
             }
         }
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -61,6 +61,10 @@ pub enum AdapterNotice {
     QueryTimestamp {
         timestamp: mz_repr::Timestamp,
     },
+    EmptySubscribe {
+        as_of: mz_repr::Timestamp,
+        up_to: mz_repr::Timestamp,
+    },
 }
 
 impl AdapterNotice {
@@ -138,6 +142,9 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::QueryTimestamp { timestamp } => {
                 write!(f, "query timestamp: {}", timestamp)
+            }
+            AdapterNotice::EmptySubscribe { as_of, up_to } => {
+                write!(f, "subscribe as of {as_of} (inclusive) up to {up_to} (exclusive) is guaranteed to be empty")
             }
         }
     }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -594,7 +594,7 @@ where
                     from_desc: se.from_desc,
                     connection,
                     as_of: se.as_of,
-                    until: se.until,
+                    up_to: se.up_to,
                 };
                 sink_exports.insert(id, desc);
             }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -594,6 +594,7 @@ where
                     from_desc: se.from_desc,
                     connection,
                     as_of: se.as_of,
+                    until: se.until,
                 };
                 sink_exports.insert(id, desc);
             }

--- a/src/compute-client/src/types/sinks.proto
+++ b/src/compute-client/src/types/sinks.proto
@@ -22,6 +22,7 @@ message ProtoComputeSinkDesc {
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
     ProtoComputeSinkConnection connection = 3;
     ProtoSinkAsOf as_of = 4;
+    mz_repr.antichain.ProtoU64Antichain until = 5;
 }
 
 message ProtoComputeSinkConnection {

--- a/src/compute-client/src/types/sinks.proto
+++ b/src/compute-client/src/types/sinks.proto
@@ -22,7 +22,7 @@ message ProtoComputeSinkDesc {
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
     ProtoComputeSinkConnection connection = 3;
     ProtoSinkAsOf as_of = 4;
-    mz_repr.antichain.ProtoU64Antichain until = 5;
+    mz_repr.antichain.ProtoU64Antichain up_to = 5;
 }
 
 message ProtoComputeSinkConnection {

--- a/src/compute-client/src/types/sinks.rs
+++ b/src/compute-client/src/types/sinks.rs
@@ -30,6 +30,7 @@ pub struct ComputeSinkDesc<S: 'static = (), T = mz_repr::Timestamp> {
     pub from_desc: RelationDesc,
     pub connection: ComputeSinkConnection<S>,
     pub as_of: SinkAsOf<T>,
+    pub until: Antichain<T>,
 }
 
 impl Arbitrary for ComputeSinkDesc<CollectionMetadata, mz_repr::Timestamp> {
@@ -42,13 +43,17 @@ impl Arbitrary for ComputeSinkDesc<CollectionMetadata, mz_repr::Timestamp> {
             any::<RelationDesc>(),
             any::<ComputeSinkConnection<CollectionMetadata>>(),
             any::<SinkAsOf<mz_repr::Timestamp>>(),
+            proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..4),
         )
-            .prop_map(|(from, from_desc, connection, as_of)| ComputeSinkDesc {
-                from,
-                from_desc,
-                connection,
-                as_of,
-            })
+            .prop_map(
+                |(from, from_desc, connection, as_of, until_frontier)| ComputeSinkDesc {
+                    from,
+                    from_desc,
+                    connection,
+                    as_of,
+                    until: Antichain::from(until_frontier),
+                },
+            )
             .boxed()
     }
 }
@@ -60,6 +65,7 @@ impl RustType<ProtoComputeSinkDesc> for ComputeSinkDesc<CollectionMetadata, mz_r
             from: Some(self.from.into_proto()),
             from_desc: Some(self.from_desc.into_proto()),
             as_of: Some(self.as_of.into_proto()),
+            until: Some(self.until.into_proto()),
         }
     }
 
@@ -75,6 +81,9 @@ impl RustType<ProtoComputeSinkDesc> for ComputeSinkDesc<CollectionMetadata, mz_r
             as_of: proto
                 .as_of
                 .into_rust_if_some("ProtoComputeSinkDesc::as_of")?,
+            until: proto
+                .until
+                .into_rust_if_some("ProtoComputeSinkDesc::until")?,
         })
     }
 }

--- a/src/compute-client/src/types/sinks.rs
+++ b/src/compute-client/src/types/sinks.rs
@@ -30,7 +30,7 @@ pub struct ComputeSinkDesc<S: 'static = (), T = mz_repr::Timestamp> {
     pub from_desc: RelationDesc,
     pub connection: ComputeSinkConnection<S>,
     pub as_of: SinkAsOf<T>,
-    pub until: Antichain<T>,
+    pub up_to: Antichain<T>,
 }
 
 impl Arbitrary for ComputeSinkDesc<CollectionMetadata, mz_repr::Timestamp> {
@@ -46,12 +46,12 @@ impl Arbitrary for ComputeSinkDesc<CollectionMetadata, mz_repr::Timestamp> {
             proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..4),
         )
             .prop_map(
-                |(from, from_desc, connection, as_of, until_frontier)| ComputeSinkDesc {
+                |(from, from_desc, connection, as_of, up_to_frontier)| ComputeSinkDesc {
                     from,
                     from_desc,
                     connection,
                     as_of,
-                    until: Antichain::from(until_frontier),
+                    up_to: Antichain::from(up_to_frontier),
                 },
             )
             .boxed()
@@ -65,7 +65,7 @@ impl RustType<ProtoComputeSinkDesc> for ComputeSinkDesc<CollectionMetadata, mz_r
             from: Some(self.from.into_proto()),
             from_desc: Some(self.from_desc.into_proto()),
             as_of: Some(self.as_of.into_proto()),
-            until: Some(self.until.into_proto()),
+            up_to: Some(self.up_to.into_proto()),
         }
     }
 
@@ -81,9 +81,9 @@ impl RustType<ProtoComputeSinkDesc> for ComputeSinkDesc<CollectionMetadata, mz_r
             as_of: proto
                 .as_of
                 .into_rust_if_some("ProtoComputeSinkDesc::as_of")?,
-            until: proto
-                .until
-                .into_rust_if_some("ProtoComputeSinkDesc::until")?,
+            up_to: proto
+                .up_to
+                .into_rust_if_some("ProtoComputeSinkDesc::up_to")?,
         })
     }
 }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -59,9 +59,9 @@ where
         G: Scope<Timestamp = Timestamp>,
     {
         let desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
-        if sink.until != Antichain::default() {
+        if sink.up_to != Antichain::default() {
             unimplemented!(
-                "UNTIL is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
+                "UP TO is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
             )
         }
 

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -59,6 +59,11 @@ where
         G: Scope<Timestamp = Timestamp>,
     {
         let desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
+        if sink.until != Antichain::default() {
+            unimplemented!(
+                "UNTIL is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
+            )
+        }
 
         persist_sink(
             &sinked_collection.scope(),

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -114,7 +114,8 @@ fn subscribe<G>(
                 finished = true;
                 // We are done; indicate this by sending a batch at the
                 // empty frontier.
-                if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut() {
+                if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut()
+                {
                     subscribe_protocol.send_batch(Antichain::default(), &mut Vec::new());
                 }
             }

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -19,6 +19,7 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::Scope;
 use timely::progress::timestamp::Timestamp as TimelyTimestamp;
 use timely::progress::Antichain;
+use timely::PartialOrder;
 
 use mz_compute_client::response::{SubscribeBatch, SubscribeResponse};
 use mz_compute_client::types::sinks::{ComputeSinkDesc, SinkAsOf, SubscribeSinkConnection};
@@ -59,6 +60,7 @@ where
             sinked_collection,
             sink_id,
             sink.as_of.clone(),
+            sink.until.clone(),
             subscribe_protocol_handle,
         );
 
@@ -77,21 +79,27 @@ fn subscribe<G>(
     sinked_collection: Collection<G, Row, Diff>,
     sink_id: GlobalId,
     as_of: SinkAsOf,
+    until: Antichain<G::Timestamp>,
     subscribe_protocol_handle: Rc<RefCell<Option<SubscribeProtocol>>>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
     let mut results = Vec::new();
+    let mut finished = false;
     sinked_collection
         .inner
         .sink(Pipeline, &format!("subscribe-{}", sink_id), move |input| {
+            if finished {
+                return;
+            }
             input.for_each(|_, rows| {
                 for (row, time, diff) in rows.iter() {
-                    let should_emit = if as_of.strict {
+                    let should_emit_as_of = if as_of.strict {
                         as_of.frontier.less_than(time)
                     } else {
                         as_of.frontier.less_equal(time)
                     };
+                    let should_emit = should_emit_as_of && !until.less_equal(time);
                     if should_emit {
                         results.push((*time, row.clone(), *diff));
                     }
@@ -100,6 +108,15 @@ fn subscribe<G>(
 
             if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut() {
                 subscribe_protocol.send_batch(input.frontier().frontier().to_owned(), &mut results);
+            }
+
+            if PartialOrder::less_equal(&until.borrow(), &input.frontier().frontier()) {
+                finished = true;
+                // We are done; indicate this by sending a batch at the
+                // empty frontier.
+                if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut() {
+                    subscribe_protocol.send_batch(Antichain::default(), &mut Vec::new());
+                }
             }
         })
 }
@@ -146,7 +163,7 @@ impl SubscribeProtocol {
             self.prev_upper = upper;
             if input_exhausted {
                 // The dataflow's input has been exhausted; clear the channel,
-                // to avoid sending `TailResponse::DroppedAt`.
+                // to avoid sending `SubscribeResponse::DroppedAt`.
                 self.subscribe_response_buffer = None;
             }
         }

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -60,7 +60,7 @@ where
             sinked_collection,
             sink_id,
             sink.as_of.clone(),
-            sink.until.clone(),
+            sink.up_to.clone(),
             subscribe_protocol_handle,
         );
 
@@ -79,7 +79,7 @@ fn subscribe<G>(
     sinked_collection: Collection<G, Row, Diff>,
     sink_id: GlobalId,
     as_of: SinkAsOf,
-    until: Antichain<G::Timestamp>,
+    up_to: Antichain<G::Timestamp>,
     subscribe_protocol_handle: Rc<RefCell<Option<SubscribeProtocol>>>,
 ) where
     G: Scope<Timestamp = Timestamp>,
@@ -99,7 +99,7 @@ fn subscribe<G>(
                     } else {
                         as_of.frontier.less_equal(time)
                     };
-                    let should_emit = should_emit_as_of && !until.less_equal(time);
+                    let should_emit = should_emit_as_of && !up_to.less_equal(time);
                     if should_emit {
                         results.push((*time, row.clone(), *diff));
                     }
@@ -110,7 +110,7 @@ fn subscribe<G>(
                 subscribe_protocol.send_batch(input.frontier().frontier().to_owned(), &mut results);
             }
 
-            if PartialOrder::less_equal(&until.borrow(), &input.frontier().frontier()) {
+            if PartialOrder::less_equal(&up_to.borrow(), &input.frontier().frontier()) {
                 finished = true;
                 // We are done; indicate this by sending a batch at the
                 // empty frontier.

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -458,9 +458,7 @@ fn test_empty_subscribe_notice() {
         .unwrap();
 
     client.batch_execute("CREATE TABLE t (a int)").unwrap();
-    client
-        .batch_execute("SUBSCRIBE TO t UP TO 0")
-        .unwrap();
+    client.batch_execute("SUBSCRIBE TO t UP TO 0").unwrap();
     Retry::default()
         .max_duration(Duration::from_secs(10))
         .retry(|_| {

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -543,19 +543,19 @@ fn test_subscribe_basic() {
         }
     }
 
-    // Check that a subscription with `UNTIL` is cut off at the proper point
+    // Check that a subscription with `UP TO` is cut off at the proper point
     let begin = events[0].0;
     for (ts, _) in &events {
         client_reads
             .batch_execute(&*format!(
                 "COMMIT; BEGIN;
-            DECLARE c CURSOR FOR SUBSCRIBE t AS OF {begin} UNTIL {}",
+            DECLARE c CURSOR FOR SUBSCRIBE t AS OF {begin} UP TO {}",
                 ts
             ))
             .unwrap();
         for (expected_ts, expected_data) in events.iter() {
             if expected_ts >= ts {
-                // We hit the `UNTIL`; we should be done.
+                // We hit the `UP TO`; we should be done.
                 break;
             }
 
@@ -563,7 +563,7 @@ fn test_subscribe_basic() {
             assert_eq!(actual.get::<_, String>("data"), *expected_data);
             assert_eq!(actual.get::<_, MzTimestamp>("mz_timestamp").0, *expected_ts);
         }
-        // Make sure no rows from after or equal to the `UNTIL` show up.
+        // Make sure no rows from after or equal to the `UP TO` show up.
         // This also checks that the subscribe has been dropped, since
         // we don't specify a timeout.
         let should_be_empty = client_reads.query("FETCH c", &[]).unwrap();

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -410,6 +410,7 @@ impl ErrorResponse {
             AdapterNotice::DroppedActiveDatabase { .. } => SqlState::WARNING,
             AdapterNotice::DroppedActiveCluster { .. } => SqlState::WARNING,
             AdapterNotice::QueryTimestamp { .. } => SqlState::WARNING,
+            AdapterNotice::EmptySubscribe { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -562,6 +563,7 @@ impl Severity {
             AdapterNotice::DroppedActiveDatabase { .. } => Severity::Notice,
             AdapterNotice::DroppedActiveCluster { .. } => Severity::Notice,
             AdapterNotice::QueryTimestamp { .. } => Severity::Notice,
+            AdapterNotice::EmptySubscribe { .. } => Severity::Notice,
         }
     }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -311,6 +311,9 @@ impl ErrorResponse {
         // a various classes of uncategorized errors that use this error code
         // inappropriately.
         let code = match e {
+            // DATA_EXCEPTION to match what Postgres returns for degenerate
+            // range bounds
+            AdapterError::AbsurdSubscribeBounds { .. } => SqlState::DATA_EXCEPTION,
             AdapterError::Catalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::ConstrainedParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
@@ -410,7 +413,7 @@ impl ErrorResponse {
             AdapterNotice::DroppedActiveDatabase { .. } => SqlState::WARNING,
             AdapterNotice::DroppedActiveCluster { .. } => SqlState::WARNING,
             AdapterNotice::QueryTimestamp { .. } => SqlState::WARNING,
-            AdapterNotice::EmptySubscribe { .. } => SqlState::WARNING,
+            AdapterNotice::EqualSubscribeBounds { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -563,7 +566,7 @@ impl Severity {
             AdapterNotice::DroppedActiveDatabase { .. } => Severity::Notice,
             AdapterNotice::DroppedActiveCluster { .. } => Severity::Notice,
             AdapterNotice::QueryTimestamp { .. } => Severity::Notice,
-            AdapterNotice::EmptySubscribe { .. } => Severity::Notice,
+            AdapterNotice::EqualSubscribeBounds { .. } => Severity::Notice,
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2100,6 +2100,10 @@ impl<T: AstInfo> AstDisplay for SubscribeStatement<T> {
             f.write_str(" ");
             f.write_node(as_of);
         }
+        if let Some(up_to) = &self.up_to {
+            f.write_str(" UP TO ");
+            f.write_node(up_to);
+        }
     }
 }
 impl_display_t!(SubscribeStatement);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2084,6 +2084,7 @@ pub struct SubscribeStatement<T: AstInfo> {
     pub relation: SubscribeRelation<T>,
     pub options: Vec<SubscribeOption<T>>,
     pub as_of: Option<AsOf<T>>,
+    pub until: Option<Expr<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for SubscribeStatement<T> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2084,7 +2084,7 @@ pub struct SubscribeStatement<T: AstInfo> {
     pub relation: SubscribeRelation<T>,
     pub options: Vec<SubscribeOption<T>>,
     pub as_of: Option<AsOf<T>>,
-    pub until: Option<Expr<T>>,
+    pub up_to: Option<Expr<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for SubscribeStatement<T> {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -356,7 +356,7 @@ Uncommitted
 Union
 Unique
 Unknown
-Until
+Up
 Update
 Upsert
 Url

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -356,6 +356,7 @@ Uncommitted
 Union
 Unique
 Unknown
+Until
 Update
 Upsert
 Url

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5341,6 +5341,15 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Parse `UNTIL`, if present
+    fn parse_optional_until(&mut self) -> Result<Option<Expr<Raw>>, ParserError> {
+        if self.parse_keyword(UNTIL) {
+            self.parse_expr().map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Parse a comma-delimited list of projections after SELECT
     fn parse_select_item(&mut self) -> Result<SelectItem<Raw>, ParserError> {
         if self.consume_token(&Token::Star) {
@@ -5488,10 +5497,12 @@ impl<'a> Parser<'a> {
             vec![]
         };
         let as_of = self.parse_optional_as_of()?;
+        let until = self.parse_optional_until()?;
         Ok(Statement::Subscribe(SubscribeStatement {
             relation,
             options,
             as_of,
+            until,
         }))
     }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5341,9 +5341,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse `UNTIL`, if present
-    fn parse_optional_until(&mut self) -> Result<Option<Expr<Raw>>, ParserError> {
-        if self.parse_keyword(UNTIL) {
+    /// Parse `UP TO`, if present
+    fn parse_optional_up_to(&mut self) -> Result<Option<Expr<Raw>>, ParserError> {
+        if self.parse_keyword(UP) {
+            self.expect_keyword(TO)?;
             self.parse_expr().map(Some)
         } else {
             Ok(None)
@@ -5497,12 +5498,12 @@ impl<'a> Parser<'a> {
             vec![]
         };
         let as_of = self.parse_optional_as_of()?;
-        let until = self.parse_optional_until()?;
+        let up_to = self.parse_optional_up_to()?;
         Ok(Statement::Subscribe(SubscribeStatement {
             relation,
             options,
             as_of,
-            until,
+            up_to,
         }))
     }
 

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -25,7 +25,7 @@ DECLARE c CURSOR FOR SUBSCRIBE t
 ----
 DECLARE c CURSOR FOR SUBSCRIBE t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("t")]))), options: [], as_of: None }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("t")]))), options: [], as_of: None, up_to: None }) })
 
 parse-statement
 CLOSE c

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -789,6 +789,20 @@ SUBSCRIBE (SELECT * FROM a)
 Subscribe(SubscribeStatement { relation: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: [], as_of: None, up_to: None })
 
 parse-statement
+SUBSCRIBE foo.bar AS OF now() UP TO now() + interval '1' day
+----
+SUBSCRIBE foo.bar AS OF now() UP TO now() + INTERVAL '1' DAY
+=>
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }) })
+
+parse-statement
+SUBSCRIBE foo.bar UP TO now() + interval '1' day
+----
+SUBSCRIBE foo.bar UP TO now() + INTERVAL '1' DAY
+=>
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: Some(Op { op: Op { namespace: [], op: "+" }, expr1: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), expr2: Some(Value(Interval(IntervalValue { value: "1", precision_high: Year, precision_low: Day, fsec_max_precision: None }))) }) })
+
+parse-statement
 CREATE TABLE public.customer (
         customer_id integer DEFAULT nextval(public.customer_customer_id_seq),
         store_id smallint NOT NULL,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -737,35 +737,35 @@ SUBSCRIBE foo.bar
 ----
 SUBSCRIBE foo.bar
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE TO foo.bar
 ----
 SUBSCRIBE foo.bar
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar AS OF 123
 ----
 SUBSCRIBE foo.bar AS OF 123
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Value(Number("123")))) })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Value(Number("123")))), up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar AS OF now()
 ----
 SUBSCRIBE foo.bar AS OF now()
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar WITH (SNAPSHOT) AS OF now()
 ----
 SUBSCRIBE foo.bar WITH (SNAPSHOT) AS OF now()
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))), up_to: None })
 
 parse-statement
 SUBSCRIBE foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
@@ -779,14 +779,14 @@ SUBSCRIBE foo.bar WITH (SNAPSHOT false)
 ----
 SUBSCRIBE foo.bar WITH (SNAPSHOT = false)
 =>
-Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: Some(Value(Boolean(false))) }], as_of: None })
+Subscribe(SubscribeStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [SubscribeOption { name: Snapshot, value: Some(Value(Boolean(false))) }], as_of: None, up_to: None })
 
 parse-statement
 SUBSCRIBE (SELECT * FROM a)
 ----
 SUBSCRIBE (SELECT * FROM a)
 =>
-Subscribe(SubscribeStatement { relation: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: [], as_of: None })
+Subscribe(SubscribeStatement { relation: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: [], as_of: None, up_to: None })
 
 parse-statement
 CREATE TABLE public.customer (

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -456,6 +456,7 @@ pub struct SubscribePlan {
     pub from: SubscribeFrom,
     pub with_snapshot: bool,
     pub when: QueryWhen,
+    pub until: Option<MirScalarExpr>,
     pub copy_to: Option<CopyFormat>,
     pub emit_progress: bool,
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -456,7 +456,7 @@ pub struct SubscribePlan {
     pub from: SubscribeFrom,
     pub with_snapshot: bool,
     pub when: QueryWhen,
-    pub until: Option<MirScalarExpr>,
+    pub up_to: Option<MirScalarExpr>,
     pub copy_to: Option<CopyFormat>,
     pub emit_progress: bool,
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -808,6 +808,29 @@ where
     Ok(expr.map(map_exprs).project(project_key))
 }
 
+/// Plans an expression in the `UNTIL` position of a `SUBSCRIBE` statement.
+pub fn plan_until(
+    scx: &StatementContext,
+    mut until: Expr<Aug>,
+) -> Result<MirScalarExpr, PlanError> {
+    let scope = Scope::empty();
+    let desc = RelationDesc::empty();
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
+    transform_ast::transform_expr(scx, &mut until)?;
+    let ecx = &ExprContext {
+        qcx: &qcx,
+        name: "UNTIL",
+        scope: &scope,
+        relation_type: desc.typ(),
+        allow_aggregates: false,
+        allow_subqueries: false,
+        allow_windows: false,
+    };
+    plan_expr(ecx, &until)?
+        .type_as_any(ecx)?
+        .lower_uncorrelated()
+}
+
 /// Plans an expression in the AS OF position of a `SELECT` or `SUBSCRIBE` statement.
 pub fn plan_as_of(
     scx: &StatementContext,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -808,25 +808,25 @@ where
     Ok(expr.map(map_exprs).project(project_key))
 }
 
-/// Plans an expression in the `UNTIL` position of a `SUBSCRIBE` statement.
-pub fn plan_until(
+/// Plans an expression in the `UP TO` position of a `SUBSCRIBE` statement.
+pub fn plan_up_to(
     scx: &StatementContext,
-    mut until: Expr<Aug>,
+    mut up_to: Expr<Aug>,
 ) -> Result<MirScalarExpr, PlanError> {
     let scope = Scope::empty();
     let desc = RelationDesc::empty();
     let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
-    transform_ast::transform_expr(scx, &mut until)?;
+    transform_ast::transform_expr(scx, &mut up_to)?;
     let ecx = &ExprContext {
         qcx: &qcx,
-        name: "UNTIL",
+        name: "UP TO",
         scope: &scope,
         relation_type: desc.typ(),
         allow_aggregates: false,
         allow_subqueries: false,
         allow_windows: false,
     };
-    plan_expr(ecx, &until)?
+    plan_expr(ecx, &up_to)?
         .type_as_any(ecx)?
         .lower_uncorrelated()
 }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -422,6 +422,7 @@ pub fn plan_subscribe(
         relation,
         options,
         as_of,
+        until,
     }: SubscribeStatement<Aug>,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, PlanError> {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -32,7 +32,7 @@ use crate::ast::{
 };
 use crate::catalog::CatalogItemType;
 use crate::names::{self, Aug, ResolvedObjectName};
-use crate::plan::query::{plan_until, QueryLifetime};
+use crate::plan::query::{plan_up_to, QueryLifetime};
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::with_options::TryFromValue;
 use crate::plan::{
@@ -422,7 +422,7 @@ pub fn plan_subscribe(
         relation,
         options,
         as_of,
-        until,
+        up_to,
     }: SubscribeStatement<Aug>,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, PlanError> {
@@ -467,7 +467,7 @@ pub fn plan_subscribe(
     };
 
     let when = query::plan_as_of(scx, as_of)?;
-    let until = until.map(|until| plan_until(scx, until)).transpose()?;
+    let up_to = up_to.map(|up_to| plan_up_to(scx, up_to)).transpose()?;
 
     let SubscribeOptionExtracted {
         progress, snapshot, ..
@@ -475,7 +475,7 @@ pub fn plan_subscribe(
     Ok(Plan::Subscribe(SubscribePlan {
         from,
         when,
-        until,
+        up_to,
         with_snapshot: snapshot.unwrap_or(true),
         copy_to,
         emit_progress: progress.unwrap_or(false),


### PR DESCRIPTION
Allow users to specify `UP TO <timestamp>` in `SUBSCRIBE` commands. This is required by the frontend observability project.

### Motivation


  * This PR adds a known-desirable feature.

    Fixes https://github.com/MaterializeInc/materialize/issues/16358


### Tips for reviewer

The commit messages are basically accurate, so you can review commit-by-commit if you want.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Enable `SUBSCRIBE ... UP TO` 
