### PR TITLE
Render cleanup

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -100,7 +100,7 @@ where
         scope: S,
     ) -> Self {
         use mz_ore::collections::CollectionExt as IteratorExt;
-        let dataflow_id = scope.addr().into_element();
+        let dataflow_id = scope.addr().into_first();
         let as_of_frontier = dataflow
             .as_of
             .clone()

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -70,6 +70,10 @@ where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
 {
+    /// The scope within which all managed collections exist.
+    ///
+    /// It is an error to add any collections not contained in this scope.
+    pub(crate) scope: S,
     /// The debug name of the dataflow associated with this context.
     pub debug_name: String,
     /// The Timely ID of the dataflow associated with this context.
@@ -91,16 +95,19 @@ where
     S::Timestamp: Lattice + Refines<mz_repr::Timestamp>,
 {
     /// Creates a new empty Context.
-    pub fn for_dataflow<Plan>(
+    pub fn for_dataflow_in<Plan>(
         dataflow: &DataflowDescription<Plan, CollectionMetadata>,
-        dataflow_id: usize,
+        scope: S,
     ) -> Self {
+        use mz_ore::collections::CollectionExt as IteratorExt;
+        let dataflow_id = scope.addr().into_element();
         let as_of_frontier = dataflow
             .as_of
             .clone()
             .unwrap_or_else(|| Antichain::from_elem(Timestamp::minimum()));
 
         Self {
+            scope,
             debug_name: dataflow.debug_name.clone(),
             dataflow_id,
             as_of_frontier,

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -56,7 +56,6 @@ where
         &mut self,
         inputs: Vec<CollectionBundle<G, Row, T>>,
         linear_plan: LinearJoinPlan,
-        scope: &mut G,
     ) -> CollectionBundle<G, Row, T> {
         // Collect all error streams, and concatenate them at the end.
         let mut errors = Vec::new();
@@ -155,7 +154,7 @@ where
             // Return joined results and all produced errors collected together.
             CollectionBundle::from_collections(
                 joined,
-                differential_dataflow::collection::concatenate(scope, errors),
+                differential_dataflow::collection::concatenate(&mut self.scope, errors),
             )
         } else {
             panic!("Unexpectedly arranged join output");

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -259,14 +259,7 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Import declared indexes into the rendering context.
                 for (idx_id, idx) in &dataflow.index_imports {
-                    context.import_index(
-                        compute_state,
-                        &mut tokens,
-                        scope,
-                        region,
-                        *idx_id,
-                        &idx.0,
-                    );
+                    context.import_index(compute_state, &mut tokens, region, *idx_id, &idx.0);
                 }
 
                 // Build declared objects.
@@ -347,14 +340,7 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Import declared indexes into the rendering context.
                 for (idx_id, idx) in &dataflow.index_imports {
-                    context.import_index(
-                        compute_state,
-                        &mut tokens,
-                        scope,
-                        region,
-                        *idx_id,
-                        &idx.0,
-                    );
+                    context.import_index(compute_state, &mut tokens, region, *idx_id, &idx.0);
                 }
 
                 // Build declared objects.
@@ -428,7 +414,6 @@ where
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
-        scope: &mut G,
         region: &mut Child<'g, G, T>,
         idx_id: GlobalId,
         idx: &IndexDesc,
@@ -441,13 +426,13 @@ where
 
             let token = traces.to_drop().clone();
             let (ok_arranged, ok_button) = traces.oks_mut().import_frontier_core(
-                scope,
+                &mut region.parent,
                 &format!("Index({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
                 self.until.clone(),
             );
             let (err_arranged, err_button) = traces.errs_mut().import_frontier_core(
-                scope,
+                &mut region.parent,
                 &format!("ErrIndex({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
                 self.until.clone(),

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -119,7 +119,6 @@ use timely::PartialOrder;
 use mz_compute_client::plan::Plan;
 use mz_compute_client::types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
 use mz_expr::Id;
-use mz_ore::collections::CollectionExt as IteratorExt;
 use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
@@ -243,10 +242,8 @@ pub fn build_compute_dataflow<A: Allocate>(
 
         if recursive {
             scope.clone().iterative::<usize, _, _>(|region| {
-                let mut context = crate::render::context::Context::for_dataflow(
-                    &dataflow,
-                    scope.addr().into_element(),
-                );
+                let mut context =
+                    crate::render::context::Context::for_dataflow_in(&dataflow, region.clone());
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
                     let bundle = crate::render::CollectionBundle::from_collections(
@@ -259,7 +256,7 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Import declared indexes into the rendering context.
                 for (idx_id, idx) in &dataflow.index_imports {
-                    context.import_index(compute_state, &mut tokens, region, *idx_id, &idx.0);
+                    context.import_index(compute_state, &mut tokens, *idx_id, &idx.0);
                 }
 
                 // Build declared objects.
@@ -289,7 +286,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                             variables.insert(Id::Local(*id), (oks_v, err_v));
                         }
                         for (id, value) in ids.into_iter().zip(values.into_iter()) {
-                            let bundle = context.render_plan(value, region);
+                            let bundle = context.render_plan(value);
                             // We need to ensure that the raw collection exists, but do not have enough information
                             // here to cause that to happen.
                             let (oks, err) = bundle.collection.clone().unwrap();
@@ -299,10 +296,10 @@ pub fn build_compute_dataflow<A: Allocate>(
                             err_v.set(&err);
                         }
 
-                        let bundle = context.render_plan(*body, region);
+                        let bundle = context.render_plan(*body);
                         context.insert_id(Id::Global(object.id), bundle);
                     } else {
-                        context.build_object(region, object);
+                        context.build_object(object);
                     }
                 }
 
@@ -324,10 +321,8 @@ pub fn build_compute_dataflow<A: Allocate>(
             });
         } else {
             scope.clone().region_named(&build_name, |region| {
-                let mut context = crate::render::context::Context::for_dataflow(
-                    &dataflow,
-                    scope.addr().into_element(),
-                );
+                let mut context =
+                    crate::render::context::Context::for_dataflow_in(&dataflow, region.clone());
 
                 for (id, (oks, errs)) in imported_sources.into_iter() {
                     let bundle = crate::render::CollectionBundle::from_collections(
@@ -340,12 +335,12 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Import declared indexes into the rendering context.
                 for (idx_id, idx) in &dataflow.index_imports {
-                    context.import_index(compute_state, &mut tokens, region, *idx_id, &idx.0);
+                    context.import_index(compute_state, &mut tokens, *idx_id, &idx.0);
                 }
 
                 // Build declared objects.
                 for object in dataflow.objects_to_build {
-                    context.build_object(region, object);
+                    context.build_object(object);
                 }
 
                 // Export declared indexes.
@@ -414,7 +409,6 @@ where
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
-        region: &mut Child<'g, G, T>,
         idx_id: GlobalId,
         idx: &IndexDesc,
     ) {
@@ -426,19 +420,19 @@ where
 
             let token = traces.to_drop().clone();
             let (ok_arranged, ok_button) = traces.oks_mut().import_frontier_core(
-                &mut region.parent,
+                &self.scope.parent,
                 &format!("Index({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
                 self.until.clone(),
             );
             let (err_arranged, err_button) = traces.errs_mut().import_frontier_core(
-                &mut region.parent,
+                &self.scope.parent,
                 &format!("ErrIndex({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
                 self.until.clone(),
             );
-            let ok_arranged = ok_arranged.enter(region);
-            let err_arranged = err_arranged.enter(region);
+            let ok_arranged = ok_arranged.enter(&self.scope);
+            let err_arranged = err_arranged.enter(&self.scope);
             self.update_id(
                 Id::Global(idx.on_id),
                 CollectionBundle::from_expressions(
@@ -465,9 +459,9 @@ where
     G: Scope,
     G::Timestamp: RenderTimestamp,
 {
-    pub(crate) fn build_object(&mut self, scope: &mut G, object: BuildDesc<Plan>) {
+    pub(crate) fn build_object(&mut self, object: BuildDesc<Plan>) {
         // First, transform the relation expression into a render plan.
-        let bundle = self.render_plan(object.plan, scope);
+        let bundle = self.render_plan(object.plan);
         self.insert_id(Id::Global(object.id), bundle);
     }
 }
@@ -603,7 +597,7 @@ where
     ///
     /// The return type reflects the uncertainty about the data representation, perhaps
     /// as a stream of data, perhaps as an arrangement, perhaps as a stream of batches.
-    pub fn render_plan(&mut self, plan: Plan, scope: &mut G) -> CollectionBundle<G, Row> {
+    pub fn render_plan(&mut self, plan: Plan) -> CollectionBundle<G, Row> {
         match plan {
             Plan::Constant { rows } => {
                 // Produce both rows and errs to avoid conditional dataflow construction.
@@ -629,7 +623,7 @@ where
                             None
                         }
                     })
-                    .to_stream(scope)
+                    .to_stream(&mut self.scope)
                     .as_collection();
 
                 let mut error_time: mz_repr::Timestamp = Timestamp::minimum();
@@ -643,7 +637,7 @@ where
                             1,
                         )
                     })
-                    .to_stream(scope)
+                    .to_stream(&mut self.scope)
                     .as_collection();
 
                 CollectionBundle::from_collections(ok_collection, err_collection)
@@ -685,11 +679,11 @@ where
             }
             Plan::Let { id, value, body } => {
                 // Render `value` and bind it to `id`. Complain if this shadows an id.
-                let value = self.render_plan(*value, scope);
+                let value = self.render_plan(*value);
                 let prebound = self.insert_id(Id::Local(id), value);
                 assert!(prebound.is_none());
 
-                let body = self.render_plan(*body, scope);
+                let body = self.render_plan(*body);
                 self.remove_id(Id::Local(id));
                 body
             }
@@ -701,7 +695,7 @@ where
                 mfp,
                 input_key_val,
             } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 // If `mfp` is non-trivial, we should apply it and produce a collection.
                 if mfp.is_identity() {
                     input
@@ -718,20 +712,20 @@ where
                 mfp,
                 input_key,
             } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 self.render_flat_map(input, func, exprs, mfp, input_key)
             }
             Plan::Join { inputs, plan } => {
                 let inputs = inputs
                     .into_iter()
-                    .map(|input| self.render_plan(input, scope))
+                    .map(|input| self.render_plan(input))
                     .collect();
                 match plan {
                     mz_compute_client::plan::join::JoinPlan::Linear(linear_plan) => {
-                        self.render_join(inputs, linear_plan, scope)
+                        self.render_join(inputs, linear_plan)
                     }
                     mz_compute_client::plan::join::JoinPlan::Delta(delta_plan) => {
-                        self.render_delta_join(inputs, delta_plan, scope)
+                        self.render_delta_join(inputs, delta_plan)
                     }
                 }
             }
@@ -741,15 +735,15 @@ where
                 plan,
                 input_key,
             } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 self.render_reduce(input, key_val_plan, plan, input_key)
             }
             Plan::TopK { input, top_k_plan } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 self.render_topk(input, top_k_plan)
             }
             Plan::Negate { input } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 let (oks, errs) = input.as_specific_collection(None);
                 CollectionBundle::from_collections(oks.negate(), errs)
             }
@@ -757,19 +751,19 @@ where
                 input,
                 threshold_plan,
             } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 self.render_threshold(input, threshold_plan)
             }
             Plan::Union { inputs } => {
                 let mut oks = Vec::new();
                 let mut errs = Vec::new();
                 for input in inputs.into_iter() {
-                    let (os, es) = self.render_plan(input, scope).as_specific_collection(None);
+                    let (os, es) = self.render_plan(input).as_specific_collection(None);
                     oks.push(os);
                     errs.push(es);
                 }
-                let oks = differential_dataflow::collection::concatenate(scope, oks);
-                let errs = differential_dataflow::collection::concatenate(scope, errs);
+                let oks = differential_dataflow::collection::concatenate(&mut self.scope, oks);
+                let errs = differential_dataflow::collection::concatenate(&mut self.scope, errs);
                 CollectionBundle::from_collections(oks, errs)
             }
             Plan::ArrangeBy {
@@ -778,7 +772,7 @@ where
                 input_key,
                 input_mfp,
             } => {
-                let input = self.render_plan(*input, scope);
+                let input = self.render_plan(*input);
                 input.ensure_collections(keys, input_key, input_mfp, self.until.clone())
             }
         }


### PR DESCRIPTION
A few tidying actions that remove potential inconsistencies in rendering code.
1. Remove the `worker: usize` argument as a. it is not used, and b. it can be recovered more correctly from the `scope` argument.
2. Remove `scope` arguments in cases where they are not required.
3. Teach `Context` to track the scope in which it is built, rather than have it be passed this as an argument when called.

These all remove the potential to call methods with incorrect arguments, e.g. the wrong rendering region which .. unfortunately may have the same *type* as another region but be incorrect.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
