### PR TITLE
storage: implement simple version of souce-specific statistics

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1730,19 +1730,20 @@ pub static MZ_STORAGE_HOST_METRICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSo
     is_retained_metrics_relation: true,
 });
 
-// When
-pub static MZ_STORAGE_SOURCE_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
-    name: "mz_storage_source_statistics",
+// This will be replaced with per-replica tables once source/sink multiplexing on
+// a single cluster is supported.
+pub static MZ_SOURCE_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_source_statistics",
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::StorageSourceStatistics),
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("worker_id", ScalarType::UInt64.nullable(false))
-        // These are nullable as we may not fill them all out at the same time.
-        .with_column("snapshot_committed", ScalarType::Bool.nullable(true))
-        .with_column("messages_received", ScalarType::UInt64.nullable(true))
-        .with_column("messages_committed", ScalarType::UInt64.nullable(true))
-        .with_column("bytes_received", ScalarType::UInt64.nullable(true)),
+        .with_column("snapshot_committed", ScalarType::Bool.nullable(false))
+        .with_column("messages_received", ScalarType::UInt64.nullable(false))
+        .with_column("updates_staged", ScalarType::UInt64.nullable(false))
+        .with_column("updates_committed", ScalarType::UInt64.nullable(false))
+        .with_column("bytes_received", ScalarType::UInt64.nullable(false)),
     is_retained_metrics_relation: true,
 });
 
@@ -3078,7 +3079,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&MZ_SOURCE_STATUSES),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::Source(&MZ_STORAGE_HOST_METRICS),
-        Builtin::Source(&MZ_STORAGE_SOURCE_STATISTICS),
+        Builtin::Source(&MZ_SOURCE_STATISTICS),
         Builtin::View(&MZ_STORAGE_USAGE),
         Builtin::Table(&MZ_STORAGE_HOST_SIZES),
         Builtin::View(&MZ_SOURCE_UTILIZATION),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1730,6 +1730,22 @@ pub static MZ_STORAGE_HOST_METRICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSo
     is_retained_metrics_relation: true,
 });
 
+// When
+pub static MZ_STORAGE_SOURCE_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_storage_source_statistics",
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::StorageSourceStatistics),
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("worker_id", ScalarType::UInt64.nullable(false))
+        // These are nullable as we may not fill them all out at the same time.
+        .with_column("snapshot_committed", ScalarType::Bool.nullable(true))
+        .with_column("messages_received", ScalarType::UInt64.nullable(true))
+        .with_column("messages_committed", ScalarType::UInt64.nullable(true))
+        .with_column("bytes_received", ScalarType::UInt64.nullable(true)),
+    is_retained_metrics_relation: true,
+});
+
 pub static MZ_STORAGE_SHARDS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_storage_shards",
     schema: MZ_INTERNAL_SCHEMA,
@@ -3062,6 +3078,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&MZ_SOURCE_STATUSES),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::Source(&MZ_STORAGE_HOST_METRICS),
+        Builtin::Source(&MZ_STORAGE_SOURCE_STATISTICS),
         Builtin::View(&MZ_STORAGE_USAGE),
         Builtin::Table(&MZ_STORAGE_HOST_SIZES),
         Builtin::View(&MZ_SOURCE_UTILIZATION),

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -70,11 +70,25 @@ message ProtoStorageCommand {
 }
 
 message ProtoStorageResponse {
+    message ProtoSourceStatisticsUpdate {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        uint64 worker_id = 2;
+        bool snapshot_committed = 3;
+        uint64 messages_received = 4;
+        uint64 updates_staged = 5;
+        uint64 updates_committed = 6;
+        uint64 bytes_received = 7;
+    }
+    message ProtoStatisticsUpdates {
+        repeated ProtoSourceStatisticsUpdate source_updates = 1;
+    }
+
     message ProtoDroppedIds {
         repeated mz_repr.global_id.ProtoGlobalId ids = 1;
     }
     oneof kind {
         ProtoFrontierUppersKind frontier_uppers = 1;
         ProtoDroppedIds dropped_ids = 2;
+        ProtoStatisticsUpdates stats = 3;
     }
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -108,6 +108,10 @@ pub enum IntrospectionType {
     SourceStatusHistory,
     ShardMapping,
     StorageHostMetrics,
+
+    // Note that this single-shard introspection source will be changed to per-replica,
+    // once storage and compute are merged
+    StorageSourceStatistics,
 }
 
 /// Describes how data is written to the collection.
@@ -1022,6 +1026,9 @@ where
                             // Make sure this is dropped when the controller is
                             // dropped, so that the internal task will stop.
                             self.state.introspection_tokens.insert(id, scraper_token);
+                        }
+                        IntrospectionType::StorageSourceStatistics => {
+                            self.reconcile_managed_collection(id, vec![]).await;
                         }
                         IntrospectionType::SourceStatusHistory
                         | IntrospectionType::SinkStatusHistory => {

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -30,6 +30,8 @@ use super::persist_handles;
 
 #[derive(Debug, Clone)]
 pub struct CollectionManager {
+    // TODO(guswynn): this should be a sync mutex, as it protects
+    // normal data.
     collections: Arc<Mutex<HashSet<GlobalId>>>,
     tx: mpsc::Sender<(GlobalId, Vec<(Row, Diff)>)>,
 }

--- a/src/storage-client/src/controller/metrics_scraper.rs
+++ b/src/storage-client/src/controller/metrics_scraper.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! A tokio task (and support machinery) for maintaining storage-managed
-//! collections.
+//! A tokio task (and support machinery) for scraping and writing down
+//! metrics.
 
 use std::any::Any;
 use std::time::Duration;
@@ -45,7 +45,7 @@ pub(super) fn spawn_metrics_scraper(
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 
     mz_ore::task::spawn(|| "metrics_scraper", async move {
-        // Keep track of what we think the contents of the output
+        // Keep track of what we think is the contents of the output
         // collection, so that we can emit the required retractions/updates
         // when we learn about new metrics.
         //
@@ -58,6 +58,7 @@ pub(super) fn spawn_metrics_scraper(
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
+            // TODO(guswynn): reduce the amount of un-formattable code here.
             tokio::select! {
                 _msg = &mut shutdown_rx => {
                     break;

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -352,6 +352,10 @@ where
                 }
                 Some(StorageResponse::DroppedIds(dropped_ids))
             }
+            StorageResponse::StatisticsUpdates(stats) => {
+                // Just forward it along.
+                Some(StorageResponse::StatisticsUpdates(stats))
+            }
         }
     }
 }

--- a/src/storage-client/src/controller/statistics.rs
+++ b/src/storage-client/src/controller/statistics.rs
@@ -1,0 +1,105 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A tokio task (and support machinery) for producing storage statistics.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use itertools::Itertools;
+use timely::progress::ChangeBatch;
+use tokio::sync::oneshot;
+
+use mz_ore::cast::CastFrom;
+use mz_repr::{Datum, GlobalId, Row};
+
+use crate::client::SourceStatisticsUpdate;
+use crate::controller::collection_mgmt::CollectionManager;
+
+/// Spawns a task that continually (at an interval) writes statistics from storaged's
+/// that are consolidated in shared memory in the controller.
+pub(super) fn spawn_statistics_scraper(
+    statistics_collection_id: GlobalId,
+    collection_mgmt: CollectionManager,
+    shared_stats: Arc<Mutex<HashMap<GlobalId, HashMap<usize, SourceStatisticsUpdate>>>>,
+) -> Box<dyn Any + Send + Sync> {
+    // TODO(guswynn): Should this be configurable? Maybe via LaunchDarkly?
+    const STATISTICS_INTERVAL: Duration = Duration::from_secs(30);
+
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+    mz_ore::task::spawn(|| "statistics_scraper", async move {
+        // Keep track of what we think is the contents of the output
+        // collection, so that we can emit the required retractions/updates
+        // when we learn about new metrics.
+        //
+        // We assume that `shared_stats` is kept up-to-date by the controller.
+        let mut current_metrics = ChangeBatch::new();
+
+        let mut interval = tokio::time::interval(STATISTICS_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _msg = &mut shutdown_rx => {
+                    break;
+                }
+
+                _ = interval.tick() => {
+                    let mut row_buf = Row::default();
+                    let mut correction = current_metrics
+                        .iter()
+                        .cloned()
+                        .map(|(row, diff)| (row, -diff))
+                        .collect_vec();
+
+                    // Ideally we move quickly when holding the lock here, as it can hold
+                    // up the coordinator. Because we are just moving some data around, we should
+                    // be fine!
+                    //
+                    // TODO: consider using a RwLock instead of a mutex.
+                    {
+                        let shared_stats = shared_stats.lock().expect("poisoned");
+
+                        for (src_id, sources) in shared_stats.iter() {
+                            for (worker_id, stats) in sources.iter() {
+                                let mut packer = row_buf.packer();
+
+                                packer.push(Datum::from(src_id.to_string().as_str()));
+                                packer.push(Datum::from(u64::cast_from(*worker_id)));
+                                packer.push(Datum::from(stats.snapshot_committed));
+                                packer.push(Datum::from(stats.messages_received));
+                                packer.push(Datum::from(stats.updates_staged));
+                                packer.push(Datum::from(stats.updates_committed));
+                                packer.push(Datum::from(stats.bytes_received));
+
+                                correction.push((row_buf.clone(), 1));
+                            }
+                        }
+                    }
+
+                    // Update our view of the output collection and write updates
+                    // out to the collection.
+                    if !correction.is_empty() {
+                        current_metrics.extend(correction.iter().cloned());
+                        collection_mgmt
+                            .append_to_collection(statistics_collection_id, correction)
+                            .await;
+                    }
+                }
+            }
+        }
+
+        tracing::info!("shutting down statistics sender task");
+    });
+
+    Box::new(shutdown_tx)
+}

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -99,6 +99,11 @@ where
         resume_upper: resume_upper.clone(),
         storage_metadata: description.ingestion_metadata.clone(),
         persist_clients: Arc::clone(&storage_state.persist_clients),
+        source_statistics: storage_state
+            .source_statistics
+            .get(&id)
+            .expect("statistics initialized")
+            .clone(),
     };
 
     // TODO(petrosagg): put the description as-is in the RawSourceCreationConfig instead of cloning

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -105,6 +105,7 @@ pub fn serve(
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
                 dropped_ids: Vec::new(),
+                source_statistics: HashMap::new(),
             },
         }
         .run()

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -47,6 +47,7 @@ mod reclock;
 mod resumption;
 mod s3;
 mod source_reader_pipeline;
+pub mod statistics;
 // Public for integration testing.
 #[doc(hidden)]
 pub mod testscript;

--- a/src/storage/src/source/statistics.rs
+++ b/src/storage/src/source/statistics.rs
@@ -1,0 +1,94 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Helpers for managing storage statistics.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use timely::progress::frontier::Antichain;
+use timely::progress::Timestamp;
+
+use mz_repr::GlobalId;
+use mz_storage_client::client::SourceStatisticsUpdate;
+
+/// A helper struct designed to make it easy for operators to update metrics
+#[derive(Clone)]
+pub struct SourceStatistics {
+    // We just use `SourceStatisticsUpdate` for convenience here!
+    // The boolean its an initialization flag, to ensure we
+    // don't report a false `snapshot_committed` value before
+    // the `persist_sink` reports the current shard upper.
+    // TODO(guswynn): this boolean is kindof gross, it should
+    // probably be cleaned up.
+    stats: Rc<RefCell<(bool, SourceStatisticsUpdate)>>,
+}
+
+impl SourceStatistics {
+    pub fn new(id: GlobalId, index: usize) -> Self {
+        Self {
+            stats: Rc::new(RefCell::new((
+                false,
+                SourceStatisticsUpdate {
+                    id,
+                    worker_id: index,
+                    snapshot_committed: false,
+                    messages_received: 0,
+                    updates_staged: 0,
+                    updates_committed: 0,
+                    bytes_received: 0,
+                },
+            ))),
+        }
+    }
+
+    /// Return a snapshot of the stats data, if its been initialized.
+    pub fn snapshot(&self) -> Option<SourceStatisticsUpdate> {
+        let inner = self.stats.borrow();
+        inner.0.then(|| inner.1.clone())
+    }
+
+    /// Set the `snapshot_committed` stat based on the reported upper, and
+    /// mark the stats as initialized.
+    // TODO(guswynn): Actually test that this initialization logic works.
+    pub fn initialize_snapshot_committed<T: Timestamp>(&self, upper: &Antichain<T>) {
+        self.update_snapshot_committed(upper);
+        self.stats.borrow_mut().0 = true;
+    }
+
+    /// Set the `snapshot_committed` stat based on the reported upper.
+    pub fn update_snapshot_committed<T: Timestamp>(&self, upper: &Antichain<T>) {
+        let value = *upper != Antichain::from_elem(T::minimum());
+        self.stats.borrow_mut().1.snapshot_committed = value
+    }
+
+    /// Increment the `messages_received` stat.
+    pub fn inc_messages_received_by(&self, value: u64) {
+        let mut cur = self.stats.borrow_mut();
+        cur.1.messages_received = cur.1.messages_received + value;
+    }
+
+    /// Increment the `updates` stat.
+    pub fn inc_updates_staged_by(&self, value: u64) {
+        let mut cur = self.stats.borrow_mut();
+        cur.1.updates_staged = cur.1.updates_staged + value;
+    }
+
+    /// Increment the `messages_committed` stat.
+    pub fn inc_updates_committed_by(&self, value: u64) {
+        let mut cur = self.stats.borrow_mut();
+        cur.1.updates_committed = cur.1.updates_committed + value;
+    }
+
+    /// Increment the `bytes_received` stat.
+    pub fn inc_bytes_received_by(&self, value: u64) {
+        let mut cur = self.stats.borrow_mut();
+        cur.1.bytes_received = cur.1.bytes_received + value;
+    }
+}

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -26,7 +26,6 @@ use timely::dataflow::channels::pact::{Exchange, ParallelizationContract};
 use timely::scheduling::activate::SyncActivator;
 use timely::Data;
 
-use mz_avro::types::Value;
 use mz_expr::PartitionId;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
@@ -640,13 +639,6 @@ impl MaybeLength for Vec<u8> {
 impl MaybeLength for mz_repr::Row {
     fn len(&self) -> Option<usize> {
         Some(self.data().len())
-    }
-}
-
-impl MaybeLength for Value {
-    // Not possible to compute a size in bytes without recursively traversing the entire tree.
-    fn len(&self) -> Option<usize> {
-        None
     }
 }
 

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -231,6 +231,7 @@ where
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
                 dropped_ids: Vec::new(),
+                source_statistics: HashMap::new(),
             };
 
             let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -23,7 +23,7 @@ reset-server
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1' AND name NOT LIKE '%_2' AND name NOT LIKE '%_3') - (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name LIKE '%_1');
 ----
-4
+5
 
 # This test checks if the views in mz_catalog are also present in a postfixed
 # way. If this test fails and you added new view that uses introspection

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -729,6 +729,10 @@ mz_sink_utilization
 VIEW
 materialize
 mz_internal
+mz_source_statistics
+SOURCE
+materialize
+mz_internal
 mz_source_status_history
 SOURCE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -520,6 +520,7 @@ mz_scheduling_parks_internal                    log   <null>
 mz_sink_status_history                          source <null>
 mz_source_status_history                        source <null>
 mz_storage_host_metrics                         source <null>
+mz_source_statistics                            source <null>
 mz_storage_shards                               source <null>
 mz_worker_compute_frontiers                     log   <null>
 mz_worker_compute_import_frontiers              log   <null>

--- a/test/testdrive/storage-statistics.td
+++ b/test/testdrive/storage-statistics.td
@@ -1,0 +1,124 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+$ kafka-create-topic topic=upsert partitions=1
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "fish"} {"f1": "fish", "f2": 1000}
+{"key": "bird1"} {"f1":"goose", "f2": 1}
+{"key": "birdmore"} {"f1":"geese", "f2": 2}
+{"key": "mammal1"} {"f1": "moose", "f2": 1}
+{"key": "bird1"}
+{"key": "birdmore"} {"f1":"geese", "f2": 56}
+{"key": "mammalmore"} {"f1": "moose", "f2": 42}
+{"key": "mammal1"}
+{"key": "mammalmore"} {"f1":"moose", "f2": 2}
+
+$ kafka-create-topic topic=metrics-test partitions=1
+$ kafka-ingest topic=metrics-test format=bytes
+jack,jill
+goofus,gallant
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE SOURCE metrics_test_source (a, b)
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-metrics-test-${testdrive.seed}')
+  FORMAT CSV WITH 2 COLUMNS
+  INCLUDE OFFSET
+
+> CREATE SOURCE upsert
+  FROM KAFKA CONNECTION kafka_conn (TOPIC
+  'testdrive-upsert-${testdrive.seed}'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  INCLUDE OFFSET
+  ENVELOPE UPSERT
+
+# Also test a source with multiple sub-sources.
+> CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
+
+# NOTE: These queries are slow to succeed because the default metrics scraping
+# interval is 30 seconds.
+
+# MIN is a sneaky way to `AND` booleans :)
+> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('metrics_test_source')
+  GROUP BY s.name
+  ORDER BY s.name
+metrics_test_source true 2 2 2 true
+
+> DROP SOURCE metrics_test_source
+
+# Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
+# Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
+# jitter on when metrics are produced for each sub-source.
+> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')
+  GROUP BY s.name
+  ORDER BY s.name
+accounts       true      false   true  true  false
+auction_house  true      true    false false true
+auctions       true      false   true  true  false
+bids           true      false   true  true  false
+organizations  true      false   true  true  false
+users          true      false   true  true  false
+
+> DROP SOURCE auction_house
+
+# Test upsert
+
+# Note that we see 9 messages received, but only 3 updates, because there are only
+# 3 active keys, as all the messages are received in 1 second.
+> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+upsert true 9 3 3 true
+
+$ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
+{"key": "mammalmore"} {"f1":"moose2", "f2": 2}
+
+# An update is 1 more messages received, but is 2 updates (1 insert and 1 delete).
+> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
+  FROM mz_sources s
+  JOIN mz_internal.mz_source_statistics u ON s.id = u.id
+  WHERE s.name IN ('upsert')
+  GROUP BY s.name
+  ORDER BY s.name
+upsert true 10 5 5 true
+
+> DROP SOURCE upsert


### PR DESCRIPTION
As described here: https://www.notion.so/materialize/User-facing-metrics-for-Sources-9603b61224a04a749969702e04662ed3#ca9365f66fb947128c0608906e556620

The implementation was relatively straightforward, but revealed a few subtleties around how we want to present some data. These are mostly documented in the docs I added to this pr, but I feel we should discuss them here:
- In general I counted retractions and insertions the same.
- `messages_received` and `messages_committed` can diverge because envelopes like `UPSERT` consolidate in within timestamps AND can produce 2 messages to commit (an insert and a retraction).
  - Its possible to move `messages_received` to just track the rows (both retractions and inserts) we are putting in persist batches, but that might is technically a different concept. Do we want two metrics?
- `bytes_received` has numbers that depend on the type of source.
- Its unclear how we want multi-output sources to work. In this pr, I just consolidated them into the same data, but its possible we want different rows for each sub-source.
  - I didn't add a test for multi-output sources because I want to discuss this first
  - Moving to this will likely fix a data-race bug in this pr, where `snapshot_finished` can be updated by the underlying sources too early. 
- Note also that these stats are also reset to 0 on restart...this seems reasonable to me, as this is the same way prometheus works!
- When sources are dropped, I don't yet clear out the data in the shard
  

Overall, the above issues show that we may want to add columns in the future...which means we need to expect users to not materialize `select * from mz_storage_source_statistics`, and that the ui will select specific columns...are these reasonable expectations?

### Motivation


  * This PR adds a known-desirable feature.


### Tips for reviewer
See above.

This pr can be reviewed as separate commits, if you want
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Added `mz_source_statistics`, which contains useful stats about sources
