### PR TITLE
test/cloudtest: various improvements

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -11,29 +11,7 @@
 
 set -euo pipefail
 
-# read_list PREFIX
-#
-# Appends the environment variables `PREFIX_0`, `PREFIX_1`, ... `PREFIX_N` to
-# the `result` global variable, stopping when `PREFIX_N` is an empty string.
-read_list() {
-    result=()
-
-    local i=0
-    local param="${1}_${i}"
-
-    if [[ "${!1:-}" ]]; then
-        echo "error: pytest arguments must be an array, not a string" >&2
-        exit 1
-    fi
-
-    while [[ "${!param:-}" ]]; do
-        result+=("${!param}")
-        i=$((i+1))
-        param="${1}_${i}"
-    done
-
-    [[ ${#result[@]} -gt 0 ]] || return 1
-}
+. misc/shlib/shlib.bash
 
 run_args=("--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml")
 if read_list BUILDKITE_PLUGIN_CLOUDTEST_ARGS; then
@@ -42,32 +20,14 @@ if read_list BUILDKITE_PLUGIN_CLOUDTEST_ARGS; then
     done
 fi
 
-# Make sure KinD is running
-
-echo "--- KinD: Make sure KinD is running ..."
-
-bin/ci-builder run stable kind create cluster --config misc/kind/cluster.yaml --wait 30s || true
-
-# Make sure a kubeconfig file is generated and placed in $KUBECONFIG
-# of the ci-builder container, as defined in its Dockerfile
-
-bin/ci-builder run stable kind export kubeconfig
-
-# Apply additional KinD configuration
-for yaml in "misc/kind/configmaps/"*; do
-    bin/ci-builder run stable kubectl --context kind-kind apply -f "$yaml"
-done
-
-# Restart the K8s CoreDNS service
-bin/ci-builder run stable docker exec kind-control-plane kubectl rollout restart -n kube-system deployment/coredns
+ci_collapsed_heading "kind: Make sure kind is running..."
+bin/ci-builder run stable test/cloudtest/setup
 
 # Sometimes build cancellations prevent us from properly cleaning up the last
-# cloudtest run, so force a cleanup just in case
+# cloudtest run, so force a cleanup just in case.
+ci_collapsed_heading "kind: Purging state from previous builds..."
+bin/ci-builder run stable test/cloudtest/reset
+rm -f kubectl-*.log
 
-echo "--- KinD: Purging containers and volumes from previous builds ..."
-
-bin/ci-builder run stable kubectl --context kind-kind delete all --all || true
-
-echo "+++ cloudtest: Running \`bin/pytest ${run_args[*]}\`" >&2
-
+ci_uncollapsed_heading "+++ cloudtest: Running \`bin/pytest ${run_args[*]}\`"
 bin/ci-builder run stable bin/pytest "${run_args[@]}"

--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -9,23 +9,23 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-set -xeu
+set -euo pipefail
 
-echo "~~~ Cleaning up after cloudtest" >&2
+. misc/shlib/shlib.bash
 
-bin/ci-builder run stable kubectl --context kind-kind get pods -o name | grep -v -E 'kubernetes|minio|postgres|redpanda' | xargs -L 1 bin/ci-builder run stable kubectl --context kind-kind logs --prefix=true > kubectl-get-logs.log || true
-buildkite-agent artifact upload kubectl-get-logs.log
+kubectl() {
+    bin/ci-builder run stable kubectl --context=kind-cloudtest "$@"
+}
 
-bin/ci-builder run stable kubectl --context kind-kind get pods -o name | grep -v -E 'kubernetes|minio|postgres|redpanda' | xargs -L 1 bin/ci-builder run stable kubectl --context kind-kind logs --previous --prefix=true > kubectl-get-logs-previous.log || true
-buildkite-agent artifact upload kubectl-get-logs-previous.log
+ci_unimportant_heading "cloudtest: Uploading logs..."
+for pod in $(kubectl get pods -o name | grep -v -E 'kubernetes|minio|cockroach|redpanda'); do
+  kubectl logs --prefix=true "$pod" &>> kubectl-get-logs.log || true
+  kubectl logs --previous --prefix=true "$pod" &>> kubectl-get-logs-previous.log || true
+done
+kubectl get events > kubectl-get-events.log || true
+kubectl get all > kubectl-get-all.log || true
+kubectl describe all > kubectl-describe-all.log || true
+buildkite-agent artifact upload "kubectl-*.log"
 
-bin/ci-builder run stable kubectl --context kind-kind get events > kubectl-get-events.log || true
-buildkite-agent artifact upload kubectl-get-events.log
-
-bin/ci-builder run stable kubectl --context kind-kind get all > kubectl-get-all.log || true
-buildkite-agent artifact upload kubectl-get-all.log
-
-bin/ci-builder run stable kubectl --context kind-kind describe all > kubectl-describe-all.log || true
-buildkite-agent artifact upload kubectl-describe-all.log
-
-bin/ci-builder run stable kubectl --context kind-kind delete all --all
+ci_unimportant_heading "cloudtest: Resetting..."
+bin/ci-builder run stable test/cloudtest/reset

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -11,32 +11,10 @@
 
 set -euo pipefail
 
+. misc/shlib/shlib.bash
+
 mzcompose() {
     bin/ci-builder run stable bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
-}
-
-# read_list PREFIX
-#
-# Appends the environment variables `PREFIX_0`, `PREFIX_1`, ... `PREFIX_N` to
-# the `result` global variable, stopping when `PREFIX_N` is an empty string.
-read_list() {
-    result=()
-
-    local i=0
-    local param="${1}_${i}"
-
-    if [[ "${!1:-}" ]]; then
-        echo "error: mzcompose command must be an array, not a string" >&2
-        exit 1
-    fi
-
-    while [[ "${!param:-}" ]]; do
-        result+=("${!param}")
-        i=$((i+1))
-        param="${1}_${i}"
-    done
-
-    [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
 service=${BUILDKITE_PLUGIN_MZCOMPOSE_RUN:-default}
@@ -50,22 +28,22 @@ fi
 # Sometimes build cancellations prevent us from properly cleaning up the last
 # Docker Compose run, which can leave old containers or volumes around that will
 # interfere with this build.
-echo "--- :docker: Purging containers and volumes from previous builds"
+ci_collapsed_heading ":docker: Purging containers and volumes from previous builds"
 mzcompose --mz-quiet kill
 mzcompose --mz-quiet rm --force -v
 mzcompose --mz-quiet down --volumes
 
-echo "--- :docker: Rebuilding non-mzbuild containers"
+ci_collapsed_heading ":docker: Rebuilding non-mzbuild containers"
 mzcompose --mz-quiet build
 
 # Start dependencies under a different heading so that the main heading is less
 # noisy. But not if the service is actually a workflow, in which case it will
 # do its own dependency management.
 if ! mzcompose --mz-quiet list-workflows | grep -q "$service"; then
-    echo "--- :docker: Starting dependencies" >&2
+    ci_collapsed_heading ":docker: Starting dependencies"
     mzcompose up -d --scale "$service=0" "$service"
 fi
 
-echo "+++ :docker: Running \`mzcompose run ${run_args[*]}\`" >&2
+ci_uncollapsed_heading ":docker: Running \`mzcompose run ${run_args[*]}\`"
 
 mzcompose run "${run_args[@]}"

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -11,7 +11,9 @@
 
 set -euo pipefail
 
-echo "~~~ :docker: Cleaning up after mzcompose" >&2
+. misc/shlib/shlib.bash
+
+ci_unimportant_heading ":docker: Cleaning up after mzcompose"
 
 run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -1,49 +1,57 @@
 # Introduction
 
-`cloudtest` is a test framework that allows testing Materialize inside Kubernetes.
+cloudtest is a test framework that allows testing Materialize inside Kubernetes.
 
-Using a K8s environment for testing has the advantage that the same orchestrator that
-is used in the Cloud is used to spawn clusterds. K8s will also be responsible
-for restarting any containers that have exited.
+Using a Kubernetes environment for testing has the advantage of exercising the
+same code paths used in production used to orchestrate cloud resources (e.g.,
+clusters and secrets). Kubernetes will also be responsible for restarting any
+containers that have exited.
 
-The framework is pased on pytest and KinD and uses, for the most part, the official `kubernetes`
-python library to control the K8s cluster.
+Notable deviations from production include:
 
-# Installation and setup
+  * Using [MinIO] instead of S3 for `persist` blob storage.
+  * Using a single-node CockroachDB installation instead of Cockroach Cloud.
+  * No access to AWS resources like VPC endpoints.
 
-1. Install kubectl
+The framework is based on [pytest] and [kind] and uses, for the most part, the
+official [`kubernetes`] Python library to control the Kubernetes cluster.
 
-```
-curl -LO "https://dl.k8s.io/release/v1.24.3/bin/linux/amd64/kubectl"
-chmod +x kubectl
-sudo mv kubectl /usr/local/bin
-```
+# Setup
 
-2. Install KinD
+1. Install [kubectl], the official Kubernetes command-line tool:
 
-```
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
-chmod +x kind
-sudo mv kind /usr/local/bin
-```
+    ```
+    curl -fL https://dl.k8s.io/release/v1.24.3/bin/linux/amd64/kubectl > kubectl
+    chmod +x kubectl
+    sudo mv kubectl /usr/local/bin
+    ```
 
-More installation options are available here [https://kind.sigs.k8s.io/docs/user/quick-start/#installing-with-a-package-manager]
+    See the [official kubectl installation instructions][kubectl-installation]
+    for additional installation options.
 
-3. Create a Kubernetes KinD cluster
+2. Install [kind], which manages local Kubernetes clusters:
 
-```
-kind create cluster --config=misc/kind/cluster.yaml
-for yaml in "misc/kind/configmaps/"*; do
-    kubectl --context kind-kind apply -f "$yaml"
-done
+    ```
+    curl -fL https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64 > kind
+    chmod +x kind
+    sudo mv kind /usr/local/bin
+    ```
 
-docker exec kind-control-plane kubectl rollout restart -n kube-system deployment/coredns
-```
+    See the [official kind installation instructions][kind-installation]
+    for additional installation options.
+
+3. Create and configure a dedicated kind cluster for cloudtest:
+
+    ```
+    cd test/cloudtest
+    ./setup
+    ```
 
 # Running tests
 
+To run all short tests:
+
 ```
-cd test/cloudtest
 ./pytest
 ```
 
@@ -53,31 +61,43 @@ To run a single test:
 ./pytest -k test_name_goes_here
 ```
 
-⚠️ By default, `cloudtest` builds Materialize in release mode. You can instead
+⚠️ By default, cloudtest builds Materialize in release mode. You can instead
 build in debug mode by passing the `--dev` flag:
 
 ```
 ./pytest --dev [-k TEST]
 ```
 
-## Checking K8s cluster status
+To check the cluster status:
 
 ```
-kubectl --context kind-kind get all
+kubectl --context=kind-cloudtest get all
 ```
 
-## Resetting the K8s cluster
-
-This command removes almost all resources from the K8s cluster, so that a test can be rerun.
+Consider also using the [k9s] terminal user interface:
 
 ```
-kubectl --context kind-kind delete all --all
+k9s --context=kind-cloudtest
+```
+
+To remove all resources from the Kubernetes cluster, so that a test can be rerun
+without needing to reset the cluster:
+
+```
+./reset
+```
+
+To remove the Kubernetes cluster entirely:
+
+```
+./teardown
 ```
 
 # Interactive development
 
-`cloudtest` is the recommended tool for deploying a local build of Materialize
-to Kubernetes, where you can manually connect to the cluster and run tests.
+cloudtest is also the recommended tool for deploying a local build of
+Materialize to Kubernetes, where you can connect to the cluster and
+interactively run tests by hand.
 
 Use the `test_wait` workflow, which does nothing but wait for the default
 cluster to become ready:
@@ -88,21 +108,21 @@ cluster to become ready:
 
 # Writing tests
 
-See the examples in `test/clustertest/test_smoke.py`
+See the examples in `test/clustertest/test_smoke.py`.
 
 The tests folow pytest conventions:
 
-```
+```python
 from materialize.cloudtest.application import MaterializeApplication
 
 def test_something(mz: MaterializeApplication) -> None:
     assert ...
 ```
 
-The `MaterializeApplication` object is what creates the K8s cluster. It is instantiated once per `pytest` invocation
+The `MaterializeApplication` object is what creates the Kubernetes cluster. It
+is instantiated once per `pytest` invocation
 
 ## Waiting for a resource to reach a particular state
-
 
 ```
 from materialize.cloudtest.wait import wait
@@ -110,83 +130,93 @@ from materialize.cloudtest.wait import wait
 wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
 ```
 
-`wait` uses `kubectl wait` behind the scenes. Here is what the `kubectl wait` documentation has to say about the possible conditions:
+`wait` uses `kubectl wait` behind the scenes. Here is what the `kubectl wait`
+documentation has to say about the possible conditions:
 
-```
-  # Wait for the pod "busybox1" to contain the status condition of type "Ready"
-  kubectl wait --for=condition=Ready pod/busybox1
+```shell
+# Wait for the pod "busybox1" to contain the status condition of type "Ready"
+kubectl wait --for=condition=Ready pod/busybox1
 
-  # The default value of status condition is true; you can wait for other targets after an equal delimiter (compared
+# The default value of status condition is true; you can wait for other targets after an equal delimiter (compared
 after Unicode simple case folding, which is a more general form of case-insensitivity):
-  kubectl wait --for=condition=Ready=false pod/busybox1
+kubectl wait --for=condition=Ready=false pod/busybox1
 
-  # Wait for the pod "busybox1" to contain the status phase to be "Running".
-  kubectl wait --for=jsonpath='{.status.phase}'=Running pod/busybox1
+# Wait for the pod "busybox1" to contain the status phase to be "Running".
+kubectl wait --for=jsonpath='{.status.phase}'=Running pod/busybox1
 
-  # Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command
-  kubectl delete pod/busybox1
-  kubectl wait --for=delete pod/busybox1 --timeout=60s
+# Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command
+kubectl delete pod/busybox1
+kubectl wait --for=delete pod/busybox1 --timeout=60s
 ```
 
-In particular, to wait unti a resource has been deleted:
+In particular, to wait until a resource has been deleted:
 
-```
+```python
 wait(condition="delete", resource="secret/some_secret")
 ```
 
 ## Running testdrive
 
-```
-    mz.testdrive.run_string(
-        dedent(
-            """
-            > SELECT 1;
-            1
-            """
-        )
+```python
+mz.testdrive.run_string(
+    dedent(
+        """
+        > SELECT 1;
+        1
+        """
     )
+)
 ```
 
-Note that each invocation of `testdrive` will drop the current database and recreate it. If you want
-to run multiple `testdrive` fragments within the same test, use `no_reset=True` to prevent cleanup
-and `seed=N` to make sure they all share the same random seed:
+Note that each invocation of `testdrive` will drop the current database and
+recreate it. If you want to run multiple `testdrive` fragments within the same
+test, use `no_reset=True` to prevent cleanup and `seed=N` to make sure they all
+share the same random seed:
 
-```
-    mz.testdrive.run_string(..., no_reset=True, seed = N)
+```python
+mz.testdrive.run_string(..., no_reset=True, seed = N)
 ```
 
 ## Running one-off SQL statements
 
 If no result set is expected:
 
-```
-    mz.environmentd.sql("DROP TABLE t1;")
-```
-
-To fetch the result set:
-
-```
-    id = mz.environmentd.sql_query("SELECT id FROM mz_secrets WHERE name = 'username'")[
-        0
-    ][0]
+```python
+mz.environmentd.sql("DROP TABLE t1;")
 ```
 
-## Interacting with the cluster via kubectl
+To fetch a result set:
+
+```python
+id = mz.environmentd.sql_query("SELECT id FROM mz_secrets WHERE name = 'username'")[0][0]
+```
+
+## Interacting with the Kubernetes cluster via kubectl
 
 You can call `kubectl` and collect its output as follows:
 
 ```
-    secret_description = mz.kubectl("describe", "secret", "some_secret")
+secret_description = mz.kubectl("describe", "secret", "some_secret")
 ```
 
-## Interacting with the K8s cluster via API
+## Interacting with the Kubernetes cluster via API
 
 The following methods
 
-```
-   mz.environmentd.api()
-   mz.environmentd.apps_api()
-   mz.environmentd.rbac_api()
+```python
+mz.environmentd.api()
+mz.environmentd.apps_api()
+mz.environmentd.rbac_api()
 ```
 
-return API handles that can then be used with the official `kubernetes` python module.
+return API handles that can then be used with the official [`kubernetes`] Python
+module.
+
+[`kubernetes`]: https://github.com/kubernetes-client/python
+[k9s]: https://k9scli.io
+[kind-installation]: https://kind.sigs.k8s.io/docs/user/quick-start/#installing-with-a-package-manager
+[kind]: https://kind.sigs.k8s.io
+[kubectl-installation]: https://kubernetes.io/docs/tasks/tools/
+[kubectl]: https://kubernetes.io/docs/reference/kubectl/
+[MinIO]: https://min.io
+[pytest]: https://pytest.org

--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -58,6 +58,7 @@ class Application:
                         "kind",
                         "load",
                         "docker-image",
+                        "--name=cloudtest",
                         dep.spec(),
                     ]
                 )
@@ -68,7 +69,7 @@ class Application:
         ).decode("ascii")
 
     def context(self) -> str:
-        return "kind-kind"
+        return "kind-cloudtest"
 
 
 class MaterializeApplication(Application):
@@ -84,7 +85,7 @@ class MaterializeApplication(Application):
         self.release_mode = release_mode
         self.aws_region = aws_region
 
-        # Register the VpcEndpoint CRD
+        # Register the VpcEndpoint CRD.
         self.kubectl(
             "apply",
             "-f",
@@ -94,7 +95,7 @@ class MaterializeApplication(Application):
             ),
         )
 
-        # Start metrics-server
+        # Start metrics-server.
         self.kubectl(
             "apply",
             "-f",
@@ -131,12 +132,12 @@ class MaterializeApplication(Application):
 
         self.images = ["environmentd", "clusterd", "testdrive", "postgres"]
 
-        # Label the minicube nodes in a way that mimics Materialize cloud
+        # Label the kind nodes in a way that mimics production.
         for node in [
-            "kind-control-plane",
-            "kind-worker",
-            "kind-worker2",
-            "kind-worker3",
+            "cloudtest-control-plane",
+            "cloudtest-worker",
+            "cloudtest-worker2",
+            "cloudtest-worker3",
         ]:
             self.kubectl(
                 "label",

--- a/misc/python/materialize/cloudtest/exists.py
+++ b/misc/python/materialize/cloudtest/exists.py
@@ -14,15 +14,15 @@ from materialize import ui
 from materialize.ui import UIError
 
 
-def exists(resource: str, context: str = "kind-kind") -> None:
+def exists(resource: str, context: str = "kind-cloudtest") -> None:
     _exists(resource, True, context)
 
 
-def not_exists(resource: str, context: str = "kind-kind") -> None:
+def not_exists(resource: str, context: str = "kind-cloudtest") -> None:
     _exists(resource, False, context)
 
 
-def _exists(resource: str, should_exist: bool, context: str = "kind-kind") -> None:
+def _exists(resource: str, should_exist: bool, context: str = "kind-cloudtest") -> None:
     cmd = ["kubectl", "get", "--output", "name", resource, "--context", context]
     ui.progress(f'running {" ".join(cmd)} ... ')
 

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -51,7 +51,7 @@ class K8sResource:
         return RbacAuthorizationV1Api(api_client)
 
     def context(self) -> str:
-        return "kind-kind"
+        return "kind-cloudtest"
 
     def namespace(self) -> str:
         return "default"

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -91,9 +91,9 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         s3_endpoint = urllib.parse.quote("http://minio-service.default:9000")
 
         args = [
-            "--availability-zone=kind-worker",
-            "--availability-zone=kind-worker2",
-            "--availability-zone=kind-worker3",
+            "--availability-zone=cloudtest-worker",
+            "--availability-zone=cloudtest-worker2",
+            "--availability-zone=cloudtest-worker3",
             "--aws-account-id=123456789000",
             "--aws-external-id-prefix=eb5cb59b-e2fe-41f3-87ca-d2176a495345",
             "--announce-egress-ip=1.2.3.4",

--- a/misc/python/materialize/cloudtest/wait.py
+++ b/misc/python/materialize/cloudtest/wait.py
@@ -19,7 +19,7 @@ def wait(
     condition: str,
     resource: str,
     timeout_secs: int = 300,
-    context: str = "kind-kind",
+    context: str = "kind-cloudtest",
     *,
     label: Optional[str] = None,
 ) -> None:

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -98,6 +98,10 @@ try_finish() {
     exit 0
 }
 
+ci_unimportant_heading() {
+    echo "~~~" "$@" >&2
+}
+
 ci_collapsed_heading() {
     echo "---" "$@" >&2
 }
@@ -133,6 +137,30 @@ ci_status_report() {
     if ((ci_try_passed != ci_try_total)); then
         exit 1
     fi
+}
+
+# read_list PREFIX
+#
+# Appends the environment variables `PREFIX_0`, `PREFIX_1`, ... `PREFIX_N` to
+# the `result` global variable, stopping when `PREFIX_N` is an empty string.
+read_list() {
+    result=()
+
+    local i=0
+    local param="${1}_${i}"
+
+    if [[ "${!1:-}" ]]; then
+        echo "error: mzcompose command must be an array, not a string" >&2
+        exit 1
+    fi
+
+    while [[ "${!param:-}" ]]; do
+        result+=("${!param}")
+        i=$((i+1))
+        param="${1}_${i}"
+    done
+
+    [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
 # mapfile_shim [array]

--- a/test/cloudtest/reset
+++ b/test/cloudtest/reset
@@ -9,4 +9,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-exec "$(dirname "$0")"/../../bin/pytest -m 'not long' "$@"
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+. misc/shlib/shlib.bash
+
+run kubectl --context=kind-cloudtest delete all --all
+run kubectl --context=kind-cloudtest delete pvc --all

--- a/test/cloudtest/setup
+++ b/test/cloudtest/setup
@@ -9,4 +9,16 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-exec "$(dirname "$0")"/../../bin/pytest -m 'not long' "$@"
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+. misc/shlib/shlib.bash
+
+run kind create cluster --name=cloudtest --config=misc/kind/cluster.yaml --wait=60s || true
+
+for f in misc/kind/configmaps/*; do
+    run kubectl --context=kind-cloudtest apply -f "$f"
+done
+
+run kubectl --context=kind-cloudtest rollout restart -n kube-system deployment/coredns

--- a/test/cloudtest/teardown
+++ b/test/cloudtest/teardown
@@ -9,4 +9,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-exec "$(dirname "$0")"/../../bin/pytest -m 'not long' "$@"
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+. misc/shlib/shlib.bash
+
+run kind delete cluster --name=cloudtest

--- a/test/cloudtest/test_antiaffinity.py
+++ b/test/cloudtest/test_antiaffinity.py
@@ -80,9 +80,9 @@ def test_create_cluster_replica_zone_specified(mz: MaterializeApplication) -> No
     mz.environmentd.sql(
         """
         CREATE CLUSTER antiaffinity_cluster1 REPLICAS ();
-        CREATE CLUSTER REPLICA antiaffinity_cluster1.antiaffinity_replica1 SIZE '1' , AVAILABILITY ZONE 'kind-worker3';
-        CREATE CLUSTER REPLICA antiaffinity_cluster1.antiaffinity_replica2 SIZE '1' , AVAILABILITY ZONE 'kind-worker3';
-        CREATE CLUSTER REPLICA antiaffinity_cluster1.antiaffinity_replica3 SIZE '1' , AVAILABILITY ZONE 'kind-worker3';
+        CREATE CLUSTER REPLICA antiaffinity_cluster1.antiaffinity_replica1 SIZE '1' , AVAILABILITY ZONE 'cloudtest-worker3';
+        CREATE CLUSTER REPLICA antiaffinity_cluster1.antiaffinity_replica2 SIZE '1' , AVAILABILITY ZONE 'cloudtest-worker3';
+        CREATE CLUSTER REPLICA antiaffinity_cluster1.antiaffinity_replica3 SIZE '1' , AVAILABILITY ZONE 'cloudtest-worker3';
         """
     )
 


### PR DESCRIPTION
@philip-stoev the primary motivation here was the addition of the `setup` and `reset` scripts to improve the DX, and then I made a few more improvements while I was in the area. cloudtest is really 👌🏽—thank you so much for writing it!

* Share the `read_list` helper in the cloudtest Buildkite plugin with mzcompose, to avoid duplicating code.

* Use shlib in the mzcompose and cloudtest Buildkite plugins. In particular this allows use of the `ci_*_heading` functions, which are more readable than emitting Buildkite headings by hand.

* Introduce a `kubectl` function in the cloudtest Buildkite plugin to cut down on the verbosity of invoking kubectl.

* Introduce `setup`, `reset`, and `teardown` scripts in test/cloudtest, then use them in the cloudtest Buildkite plugin and in the developer documentation. This makes using cloudtest more ergonomic as a developer, as you don't have to either remember or copy/paste a complicated series of commands to use cloudtest, and also allows for sharing code between CI and local development.

* Change the name of the kind cluster from "kind-kind" to "kind-cloudtest". This plays better with other uses of kind on the same machine, which might use the default cluster name.

* Improve formatting and some spelling/grammar errors in the cloudtest developer documentation. Also add a few links to documentation, and recommend the use of k9s.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
