### PR TITLE
Add validation of AWS PrivateLink connection object's availability zones

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -77,6 +77,12 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             V1EnvVar(name="AWS_REGION", value="minio"),
             V1EnvVar(name="AWS_ACCESS_KEY_ID", value="minio"),
             V1EnvVar(name="AWS_SECRET_ACCESS_KEY", value="minio123"),
+            V1EnvVar(name="MZ_ANNOUNCE_EGRESS_IP", value="1.2.3.4,88.77.66.55"),
+            V1EnvVar(name="MZ_AWS_ACCOUNT_ID", value="123456789000"),
+            V1EnvVar(
+                name="MZ_AWS_EXTERNAL_ID_PREFIX",
+                value="eb5cb59b-e2fe-41f3-87ca-d2176a495345",
+            ),
         ]
 
         for (k, v) in self.env.items():
@@ -118,6 +124,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             args += [
                 "--clusterd-image",
                 self.image("clusterd", tag=self.tag, release_mode=self.release_mode),
+                "--aws-privatelink-availability-zones=use1-az1,use1-az2",
             ]
         else:
             args += [

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -193,6 +193,7 @@ pub struct CatalogState {
     system_configuration: SystemVars,
     egress_ips: Vec<Ipv4Addr>,
     aws_principal_context: Option<AwsPrincipalContext>,
+    aws_privatelink_availability_zones: Option<HashSet<String>>,
 }
 
 impl CatalogState {
@@ -2225,6 +2226,7 @@ impl<S: Append> Catalog<S> {
                 system_configuration: SystemVars::default(),
                 egress_ips: config.egress_ips,
                 aws_principal_context: config.aws_principal_context,
+                aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
             },
             transient_revision: 0,
             storage: Arc::new(Mutex::new(config.storage)),
@@ -3296,6 +3298,7 @@ impl<S: Append> Catalog<S> {
             secrets_reader,
             egress_ips: vec![],
             aws_principal_context: None,
+            aws_privatelink_availability_zones: None,
             system_parameter_frontend: None,
         })
         .await?;
@@ -6109,6 +6112,10 @@ impl SessionCatalog for ConnCatalog<'_> {
 
     fn now(&self) -> EpochMillis {
         (self.state.config().now)()
+    }
+
+    fn aws_privatelink_availability_zones(&self) -> Option<HashSet<String>> {
+        self.state.aws_privatelink_availability_zones.clone()
     }
 }
 

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -62,6 +62,8 @@ pub struct Config<'a, S> {
     pub egress_ips: Vec<Ipv4Addr>,
     /// Context for generating an AWS Principal.
     pub aws_principal_context: Option<AwsPrincipalContext>,
+    /// Supported AWS PrivateLink availability zone ids.
+    pub aws_privatelink_availability_zones: Option<HashSet<String>>,
     /// A optional frontend used to pull system parameters for initial sync in
     /// Catalog::open. A `None` value indicates that the initial sync should be
     /// skipped.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -538,6 +538,16 @@ pub struct Args {
     #[clap(long, env = "AWS_ACCOUNT_ID")]
     aws_account_id: Option<String>,
 
+    /// The list of supported AWS PrivateLink availability zone ids.
+    /// Must be zone IDs, of format e.g. "use-az1".
+    #[clap(
+        long,
+        env = "AWS_PRIVATELINK_AVAILABILITY_ZONES",
+        multiple = true,
+        use_delimiter = true
+    )]
+    aws_privatelink_availability_zones: Option<Vec<String>>,
+
     // === Tracing options. ===
     #[clap(flatten)]
     tracing: TracingCliArgs,
@@ -827,6 +837,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         segment_api_key: args.segment_api_key,
         egress_ips: args.announce_egress_ip,
         aws_account_id: args.aws_account_id,
+        aws_privatelink_availability_zones: args.aws_privatelink_availability_zones,
         launchdarkly_sdk_key: args.launchdarkly_sdk_key,
         launchdarkly_key_map: args
             .launchdarkly_key_map

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -195,6 +195,8 @@ pub struct Config {
     pub egress_ips: Vec<Ipv4Addr>,
     /// 12-digit AWS account id, which will be used to generate an AWS Principal.
     pub aws_account_id: Option<String>,
+    /// Supported AWS PrivateLink availability zone ids.
+    pub aws_privatelink_availability_zones: Option<Vec<String>>,
     /// An SDK key for LaunchDarkly. Enables system parameter synchronization
     /// with LaunchDarkly.
     pub launchdarkly_sdk_key: Option<String>,
@@ -412,6 +414,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         consolidations_tx,
         consolidations_rx,
         aws_account_id: config.aws_account_id,
+        aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
     })
     .await?;
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -319,6 +319,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         segment_api_key: None,
         egress_ips: vec![],
         aws_account_id: None,
+        aws_privatelink_availability_zones: None,
         launchdarkly_sdk_key: None,
         launchdarkly_key_map: Default::default(),
         config_sync_loop_interval: None,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -201,6 +201,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// this means the Unix epoch. This can safely be mocked in tests and start
     /// at 0.
     fn now(&self) -> EpochMillis;
+
+    /// Returns the set of supported AWS PrivateLink availability zone ids.
+    fn aws_privatelink_availability_zones(&self) -> Option<HashSet<String>>;
 }
 
 /// Configuration associated with a catalog.
@@ -920,6 +923,10 @@ impl SessionCatalog for DummyCatalog {
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
         name
+    }
+
+    fn aws_privatelink_availability_zones(&self) -> Option<HashSet<String>> {
+        unimplemented!()
     }
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3050,6 +3050,16 @@ pub fn plan_create_connection(
         CreateConnection::AwsPrivatelink { with_options } => {
             let c = AwsPrivatelinkConnectionOptionExtracted::try_from(with_options)?;
             let connection = AwsPrivatelinkConnection::try_from(c)?;
+            if let Some(supported_azs) = scx.catalog.aws_privatelink_availability_zones() {
+                for connection_az in &connection.availability_zones {
+                    if !supported_azs.contains(connection_az) {
+                        return Err(PlanError::InvalidPrivatelinkAvailabilityZone {
+                            name: connection_az.to_string(),
+                            supported_azs,
+                        });
+                    }
+                }
+            }
             Connection::AwsPrivatelink(connection)
         }
         CreateConnection::Ssh { with_options } => {

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
@@ -305,6 +305,10 @@ impl SessionCatalog for TestCatalog {
 
     fn now(&self) -> EpochMillis {
         (self.config().now)()
+    }
+
+    fn aws_privatelink_availability_zones(&self) -> Option<HashSet<String>> {
+        unimplemented!()
     }
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -880,6 +880,7 @@ impl RunnerInner {
             segment_api_key: None,
             egress_ips: vec![],
             aws_account_id: None,
+            aws_privatelink_availability_zones: None,
             launchdarkly_sdk_key: None,
             launchdarkly_key_map: Default::default(),
             config_sync_loop_interval: None,

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -408,6 +408,7 @@ impl Usage {
             secrets_reader,
             egress_ips: vec![],
             aws_principal_context: None,
+            aws_privatelink_availability_zones: None,
             system_parameter_frontend: None,
         })
         .await?;

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -27,7 +27,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
         CREATE CONNECTION privatelinkconn
         TO AWS PRIVATELINK (
             SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
-            AVAILABILITY ZONES ('use1-az1', 'use1-az4')
+            AVAILABILITY ZONES ('use1-az1', 'use1-az2')
         )
         """
     )
@@ -118,3 +118,18 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
     mz.environmentd.sql("DROP CONNECTION privatelinkconn")
 
     not_exists(resource=f"vpcendpoint/connection-{aws_connection_id}")
+
+    with pytest.raises(
+        ProgrammingError, match='invalid AWS PrivateLink availability zone "us-east-1a"'
+    ):
+        mz.environmentd.sql(
+            dedent(
+                """\
+                CREATE CONNECTION privatelinkconn2
+                TO AWS PRIVATELINK (
+                SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
+                AVAILABILITY ZONES ('use1-az2', 'us-east-1a')
+                );
+                """
+            )
+        )


### PR DESCRIPTION
Also add `--aws-privatelink-availability-zones` environment var to use for the validation.

Resolves #16499.
### Tips for reviewer

* I made the environment var an `Option` so that it doesn't require synchronization with the cloud release, but should it always be required? If so, we could stagger it as 1) add the environment variable 2) cloud starts passing the env var 3) add the validation logic.
* I also used `Vec` type for the var and later cast it to a `HashSet` in the Catalog config, because I couldn't seem to figure out how to make the var itself a HashSet. I was getting the error `the trait bound `HashSet<std::string::String>: FromStr` is not satisfied`.
* Is there a better place to put this validation than `ddl.rs` that requires less plumbing thru of the list?

* Re migrations: what will happen on startup if an environment already has an invalid connection object? Do stashed objects go thru that `ddl.rs` flow on startup?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
