### PR TITLE
Render some LIR::LetRec expressions

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -173,6 +173,11 @@ impl<S: Append + 'static> Coordinator<S> {
             dataflow.set_as_of(since);
         }
 
+        // Ensure all expressions are normalized before finalizing.
+        for build in dataflow.objects_to_build.iter_mut() {
+            mz_transform::normalize_lets::normalize_lets(&mut build.plan.0).unwrap();
+        }
+
         mz_compute_client::plan::Plan::finalize_dataflow(dataflow)
             .expect("Dataflow planning failed; unrecoverable error")
     }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -285,9 +285,13 @@ pub fn build_compute_dataflow<A: Allocate>(
                             let oks_v = Variable::new(region, Product::new(Default::default(), 1));
                             let err_v = Variable::new(region, Product::new(Default::default(), 1));
 
+                            use differential_dataflow::operators::Consolidate;
                             context.insert_id(
                                 Id::Local(*id),
-                                CollectionBundle::from_collections(oks_v.clone(), err_v.clone()),
+                                CollectionBundle::from_collections(
+                                    oks_v.consolidate(),
+                                    err_v.consolidate(),
+                                ),
                             );
                             variables.insert(Id::Local(*id), (oks_v, err_v));
                         }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -152,10 +152,11 @@ pub fn build_compute_dataflow<A: Allocate>(
 ) {
     // Mutually recursive view definitions require special handling.
     let recursive = dataflow.objects_to_build.iter().any(|object| {
-        use mz_expr::CollectionPlan;
-        let mut depends_on = BTreeSet::new();
-        object.plan.depends_on_into(&mut depends_on);
-        depends_on.into_iter().any(|id| id >= object.id)
+        if let Plan::LetRec { .. } = object.plan {
+            true
+        } else {
+            false
+        }
     });
 
     // Determine indexes to export
@@ -269,31 +270,43 @@ pub fn build_compute_dataflow<A: Allocate>(
                 }
 
                 // Build declared objects.
-                // It is important that we only use the `Variable` until the object is bound.
-                // At that point, all subsequent uses should have access to the object itself.
-                let mut variables = BTreeMap::new();
-                for object in dataflow.objects_to_build.iter() {
-                    use differential_dataflow::operators::iterate::Variable;
-
-                    let oks_v = Variable::new(region, Product::new(Default::default(), 1));
-                    let err_v = Variable::new(region, Product::new(Default::default(), 1));
-
-                    context.insert_id(
-                        Id::Global(object.id),
-                        CollectionBundle::from_collections(oks_v.clone(), err_v.clone()),
-                    );
-                    variables.insert(object.id, (oks_v, err_v));
-                }
+                let mut any_letrec = false;
                 for object in dataflow.objects_to_build {
-                    let id = object.id;
-                    let bundle = context.render_plan(object.plan, region, region.index());
-                    // We need to ensure that the raw collection exists, but do not have enough information
-                    // here to cause that to happen.
-                    let (oks, err) = bundle.collection.clone().unwrap();
-                    context.insert_id(Id::Global(object.id), bundle);
-                    let (oks_v, err_v) = variables.remove(&id).unwrap();
-                    oks_v.set(&oks);
-                    err_v.set(&err);
+                    if let Plan::LetRec { ids, values, body } = object.plan {
+                        assert!(!any_letrec, "Cannot render multiple instances of LetRec");
+                        any_letrec = true;
+                        // Build declared objects.
+                        // It is important that we only use the `Variable` until the object is bound.
+                        // At that point, all subsequent uses should have access to the object itself.
+                        let mut variables = BTreeMap::new();
+                        for id in ids.iter() {
+                            use differential_dataflow::operators::iterate::Variable;
+
+                            let oks_v = Variable::new(region, Product::new(Default::default(), 1));
+                            let err_v = Variable::new(region, Product::new(Default::default(), 1));
+
+                            context.insert_id(
+                                Id::Local(*id),
+                                CollectionBundle::from_collections(oks_v.clone(), err_v.clone()),
+                            );
+                            variables.insert(Id::Local(*id), (oks_v, err_v));
+                        }
+                        for (id, value) in ids.into_iter().zip(values.into_iter()) {
+                            let bundle = context.render_plan(value, region, region.index());
+                            // We need to ensure that the raw collection exists, but do not have enough information
+                            // here to cause that to happen.
+                            let (oks, err) = bundle.collection.clone().unwrap();
+                            context.insert_id(Id::Local(id), bundle);
+                            let (oks_v, err_v) = variables.remove(&Id::Local(id)).unwrap();
+                            oks_v.set(&oks);
+                            err_v.set(&err);
+                        }
+
+                        let bundle = context.render_plan(*body, region, region.index());
+                        context.insert_id(Id::Global(object.id), bundle);
+                    } else {
+                        context.build_object(region, object);
+                    }
                 }
 
                 // Export declared indexes.

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -9,15 +9,141 @@
 
 mode cockroach
 
+## Test correct (intended) behavior:
+
 ## Test a plausibly correct recursive query.
-## query I
-## WITH MUTUALLY RECURSIVE
-##     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
-##     bar (a int) as (SELECT a FROM foo)
-## SELECT * FROM bar;
-## ----
-## 1
-## 1
+query I
+WITH MUTUALLY RECURSIVE
+    foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
+    bar (a int) as (SELECT a FROM foo)
+SELECT * FROM bar;
+----
+1
+1
+
+## Test a straightforward recursive query.
+## This could not terminate if we fail to consolidate iterates.
+query I
+WITH MUTUALLY RECURSIVE
+    t (n int) AS (
+        VALUES (1)
+        UNION ALL
+        SELECT n+1 FROM t WHERE n < 100
+    )
+SELECT sum(n) FROM t;
+----
+5050
+
+## Test a straightforward mutually recursive query.
+query I
+WITH MUTUALLY RECURSIVE
+    evens(n int) AS (
+        VALUES (1)
+        UNION ALL
+        SELECT n+1 FROM odds WHERE n < 100
+    ),
+    odds (n int) AS (
+        VALUES (0)
+        UNION ALL
+        SELECT n+1 FROM evens
+    ),
+    both (n int) AS (
+        SELECT * FROM evens
+        UNION ALL
+        SELECT * FROM odds
+    )
+SELECT sum(n) FROM both;
+----
+10100
+
+## Test a potentially surprising recursive query.
+## The analogue of this query in postgres produces only powers of two.
+query I
+WITH MUTUALLY RECURSIVE
+    numbers (n int) as (
+        VALUES (1)
+        UNION ALL
+        (
+            WITH rebound AS (SELECT * FROM numbers)
+            SELECT distinct t1.n + t2.n AS n
+            FROM rebound AS t1, rebound AS t2
+            WHERE t1.n <= 256 AND t2.n <= 256
+        )
+    )
+SELECT count(*) FROM numbers;
+----
+512
+
+## Test a correlated recursive subquery.
+query II
+SELECT bound, (
+    WITH MUTUALLY RECURSIVE
+        numbers (n int) as (
+            VALUES (1)
+            UNION ALL
+            (
+                WITH rebound AS (SELECT * FROM numbers)
+                SELECT distinct t1.n + t2.n AS n
+                FROM rebound AS t1, rebound AS t2
+                WHERE t1.n <= bound AND t2.n <= bound
+            )
+        )
+    SELECT count(*) FROM numbers
+)
+FROM (
+    SELECT generate_series AS bound FROM generate_series(1, 10)
+);
+----
+1  2
+2  4
+3  6
+4  8
+5  10
+6  12
+7  14
+8  16
+9  18
+10  20
+
+## Test recursive name resolution in SELECT subquery
+query III
+WITH MUTUALLY RECURSIVE
+    foo (a int, b int) AS (SELECT (
+        SELECT MIN(c) FROM bar
+    ), 2 UNION SELECT 5, 5 FROM bar),
+    bar (c int) as (SELECT a FROM foo)
+SELECT * FROM foo, bar;
+----
+5  2  5
+5  2  5
+5  5  5
+5  5  5
+
+## Test recursive name resolution in FROM clause
+query III
+WITH MUTUALLY RECURSIVE
+    foo (a int, b int) AS (
+        SELECT 1, 2 UNION
+        SELECT * FROM (
+            SELECT MIN(c), 2 FROM bar
+        )
+    ),
+    bar (c int) as (SELECT a FROM foo)
+SELECT * FROM foo, bar;
+----
+1  2  1
+
+## Test recursive name resolution in FROM clause
+query I
+WITH MUTUALLY RECURSIVE
+    foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
+    bar (a int) as (SELECT a FROM foo)
+SELECT (SELECT COUNT(*) FROM foo) FROM bar;
+----
+2
+2
+
+## Test error cases
 
 ## Test a recursive query with mismatched types.
 statement error did not match inferred type
@@ -73,45 +199,7 @@ WITH MUTUALLY RECURSIVE
     bar (a int) as (SELECT a FROM foo)
 SELECT a FROM foo, bar;
 
-## Test recursive name resolution in SELECT subquery
-## query III
-## WITH MUTUALLY RECURSIVE
-##     foo (a int, b int) AS (SELECT (
-##         SELECT MIN(c) FROM bar
-##     ), 2 UNION SELECT 5, 5 FROM bar),
-##     bar (c int) as (SELECT a FROM foo)
-## SELECT * FROM foo, bar;
-## ----
-## 5  2  5
-## 5  2  5
-## 5  5  5
-## 5  5  5
-
-## Test recursive name resolution in FROM clause
-## query III
-## WITH MUTUALLY RECURSIVE
-##     foo (a int, b int) AS (
-##         SELECT 1, 2 UNION
-##         SELECT * FROM (
-##             SELECT MIN(c), 2 FROM bar
-##         )
-##     ),
-##     bar (c int) as (SELECT a FROM foo)
-## SELECT * FROM foo, bar;
-## ----
-## 1  2  1
-
-## Test recursive name resolution in FROM clause
-## query I
-## WITH MUTUALLY RECURSIVE
-##     foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
-##     bar (a int) as (SELECT a FROM foo)
-## SELECT (SELECT COUNT(*) FROM foo) FROM bar;
-## ----
-## 2
-## 2
-
-## Explain plans:
+## Test Explain plans:
 
 ## Test a plausibly correct recursive query.
 query T multiline


### PR DESCRIPTION
This PR demonstrates how to render some `LIR::LetRec` stages, specifically expressions rooted by one such stage containing no other such stages. This roughly corresponds to what we can execute in one iterative scope; doing any more (nested or sequenced stages) would require some more substantial cleverness.

The changes are primarily 
1. Making sure that all `LetRec` bindings result in a "raw" collection (not an arrangement), and
2. Teaching rendering to look for `LetRec` and form the `Variable` bindings that are required.

The use of `LetRec` at all is currently behind `--unsafe-mode`, and this shouldn't change the behavior of any other rendering (I hope). The behavior on unsupported patterns is to send `computed` into a crash-loop until the offending dataflow is dropped, which doesn't seem like the end of the world. 

There is the potential that one can create multiple objects to build, two of which each contain one `LetRec`; we *will* render this, incorrectly (the two should be sequenced, but will instead be run concurrently). Probably best to crash in this case rather than return a wrong result, which I can make happen.

Up for discussion primarily, but also to think about how far to take it before merging.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
