### PR TITLE
nexttest.toml: fix precedence override

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,15 +1,18 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2 }
 
-[[profile.default.overrides]]
-filter = "package(mz-environmentd)"
-threads-required = 8
-slow-timeout = { period = "120s", terminate-after = 2 }
+# For a given configuration parameter, the first override to match wins. Keep
+# these sorted in order from most specific to least specific.
 
 [[profile.default.overrides]]
 filter = "package(mz-environmentd) and test(test_pgtest)"
 threads-required = 8
 slow-timeout = { period = "300s", terminate-after = 2 }
+
+[[profile.default.overrides]]
+filter = "package(mz-environmentd)"
+threads-required = 8
+slow-timeout = { period = "120s", terminate-after = 2 }
 
 [profile.ci]
 junit = { path = "junit_cargo-test.xml" }


### PR DESCRIPTION
The first override in nexttest.toml applies, not the last. Reorder from most specific to least specific, rather than least specific to most specific.

This corrects a bug in 496ad1efe.


### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
