### PR TITLE
persist: begin hooking up PersistConfig to LaunchDarkly

### DIFF
--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -359,7 +359,7 @@ static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<String>>> = Lazy::new(|
     safe: true,
 });
 
-/// Controls [`PersistConfig::blob_target_size`].
+/// Controls [`mz_persist_client::cfg::DynamicConfig::blob_target_size`].
 const PERSIST_BLOB_TARGET_SIZE: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("persist_blob_target_size"),
     value: &PersistConfig::DEFAULT_BLOB_TARGET_SIZE,
@@ -368,7 +368,7 @@ const PERSIST_BLOB_TARGET_SIZE: ServerVar<usize> = ServerVar {
     safe: true,
 };
 
-/// Controls [`PersistConfig::compaction_minimum_timeout`].
+/// Controls [`mz_persist_client::cfg::DynamicConfig::compaction_minimum_timeout`].
 const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("persist_compaction_minimum_timeout"),
     value: &PersistConfig::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -161,8 +161,9 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             self.compute_state.max_result_size = v;
         }
 
-        // TODO(#16753): apply config to `self.compute_state.persist_clients`
-        let _ = params.persist;
+        params
+            .persist
+            .apply(self.compute_state.persist_clients.cfg())
     }
 
     fn handle_create_dataflows(

--- a/src/persist-client/README.md
+++ b/src/persist-client/README.md
@@ -105,8 +105,8 @@ bigger than this cap.
   outstanding.
 
 [BatchBuilder]: crate::batch::BatchBuilder
-[blob_target_size]: crate::PersistConfig::blob_target_size
-[batch_builder_max_outstanding_parts]: crate::PersistConfig::batch_builder_max_outstanding_parts
+[blob_target_size]: crate::cfg::DynamicConfig::blob_target_size
+[batch_builder_max_outstanding_parts]: crate::cfg::DynamicConfig::batch_builder_max_outstanding_parts
 
 A persist reader uses as most `3B` memory per [Listen] and per [Subscribe].
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -646,7 +646,7 @@ impl Service for TransactorService {
         // always downgrade the since of critical handles when asked
         config.critical_downgrade_interval = Duration::from_secs(0);
         // set a live diff scan limit such that we'll explore both the fast and slow paths
-        config.state_versions_recent_live_diffs_limit = 5;
+        config.set_state_versions_recent_live_diffs_limit(5);
         let consensus = match &args.consensus_uri {
             Some(consensus_uri) => {
                 let cfg = ConsensusConfig::try_from(

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -11,6 +11,8 @@
 
 //! The tunable knobs for persist.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use mz_build_info::BuildInfo;
@@ -72,79 +74,30 @@ include!(concat!(env!("OUT_DIR"), "/mz_persist_client.cfg.rs"));
 ///
 /// TODO: Move these tuning notes into SessionVar descriptions once we have
 /// SystemVars for most of these.
+//
+// TODO: The configs left here don't react dynamically to changes. Move as many
+// of them to DynamicConfig as possible.
 #[derive(Debug, Clone)]
 pub struct PersistConfig {
     /// Info about which version of the code is running.
     pub(crate) build_version: Version,
+    /// Hostname of this persist user. Stored in state and used for debugging.
+    pub hostname: String,
     /// A clock to use for all leasing and other non-debugging use.
     pub now: NowFn,
-    /// A target maximum size of blob payloads in bytes. If a logical "batch" is
-    /// bigger than this, it will be broken up into smaller, independent pieces.
-    /// This is best-effort, not a guarantee (though as of 2022-06-09, we happen
-    /// to always respect it). This target size doesn't apply for an individual
-    /// update that exceeds it in size, but that scenario is almost certainly a
-    /// mis-use of the system.
-    pub blob_target_size: usize,
-    /// The maximum number of parts (s3 blobs) that [crate::batch::BatchBuilder]
-    /// will pipeline before back-pressuring [crate::batch::BatchBuilder::add]
-    /// calls on previous ones finishing.
-    pub batch_builder_max_outstanding_parts: usize,
+    /// Configurations that can be dynamically updated.
+    pub(crate) dynamic: Arc<DynamicConfig>,
     /// Whether to physically and logically compact batches in blob storage.
     pub compaction_enabled: bool,
-    /// The upper bound on compaction's memory consumption. The value must be at
-    /// least 4*`blob_target_size`. Increasing this value beyond the minimum allows
-    /// compaction to merge together more runs at once, providing greater
-    /// consolidation of updates, at the cost of greater memory usage.
-    pub compaction_memory_bound_bytes: usize,
-    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
-    /// if the number of inputs is at least this many. Compaction is performed
-    /// if any of the heuristic criteria are met (they are OR'd).
-    pub compaction_heuristic_min_inputs: usize,
-    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
-    /// if the number of batch parts is at least this many. Compaction is performed
-    /// if any of the heuristic criteria are met (they are OR'd).
-    pub compaction_heuristic_min_parts: usize,
-    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
-    /// if the number of updates is at least this many. Compaction is performed
-    /// if any of the heuristic criteria are met (they are OR'd).
-    pub compaction_heuristic_min_updates: usize,
     /// In Compactor::compact_and_apply_background, the maximum number of concurrent
     /// compaction requests that can execute for a given shard.
     pub compaction_concurrency_limit: usize,
     /// In Compactor::compact_and_apply_background, the maximum number of pending
     /// compaction requests to queue.
     pub compaction_queue_size: usize,
-    /// The maximum number of concurrent blob deletes during garbage collection.
-    pub gc_blob_delete_concurrency_limit: usize,
-    /// In Compactor::compact_and_apply_background, the minimum amount of time to
-    /// allow a compaction request to run before timing it out. A request may be
-    /// given a timeout greater than this value depending on the inputs' size
-    pub compaction_minimum_timeout: Duration,
     /// The maximum size of the connection pool to Postgres/CRDB when performing
     /// consensus reads and writes.
     pub consensus_connection_pool_max_size: usize,
-    /// The minimum TTL of a connection to Postgres/CRDB before it is proactively
-    /// terminated. Connections are routinely culled to balance load against the
-    /// downstream database.
-    pub consensus_connection_pool_ttl: Duration,
-    /// The minimum time between TTLing connections to Postgres/CRDB. This delay is
-    /// used to stagger reconnections to avoid stampedes and high tail latencies.
-    /// This value should be much less than `consensus_connection_pool_ttl` so that
-    /// reconnections are biased towards terminating the oldest connections first.
-    /// A value of `consensus_connection_pool_ttl / consensus_connection_pool_max_size`
-    /// is likely a good place to start so that all connections are rotated when the
-    /// pool is fully used.
-    pub consensus_connection_pool_ttl_stagger: Duration,
-    /// The # of diffs to initially scan when fetching the latest consensus state, to
-    /// determine which requests go down the fast vs slow path. Should be large enough
-    /// to fetch all live diffs in the steady-state, and small enough to query Consensus
-    /// at high volume. Steady-state usage should accommodate readers that require
-    /// seqno-holds for reasonable amounts of time, which to start we say is 10s of minutes.
-    ///
-    /// This value ought to be defined in terms of `NEED_ROLLUP_THRESHOLD` to approximate
-    /// when we expect rollups to be written and therefore when old states will be truncated
-    /// by GC.
-    pub state_versions_recent_live_diffs_limit: usize,
     /// Length of time after a writer's last operation after which the writer
     /// may be expired.
     pub writer_lease_duration: Duration,
@@ -153,8 +106,6 @@ pub struct PersistConfig {
     pub reader_lease_duration: Duration,
     /// Length of time between critical handles' calls to downgrade since
     pub critical_downgrade_interval: Duration,
-    /// Hostname of this persist user. Stored in state and used for debugging.
-    pub hostname: String,
 }
 
 impl PersistConfig {
@@ -165,23 +116,25 @@ impl PersistConfig {
         Self {
             build_version: build_info.semver_version(),
             now,
-            blob_target_size: Self::DEFAULT_BLOB_TARGET_SIZE,
-            batch_builder_max_outstanding_parts: 2,
+            dynamic: Arc::new(DynamicConfig {
+                batch_builder_max_outstanding_parts: AtomicUsize::new(2),
+                blob_target_size: AtomicUsize::new(Self::DEFAULT_BLOB_TARGET_SIZE),
+                compaction_heuristic_min_inputs: AtomicUsize::new(8),
+                compaction_heuristic_min_parts: AtomicUsize::new(8),
+                compaction_heuristic_min_updates: AtomicUsize::new(1024),
+                compaction_memory_bound_bytes: AtomicUsize::new(1024 * MB),
+                compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
+                consensus_connection_pool_ttl: Duration::from_secs(300),
+                consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
+                gc_blob_delete_concurrency_limit: AtomicUsize::new(32),
+                state_versions_recent_live_diffs_limit: AtomicUsize::new(usize::cast_from(
+                    30 * Self::NEED_ROLLUP_THRESHOLD,
+                )),
+            }),
             compaction_enabled: !compaction_disabled,
-            compaction_memory_bound_bytes: 1024 * MB,
-            compaction_heuristic_min_inputs: 8,
-            compaction_heuristic_min_parts: 8,
-            compaction_heuristic_min_updates: 1024,
             compaction_concurrency_limit: 5,
             compaction_queue_size: 20,
-            gc_blob_delete_concurrency_limit: 32,
-            compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
             consensus_connection_pool_max_size: 50,
-            consensus_connection_pool_ttl: Duration::from_secs(300),
-            consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
-            state_versions_recent_live_diffs_limit: usize::cast_from(
-                30 * Self::NEED_ROLLUP_THRESHOLD,
-            ),
             writer_lease_duration: 60 * Duration::from_secs(60),
             reader_lease_duration: Self::DEFAULT_READ_LEASE_DURATION,
             critical_downgrade_interval: Duration::from_secs(30),
@@ -208,9 +161,9 @@ impl PersistConfig {
 pub(crate) const MB: usize = 1024 * 1024;
 
 impl PersistConfig {
-    /// Default value for [`PersistConfig::blob_target_size`].
+    /// Default value for [`DynamicConfig::blob_target_size`].
     pub const DEFAULT_BLOB_TARGET_SIZE: usize = 128 * MB;
-    /// Default value for [`PersistConfig::compaction_minimum_timeout`].
+    /// Default value for [`DynamicConfig::compaction_minimum_timeout`].
     pub const DEFAULT_COMPACTION_MINIMUM_TIMEOUT: Duration = Duration::from_secs(90);
 
     // Move this to a PersistConfig field when we actually have read leases.
@@ -221,6 +174,14 @@ impl PersistConfig {
 
     // Tuning notes: Picked arbitrarily.
     pub(crate) const NEED_ROLLUP_THRESHOLD: u64 = 128;
+
+    // TODO: Get rid of this in favor of using PersistParameters at the
+    // relevant callsites.
+    pub fn set_state_versions_recent_live_diffs_limit(&self, val: usize) {
+        self.dynamic
+            .state_versions_recent_live_diffs_limit
+            .store(val, DynamicConfig::STORE_ORDERING);
+    }
 }
 
 impl ConsensusKnobs for PersistConfig {
@@ -229,11 +190,155 @@ impl ConsensusKnobs for PersistConfig {
     }
 
     fn connection_pool_ttl(&self) -> Duration {
-        self.consensus_connection_pool_ttl
+        self.dynamic.consensus_connection_pool_ttl()
     }
 
     fn connection_pool_ttl_stagger(&self) -> Duration {
+        self.dynamic.consensus_connection_pool_ttl_stagger()
+    }
+}
+
+/// Persist configurations that can be dynamically updated.
+///
+/// Persist is expected to react to each of these such that updating the value
+/// returned by the function takes effect in persist (i.e. no caching it). This
+/// should happen "as promptly as reasonably possible" where that's defined by
+/// the tradeoffs of complexity vs promptness. For example, we might use a
+/// consistent version of [Self::blob_target_size] for the entirety of a single
+/// compaction call. However, it should _never_ require a process restart for an
+/// update of these to take effect.
+///
+/// These are hooked up to LaunchDarkly.
+#[derive(Debug)]
+pub struct DynamicConfig {
+    batch_builder_max_outstanding_parts: AtomicUsize,
+    blob_target_size: AtomicUsize,
+    compaction_heuristic_min_inputs: AtomicUsize,
+    compaction_heuristic_min_parts: AtomicUsize,
+    compaction_heuristic_min_updates: AtomicUsize,
+    compaction_memory_bound_bytes: AtomicUsize,
+    gc_blob_delete_concurrency_limit: AtomicUsize,
+    state_versions_recent_live_diffs_limit: AtomicUsize,
+
+    // TODO: Figure out how to make these dynamic.
+    compaction_minimum_timeout: Duration,
+    consensus_connection_pool_ttl: Duration,
+    consensus_connection_pool_ttl_stagger: Duration,
+}
+
+impl DynamicConfig {
+    // TODO: Decide if we can relax these.
+    const LOAD_ORDERING: Ordering = Ordering::SeqCst;
+    const STORE_ORDERING: Ordering = Ordering::SeqCst;
+
+    /// The maximum number of parts (s3 blobs) that [crate::batch::BatchBuilder]
+    /// will pipeline before back-pressuring [crate::batch::BatchBuilder::add]
+    /// calls on previous ones finishing.
+    pub fn batch_builder_max_outstanding_parts(&self) -> usize {
+        self.batch_builder_max_outstanding_parts
+            .load(Self::LOAD_ORDERING)
+    }
+
+    /// A target maximum size of blob payloads in bytes. If a logical "batch" is
+    /// bigger than this, it will be broken up into smaller, independent pieces.
+    /// This is best-effort, not a guarantee (though as of 2022-06-09, we happen
+    /// to always respect it). This target size doesn't apply for an individual
+    /// update that exceeds it in size, but that scenario is almost certainly a
+    /// mis-use of the system.
+    pub fn blob_target_size(&self) -> usize {
+        self.blob_target_size.load(Self::LOAD_ORDERING)
+    }
+
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of inputs is at least this many. Compaction is performed
+    /// if any of the heuristic criteria are met (they are OR'd).
+    pub fn compaction_heuristic_min_inputs(&self) -> usize {
+        self.compaction_heuristic_min_inputs
+            .load(Self::LOAD_ORDERING)
+    }
+
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of batch parts is at least this many. Compaction is performed
+    /// if any of the heuristic criteria are met (they are OR'd).
+    pub fn compaction_heuristic_min_parts(&self) -> usize {
+        self.compaction_heuristic_min_parts
+            .load(Self::LOAD_ORDERING)
+    }
+
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of updates is at least this many. Compaction is performed
+    /// if any of the heuristic criteria are met (they are OR'd).
+    pub fn compaction_heuristic_min_updates(&self) -> usize {
+        self.compaction_heuristic_min_updates
+            .load(Self::LOAD_ORDERING)
+    }
+
+    /// The upper bound on compaction's memory consumption. The value must be at
+    /// least 4*`blob_target_size`. Increasing this value beyond the minimum allows
+    /// compaction to merge together more runs at once, providing greater
+    /// consolidation of updates, at the cost of greater memory usage.
+    pub fn compaction_memory_bound_bytes(&self) -> usize {
+        self.compaction_memory_bound_bytes.load(Self::LOAD_ORDERING)
+    }
+
+    /// In Compactor::compact_and_apply_background, the minimum amount of time to
+    /// allow a compaction request to run before timing it out. A request may be
+    /// given a timeout greater than this value depending on the inputs' size
+    pub fn compaction_minimum_timeout(&self) -> Duration {
+        self.compaction_minimum_timeout
+    }
+
+    /// The minimum TTL of a connection to Postgres/CRDB before it is proactively
+    /// terminated. Connections are routinely culled to balance load against the
+    /// downstream database.
+    pub fn consensus_connection_pool_ttl(&self) -> Duration {
+        self.consensus_connection_pool_ttl
+    }
+    /// The minimum time between TTLing connections to Postgres/CRDB. This delay is
+    /// used to stagger reconnections to avoid stampedes and high tail latencies.
+    /// This value should be much less than `consensus_connection_pool_ttl` so that
+    /// reconnections are biased towards terminating the oldest connections first.
+    /// A value of `consensus_connection_pool_ttl / consensus_connection_pool_max_size`
+    /// is likely a good place to start so that all connections are rotated when the
+    /// pool is fully used.
+    pub fn consensus_connection_pool_ttl_stagger(&self) -> Duration {
         self.consensus_connection_pool_ttl_stagger
+    }
+
+    /// The maximum number of concurrent blob deletes during garbage collection.
+    pub fn gc_blob_delete_concurrency_limit(&self) -> usize {
+        self.gc_blob_delete_concurrency_limit
+            .load(Self::LOAD_ORDERING)
+    }
+
+    /// The # of diffs to initially scan when fetching the latest consensus state, to
+    /// determine which requests go down the fast vs slow path. Should be large enough
+    /// to fetch all live diffs in the steady-state, and small enough to query Consensus
+    /// at high volume. Steady-state usage should accommodate readers that require
+    /// seqno-holds for reasonable amounts of time, which to start we say is 10s of minutes.
+    ///
+    /// This value ought to be defined in terms of `NEED_ROLLUP_THRESHOLD` to approximate
+    /// when we expect rollups to be written and therefore when old states will be truncated
+    /// by GC.
+    pub fn state_versions_recent_live_diffs_limit(&self) -> usize {
+        self.state_versions_recent_live_diffs_limit
+            .load(Self::LOAD_ORDERING)
+    }
+
+    // TODO: Get rid of these in favor of using PersistParameters at the
+    // relevant callsites.
+    #[cfg(test)]
+    pub fn set_blob_target_size(&self, val: usize) {
+        self.blob_target_size.store(val, Self::LOAD_ORDERING);
+    }
+    #[cfg(test)]
+    pub fn set_batch_builder_max_outstanding_parts(&self, val: usize) {
+        self.batch_builder_max_outstanding_parts
+            .store(val, Self::LOAD_ORDERING);
+    }
+    pub fn set_compaction_memory_bound_bytes(&self, val: usize) {
+        self.compaction_memory_bound_bytes
+            .store(val, Self::LOAD_ORDERING);
     }
 }
 
@@ -266,26 +371,65 @@ impl BlobKnobs for PersistConfig {
 /// interpreted to mean "use the previous value".
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Arbitrary)]
 pub struct PersistParameters {
-    /// Configures [`PersistConfig::blob_target_size`].
+    /// Configures [`DynamicConfig::blob_target_size`].
     pub blob_target_size: Option<usize>,
-    /// Configures [`PersistConfig::compaction_minimum_timeout`].
+    /// Configures [`DynamicConfig::compaction_minimum_timeout`].
     pub compaction_minimum_timeout: Option<Duration>,
 }
 
 impl PersistParameters {
     /// Update the parameter values with the set ones from `other`.
     pub fn update(&mut self, other: PersistParameters) {
-        if let Some(v) = other.blob_target_size {
-            self.blob_target_size = Some(v);
+        // Deconstruct self and other so we get a compile failure if new fields
+        // are added.
+        let Self {
+            blob_target_size: self_blob_target_size,
+            compaction_minimum_timeout: self_compaction_minimum_timeout,
+        } = self;
+        let Self {
+            blob_target_size: other_blob_target_size,
+            compaction_minimum_timeout: other_compaction_minimum_timeout,
+        } = other;
+        if let Some(v) = other_blob_target_size {
+            *self_blob_target_size = Some(v);
         }
-        if let Some(v) = other.compaction_minimum_timeout {
-            self.compaction_minimum_timeout = Some(v);
+        if let Some(v) = other_compaction_minimum_timeout {
+            *self_compaction_minimum_timeout = Some(v);
         }
     }
 
     /// Return whether all parameters are unset.
     pub fn all_unset(&self) -> bool {
-        self.blob_target_size.is_none() && self.compaction_minimum_timeout.is_none()
+        // TODO: Where is this called? We could save a tiny bit of boilerplate
+        // by comparing self to Self::default().
+        //
+        // Deconstruct self so we get a compile failure if new fields are added.
+        let Self {
+            blob_target_size,
+            compaction_minimum_timeout,
+        } = self;
+        blob_target_size.is_none() && compaction_minimum_timeout.is_none()
+    }
+
+    /// Applies the parameter values to persist's in-memory config object.
+    ///
+    /// Note that these overrides are not all applied atomically: i.e. it's
+    /// possible for persist to race with this and see some but not all of the
+    /// parameters applied.
+    pub fn apply(&self, cfg: &PersistConfig) {
+        // Deconstruct self so we get a compile failure if new fields are added.
+        let Self {
+            blob_target_size,
+            compaction_minimum_timeout,
+        } = self;
+        if let Some(blob_target_size) = blob_target_size {
+            cfg.dynamic
+                .blob_target_size
+                .store(*blob_target_size, DynamicConfig::STORE_ORDERING);
+        }
+        if let Some(_compaction_minimum_timeout) = compaction_minimum_timeout {
+            // TODO: Figure out how to represent Durations in DynamicConfig.
+        }
     }
 }
 

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -208,7 +208,15 @@ impl ConsensusKnobs for PersistConfig {
 /// compaction call. However, it should _never_ require a process restart for an
 /// update of these to take effect.
 ///
-/// These are hooked up to LaunchDarkly.
+/// These are hooked up to LaunchDarkly. Specifically, LaunchDarkly configs are
+/// serialized into a [PersistParameters]. In environmentd, these are applied
+/// directly via [PersistParameters::apply] to the [PersistConfig] in
+/// [crate::cache::PersistClientCache]. There is one `PersistClientCache` per
+/// process, and every `PersistConfig` shares the same `Arc<DynamicConfig>`, so
+/// this affects all [DynamicConfig] usage in the process. The
+/// `PersistParameters` is also sent via the compute and storage command
+/// streams, which then apply it to all computed/storaged/clusterd processes as
+/// well.
 #[derive(Debug)]
 pub struct DynamicConfig {
     batch_builder_max_outstanding_parts: AtomicUsize,

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -34,7 +34,7 @@ use tracing::log::warn;
 use tracing::{debug, debug_span, trace, Instrument, Span};
 
 use crate::async_runtime::CpuHeavyRuntime;
-use crate::batch::BatchBuilder;
+use crate::batch::{BatchBuilder, BatchBuilderConfig};
 use crate::cfg::MB;
 use crate::fetch::{fetch_batch_part, EncodedPart};
 use crate::internal::machine::{retry_external, Machine};
@@ -63,6 +63,23 @@ pub struct CompactReq<T> {
 pub struct CompactRes<T> {
     /// The compacted batch.
     pub output: HollowBatch<T>,
+}
+
+/// A snapshot of dynamic configs to make it easier to reason about an
+/// individual run of compaction.
+#[derive(Debug, Clone)]
+pub struct CompactConfig {
+    pub(crate) compaction_memory_bound_bytes: usize,
+    pub(crate) batch: BatchBuilderConfig,
+}
+
+impl From<&PersistConfig> for CompactConfig {
+    fn from(value: &PersistConfig) -> Self {
+        CompactConfig {
+            compaction_memory_bound_bytes: value.dynamic.compaction_memory_bound_bytes(),
+            batch: BatchBuilderConfig::from(value),
+        }
+    }
 }
 
 /// A service for performing physical and logical compaction.
@@ -194,11 +211,11 @@ where
         // were just written, but it does result in non-trivial blob traffic
         // (especially in aggregate). This heuristic is something we'll need to
         // tune over time.
-        let should_compact = req.inputs.len() >= self.cfg.compaction_heuristic_min_inputs
+        let should_compact = req.inputs.len() >= self.cfg.dynamic.compaction_heuristic_min_inputs()
             || req.inputs.iter().map(|x| x.parts.len()).sum::<usize>()
-                >= self.cfg.compaction_heuristic_min_parts
+                >= self.cfg.dynamic.compaction_heuristic_min_parts()
             || req.inputs.iter().map(|x| x.len).sum::<usize>()
-                >= self.cfg.compaction_heuristic_min_updates;
+                >= self.cfg.dynamic.compaction_heuristic_min_updates();
         if !should_compact {
             self.metrics.compaction.skipped.inc();
             return None;
@@ -249,7 +266,7 @@ where
             .sum::<usize>();
         let timeout = Duration::max(
             // either our minimum timeout
-            cfg.compaction_minimum_timeout,
+            cfg.dynamic.compaction_minimum_timeout(),
             // or 1s per MB of input data
             Duration::from_secs(u64::cast_from(total_input_bytes / MB)),
         );
@@ -269,7 +286,7 @@ where
                 .spawn_named(
                     || "persist::compact::consolidate",
                     Self::compact(
-                        cfg.clone(),
+                        CompactConfig::from(&cfg),
                         Arc::clone(&blob),
                         Arc::clone(&metrics),
                         Arc::clone(&cpu_heavy_runtime),
@@ -346,7 +363,7 @@ where
     ///     2. fetching parts from runs
     ///     3. additional in-flight requests to Blob
     ///
-    /// 1. In-progress work is bounded by 2 * [crate::PersistConfig::blob_target_size]. This
+    /// 1. In-progress work is bounded by 2 * [BatchBuilderConfig::blob_target_size]. This
     ///    usage is met at two mutually exclusive moments:
     ///   * When reading in a part, we hold the columnar format in memory while writing its
     ///     contents into a heap.
@@ -356,14 +373,14 @@ where
     /// 2. When compacting runs, only 1 part from each one is held in memory at a time.
     ///    Compaction will determine an appropriate number of runs to compact together
     ///    given the memory bound and accounting for the reservation in (1). A minimum
-    ///    of 2 * [crate::PersistConfig::blob_target_size] of memory is expected, to be
+    ///    of 2 * [BatchBuilderConfig::blob_target_size] of memory is expected, to be
     ///    able to at least have the capacity to compact two runs together at a time,
     ///    and more runs will be compacted together if more memory is available.
     ///
     /// 3. If there is excess memory after accounting for (1) and (2), we increase the
     ///    number of outstanding parts we can keep in-flight to Blob.
     pub async fn compact(
-        cfg: PersistConfig,
+        cfg: CompactConfig,
         blob: Arc<dyn Blob + Send + Sync>,
         metrics: Arc<Metrics>,
         cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
@@ -372,9 +389,9 @@ where
     ) -> Result<CompactRes<T>, anyhow::Error> {
         let () = Self::validate_req(&req)?;
         // compaction needs memory enough for at least 2 runs and 2 in-progress parts
-        assert!(cfg.compaction_memory_bound_bytes >= 4 * cfg.blob_target_size);
+        assert!(cfg.compaction_memory_bound_bytes >= 4 * cfg.batch.blob_target_size);
         // reserve space for the in-progress part to be held in-mem representation and columnar
-        let in_progress_part_reserved_memory_bytes = 2 * cfg.blob_target_size;
+        let in_progress_part_reserved_memory_bytes = 2 * cfg.batch.blob_target_size;
         // then remaining memory will go towards pulling down as many runs as we can
         let run_reserved_memory_bytes =
             cfg.compaction_memory_bound_bytes - in_progress_part_reserved_memory_bytes;
@@ -397,11 +414,11 @@ where
             // flight, but if we have excess, we can use it to increase our write parallelism
             let extra_outstanding_parts = (run_reserved_memory_bytes
                 .saturating_sub(run_chunk_max_memory_usage))
-                / cfg.blob_target_size;
-            let mut compact_cfg = cfg.clone();
-            compact_cfg.batch_builder_max_outstanding_parts = 1 + extra_outstanding_parts;
+                / cfg.batch.blob_target_size;
+            let mut run_cfg = cfg.clone();
+            run_cfg.batch.batch_builder_max_outstanding_parts = 1 + extra_outstanding_parts;
             let batch = Self::compact_runs(
-                &compact_cfg,
+                &run_cfg,
                 &req.shard_id,
                 &req.desc,
                 runs,
@@ -462,7 +479,7 @@ where
     /// determine the order in which runs are selected.
     fn chunk_runs<'a>(
         req: &'a CompactReq<T>,
-        cfg: &PersistConfig,
+        cfg: &CompactConfig,
         metrics: &Metrics,
         run_reserved_memory_bytes: usize,
     ) -> Vec<(Vec<(&'a Description<T>, &'a [HollowBatchPart])>, usize)> {
@@ -478,7 +495,7 @@ where
                 .iter()
                 .map(|x| x.encoded_size_bytes)
                 .max()
-                .unwrap_or(cfg.blob_target_size);
+                .unwrap_or(cfg.batch.blob_target_size);
             current_chunk.push(*run);
             current_chunk_max_memory_usage += run_greatest_part_size;
 
@@ -488,7 +505,7 @@ where
                     .iter()
                     .map(|x| x.encoded_size_bytes)
                     .max()
-                    .unwrap_or(cfg.blob_target_size);
+                    .unwrap_or(cfg.batch.blob_target_size);
 
                 // if we can fit the next run in our chunk without going over our reserved memory, we should do so
                 if current_chunk_max_memory_usage + next_run_greatest_part_size
@@ -563,7 +580,7 @@ where
     /// Maximum possible memory usage is `(# runs + 2) * [crate::PersistConfig::blob_target_size]`
     async fn compact_runs<'a>(
         // note: 'a cannot be elided due to https://github.com/rust-lang/rust/issues/63033
-        cfg: &'a PersistConfig,
+        cfg: &'a CompactConfig,
         shard_id: &'a ShardId,
         desc: &'a Description<T>,
         runs: Vec<(&'a Description<T>, &'a [HollowBatchPart])>,
@@ -579,7 +596,7 @@ where
         // between the two.
         //
         // For now, invent some some extra budget out of thin air for prefetch.
-        let prefetch_budget_bytes = 2 * cfg.blob_target_size;
+        let prefetch_budget_bytes = 2 * cfg.batch.blob_target_size;
 
         let mut sorted_updates = BinaryHeap::new();
 
@@ -600,7 +617,7 @@ where
         let mut timings = Timings::default();
 
         let mut batch = BatchBuilder::new(
-            cfg.clone(),
+            cfg.batch.clone(),
             Arc::clone(&metrics),
             metrics.compaction.batch.clone(),
             desc.lower().clone(),
@@ -933,8 +950,8 @@ mod tests {
             (("1".to_owned(), "one".to_owned()), 1, 1),
         ];
 
-        let mut cache = new_test_client_cache();
-        cache.cfg.blob_target_size = 100;
+        let cache = new_test_client_cache();
+        cache.cfg.dynamic.set_blob_target_size(100);
         let (mut write, _) = cache
             .open(PersistLocation {
                 blob_uri: "mem://".to_owned(),
@@ -963,7 +980,7 @@ mod tests {
             inputs: vec![b0, b1],
         };
         let res = Compactor::<String, (), u64, i64>::compact(
-            write.cfg.clone(),
+            CompactConfig::from(&write.cfg),
             Arc::clone(&write.blob),
             Arc::clone(&write.metrics),
             Arc::new(CpuHeavyRuntime::new()),

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -228,7 +228,13 @@ where
             futures.collect().await
         }
 
-        let delete_semaphore = Semaphore::new(machine.applier.cfg.gc_blob_delete_concurrency_limit);
+        let delete_semaphore = Semaphore::new(
+            machine
+                .applier
+                .cfg
+                .dynamic
+                .gc_blob_delete_concurrency_limit(),
+        );
 
         let mut step_start = Instant::now();
         let mut report_step_timing = |counter: &Counter| {

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -476,7 +476,7 @@ impl StateVersions {
         T: Timestamp + Lattice + Codec64,
     {
         let path = shard_id.to_string();
-        let scan_limit = self.cfg.state_versions_recent_live_diffs_limit;
+        let scan_limit = self.cfg.dynamic.state_versions_recent_live_diffs_limit();
         let oldest_diffs =
             retry_external(&self.metrics.retries.external.fetch_state_scan, || async {
                 self.consensus

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -652,8 +652,8 @@ mod tests {
         // Configure an aggressively small blob_target_size so we get some
         // amount of coverage of that in tests. Similarly, for max_outstanding.
         let mut cache = PersistClientCache::new_no_metrics();
-        cache.cfg.blob_target_size = 10;
-        cache.cfg.batch_builder_max_outstanding_parts = 1;
+        cache.cfg.dynamic.set_blob_target_size(10);
+        cache.cfg.dynamic.set_batch_builder_max_outstanding_parts(1);
 
         // Enable compaction in tests to ensure we get coverage.
         cache.cfg.compaction_enabled = true;

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -29,7 +29,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug_span, instrument, warn, Instrument};
 use uuid::Uuid;
 
-use crate::batch::{validate_truncate_batch, Added, Batch, BatchBuilder};
+use crate::batch::{validate_truncate_batch, Added, Batch, BatchBuilder, BatchBuilderConfig};
 use crate::error::{InvalidUsage, UpperMismatch};
 use crate::internal::compact::Compactor;
 use crate::internal::encoding::SerdeWriterEnrichedHollowBatch;
@@ -524,7 +524,7 @@ where
     /// O(MB) come talk to us.
     pub fn builder(&mut self, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
         BatchBuilder::new(
-            self.cfg.clone(),
+            BatchBuilderConfig::from(&self.cfg),
             Arc::clone(&self.metrics),
             self.metrics.user.clone(),
             lower,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -910,7 +910,7 @@ where
     }
 
     fn update_configuration(&mut self, config_params: StorageParameters) {
-        // TODO(#16753): apply config to `self.persist`
+        config_params.persist.apply(self.persist.cfg());
 
         for client in self.state.clients.values_mut() {
             client.send(StorageCommand::UpdateConfiguration(config_params.clone()));

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -963,9 +963,7 @@ impl StorageState {
             StorageCommand::InitializationComplete => (),
             StorageCommand::UpdateConfiguration(params) => {
                 tracing::info!("Applying configuration update: {params:?}");
-
-                // TODO(#16753): apply config to `self.storage_state.persist_clients`
-                let _ = params.persist;
+                params.persist.apply(self.persist_clients.cfg());
             }
             StorageCommand::CreateSources(ingestions) => {
                 for ingestion in ingestions {


### PR DESCRIPTION
This introduces DynamicConfig, which is a new abstraction around
configuration that can change on a lifetime shorter than a process. It
also hooks up blob_target_size end-to-end between LaunchDarkly and
PersistConfig (huge ty to Jan for doing all the hard bits here).

All configs where the usage currently adjusted dynamically are moved to
DynamicConfig. However, intentionally left out of scope:
- Hooking up compaction_minimum_timeout up end-to-end. Handling dynamic
  configs of type Duration has some tradeoffs we still need to explore.
- Making Vars and LaunchDarkly entries for every persist config; this is
  entirely boilerplate but it's a _lot_ of boilerplate

This hooks up the last mile of LaunchDarkly->PersistConfig and thus...

Closes #16753

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
