### PR TITLE
compute: wire up persist_source flow control

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -25,6 +25,7 @@ use timely::progress::frontier::Antichain;
 use timely::progress::reachability::logging::TrackerEvent;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, Mutex};
+use tracing::{error, span, Level};
 use uuid::Uuid;
 
 use mz_compute_client::command::{ComputeCommand, ComputeCommandHistory, ComputeParameter, Peek};
@@ -41,7 +42,7 @@ use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
 use mz_timely_util::activator::RcActivator;
 use mz_timely_util::operator::CollectionExt;
-use tracing::{error, span, Level};
+use mz_timely_util::probe;
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
@@ -65,6 +66,12 @@ pub struct ComputeState {
     /// Frontier of sink writes (all subsequent writes will be at times at or
     /// equal to this frontier)
     pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
+    /// Probe handles for regulating the output of dataflow sources.
+    ///
+    /// Keys are IDs of indexes that are (transitively) fed by a flow-controlled source. New
+    /// dataflows that depend on these indexes are expected to report their output frontiers
+    /// through the corresponding probe handles.
+    pub flow_control_probes: HashMap<GlobalId, Vec<probe::Handle<Timestamp>>>,
     /// Peek commands that are awaiting fulfillment.
     pub pending_peeks: HashMap<Uuid, PendingPeek>,
     /// Tracks the frontier information that has been sent over `response_tx`.
@@ -218,6 +225,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 self.compute_state.sink_tokens.remove(&id);
                 // Index-specific work:
                 self.compute_state.traces.del_trace(&id);
+                self.compute_state.flow_control_probes.remove(&id);
 
                 // Work common to sinks and indexes (removing frontier tracking and cleaning up logging).
                 let prev_frontier = self

--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -28,8 +28,14 @@ pub(crate) fn persist_sink<G>(
     let desired_collection = log_collection.map(Ok);
     let as_of = Antichain::from_elem(Timestamp::minimum());
 
-    let token =
-        crate::sink::persist_sink(target_id, target, desired_collection, as_of, compute_state);
+    let token = crate::sink::persist_sink(
+        target_id,
+        target,
+        desired_collection,
+        as_of,
+        compute_state,
+        Vec::new(),
+    );
 
     compute_state.sink_tokens.insert(
         target_id,

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -21,6 +21,7 @@ use mz_expr::{permutation_for_arrangement, MapFilterProject};
 use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
+use mz_timely_util::probe;
 
 use crate::compute_state::SinkToken;
 use crate::render::{context::Context, RenderTimestamp};
@@ -38,6 +39,7 @@ where
         import_ids: BTreeSet<GlobalId>,
         sink_id: GlobalId,
         sink: &ComputeSinkDesc<CollectionMetadata>,
+        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) {
         let sink_render = get_sink_render_for::<G>(&sink.connection);
 
@@ -80,6 +82,7 @@ where
             sink_id,
             ok_collection,
             err_collection,
+            probes,
         );
 
         if let Some(sink_token) = sink_token {
@@ -108,6 +111,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
+        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = mz_repr::Timestamp>;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -603,6 +603,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         std::cell::RefCell::new(Vec::new()),
                     ),
                     sink_write_frontiers: HashMap::new(),
+                    flow_control_probes: HashMap::new(),
                     pending_peeks: HashMap::new(),
                     reported_frontiers: HashMap::new(),
                     dropped_collections: Vec::new(),

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -38,6 +38,7 @@ use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sources::SourceData;
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::probe::{self, ProbeNotify};
 
 use crate::compute_state::ComputeState;
 use crate::render::sinks::SinkRender;
@@ -53,6 +54,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
+        probes: Vec<probe::Handle<Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
@@ -70,6 +72,7 @@ where
             desired_collection,
             sink.as_of.frontier.clone(),
             compute_state,
+            probes,
         )
     }
 }
@@ -80,6 +83,7 @@ pub(crate) fn persist_sink<G>(
     desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
     as_of: Antichain<Timestamp>,
     compute_state: &mut ComputeState,
+    probes: Vec<probe::Handle<Timestamp>>,
 ) -> Option<Rc<dyn Any>>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -115,6 +119,7 @@ where
             persist_collection,
             as_of,
             compute_state,
+            probes,
         ),
         token,
     )))
@@ -148,6 +153,7 @@ fn install_desired_into_persist<G>(
     persist_collection: Collection<G, Result<Row, DataflowError>, Diff>,
     as_of: Antichain<Timestamp>,
     compute_state: &mut crate::compute_state::ComputeState,
+    mut probes: Vec<probe::Handle<Timestamp>>,
 ) -> Option<Rc<dyn Any>>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -208,6 +214,10 @@ where
     );
 
     append_frontier_stream.connect_loop(persist_feedback_handle);
+
+    for handle in &mut probes {
+        append_frontier_stream.probe_notify_with(handle);
+    }
 
     let token = Rc::new((mint_token, write_token, append_token));
 


### PR DESCRIPTION
This PR introduces frontier feedback edges from dataflow outputs to the `persist_source`s they (transitively) depend on. `persist_source`s can use this feedback to limit their output according to a specified limit on in-flight bytes.

The feedback is implemented by connecting probes to the dataflow outputs (indexes, persist sinks, and subscribes) and using the frontier advancements reported by those to feed dataflow streams that are passed into the respective `persist_source`s.

All `persist_source`s in a dataflow share the same probe, but probes are not shared between sources in different dataflows. As a result, if a dataflow transitively depends on `persist_source`s from multiple other dataflows, that dataflow's outputs have multiple probes attached.

This PR does not yet switch on flow control. This is because a) there is a known bug where switching enabling flow control can stall dataflows (#16995) and b) we still need to do testing to determine a sensible limit on in-flight bytes that doesn't degrade performance.

[0]: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1671197669249869

### Motivation

  * This PR adds a known-desirable feature.

Advances #15974.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
