### PR TITLE
compute: remove a panic from reduce implementation

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1347,7 +1347,7 @@ where
                             (
                                 AggregateFunc::SumUInt64,
                                 AccumInner::SimpleNumber { accum, .. },
-                            ) => Datum::from(u128::try_from(*accum).unwrap_or_else(|_| panic!("Invalid accumulated result {accum} for unsigned function"))),
+                            ) => Datum::from(*accum),
                             (
                                 AggregateFunc::SumFloat32,
                                 AccumInner::Float {


### PR DESCRIPTION
The output type of SumUint64 is Numeric, which can handle negative values, but the reduce implementation was panicking on negative values by casting to Numeric via an unsigned type (i128 -> u128 -> Numeric).

This commit removes the panic by casting directly from i128 to Numeric, as we're moving in the direction of making reduce less panicky (see issue #8066).

This mitigates the crash we were seeing in #_incident-28, in which a canceled query that used SumUint64 could result in the reduce operator observing partial data and panicking due to the negative accumulation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR mitigates a bug discovered in incident 28.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
