### PR TITLE
nexttest.toml: bump the environmentd::test_pgtest timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,11 @@ filter = "package(mz-environmentd)"
 threads-required = 8
 slow-timeout = { period = "120s", terminate-after = 2 }
 
+[[profile.default.overrides]]
+filter = "package(mz-environmentd) and test(test_pgtest)"
+threads-required = 8
+slow-timeout = { period = "300s", terminate-after = 2 }
+
 [profile.ci]
 junit = { path = "junit_cargo-test.xml" }
 fail-fast = false


### PR DESCRIPTION
This test routinely takes about 230-240s to run, which means it occasionally times out. Give it a 5m slow timeout by default to give it some headroom in CI.


### Motivation

  * This PR fixes a previously unreported CI flake.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
