### PR TITLE
compute: configure DD's idle_merge_effort

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -168,31 +168,34 @@ impl ClusterClient<PartitionedClient> {
 
         let (builders, other) = initialize_networking(&comm_config, epoch).await?;
 
-        let workers = comm_config.workers;
-        let worker_guards = execute_from(
-            builders,
-            other,
-            WorkerConfig::default(),
-            move |timely_worker| {
-                let timely_worker_index = timely_worker.index();
-                let _tokio_guard = tokio_executor.enter();
-                let client_rx = client_rxs.lock().unwrap()[timely_worker_index % workers]
-                    .take()
-                    .unwrap();
-                let _trace_metrics = trace_metrics.clone();
-                let _compute_metrics = compute_metrics.clone();
-                let persist_clients = Arc::clone(&persist_clients);
-                Worker {
-                    timely_worker,
-                    client_rx,
-                    compute_state: None,
-                    trace_metrics: trace_metrics.clone(),
-                    compute_metrics: compute_metrics.clone(),
-                    persist_clients,
-                }
-                .run()
+        let mut worker_config = WorkerConfig::default();
+        differential_dataflow::configure(
+            &mut worker_config,
+            &differential_dataflow::Config {
+                idle_merge_effort: Some(1000),
             },
-        )
+        );
+
+        let workers = comm_config.workers;
+        let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {
+            let timely_worker_index = timely_worker.index();
+            let _tokio_guard = tokio_executor.enter();
+            let client_rx = client_rxs.lock().unwrap()[timely_worker_index % workers]
+                .take()
+                .unwrap();
+            let _trace_metrics = trace_metrics.clone();
+            let _compute_metrics = compute_metrics.clone();
+            let persist_clients = Arc::clone(&persist_clients);
+            Worker {
+                timely_worker,
+                client_rx,
+                compute_state: None,
+                trace_metrics: trace_metrics.clone(),
+                compute_metrics: compute_metrics.clone(),
+                persist_clients,
+            }
+            .run()
+        })
         .map_err(|e| anyhow!("{e}"))?;
 
         Ok(TimelyContainer {


### PR DESCRIPTION
This PR sets the `idle_merge_effort` configuration option of differential dataflow, which controls how much work DD spends on compacting arrangements. Anecdotically, the value 1000 provides a good trade-of between CPU time spent compacting more eagerly and memory saved by compacting earlier.

We might want to tune this value later, but it is clear that it should not be `None`. Setting the option to `None` means that arrangement compaction only happens in response to new updates arriving, so if a dataflow receives no updates for a while, its arrangements may sit around uncompacted, wasting precious memory.

### Motivation

  * This PR adds a known-desirable feature.

Advances #15974 by ensuring arrangements are compacted quickly during hydration.

### Tips for Reviewers

I thought about adding a CLI flag to control this setting, but decided not to because that would likely cause conflicts for Nikhil's storage-compute unification PR. We can always add it later, should people think it would be useful.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
