### PR TITLE
persist_source: fix memory leak in in-flight parts tracking

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -105,6 +105,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use differential_dataflow::lattice::Lattice;
 use differential_dataflow::AsCollection;
 use timely::communication::Allocate;
 use timely::dataflow::operators::to_stream::ToStream;
@@ -112,6 +113,7 @@ use timely::dataflow::operators::InspectCore;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::order::Product;
+use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 use timely::worker::Worker as TimelyWorker;
 use timely::PartialOrder;
@@ -204,9 +206,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     dataflow.as_of.clone(),
                     dataflow.until.clone(),
                     mfp.as_mut(),
-                    // TODO: provide a more meaningful flow control input
-                    &timely::dataflow::operators::generic::operator::empty(region),
-                    NO_FLOW_CONTROL,
+                    None,
                     // Copy the logic in DeltaJoin/Get/Join to start.
                     |_timer, count| count > 1_000_000,
                 );
@@ -806,10 +806,6 @@ where
         }
     }
 }
-
-use differential_dataflow::lattice::Lattice;
-use mz_storage_client::source::persist_source::NO_FLOW_CONTROL;
-use timely::progress::timestamp::Refines;
 
 /// A timestamp type that can be used for operations within MZ's dataflow layer.
 pub trait RenderTimestamp: Timestamp + Lattice + Refines<mz_repr::Timestamp> {

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -35,7 +35,6 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriterEnrichedHollowBatch;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
-use mz_storage_client::source::persist_source::NO_FLOW_CONTROL;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sources::SourceData;
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
@@ -77,7 +76,7 @@ where
 }
 
 pub(crate) fn persist_sink<G>(
-    scope: &G,
+    _scope: &G,
     sink_id: GlobalId,
     target: &CollectionMetadata,
     desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
@@ -100,9 +99,7 @@ where
         source_as_of,
         Antichain::new(), // we want all updates
         None,             // no MFP
-        // TODO: provide a more meaningful flow control input
-        &timely::dataflow::operators::generic::operator::empty(scope),
-        NO_FLOW_CONTROL,
+        None,             // no flow control
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -71,10 +71,7 @@ pub fn shard_source<K, V, D, G>(
     shard_id: ShardId,
     as_of: Option<Antichain<G::Timestamp>>,
     until: Antichain<G::Timestamp>,
-    // Use Infallible to statically ensure that no data can ever be sent. TODO:
-    // Replace Infallible with `!` once the latter is stabilized.
-    flow_control_input: &Stream<G, Infallible>,
-    flow_control_max_inflight_bytes: usize,
+    flow_control: Option<FlowControl<G>>,
 ) -> (Stream<G, FetchedPart<K, V, G::Timestamp, D>>, Rc<dyn Any>)
 where
     K: Debug + Codec,
@@ -118,8 +115,7 @@ where
         shard_id.clone(),
         as_of,
         until,
-        flow_control_input,
-        flow_control_max_inflight_bytes,
+        flow_control,
         consumed_part_rx,
         chosen_worker,
     );
@@ -134,8 +130,18 @@ where
     (parts, token)
 }
 
-/// Informs a `persist_source` to skip flow control on its output
-pub const NO_FLOW_CONTROL: usize = usize::MAX;
+/// Flow control configuration.
+#[derive(Debug)]
+pub struct FlowControl<G: Scope> {
+    /// Stream providing in-flight frontier updates.
+    ///
+    /// As implied by its type, this stream never emits data, only progress updates.
+    ///
+    /// TODO: Replace `Infallible` with `!` once the latter is stabilized.
+    pub progress_stream: Stream<G, Infallible>,
+    /// Maximum number of in-flight bytes.
+    pub max_inflight_bytes: usize,
+}
 
 pub(crate) fn shard_source_descs<K, V, D, G>(
     scope: &G,
@@ -145,10 +151,7 @@ pub(crate) fn shard_source_descs<K, V, D, G>(
     shard_id: ShardId,
     as_of: Option<Antichain<G::Timestamp>>,
     until: Antichain<G::Timestamp>,
-    // Use Infallible to statically ensure that no data can ever be sent. TODO:
-    // Replace Infallible with `!` once the latter is stabilized.
-    flow_control_input: &Stream<G, Infallible>,
-    flow_control_max_inflight_bytes: usize,
+    flow_control: Option<FlowControl<G>>,
     mut consumed_part_rx: mpsc::UnboundedReceiver<SerdeLeasedBatchPart>,
     chosen_worker: usize,
 ) -> (Stream<G, (usize, SerdeLeasedBatchPart)>, ShutdownButton<()>)
@@ -253,11 +256,20 @@ where
     // just get the value directly with a function call.
     let mut pinned_stream = Box::pin(async_stream);
 
+    let (flow_control_stream, flow_control_bytes) = match flow_control {
+        Some(fc) => (fc.progress_stream, Some(fc.max_inflight_bytes)),
+        None => (
+            timely::dataflow::operators::generic::operator::empty(scope),
+            None,
+        ),
+    };
+
     let mut builder =
         AsyncOperatorBuilder::new(format!("shard_source_descs({})", name), scope.clone());
     let (mut descs_output, descs_stream) = builder.new_output();
+
     let mut flow_control_input = builder.new_input_connection(
-        flow_control_input,
+        &flow_control_stream,
         Pipeline,
         // Disconnect the flow_control_input from the output capabilities of the
         // operator. We could leave it connected without risking deadlock so
@@ -276,10 +288,12 @@ where
         let mut inflight_bytes = 0;
         let mut inflight_parts: Vec<(Antichain<G::Timestamp>, usize)> = Vec::new();
 
+        let max_inflight_bytes = flow_control_bytes.unwrap_or(usize::MAX);
+
         loop {
             // While we have budget left for fetching more parts, read from the
             // subscription and pass them on.
-            while inflight_bytes < flow_control_max_inflight_bytes {
+            while inflight_bytes < max_inflight_bytes {
                 match pinned_stream.next().await {
                     Some(Ok((parts, progress, size_in_bytes))) => {
                         let session_cap = cap_set.delayed(&current_ts);
@@ -341,7 +355,7 @@ where
             // with the handle, so even if we never make it to this block (e.g.
             // budget of usize::MAX), because the stream has no data, we don't
             // cause unbounded buffering in timely.
-            while inflight_bytes >= flow_control_max_inflight_bytes {
+            while inflight_bytes >= max_inflight_bytes {
                 // Get an upper bound until which we should produce data
                 let flow_control_upper = match flow_control_input.next().await {
                     Some(Event::Progress(frontier)) => frontier,

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -26,7 +26,6 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistLocation, ShardId};
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::source::persist_source;
-use mz_storage_client::source::persist_source::NO_FLOW_CONTROL;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sinks::{
     MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
@@ -63,8 +62,7 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
         Some(sink.as_of.frontier.clone()),
         timely::progress::Antichain::new(),
         None,
-        &timely::dataflow::operators::generic::operator::empty(scope),
-        NO_FLOW_CONTROL,
+        None,
         // Copy the logic in DeltaJoin/Get/Join to start.
         |_timer, count| count > 1_000_000,
     );

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -25,7 +25,6 @@ use tokio::runtime::Handle as TokioHandle;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
-use mz_storage_client::source::persist_source::NO_FLOW_CONTROL;
 use mz_storage_client::types::errors::{DataflowError, DecodeError, EnvelopeError};
 use mz_storage_client::types::sources::{encoding::*, *};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
@@ -343,8 +342,7 @@ where
                                     Some(as_of),
                                     Antichain::new(),
                                     None,
-                                    &timely::dataflow::operators::generic::operator::empty(scope),
-                                    NO_FLOW_CONTROL,
+                                    None,
                                     // Copy the logic in DeltaJoin/Get/Join to start.
                                     |_timer, count| count > 1_000_000,
                                 );
@@ -403,8 +401,7 @@ where
                                 Some(Antichain::from_elem(previous_as_of)),
                                 Antichain::new(),
                                 None,
-                                &timely::dataflow::operators::generic::operator::empty(scope),
-                                NO_FLOW_CONTROL,
+                                None,
                                 // Copy the logic in DeltaJoin/Get/Join to start.
                                 |_timer, count| count > 1_000_000,
                             );


### PR DESCRIPTION
This PR fixes a memory leak in the `persist_source` that would occur when flow control was disabled.

It also modifies the `persist_source` API by replacing the two flow control parameters with a single optional one. The intention is to make the API less confusing and to make implementing the memory leak fix easier.

### Motivation

  * This PR fixes a recognized bug.

Part of https://github.com/MaterializeInc/materialize/issues/16699.

### Tips for reviewer

The PR has two commits that include additional descriptions. I recommend looking at them separately, even though you don't have to because the second commit is tiny!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
