### PR TITLE
compute: intra-ts thinning for monotonic topk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,6 +3550,7 @@ dependencies = [
  "prometheus",
  "scopeguard",
  "serde",
+ "smallvec",
  "timely",
  "tokio",
  "tracing",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -32,6 +32,7 @@ once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
+smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.23.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"

--- a/test/testdrive/top-k-monotonic.td
+++ b/test/testdrive/top-k-monotonic.td
@@ -1,0 +1,53 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test monotonicity analyses which derive from ENVELOPE NONE sources.
+# Note that these only test the implementation for monotonic sources,
+# they do not test that the analysis doesn't have false positives on
+# non-monotonic sources.
+
+$ set non-dbz-schema={
+    "type": "record",
+    "name": "cpx",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=non-dbz-data
+
+$ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp=1
+{"a": 1, "b": 1}
+{"a": 1, "b": 2}
+{"a": 1, "b": 3}
+{"a": 1, "b": 4}
+{"a": 1, "b": 5}
+{"a": 2, "b": 1000}
+{"a": 2, "b": 1001}
+{"a": 2, "b": 1002}
+{"a": 2, "b": 1003}
+{"a": 2, "b": 1004}
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE SOURCE non_dbz_data
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-dbz-data-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+# Create a monotonic topk plan that has both a limit and a group to test that thinning works as expected
+> SELECT * FROM (SELECT DISTINCT a FROM non_dbz_data) grp, LATERAL (SELECT b FROM non_dbz_data WHERE a = grp.a ORDER BY b LIMIT 2);
+a b
+---------
+1 1
+1 2
+2 1000
+2 1001


### PR DESCRIPTION
### Motivation

This PR implements a pre-arrangement thinning of monotonic collections that are on their way to a topk computation. This thinning has the advantage of being able to be performed in a streaming fashion even for single timestamps that might contain a lot of data.

With this change a monotonic collection flowing into a top 3 operator whose snapshot is 10GB can be performed on machines with very little RAM as we will incrementally discard records that cannot possible be in the top 3 as rows flow in.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
