### PR TITLE
timely-util: define `ProbeNotify` trait

### DIFF
--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -16,6 +16,4 @@ serde = { version = "1.0.147", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
-
-[dev-dependencies]
 tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -21,5 +21,6 @@ pub mod event;
 pub mod operator;
 pub mod order;
 pub mod panic;
+pub mod probe;
 pub mod progress;
 pub mod replay;

--- a/src/timely-util/src/probe.rs
+++ b/src/timely-util/src/probe.rs
@@ -1,0 +1,146 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use timely::dataflow::operators::InspectCore;
+use timely::dataflow::{Scope, Stream};
+use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
+use timely::progress::Timestamp;
+use timely::Data;
+use tokio::sync::Notify;
+
+/// Monitors progress at a `Stream`.
+trait ProbeNotify<G: Scope, D: Data> {
+    /// Constructs a progress probe which indicates which timestamps have elapsed at the operator.
+    fn probe_notify(&self) -> Handle<G::Timestamp>;
+
+    /// Inserts a progress probe in a stream.
+    fn probe_notify_with(&self, handle: &mut Handle<G::Timestamp>) -> Stream<G, D>;
+}
+
+impl<G: Scope, D: Data> ProbeNotify<G, D> for Stream<G, D> {
+    fn probe_notify(&self) -> Handle<G::Timestamp> {
+        let mut handle = Handle::default();
+        self.probe_notify_with(&mut handle);
+        handle
+    }
+
+    fn probe_notify_with(&self, handle: &mut Handle<G::Timestamp>) -> Stream<G, D> {
+        let mut handle = handle.clone();
+        self.inspect_container(move |update| {
+            if let Err(frontier) = update {
+                handle.downgrade(frontier);
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct Handle<T: Timestamp> {
+    /// The overall shared frontier managed by all the handles
+    frontier: Rc<RefCell<MutableAntichain<T>>>,
+    /// The private frontier containing the changes produced by this handle only
+    handle_frontier: Antichain<T>,
+    notify: Rc<Notify>,
+}
+
+impl<T: Timestamp> Default for Handle<T> {
+    fn default() -> Self {
+        Handle {
+            frontier: Rc::new(RefCell::new(MutableAntichain::new_bottom(T::minimum()))),
+            handle_frontier: Antichain::from_elem(T::minimum()),
+            notify: Rc::new(Notify::new()),
+        }
+    }
+}
+
+impl<T: Timestamp> Handle<T> {
+    /// Wait for the frontier monitored by this probe to progress
+    pub async fn progressed(&self) {
+        self.notify.notified().await
+    }
+
+    /// Returns true iff the frontier is strictly less than `time`.
+    #[inline]
+    pub fn less_than(&self, time: &T) -> bool {
+        self.frontier.borrow().less_than(time)
+    }
+    /// Returns true iff the frontier is less than or equal to `time`.
+    #[inline]
+    pub fn less_equal(&self, time: &T) -> bool {
+        self.frontier.borrow().less_equal(time)
+    }
+    /// Returns true iff the frontier is empty.
+    #[inline]
+    pub fn done(&self) -> bool {
+        self.frontier.borrow().is_empty()
+    }
+
+    /// Invokes a method on the frontier, returning its result.
+    ///
+    /// This method allows inspection of the frontier, which cannot be returned by reference as
+    /// it is on the other side of a `RefCell`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mz_timely_util::probe::Handle;
+    ///
+    /// let handle = Handle::<usize>::default();
+    /// let frontier = handle.with_frontier(|frontier| frontier.to_vec());
+    /// ```
+    #[inline]
+    pub fn with_frontier<R, F: FnMut(AntichainRef<T>) -> R>(&self, mut function: F) -> R {
+        function(self.frontier.borrow().frontier())
+    }
+
+    #[inline]
+    fn downgrade(&mut self, new_frontier: &[T]) {
+        let mut frontier = self.frontier.borrow_mut();
+        let changes = frontier.update_iter(
+            self.handle_frontier
+                .iter()
+                .map(|t| (t.clone(), -1))
+                .chain(new_frontier.iter().map(|t| (t.clone(), 1))),
+        );
+        self.handle_frontier.clear();
+        self.handle_frontier.extend(new_frontier.iter().cloned());
+        if changes.count() > 0 {
+            self.notify.notify_waiters();
+        }
+    }
+}
+
+impl<T: Timestamp> Drop for Handle<T> {
+    fn drop(&mut self) {
+        // This handle is being dropped so remove it from the overall calculation
+        self.frontier
+            .borrow_mut()
+            .update_iter(self.handle_frontier.iter().map(|t| (t.clone(), -1)));
+    }
+}
+
+impl<T: Timestamp> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        self.frontier.borrow_mut().update_iter([(T::minimum(), 1)]);
+        Handle {
+            frontier: Rc::clone(&self.frontier),
+            handle_frontier: Antichain::from_elem(T::minimum()),
+            notify: Rc::clone(&self.notify),
+        }
+    }
+}


### PR DESCRIPTION
### Motivation


This PR defices a `ProbeNotify` trait that is available for all timely Streams which is functionally identical to the built-in `Probe` trait with the exception that it supports progress notifications to consumers of the handle.

This is done via the `Handle::progressed()` async function which will resolve when the managed frontier has made progress.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
