### PR TITLE
sqllogictest: fix merge skew prohibiting as conversions

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1600,11 +1600,15 @@ impl<'a> RewriteBuffer<'a> {
         query: &str,
     ) {
         // Output everything before this error message.
+        // TODO(benesch): is it possible to rewrite this to avoid `as`?
+        #[allow(clippy::as_conversions)]
         let err_offset = old_err.as_ptr() as usize - input.as_ptr() as usize;
         self.flush_to(err_offset);
         self.append(new_err);
         self.append("\n");
         self.append(query);
+        // TODO(benesch): is it possible to rewrite this to avoid `as`?
+        #[allow(clippy::as_conversions)]
         self.skip_to(query.as_ptr() as usize - input.as_ptr() as usize + query.len())
     }
 


### PR DESCRIPTION
#16589 merged skewed with `as` conversion prohibition. Fixing.

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
