### PR TITLE
sql: fix + test range ordering w/r/t NULL

### DIFF
--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -124,6 +124,8 @@ pub enum Datum<'a> {
     /// A universally unique identifier.
     Uuid(Uuid),
     MzTimestamp(crate::Timestamp),
+    /// A range of values, e.g. [-1, 1).
+    Range(Range<DatumNested<'a>>),
     /// A placeholder value.
     ///
     /// Dummy values are never meant to be observed. Many operations on `Datum`
@@ -149,8 +151,11 @@ pub enum Datum<'a> {
     // calling `<` on Datums (see `fn lt` in scalar/func.rs).
     /// An unknown value.
     Null,
-    /// A range of values, e.g. [-1, 1).
-    Range(Range<DatumNested<'a>>),
+    // WARNING! DON'T PLACE NEW DATUM VARIANTS HERE!
+    //
+    // This order of variants of this enum determines how nulls sort. We
+    // have decided that nulls should sort last in Materialize, so all
+    // other datum variants should appear before `Null`.
 }
 
 impl TryFrom<Datum<'_>> for bool {

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -7,6 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+#
+# meta
+
+# Ensure range sorts of null correctly
+query B
+SELECT ARRAY['(,)']::int4range[] < ARRAY[NULL]::int4range[];
+----
+true
+
 
 #
 # int4range
@@ -450,6 +459,7 @@ CREATE TABLE int4range_values (a int4range);
 
 statement ok
 INSERT INTO int4range_values VALUES
+    (null),
     ('[,1)'::int4range),
     ('[,1]'::int4range),
     ('[,)'::int4range),
@@ -494,6 +504,7 @@ empty
 [1,)
 [2,)
 [2,)
+NULL
 
 query T
 SELECT a::text AS t FROM int4range_values EXCEPT SELECT column1::text FROM (VALUES
@@ -519,6 +530,7 @@ SELECT a::text AS t FROM int4range_values EXCEPT SELECT column1::text FROM (VALU
     (int4range(1,null,'(]'))
 ) t;
 ----
+NULL
 
 query error invalid range bound flags
 SELECT int4range(null,null,' (]');
@@ -1084,6 +1096,7 @@ CREATE TABLE int8range_values (a int8range);
 
 statement ok
 INSERT INTO int8range_values VALUES
+    (null),
     ('[,1)'::int8range),
     ('[,1]'::int8range),
     ('[,)'::int8range),
@@ -1128,6 +1141,7 @@ empty
 [1,)
 [2,)
 [2,)
+NULL
 
 query T
 SELECT a::text AS t FROM int8range_values EXCEPT SELECT column1::text FROM (VALUES
@@ -1153,6 +1167,7 @@ SELECT a::text AS t FROM int8range_values EXCEPT SELECT column1::text FROM (VALU
     (int8range(1,null,'(]'))
 ) t;
 ----
+NULL
 
 
 # Test range in list
@@ -1647,6 +1662,7 @@ CREATE TABLE daterange_values (a daterange);
 
 statement ok
 INSERT INTO daterange_values VALUES
+    (null),
     ('[,)'::daterange),
     ('[,1970-01-01]'::daterange),
     ('[,)'::daterange),
@@ -1683,6 +1699,7 @@ empty
 [1970-01-01,)
 [1970-01-02,)
 [1970-01-02,)
+NULL
 
 query T
 SELECT a::text AS t FROM daterange_values EXCEPT SELECT column1::text FROM (VALUES
@@ -1704,6 +1721,7 @@ SELECT a::text AS t FROM daterange_values EXCEPT SELECT column1::text FROM (VALU
     (daterange('1970-01-01',null,'(]'))
 ) t;
 ----
+NULL
 
 
 # Test range in list


### PR DESCRIPTION
Overlooked where `Datum::Range` should be placed. Fixed + added some tests.

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
