### PR TITLE
doc/developer: don't suggest binding port 8080 for Cockroach UI

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -58,7 +58,7 @@ brew services start cockroach
 On Linux, we recommend using Docker:
 
 ```shell
-docker run --name=cockroach -d -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:v22.2.0 start-single-node --insecure
+docker run --name=cockroach -d -p 26257:26257 -p 26258:8080 cockroachdb/cockroach:v22.2.0 start-single-node --insecure
 ```
 
 If you can successfully connect to CockroachDB with either


### PR DESCRIPTION
CockroachDB runs its admin web UI on port 8080. The developer guide previously suggested forwarding this port to the host machine to make debugging Cockroach easier, but port 8080 is a common port and likely to be in use by another tool.

Change the developer guide to instead suggest binding port 26258 on the host to port 8080 in the container. Port 26258 is much less likely to be in use by another tool.

The admin UI port is not directly used by the Materialize development environment, so there are no other references to this port that need to be adjusted.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes an issue reported by @sploiselle on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
