### PR TITLE
mz: cleanup header management

### DIFF
--- a/src/mz/src/configuration.rs
+++ b/src/mz/src/configuration.rs
@@ -14,7 +14,6 @@ use std::{collections::BTreeMap, fmt::Display, fs, path::PathBuf};
 use anyhow::{bail, Context};
 use dirs::home_dir;
 use once_cell::sync::Lazy;
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -310,13 +309,8 @@ impl Profile<'_> {
     ) -> Result<ValidProfile<'_>, anyhow::Error> {
         let api_token: FronteggAPIToken = self.profile.app_password.as_str().try_into()?;
 
-        let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-
         let authentication_result = client
             .post(self.endpoint().api_token_auth_url())
-            .headers(headers)
             .json(&api_token)
             .send()
             .await

--- a/src/mz/src/login.rs
+++ b/src/mz/src/login.rs
@@ -14,12 +14,11 @@ use std::net::SocketAddr;
 use anyhow::{bail, Context, Ok, Result};
 use axum::http::StatusCode;
 use axum::{extract::Query, response::IntoResponse, routing::get, Router};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
 use tokio::sync::broadcast::{channel, Sender};
 
 use crate::configuration::{Configuration, Endpoint, FronteggAPIToken, FronteggAuth};
-use crate::utils::trim_newline;
+use crate::utils::{trim_newline, RequestBuilderExt};
 use crate::BrowserAPIToken;
 
 /// Request handler for the server waiting the browser API token creation
@@ -89,21 +88,12 @@ pub(crate) async fn generate_api_token(
     access_token_response: FronteggAuth,
     description: &String,
 ) -> Result<FronteggAPIToken, reqwest::Error> {
-    let authorization: String = format!("Bearer {}", access_token_response.access_token);
-
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(authorization.as_str()).unwrap(),
-    );
     let mut body = HashMap::new();
     body.insert("description", description);
 
     client
         .post(endpoint.api_token_url())
-        .headers(headers)
+        .authenticate(&access_token_response)
         .json(&body)
         .send()
         .await?
@@ -122,13 +112,8 @@ async fn authenticate_user(
     access_token_request_body.insert("email", email);
     access_token_request_body.insert("password", password);
 
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-
     let response = client
         .post(endpoint.user_auth_url())
-        .headers(headers)
         .json(&access_token_request_body)
         .send()
         .await?;
@@ -147,6 +132,7 @@ async fn authenticate_user(
 /// Log the user using the console, generates an API token and saves the new profile data.
 pub(crate) async fn login_with_console(
     endpoint: Endpoint,
+    client: &Client,
     profile_name: &String,
     config: &mut Configuration,
 ) -> Result<()> {
@@ -162,14 +148,12 @@ pub(crate) async fn login_with_console(
     let _ = std::io::stdout().flush();
     let password = rpassword::read_password().unwrap();
 
-    let client = Client::new();
-
     // Check if there is a secret somewhere.
     // If there is none save the api token someone on the root folder.
-    let auth_user = authenticate_user(&endpoint, &client, &email, &password).await?;
+    let auth_user = authenticate_user(&endpoint, client, &email, &password).await?;
     let api_token = generate_api_token(
         &endpoint,
-        &client,
+        client,
         auth_user,
         &String::from("App password for the CLI"),
     )

--- a/src/mz/src/password.rs
+++ b/src/mz/src/password.rs
@@ -9,10 +9,9 @@
 
 use std::collections::HashMap;
 
-use crate::configuration::ValidProfile;
 use crate::FronteggAppPassword;
+use crate::{configuration::ValidProfile, utils::RequestBuilderExt};
 use anyhow::{Context, Result};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
 
 /// Get Frontegg API tokens using an access token
@@ -20,21 +19,12 @@ pub(crate) async fn list_passwords(
     client: &Client,
     valid_profile: &ValidProfile<'_>,
 ) -> Result<Vec<FronteggAppPassword>> {
-    let authorization: String = format!("Bearer {}", valid_profile.frontegg_auth.access_token);
-
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(authorization.as_str()).unwrap(),
-    );
     let mut body = HashMap::new();
     body.insert("description", &"App password for the CLI");
 
     client
         .get(valid_profile.profile.endpoint().api_token_url())
-        .headers(headers)
+        .authenticate(&valid_profile.frontegg_auth)
         .json(&body)
         .send()
         .await

--- a/src/mz/src/utils.rs
+++ b/src/mz/src/utils.rs
@@ -7,8 +7,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use reqwest::{Client, ClientBuilder, RequestBuilder};
 use std::time::Duration;
+
+use crate::configuration::FronteggAuth;
+
+/// Create a stanard client with common
+/// header values for all requests.
+pub fn new_client() -> Result<Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    ClientBuilder::new()
+        .default_headers(headers)
+        .build()
+        .context("failed to create client")
+}
+
+/// Extgension methods for building API requests
+pub(crate) trait RequestBuilderExt {
+    /// Authenticate the client with frontegg
+    fn authenticate(self, auth: &FronteggAuth) -> Self;
+}
+
+impl RequestBuilderExt for RequestBuilder {
+    fn authenticate(self, auth: &FronteggAuth) -> Self {
+        let authorization = format!("Bearer {}", auth.access_token);
+        self.header(AUTHORIZATION, &authorization)
+    }
+}
 
 /// Trim lines. Useful when reading input data.
 pub(crate) fn trim_newline(s: &mut String) {

--- a/src/mz/src/utils.rs
+++ b/src/mz/src/utils.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use crate::configuration::FronteggAuth;
 
-/// Create a stanard client with common
+/// Create a standard client with common
 /// header values for all requests.
 pub fn new_client() -> Result<Client> {
     let mut headers = HeaderMap::new();


### PR DESCRIPTION
### Motivation

The CLI specifies the same reqwest client headers across multiple functions. This pulls them out as default headers specified on the builder. It also adds an extension method to simplify authenticating against frontegg. 

### Tips for reviewer

Hide whitespace changes when reviewing. `cargo fmt` had a field day with `main.rs`. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

