### PR TITLE
Repr error

### DIFF
--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -20,6 +20,7 @@ fn main() {
         .extern_path(".mz_repr.adt.regex", "::mz_repr::adt::regex")
         .extern_path(".mz_repr.adt.varchar", "::mz_repr::adt::varchar")
         .extern_path(".mz_repr.chrono", "::mz_repr::chrono")
+        .extern_path(".mz_repr.error", "::mz_repr::error")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.row", "::mz_repr")

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -22,6 +22,7 @@ import "repr/src/adt/numeric.proto";
 import "repr/src/adt/regex.proto";
 import "repr/src/adt/varchar.proto";
 import "repr/src/chrono.proto";
+import "repr/src/error.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 import "repr/src/strconv.proto";
@@ -721,5 +722,6 @@ message ProtoEvalError {
         google.protobuf.Empty mz_timestamp_out_of_range = 59;
         google.protobuf.Empty mz_timestamp_step_overflow = 60;
         google.protobuf.Empty timestamp_cannot_be_nan = 61;
+        mz_repr.error.ProtoAdtError adt = 62;
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2489,6 +2489,12 @@ impl From<TimestampError> for EvalError {
     }
 }
 
+impl From<AdtError> for EvalError {
+    fn from(value: AdtError) -> Self {
+        EvalError::Adt(value)
+    }
+}
+
 impl RustType<ProtoEvalError> for EvalError {
     fn into_proto(&self) -> ProtoEvalError {
         use proto_eval_error::Kind::*;

--- a/src/ore/src/checked_ops_complex.rs
+++ b/src/ore/src/checked_ops_complex.rs
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! More generic versions of `num_traits::ops::checked`
+
+pub trait CheckedAddComplex<I>: Sized {
+    type Output;
+    fn checked_add_compex(&self, v: &I) -> Option<Self::Output>;
+}

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -17,6 +17,7 @@ fn main() {
             &[
                 "repr/src/antichain.proto",
                 "repr/src/chrono.proto",
+                "repr/src/error.proto",
                 "repr/src/global_id.proto",
                 "repr/src/row.proto",
                 "repr/src/strconv.proto",
@@ -29,6 +30,7 @@ fn main() {
                 "repr/src/adt/interval.proto",
                 "repr/src/adt/numeric.proto",
                 "repr/src/adt/regex.proto",
+                "repr/src/adt/timestamp.proto",
                 "repr/src/adt/varchar.proto",
             ],
             &[".."],

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -20,6 +20,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::adt::datetime::DateTimeField;
 use crate::adt::numeric::{DecimalLike, Numeric};
+use crate::error::AdtError;
+
+use super::timestamp::TimestampError;
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.interval.rs"));
 
@@ -66,6 +69,16 @@ impl RustType<ProtoInterval> for Interval {
             days: proto.days,
             micros: proto.micros,
         })
+    }
+}
+
+pub enum IntervalError {
+    OutOfRange,
+}
+
+impl crate::error::GenericError for Interval {
+    fn out_of_range() -> AdtError {
+        AdtError::Timestamp(TimestampError::OutOfRange)
     }
 }
 

--- a/src/repr/src/adt/timestamp.proto
+++ b/src/repr/src/adt/timestamp.proto
@@ -1,0 +1,20 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package mz_repr.adt.timestamp;
+
+message ProtoTimestampError {
+    oneof kind {
+        google.protobuf.Empty out_of_range = 1;
+    }
+}

--- a/src/repr/src/error.proto
+++ b/src/repr/src/error.proto
@@ -1,0 +1,24 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+import "repr/src/adt/timestamp.proto";
+
+package mz_repr.error;
+
+message ProtoAdtError {
+    oneof kind {
+        mz_repr.adt.timestamp.ProtoTimestampError timestamp = 1;
+    }
+}

--- a/src/repr/src/error.proto
+++ b/src/repr/src/error.proto
@@ -20,5 +20,7 @@ package mz_repr.error;
 message ProtoAdtError {
     oneof kind {
         mz_repr.adt.timestamp.ProtoTimestampError timestamp = 1;
+        google.protobuf.Empty u_int16_out_of_range = 2;
+        google.protobuf.Empty u_int32_out_of_range = 3;
     }
 }

--- a/src/repr/src/error.rs
+++ b/src/repr/src/error.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+use mz_lowertest::MzReflect;
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
+
+use crate::adt::timestamp::TimestampError;
+
+include!(concat!(env!("OUT_DIR"), "/mz_repr.error.rs"));
+
+#[derive(
+    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+)]
+pub enum AdtError {
+    Timestamp(TimestampError),
+}
+
+impl std::fmt::Display for AdtError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            AdtError::Timestamp(e) => e.fmt(f),
+        }
+    }
+}
+
+impl From<TimestampError> for AdtError {
+    fn from(value: TimestampError) -> Self {
+        AdtError::Timestamp(value)
+    }
+}
+
+impl RustType<ProtoAdtError> for AdtError {
+    fn into_proto(&self) -> ProtoAdtError {
+        use proto_adt_error::Kind::*;
+        let kind = match self {
+            AdtError::Timestamp(t) => Timestamp(t.into_proto()),
+        };
+        ProtoAdtError { kind: Some(kind) }
+    }
+
+    fn from_proto(proto: ProtoAdtError) -> Result<Self, TryFromProtoError> {
+        use proto_adt_error::Kind::*;
+        match proto.kind {
+            Some(kind) => match kind {
+                Timestamp(t) => Ok(AdtError::Timestamp(t.into_rust()?)),
+            },
+            None => Err(TryFromProtoError::missing_field("ProtoAdtError::kind")),
+        }
+    }
+}

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -33,6 +33,7 @@ mod timestamp;
 pub mod adt;
 pub mod antichain;
 pub mod chrono;
+pub mod error;
 pub mod explain_new;
 pub mod global_id;
 pub mod strconv;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -111,6 +111,7 @@ impl TypeCategory {
     pub fn from_param(param: &ParamType) -> Self {
         match param {
             ParamType::Any
+            | ParamType::AnyElement
             | ParamType::ArrayAny
             | ParamType::ArrayAnyCompatible
             | ParamType::AnyCompatible
@@ -674,6 +675,9 @@ pub enum ParamType {
     /// A pseudotype permitting any type, permitting other "Compatibility"-type
     /// parameters to find the best common type.
     AnyCompatible,
+    /// An pseudotype permitting any type, requiring other "Any"-type parameters
+    /// to be of the same type.
+    AnyElement,
     /// An pseudotype permitting any array type, requiring other "Any"-type
     /// parameters to be of the same type.
     ArrayAny,
@@ -716,7 +720,7 @@ impl ParamType {
         use ScalarType::*;
 
         match self {
-            Any | AnyCompatible | ListElementAnyCompatible => true,
+            Any | AnyElement | AnyCompatible | ListElementAnyCompatible => true,
             ArrayAny | ArrayAnyCompatible => matches!(t, Array(..) | Int2Vector),
             ListAny | ListAnyCompatible => matches!(t, List { .. }),
             MapAny | MapAnyCompatible => matches!(t, Map { .. }),
@@ -758,7 +762,8 @@ impl ParamType {
     fn is_polymorphic(&self) -> bool {
         use ParamType::*;
         match self {
-            ArrayAny
+            AnyElement
+            | ArrayAny
             | ArrayAnyCompatible
             | AnyCompatible
             | ListAny
@@ -771,7 +776,7 @@ impl ParamType {
             // polymorphic behavior. For more detail, see
             // `PolymorphicCompatClass::StructuralEq`.
             | RecordAny => true,
-            Any | Plain(_) => false,
+            Any | Plain(_)  => false,
         }
     }
 
@@ -786,6 +791,7 @@ impl ParamType {
             }
             ParamType::Any => "any",
             ParamType::AnyCompatible => "anycompatible",
+            ParamType::AnyElement => "anyelement",
             ParamType::ArrayAny => "anyarray",
             ParamType::ArrayAnyCompatible => "anycompatiblearray",
             ParamType::ListAny => "list",
@@ -1325,7 +1331,7 @@ enum PolymorphicCompatClass {
     /// Represents the older "Any"-style matching of PG polymorphic types, which
     /// constrains all types to be of the same type, i.e. does not attempt to
     /// promote parameters to a best common type.
-    BaseEq,
+    Any,
     /// Represent's Postgres' "anycompatible"-type polymorphic resolution.
     ///
     /// > Selection of the common type considers the actual types of
@@ -1373,7 +1379,7 @@ impl TryFrom<&ParamType> for PolymorphicCompatClass {
         use ParamType::*;
 
         Ok(match param {
-            ArrayAny | ListAny | MapAny | NonVecAny => PolymorphicCompatClass::BaseEq,
+            AnyElement | ArrayAny | ListAny | MapAny | NonVecAny => PolymorphicCompatClass::Any,
             ArrayAnyCompatible | AnyCompatible => PolymorphicCompatClass::BestCommonAny,
             ListAnyCompatible | ListElementAnyCompatible => PolymorphicCompatClass::BestCommonList,
             MapAnyCompatible => PolymorphicCompatClass::BestCommonMap,
@@ -1388,7 +1394,7 @@ impl PolymorphicCompatClass {
         use PolymorphicCompatClass::*;
         match self {
             StructuralEq => from.structural_eq(to),
-            BaseEq => from.base_eq(to),
+            Any => from.base_eq(to),
             _ => typeconv::can_cast(ecx, CastContext::Implicit, from, to),
         }
     }
@@ -1441,9 +1447,11 @@ impl PolymorphicSolution {
         use ParamType::*;
 
         self.seen.push(match param {
-            AnyCompatible | ArrayAny | ListAny | ListAnyCompatible | MapAny | MapAnyCompatible
-            | NonVecAny | RecordAny => seen,
-            ArrayAnyCompatible => seen.map(|array| array.unwrap_array_element_type().clone()),
+            // These represent the keys of their respective compatibility classes.
+            AnyElement | AnyCompatible | ListAnyCompatible |  MapAnyCompatible | NonVecAny | RecordAny => seen,
+            MapAny => seen.map(|array| array.unwrap_map_value_type().clone()),
+            ListAny => seen.map(|array| array.unwrap_list_element_type().clone()),
+            ArrayAny | ArrayAnyCompatible => seen.map(|array| array.unwrap_array_element_type().clone()),
             ListElementAnyCompatible => seen.map(|el| ScalarType::List {
                 custom_id: None,
                 element_type: Box::new(el),
@@ -1496,16 +1504,33 @@ impl PolymorphicSolution {
                         custom_id: None,
                     }),
                     // Do not infer type.
-                    PolymorphicCompatClass::StructuralEq | PolymorphicCompatClass::BaseEq => None,
+                    PolymorphicCompatClass::StructuralEq | PolymorphicCompatClass::Any => None,
                 },
             }
         } else {
             // If we saw any polymorphic parameters, we must have determined the
             // compatibility type.
             let compat = self.compat.as_ref().unwrap();
-            let r = match typeconv::guess_best_common_type(ecx, &self.seen) {
-                Ok(r) => r,
-                Err(_) => return false,
+
+            let r = match compat {
+                PolymorphicCompatClass::Any => {
+                    let mut s = self
+                        .seen
+                        .iter()
+                        .filter_map(|f| f.clone())
+                        .collect::<Vec<_>>();
+                    let (candiate, remaining) =
+                        s.split_first().expect("have at least one non-None element");
+                    if remaining.iter().all(|r| r.base_eq(candiate)) {
+                        s.remove(0)
+                    } else {
+                        return false;
+                    }
+                }
+                _ => match typeconv::guess_best_common_type(ecx, &self.seen) {
+                    Ok(r) => r,
+                    Err(_) => return false,
+                },
             };
 
             // Ensure the best common type is compatible.
@@ -1542,12 +1567,21 @@ impl PolymorphicSolution {
         );
 
         match param {
-            AnyCompatible | ArrayAny | ListAny | ListAnyCompatible | MapAny | MapAnyCompatible
-            | NonVecAny => self.key.clone(),
-            ArrayAnyCompatible => self
+            AnyElement | AnyCompatible | ListAnyCompatible | MapAnyCompatible | NonVecAny => {
+                self.key.clone()
+            }
+            ArrayAny | ArrayAnyCompatible => self
                 .key
                 .as_ref()
                 .map(|key| ScalarType::Array(Box::new(key.clone()))),
+            ListAny => self.key.as_ref().map(|key| ScalarType::List {
+                element_type: Box::new(key.clone()),
+                custom_id: None,
+            }),
+            MapAny => self.key.as_ref().map(|key| ScalarType::Map {
+                value_type: Box::new(key.clone()),
+                custom_id: None,
+            }),
             ListElementAnyCompatible => self
                 .key
                 .as_ref()


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
