### PR TITLE
adapter,environmentd: move segment context fields to properties

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -41,7 +41,7 @@ use crate::coord::appends::BuiltinTableUpdateSource;
 use crate::coord::Coordinator;
 use crate::session::vars::SystemVars;
 use crate::session::Session;
-use crate::telemetry::EnvironmentIdExt;
+use crate::telemetry::SegmentClientExt;
 use crate::util::ComputeSinkId;
 use crate::{catalog, AdapterError};
 
@@ -303,14 +303,11 @@ impl<S: Append + 'static> Coordinator<S> {
                     event.object_type.as_title_case(),
                     event.event_type.as_title_case()
                 );
-                segment_client.track(
+                segment_client.environment_track(
+                    &self.catalog.config().environment_id,
                     user_metadata.user_id,
                     event_type,
-                    json!({
-                        "event_source": "environmentd",
-                        "details": event.details.as_json(),
-                    }),
-                    Some(self.catalog.config().environment_id.as_segment_context()),
+                    json!({ "details": event.details.as_json() }),
                 );
             }
         }

--- a/src/adapter/src/telemetry.rs
+++ b/src/adapter/src/telemetry.rs
@@ -10,21 +10,63 @@
 //! Telemetry utilities.
 
 use serde_json::json;
+use uuid::Uuid;
 
 use mz_sql::catalog::EnvironmentId;
 
-/// Extension trait for [`EnvironmentId`].
-pub trait EnvironmentIdExt {
-    /// Returns the Segment context fields associated with this environment ID.
-    fn as_segment_context(&self) -> serde_json::Value;
+/// Extension trait for [`mz_segment::Client`].
+pub trait SegmentClientExt {
+    /// Tracks an event associated with an environment.
+    fn environment_track<S>(
+        &self,
+        environment_id: &EnvironmentId,
+        user_id: Uuid,
+        event: S,
+        properties: serde_json::Value,
+    ) where
+        S: Into<String>;
 }
 
-impl EnvironmentIdExt for EnvironmentId {
-    fn as_segment_context(&self) -> serde_json::Value {
-        json!({
-            "group_id": self.organization_id(),
-            "cloud_provider": self.cloud_provider().to_string(),
-            "cloud_provider_region": self.cloud_provider_region(),
-        })
+impl SegmentClientExt for mz_segment::Client {
+    /// Tracks an event associated with an environment.
+    ///
+    /// Various metadata about the environment is automatically attached
+    /// using canonical field names.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `properties` is not a [`serde_json::Value::Object`].
+    fn environment_track<S>(
+        &self,
+        environment_id: &EnvironmentId,
+        user_id: Uuid,
+        event: S,
+        mut properties: serde_json::Value,
+    ) where
+        S: Into<String>,
+    {
+        {
+            let properties = match &mut properties {
+                serde_json::Value::Object(map) => map,
+                _ => {
+                    panic!("SegmentClientExt::environment_track called with non-object properties")
+                }
+            };
+            properties.insert("event_source".into(), json!("environment"));
+            properties.insert(
+                "cloud_provider".into(),
+                json!(environment_id.cloud_provider().to_string()),
+            );
+            properties.insert(
+                "cloud_provider_region".into(),
+                json!(environment_id.cloud_provider_region()),
+            );
+        }
+        self.track(
+            user_id,
+            event,
+            properties,
+            Some(json!({ "group_id": environment_id.organization_id() })),
+        );
     }
 }

--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -21,7 +21,7 @@ use serde_json::json;
 use tokio::time::{self, Duration};
 use tracing::warn;
 
-use mz_adapter::telemetry::EnvironmentIdExt;
+use mz_adapter::telemetry::SegmentClientExt;
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
 use mz_ore::task;
@@ -82,7 +82,8 @@ async fn report_rollup_loop(
             subscribes: query_total.with_label_values(&["user", "subscribe"]).get(),
         };
 
-        segment_client.track(
+        segment_client.environment_track(
+            &environment_id,
             // We use the organization ID as the user ID for events
             // that are not associated with a particular user.
             environment_id.organization_id(),
@@ -95,7 +96,6 @@ async fn report_rollup_loop(
                 "selects": current_rollup.selects - last_rollup.selects,
                 "subscribes": current_rollup.subscribes - last_rollup.subscribes,
             }),
-            Some(environment_id.as_segment_context()),
         );
 
         last_rollup = current_rollup;


### PR DESCRIPTION
Many Segment destinations only understand properties and canonical context fields, and can't understand non-canonical context fields. So promote the non-cononical context fields to properties.

Fix MaterializeInc/analytics#97.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
