### PR TITLE
deps: update URL to tokio-console fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "console-api"
 version = "0.4.0"
-source = "git+https://github.com/MaterializeInc/console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
+source = "git+https://github.com/MaterializeInc/tokio-console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
 dependencies = [
  "prost",
  "prost-types",
@@ -1189,7 +1189,7 @@ dependencies = [
 [[package]]
 name = "console-subscriber"
 version = "0.1.8"
-source = "git+https://github.com/MaterializeInc/console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
+source = "git+https://github.com/MaterializeInc/tokio-console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
 dependencies = [
  "console-api",
  "crossbeam-channel",

--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -8,7 +8,7 @@ First, install `tokio-console`. We require support for Unix domain sockets, [whi
 upstream][uds-pr], so we need to install from a fork for now.
 
 ```text
-cargo install tokio-console --git https://github.com/MaterializeInc/console.git
+cargo install tokio-console --git https://github.com/MaterializeInc/tokio-console.git
 ```
 
 Then run `environmentd`:

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -56,7 +56,7 @@ hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", features = ["rt-tokio", "trace"], optional = true }
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
-console-subscriber = { git = "https://github.com/MaterializeInc/console.git", optional = true }
+console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 


### PR DESCRIPTION
We're moving this repo from MaterializeInc/console to MaterializeInc/tokio-console, to free up the MaterializeInc/console repository for other uses.
