### PR TITLE
Add `cpu_percent_normalized` to utilization tables

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -99,6 +99,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `replica_id`     | [`uint8`] | The ID of a cluster replica.                               |
 | `process_id`     | [`uint8`] | An identifier of a compute process within a replica.       |
 | `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
+| `cpu_percent_normalized`    | [`uint8`] | Approximate CPU usage, in percent of the total number of timely workers. Can exceed 100, as threads other than timely workers may be scheduled. |
 | `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
 
 ### `mz_dataflows`
@@ -439,6 +440,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 |------------------|-----------|------------------------------------------------------------|
 | `source_id`      | [`uint8`] | The ID of a source.                                        |
 | `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
+| `cpu_percent_normalized`    | [`uint8`] | Approximate CPU usage, in percent of the total number of timely workers. Can exceed 100, as threads other than timely workers may be scheduled. |
 | `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
 
 ### `mz_sink_utilization`
@@ -452,6 +454,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 |------------------|-----------|------------------------------------------------------------|
 | `sink_id`        | [`uint8`] | The ID of a sink.                                          |
 | `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
+| `cpu_percent_normalized`    | [`uint8`] | Approximate CPU usage, in percent of the total number of timely workers. Can exceed 100, as threads other than timely workers may be scheduled. |
 | `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
 
 ### `mz_storage_host_metrics`

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2431,6 +2431,7 @@ SELECT
     r.id AS replica_id,
     m.process_id,
     m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
+    m.cpu_nano_cores::float8 / (s.workers * 10000000) AS cpu_percent_normalized,
     m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent
 FROM
     mz_cluster_replicas AS r
@@ -2445,6 +2446,7 @@ pub const MZ_SOURCE_UTILIZATION: BuiltinView = BuiltinView {
 SELECT
     sources.id AS source_id,
     m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
+    m.cpu_nano_cores::float8 / (s.workers * 10000000) AS cpu_percent_normalized,
     m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent
 FROM
     mz_sources AS sources
@@ -2459,6 +2461,7 @@ pub const MZ_SINK_UTILIZATION: BuiltinView = BuiltinView {
 SELECT
     sinks.id AS sink_id,
     m.cpu_nano_cores::float8 / s.cpu_nano_cores * 100 AS cpu_percent,
+    m.cpu_nano_cores::float8 / (s.workers * 10000000) AS cpu_percent_normalized,
     m.memory_bytes::float8 / s.memory_bytes * 100 AS memory_percent
 FROM
     mz_sinks AS sinks

--- a/test/testdrive/metrics-cluster.td
+++ b/test/testdrive/metrics-cluster.td
@@ -12,20 +12,20 @@
 > CREATE CLUSTER xyzzy REPLICAS (size_4 (SIZE '4'))
 
 > SELECT
-     c.name,
-     r.name,
-     u.process_id,
-     u.cpu_percent_normalized > 0.0,
-     u.cpu_percent > 0.0,
-     u.memory_percent > 0.0
- FROM
-     mz_clusters AS c
-         JOIN mz_cluster_replicas AS r ON r.cluster_id = c.id
-         JOIN
-             mz_internal.mz_cluster_replica_utilization AS u
-             ON r.id = u.replica_id
- WHERE c.name IN ( 'foo', 'bar', 'xyzzy' )
- ORDER BY c.name, r.name, process_id
+      c.name,
+      r.name,
+      u.process_id,
+      u.cpu_percent_normalized > 0.0,
+      u.cpu_percent > 0.0,
+      u.memory_percent > 0.0
+  FROM
+      mz_clusters AS c
+          JOIN mz_cluster_replicas AS r ON r.cluster_id = c.id
+          JOIN
+              mz_internal.mz_cluster_replica_utilization AS u
+              ON r.id = u.replica_id
+  WHERE c.name IN ( 'foo', 'bar', 'xyzzy' )
+  ORDER BY c.name, r.name, process_id
 foo size_1 0 true true true
 foo size_2_2 0 true true true
 foo size_2_2 1 true true true

--- a/test/testdrive/metrics-cluster.td
+++ b/test/testdrive/metrics-cluster.td
@@ -11,17 +11,26 @@
 > CREATE CLUSTER bar REPLICAS ()
 > CREATE CLUSTER xyzzy REPLICAS (size_4 (SIZE '4'))
 
-> SELECT c.name, r.name, u.process_id, u.cpu_percent > 0.0, u.memory_percent > 0.0
-  FROM mz_clusters c
-  JOIN mz_cluster_replicas r ON r.cluster_id = c.id
-  JOIN mz_internal.mz_cluster_replica_utilization u ON r.id = u.replica_id
-  WHERE c.name IN ('foo', 'bar', 'xyzzy')
-  ORDER BY c.name, r.name, process_id
-foo size_1 0 true true
-foo size_2_2 0 true true
-foo size_2_2 1 true true
-foo size_32 0 true true
-xyzzy size_4 0 true true
+> SELECT
+     c.name,
+     r.name,
+     u.process_id,
+     u.cpu_percent_normalized > 0.0,
+     u.cpu_percent > 0.0,
+     u.memory_percent > 0.0
+ FROM
+     mz_clusters AS c
+         JOIN mz_cluster_replicas AS r ON r.cluster_id = c.id
+         JOIN
+             mz_internal.mz_cluster_replica_utilization AS u
+             ON r.id = u.replica_id
+ WHERE c.name IN ( 'foo', 'bar', 'xyzzy' )
+ ORDER BY c.name, r.name, process_id
+foo size_1 0 true true true
+foo size_2_2 0 true true true
+foo size_2_2 1 true true true
+foo size_32 0 true true true
+xyzzy size_4 0 true true true
 
 > DROP CLUSTER foo
 > DROP CLUSTER bar

--- a/test/testdrive/metrics-storage.td
+++ b/test/testdrive/metrics-storage.td
@@ -33,17 +33,17 @@ goofus,gallant
 # interval is 20 seconds.
 
 > SELECT
-     s.name,
-     u.cpu_percent >= 0.0,
-     u.cpu_percent_normalized >= 0.0,
-     u.memory_percent > 0.0
- FROM
-     mz_sources AS s
-         JOIN
-             mz_internal.mz_source_utilization AS u
-             ON s.id = u.source_id
- WHERE s.name IN ( 'metrics_test_source' )
- ORDER BY s.name
+      s.name,
+      u.cpu_percent >= 0.0,
+      u.cpu_percent_normalized >= 0.0,
+      u.memory_percent > 0.0
+  FROM
+      mz_sources AS s
+          JOIN
+              mz_internal.mz_source_utilization AS u
+              ON s.id = u.source_id
+  WHERE s.name IN ( 'metrics_test_source' )
+  ORDER BY s.name
 metrics_test_source true true true
 
 > SELECT

--- a/test/testdrive/metrics-storage.td
+++ b/test/testdrive/metrics-storage.td
@@ -32,19 +32,33 @@ goofus,gallant
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 20 seconds.
 
-> SELECT s.name, u.cpu_percent >= 0.0, u.memory_percent > 0.0
-  FROM mz_sources s
-  JOIN mz_internal.mz_source_utilization u ON s.id = u.source_id
-  WHERE s.name IN ('metrics_test_source')
-  ORDER BY s.name
-metrics_test_source true true
+> SELECT
+     s.name,
+     u.cpu_percent >= 0.0,
+     u.cpu_percent_normalized >= 0.0,
+     u.memory_percent > 0.0
+ FROM
+     mz_sources AS s
+         JOIN
+             mz_internal.mz_source_utilization AS u
+             ON s.id = u.source_id
+ WHERE s.name IN ( 'metrics_test_source' )
+ ORDER BY s.name
+metrics_test_source true true true
 
-> SELECT s.name, u.cpu_percent >= 0.0, u.memory_percent > 0.0
-  FROM mz_sinks s
-  JOIN mz_internal.mz_sink_utilization u ON s.id = u.sink_id
-  WHERE s.name IN ('metrics_test_sink')
-  ORDER BY s.name
-metrics_test_sink true true
+> SELECT
+     s.name,
+     u.cpu_percent >= 0.0,
+     u.cpu_percent_normalized >= 0.0,
+     u.memory_percent > 0.0
+ FROM
+     mz_sinks AS s
+         JOIN
+             mz_internal.mz_sink_utilization AS u
+             ON s.id = u.sink_id
+ WHERE s.name IN ( 'metrics_test_sink' )
+ ORDER BY s.name
+metrics_test_sink true true true
 
 > DROP SINK metrics_test_sink
 > DROP SOURCE metrics_test_source

--- a/test/testdrive/metrics-storage.td
+++ b/test/testdrive/metrics-storage.td
@@ -47,17 +47,17 @@ goofus,gallant
 metrics_test_source true true true
 
 > SELECT
-     s.name,
-     u.cpu_percent >= 0.0,
-     u.cpu_percent_normalized >= 0.0,
-     u.memory_percent > 0.0
- FROM
-     mz_sinks AS s
-         JOIN
-             mz_internal.mz_sink_utilization AS u
-             ON s.id = u.sink_id
- WHERE s.name IN ( 'metrics_test_sink' )
- ORDER BY s.name
+      s.name,
+      u.cpu_percent >= 0.0,
+      u.cpu_percent_normalized >= 0.0,
+      u.memory_percent > 0.0
+  FROM
+      mz_sinks AS s
+          JOIN
+              mz_internal.mz_sink_utilization AS u
+              ON s.id = u.sink_id
+  WHERE s.name IN ( 'metrics_test_sink' )
+  ORDER BY s.name
 metrics_test_sink true true true
 
 > DROP SINK metrics_test_sink


### PR DESCRIPTION
The utilization metrics we currently report are correct (they behave similarly to tools like `top`). However, at some point, we made a policy decision to only schedule Timely workers on half the available logical cores, in an attempt to ensure that hyperthreading is not used and each worker receives its own dedicated core.

Whether that is beneficial (and even whether it actually works at all) is currently unclear; @teskje has an issue open to measure it: https://github.com/MaterializeInc/materialize/issues/16805 .

In the meantime, we do need a way for users to see approximately how much of their Timely allocation is being used. One good quick heuristic is to simply divide the total CPU usage by the number of timely workers in the process. This PR does so, naming the column `cpu_percent_normalized`. Note that the heuristic is imperfect, since other threads might be doing work while there is still some capacity available to Timely (e.g., if it turns out hyperthreading _is_ actually useful). But since timely operators are the main things doing nontrivial work in the system, that seems unlikely in practice. 

### Motivation


  * This PR adds a known-desirable feature.

    Reported by Frank on Slack: https://materializeinc.slack.com/archives/CM7ATT65S/p1671662453899139


### Tips for reviewer

The changes to the .tds are just querying one new column, but I ran the queries through mz.sqlfum.pt which created the big diff

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add `cpu_percent_normalized` column to `mz_{sink,source,cluster_replica}_utilization`
