### PR TITLE
[WIP] convert planner to use refs

### DIFF
--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -114,7 +114,7 @@ async fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
         let stmt = mz_sql::parse::parse(sql)?.into_element();
         let (stmt, _) = mz_sql::names::resolve(&catalog, stmt)?;
         let desc = mz_sql::plan::describe(&PlanContext::zero(), &catalog, stmt, &[])?;
-        assert_eq!(desc.param_types, types);
+        assert_eq!(desc.param_types, types, "{sql}");
     }
     Ok(())
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -144,37 +144,37 @@ pub fn describe(
 
         // `SHOW` statements.
         Statement::Show(ShowStatement::ShowColumns(stmt)) => {
-            show::show_columns(&scx, stmt)?.describe()?
+            show::show_columns(&scx, &stmt)?.describe()?
         }
         Statement::Show(ShowStatement::ShowCreateConnection(stmt)) => {
-            show::describe_show_create_connection(&scx, stmt)?
+            show::describe_show_create_connection(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowCreateIndex(stmt)) => {
-            show::describe_show_create_index(&scx, stmt)?
+            show::describe_show_create_index(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowCreateSink(stmt)) => {
-            show::describe_show_create_sink(&scx, stmt)?
+            show::describe_show_create_sink(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowCreateSource(stmt)) => {
-            show::describe_show_create_source(&scx, stmt)?
+            show::describe_show_create_source(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowCreateTable(stmt)) => {
-            show::describe_show_create_table(&scx, stmt)?
+            show::describe_show_create_table(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowCreateView(stmt)) => {
-            show::describe_show_create_view(&scx, stmt)?
+            show::describe_show_create_view(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowCreateMaterializedView(stmt)) => {
-            show::describe_show_create_materialized_view(&scx, stmt)?
+            show::describe_show_create_materialized_view(&scx, &stmt)?
         }
         Statement::Show(ShowStatement::ShowDatabases(stmt)) => {
-            show::show_databases(&scx, stmt)?.describe()?
+            show::show_databases(&scx, &stmt)?.describe()?
         }
         Statement::Show(ShowStatement::ShowObjects(stmt)) => {
-            show::show_objects(&scx, stmt)?.describe()?
+            show::show_objects(&scx, &stmt)?.describe()?
         }
         Statement::Show(ShowStatement::ShowSchemas(stmt)) => {
-            show::show_schemas(&scx, stmt)?.describe()?
+            show::show_schemas(&scx, &stmt)?.describe()?
         }
 
         // SCL statements.
@@ -290,33 +290,33 @@ pub fn plan(
         Statement::Update(stmt) => dml::plan_update(scx, stmt, params),
 
         // `SHOW` statements.
-        Statement::Show(ShowStatement::ShowColumns(stmt)) => show::show_columns(scx, stmt)?.plan(),
+        Statement::Show(ShowStatement::ShowColumns(stmt)) => show::show_columns(scx, &stmt)?.plan(),
         Statement::Show(ShowStatement::ShowCreateConnection(stmt)) => {
-            show::plan_show_create_connection(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_connection(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowCreateIndex(stmt)) => {
-            show::plan_show_create_index(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_index(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowCreateSink(stmt)) => {
-            show::plan_show_create_sink(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_sink(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowCreateSource(stmt)) => {
-            show::plan_show_create_source(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_source(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowCreateTable(stmt)) => {
-            show::plan_show_create_table(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_table(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowCreateView(stmt)) => {
-            show::plan_show_create_view(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_view(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowCreateMaterializedView(stmt)) => {
-            show::plan_show_create_materialized_view(scx, stmt).map(Plan::SendRows)
+            show::plan_show_create_materialized_view(scx, &stmt).map(Plan::SendRows)
         }
         Statement::Show(ShowStatement::ShowDatabases(stmt)) => {
-            show::show_databases(scx, stmt)?.plan()
+            show::show_databases(scx, &stmt)?.plan()
         }
-        Statement::Show(ShowStatement::ShowObjects(stmt)) => show::show_objects(scx, stmt)?.plan(),
-        Statement::Show(ShowStatement::ShowSchemas(stmt)) => show::show_schemas(scx, stmt)?.plan(),
+        Statement::Show(ShowStatement::ShowObjects(stmt)) => show::show_objects(scx, &stmt)?.plan(),
+        Statement::Show(ShowStatement::ShowSchemas(stmt)) => show::show_schemas(scx, &stmt)?.plan(),
 
         // SCL statements.
         Statement::Close(stmt) => scl::plan_close(scx, stmt),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1607,7 +1607,7 @@ pub fn plan_view(
         mut expr,
         mut desc,
         finishing,
-    } = query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
+    } = query::plan_root_query(scx, query, QueryLifetime::Static)?;
 
     expr.bind_parameters(params)?;
     //TODO: materialize#724 - persist finishing information with the view?
@@ -1704,7 +1704,7 @@ pub fn plan_create_materialized_view(
         mut expr,
         mut desc,
         finishing,
-    } = query::plan_root_query(scx, stmt.query, QueryLifetime::Static)?;
+    } = query::plan_root_query(scx, &mut stmt.query, QueryLifetime::Static)?;
 
     expr.bind_parameters(params)?;
     expr.finish(finishing);

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -157,10 +157,10 @@ pub fn plan_read_then_write(
 
 pub fn describe_select(
     scx: &StatementContext,
-    stmt: SelectStatement<Aug>,
+    mut stmt: SelectStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     let query::PlannedQuery { desc, .. } =
-        query::plan_root_query(scx, stmt.query, QueryLifetime::OneShot(scx.pcx()?))?;
+        query::plan_root_query(scx, &mut stmt.query, QueryLifetime::OneShot(scx.pcx()?))?;
     Ok(StatementDesc::new(Some(desc)))
 }
 
@@ -255,7 +255,7 @@ pub fn plan_explain(
     params: &Params,
 ) -> Result<Plan, PlanError> {
     let is_view = matches!(explainee, Explainee::View(_));
-    let (explainee, query) = match explainee {
+    let (explainee, mut query) = match explainee {
         Explainee::View(name) => {
             let view = scx.get_item_by_resolved_name(&name)?;
             let item_type = view.item_type();
@@ -321,7 +321,7 @@ pub fn plan_explain(
         mut expr,
         desc,
         finishing,
-    } = query::plan_root_query(scx, query, QueryLifetime::OneShot(scx.pcx()?))?;
+    } = query::plan_root_query(scx, &mut query, QueryLifetime::OneShot(scx.pcx()?))?;
     let finishing = if is_view {
         // views don't use a separate finishing
         expr.finish(finishing);
@@ -359,7 +359,7 @@ pub fn plan_explain(
 /// an `mz_expr::MirRelationExpr`, which cannot include correlated expressions.
 pub fn plan_query(
     scx: &StatementContext,
-    query: Query<Aug>,
+    mut query: Query<Aug>,
     params: &Params,
     lifetime: QueryLifetime,
 ) -> Result<query::PlannedQuery<MirRelationExpr>, PlanError> {
@@ -367,7 +367,7 @@ pub fn plan_query(
         mut expr,
         desc,
         finishing,
-    } = query::plan_root_query(scx, query, lifetime)?;
+    } = query::plan_root_query(scx, &mut query, lifetime)?;
     expr.bind_parameters(params)?;
     Ok(query::PlannedQuery {
         expr: expr.optimize_and_lower(&scx.into())?,
@@ -388,9 +388,9 @@ pub fn describe_subscribe(
             item.desc(&scx.catalog.resolve_full_name(item.name()))?
                 .into_owned()
         }
-        SubscribeRelation::Query(query) => {
+        SubscribeRelation::Query(mut query) => {
             let query::PlannedQuery { desc, .. } =
-                query::plan_root_query(scx, query, QueryLifetime::OneShot(scx.pcx()?))?;
+                query::plan_root_query(scx, &mut query, QueryLifetime::OneShot(scx.pcx()?))?;
             desc
         }
     };

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -42,7 +42,7 @@ use crate::plan::{query, HirRelationExpr, Params, Plan, PlanError, SendRowsPlan}
 
 pub fn describe_show_create_view(
     _: &StatementContext,
-    _: ShowCreateViewStatement<Aug>,
+    _: &ShowCreateViewStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -53,9 +53,9 @@ pub fn describe_show_create_view(
 
 pub fn plan_show_create_view(
     scx: &StatementContext,
-    ShowCreateViewStatement { view_name }: ShowCreateViewStatement<Aug>,
+    ShowCreateViewStatement { view_name }: &ShowCreateViewStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let view = scx.get_item_by_resolved_name(&view_name)?;
+    let view = scx.get_item_by_resolved_name(view_name)?;
     match view.item_type() {
         CatalogItemType::View => {
             let name = view_name.full_name_str();
@@ -76,7 +76,7 @@ pub fn plan_show_create_view(
 
 pub fn describe_show_create_materialized_view(
     _: &StatementContext,
-    _: ShowCreateMaterializedViewStatement<Aug>,
+    _: &ShowCreateMaterializedViewStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -87,10 +87,10 @@ pub fn describe_show_create_materialized_view(
 
 pub fn plan_show_create_materialized_view(
     scx: &StatementContext,
-    stmt: ShowCreateMaterializedViewStatement<Aug>,
+    stmt: &ShowCreateMaterializedViewStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let name = stmt.materialized_view_name;
-    let mview = scx.get_item_by_resolved_name(&name)?;
+    let name = &stmt.materialized_view_name;
+    let mview = scx.get_item_by_resolved_name(name)?;
     if let CatalogItemType::MaterializedView = mview.item_type() {
         let full_name = name.full_name_str();
         let create_sql = simplify_names(scx.catalog, mview.create_sql())?;
@@ -107,7 +107,7 @@ pub fn plan_show_create_materialized_view(
 
 pub fn describe_show_create_table(
     _: &StatementContext,
-    _: ShowCreateTableStatement<Aug>,
+    _: &ShowCreateTableStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -118,9 +118,9 @@ pub fn describe_show_create_table(
 
 pub fn plan_show_create_table(
     scx: &StatementContext,
-    ShowCreateTableStatement { table_name }: ShowCreateTableStatement<Aug>,
+    ShowCreateTableStatement { table_name }: &ShowCreateTableStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let table = scx.get_item_by_resolved_name(&table_name)?;
+    let table = scx.get_item_by_resolved_name(table_name)?;
     if table.id().is_system() {
         sql_bail!(
             "cannot show create for system object {}",
@@ -143,7 +143,7 @@ pub fn plan_show_create_table(
 
 pub fn describe_show_create_source(
     _: &StatementContext,
-    _: ShowCreateSourceStatement<Aug>,
+    _: &ShowCreateSourceStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -154,9 +154,9 @@ pub fn describe_show_create_source(
 
 pub fn plan_show_create_source(
     scx: &StatementContext,
-    ShowCreateSourceStatement { source_name }: ShowCreateSourceStatement<Aug>,
+    ShowCreateSourceStatement { source_name }: &ShowCreateSourceStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let source = scx.get_item_by_resolved_name(&source_name)?;
+    let source = scx.get_item_by_resolved_name(source_name)?;
     if source.id().is_system() {
         sql_bail!(
             "cannot show create for system object {}",
@@ -179,7 +179,7 @@ pub fn plan_show_create_source(
 
 pub fn describe_show_create_sink(
     _: &StatementContext,
-    _: ShowCreateSinkStatement<Aug>,
+    _: &ShowCreateSinkStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -190,9 +190,9 @@ pub fn describe_show_create_sink(
 
 pub fn plan_show_create_sink(
     scx: &StatementContext,
-    ShowCreateSinkStatement { sink_name }: ShowCreateSinkStatement<Aug>,
+    ShowCreateSinkStatement { sink_name }: &ShowCreateSinkStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let sink = scx.get_item_by_resolved_name(&sink_name)?;
+    let sink = scx.get_item_by_resolved_name(sink_name)?;
     if let CatalogItemType::Sink = sink.item_type() {
         let name = sink_name.full_name_str();
         let create_sql = simplify_names(scx.catalog, sink.create_sql())?;
@@ -209,7 +209,7 @@ pub fn plan_show_create_sink(
 
 pub fn describe_show_create_index(
     _: &StatementContext,
-    _: ShowCreateIndexStatement<Aug>,
+    _: &ShowCreateIndexStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -220,9 +220,9 @@ pub fn describe_show_create_index(
 
 pub fn plan_show_create_index(
     scx: &StatementContext,
-    ShowCreateIndexStatement { index_name }: ShowCreateIndexStatement<Aug>,
+    ShowCreateIndexStatement { index_name }: &ShowCreateIndexStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let index = scx.get_item_by_resolved_name(&index_name)?;
+    let index = scx.get_item_by_resolved_name(index_name)?;
     if let CatalogItemType::Index = index.item_type() {
         let name = index_name.full_name_str();
         let create_sql = simplify_names(scx.catalog, index.create_sql())?;
@@ -239,7 +239,7 @@ pub fn plan_show_create_index(
 
 pub fn describe_show_create_connection(
     _: &StatementContext,
-    _: ShowCreateConnectionStatement<Aug>,
+    _: &ShowCreateConnectionStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -250,9 +250,9 @@ pub fn describe_show_create_connection(
 
 pub fn plan_show_create_connection(
     scx: &StatementContext,
-    ShowCreateConnectionStatement { connection_name }: ShowCreateConnectionStatement<Aug>,
+    ShowCreateConnectionStatement { connection_name }: &ShowCreateConnectionStatement<Aug>,
 ) -> Result<SendRowsPlan, PlanError> {
-    let connection = scx.get_item_by_resolved_name(&connection_name)?;
+    let connection = scx.get_item_by_resolved_name(connection_name)?;
     if let CatalogItemType::Connection = connection.item_type() {
         let name = connection_name.full_name_str();
         let create_sql = simplify_names(scx.catalog, connection.create_sql())?;
@@ -269,15 +269,15 @@ pub fn plan_show_create_connection(
 
 pub fn show_databases<'a>(
     scx: &'a StatementContext<'a>,
-    ShowDatabasesStatement { filter }: ShowDatabasesStatement<Aug>,
+    ShowDatabasesStatement { filter }: &ShowDatabasesStatement<Aug>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT name FROM mz_catalog.mz_databases".to_string();
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 pub fn show_schemas<'a>(
     scx: &'a StatementContext<'a>,
-    ShowSchemasStatement { from, filter }: ShowSchemasStatement<Aug>,
+    ShowSchemasStatement { from, filter }: &ShowSchemasStatement<Aug>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let database_id = match from {
         Some(ResolvedDatabaseName::Database { id, .. }) => id.0,
@@ -294,7 +294,7 @@ pub fn show_schemas<'a>(
         FROM mz_catalog.mz_schemas
         WHERE database_id IS NULL OR database_id = {database_id}",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 pub fn show_objects<'a>(
@@ -303,7 +303,7 @@ pub fn show_objects<'a>(
         object_type,
         from,
         filter,
-    }: ShowObjectsStatement<Aug>,
+    }: &ShowObjectsStatement<Aug>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     match object_type {
         ShowObjectType::Table => show_tables(scx, from, filter),
@@ -329,67 +329,67 @@ pub fn show_objects<'a>(
 
 fn show_connections<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let query = format!(
         "SELECT name, type
         FROM mz_catalog.mz_connections
         WHERE schema_id = {schema_spec}",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_tables<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let query = format!(
         "SELECT name
         FROM mz_catalog.mz_tables
         WHERE schema_id = {schema_spec}",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_sources<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let query = format!(
         "SELECT name, type, size
         FROM mz_catalog.mz_sources
         WHERE schema_id = {schema_spec}"
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_views<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let query = format!(
         "SELECT name
         FROM mz_catalog.mz_views
         WHERE schema_id = {schema_spec}"
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_materialized_views<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    in_cluster: Option<ResolvedClusterName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    in_cluster: &Option<ResolvedClusterName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let mut where_clause = format!("schema_id = {schema_spec}");
 
     if let Some(cluster) = in_cluster {
@@ -403,13 +403,13 @@ fn show_materialized_views<'a>(
          WHERE {where_clause}"
     );
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_sinks<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = if let Some(ResolvedSchemaName::Schema { schema_spec, .. }) = from {
         schema_spec.to_string()
@@ -421,43 +421,43 @@ fn show_sinks<'a>(
          FROM mz_catalog.mz_sinks AS sinks
          WHERE schema_id = {schema_spec}",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_types<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let query = format!(
         "SELECT name
         FROM mz_catalog.mz_types
         WHERE schema_id = {schema_spec}",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 fn show_all_objects<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
     let query = format!(
         "SELECT name, type
         FROM mz_catalog.mz_objects
         WHERE schema_id = {schema_spec}",
     );
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 pub fn show_indexes<'a>(
     scx: &'a StatementContext<'a>,
-    from_schema: Option<ResolvedSchemaName>,
-    on_object: Option<ResolvedObjectName>,
-    in_cluster: Option<ResolvedClusterName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from_schema: &Option<ResolvedSchemaName>,
+    on_object: &Option<ResolvedObjectName>,
+    in_cluster: &Option<ResolvedClusterName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let mut query_filter = Vec::new();
 
@@ -499,14 +499,14 @@ pub fn show_indexes<'a>(
         itertools::join(query_filter.iter(), " AND ")
     );
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 pub fn show_columns<'a>(
     scx: &'a StatementContext<'a>,
-    ShowColumnsStatement { table_name, filter }: ShowColumnsStatement<Aug>,
+    ShowColumnsStatement { table_name, filter }: &ShowColumnsStatement<Aug>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let entry = scx.get_item_by_resolved_name(&table_name)?;
+    let entry = scx.get_item_by_resolved_name(table_name)?;
     let full_name = scx.catalog.resolve_full_name(entry.name());
 
     match entry.item_type() {
@@ -537,7 +537,7 @@ pub fn show_columns<'a>(
     ShowSelect::new(
         scx,
         query,
-        filter,
+        filter.as_ref(),
         Some("position"),
         Some(&["name", "nullable", "type"]),
     )
@@ -545,29 +545,29 @@ pub fn show_columns<'a>(
 
 pub fn show_clusters<'a>(
     scx: &'a StatementContext<'a>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT mz_clusters.name FROM mz_catalog.mz_clusters".to_string();
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 pub fn show_cluster_replicas<'a>(
     scx: &'a StatementContext<'a>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT cluster, replica, size, ready FROM mz_internal.mz_show_cluster_replicas"
         .to_string();
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 pub fn show_secrets<'a>(
     scx: &'a StatementContext<'a>,
-    from: Option<ResolvedSchemaName>,
-    filter: Option<ShowStatementFilter<Aug>>,
+    from: &Option<ResolvedSchemaName>,
+    filter: &Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let schema_spec = scx.resolve_optional_schema(&from)?;
+    let schema_spec = scx.resolve_optional_schema(from)?;
 
     let query = format!(
         "SELECT name
@@ -575,7 +575,7 @@ pub fn show_secrets<'a>(
         WHERE schema_id = {schema_spec}",
     );
 
-    ShowSelect::new(scx, query, filter, None, None)
+    ShowSelect::new(scx, query, filter.as_ref(), None, None)
 }
 
 /// An intermediate result when planning a `SHOW` query.
@@ -598,12 +598,14 @@ impl<'a> ShowSelect<'a> {
     fn new(
         scx: &'a StatementContext,
         query: String,
-        filter: Option<ShowStatementFilter<Aug>>,
+        filter: Option<&ShowStatementFilter<Aug>>,
         order: Option<&str>,
         projection: Option<&[&str]>,
     ) -> Result<ShowSelect<'a>, PlanError> {
         let filter = match filter {
-            Some(ShowStatementFilter::Like(like)) => format!("name LIKE {}", Value::String(like)),
+            Some(ShowStatementFilter::Like(like)) => {
+                format!("name LIKE {}", Value::String(like.to_string()))
+            }
             Some(ShowStatementFilter::Where(expr)) => expr.to_string(),
             None => "true".to_string(),
         };

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -15,7 +15,6 @@
 
 use uuid::Uuid;
 
-use crate::names::Aug;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
@@ -23,6 +22,7 @@ use mz_sql_parser::ast::{
     TableFactor, TableFunction, TableWithJoins, UnresolvedObjectName, Value,
 };
 
+use crate::names::Aug;
 use crate::normalize;
 use crate::plan::{PlanError, StatementContext};
 

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -7,8 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 
 use mz_expr_test_util::generate_explanation;
 use mz_lowertest::*;
@@ -61,10 +62,10 @@ fn convert_input_to_model(input: &str, catalog: &TestCatalog) -> Result<Model, S
                 Ok((stmt, _)) => stmt,
                 Err(e) => return Err(format!("unable to resolve statement {}", e)),
             };
-            if let mz_sql_parser::ast::Statement::Select(query) = stmt {
+            if let mz_sql_parser::ast::Statement::Select(mut query) = stmt {
                 let planned_query = match crate::plan::query::plan_root_query(
                     scx,
-                    query.query,
+                    &mut query.query,
                     QueryLifetime::Static,
                 ) {
                     Ok(planned_query) => planned_query,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
