### PR TITLE
mz: Add the ability to store app passwords within the local keychain for more secure storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +225,36 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-io"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -501,12 +543,12 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "once_cell",
  "percent-encoding",
  "regex",
- "sha2",
+ "sha2 0.10.6",
  "time",
  "tracing",
 ]
@@ -540,7 +582,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.6",
  "tracing",
 ]
 
@@ -837,12 +879,37 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -933,6 +1000,12 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
@@ -1078,6 +1151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1246,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -1273,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1405,7 +1496,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
@@ -1443,6 +1534,16 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1705,11 +1806,20 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.0",
  "crypto-common",
  "subtle",
 ]
@@ -1910,11 +2020,32 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+dependencies = [
+ "enumflags2_derive 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8672257d642ffdd235f6e9c723c2326ac1253c8f3c022e7cfd2e57da55b1131"
 dependencies = [
- "enumflags2_derive",
+ "enumflags2_derive 0.7.0",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1963,6 +2094,12 @@ name = "ethnum"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eac3c0b9fa6eb75255ebb42c0ba3e2210d102a66d2795afef6fed668f373311"
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eventsource-client"
@@ -2228,6 +2365,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,12 +2583,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2764,6 +2936,18 @@ dependencies = [
  "serde-value",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "keyring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fb8399ddcabfccb274577a8d90f0653e0b5b5977797c1c8834ad09839a10e5"
+dependencies = [
+ "byteorder",
+ "secret-service",
+ "security-framework",
+ "winapi",
 ]
 
 [[package]]
@@ -3135,7 +3319,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3151,6 +3335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3295,7 +3488,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.6",
  "smallvec",
  "subprocess",
  "thiserror",
@@ -3312,6 +3505,7 @@ dependencies = [
  "clap",
  "dirs",
  "indicatif",
+ "keyring",
  "mz-ore",
  "once_cell",
  "open",
@@ -3412,7 +3606,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "crc32fast",
- "digest",
+ "digest 0.10.6",
  "enum-kinds",
  "flate2",
  "itertools",
@@ -3421,7 +3615,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "snap",
  "tracing",
  "uuid",
@@ -3706,7 +3900,7 @@ dependencies = [
  "mz-sql",
  "mz-stash",
  "mz-storage-client",
- "nix",
+ "nix 0.26.1",
  "num_cpus",
  "once_cell",
  "openssl",
@@ -3763,7 +3957,7 @@ dependencies = [
  "enum-iterator",
  "fallible-iterator",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "itertools",
  "md-5",
  "mz-expr-test-util",
@@ -3790,7 +3984,7 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "sha1",
- "sha2",
+ "sha2 0.10.6",
  "uncased",
  "uuid",
  "workspace-hack",
@@ -3968,7 +4162,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "reqwest",
- "sha2",
+ "sha2 0.10.6",
  "tar",
  "walkdir",
  "workspace-hack",
@@ -4012,7 +4206,7 @@ dependencies = [
  "mz-secrets",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "tracing",
  "workspace-hack",
 ]
@@ -4974,6 +5168,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb-connect"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bb540dc6ef51cfe1916ec038ce7a620daf3a111e2502d745197cd53d6bca15"
+dependencies = [
+ "libc",
+ "socket2",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4982,7 +5199,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
 ]
@@ -5136,7 +5353,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5168,6 +5385,12 @@ name = "oorandom"
 version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open"
@@ -5373,6 +5596,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -5596,6 +5825,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "windows-sys",
+]
+
+[[package]]
 name = "polonius-the-crab"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,11 +5883,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "memchr",
  "rand",
- "sha2",
+ "sha2 0.10.6",
  "stringprep",
 ]
 
@@ -5683,7 +5926,7 @@ dependencies = [
  "findshlibs",
  "libc",
  "log",
- "nix",
+ "nix 0.26.1",
  "once_cell",
  "parking_lot",
  "smallvec",
@@ -5764,6 +6007,15 @@ checksum = "d7685ca4cc0b3ad748c22ce6803e23b55b9206ef7715b965ebeaf41639238fdc"
 dependencies = [
  "autocfg",
  "indexmap",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -6377,6 +6629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6409,10 +6667,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.0.0"
+name = "secret-service"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "e1da5c423b8783185fd3fecd1c8796c267d2c089d894ce5a93c280a5d3f780a2"
+dependencies = [
+ "aes",
+ "block-modes",
+ "hkdf",
+ "lazy_static",
+ "num",
+ "rand",
+ "serde",
+ "sha2 0.9.9",
+ "zbus",
+ "zbus_macros",
+ "zvariant",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6423,9 +6701,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6635,6 +6913,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6694,7 +6983,20 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -6705,7 +7007,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -6852,7 +7154,7 @@ dependencies = [
  "pem-rfc7468",
  "rand_core",
  "sec1",
- "sha2",
+ "sha2 0.10.6",
  "signature",
  "zeroize",
 ]
@@ -7125,7 +7427,7 @@ dependencies = [
  "bytes",
  "connection-string",
  "encoding",
- "enumflags2",
+ "enumflags2 0.7.1",
  "futures",
  "futures-sink",
  "futures-util",
@@ -7867,6 +8169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7967,6 +8275,15 @@ checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -8102,7 +8419,7 @@ dependencies = [
  "crossbeam-utils",
  "crypto-common",
  "dec",
- "digest",
+ "digest 0.10.6",
  "either",
  "flate2",
  "frunk_core",
@@ -8127,7 +8444,7 @@ dependencies = [
  "lru",
  "memchr",
  "native-tls",
- "nix",
+ "nix 0.26.1",
  "nom",
  "num-bigint",
  "num-integer",
@@ -8159,7 +8476,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "smallvec",
  "socket2",
  "syn",
@@ -8225,6 +8542,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbeb2291cd7267a94489b71376eda33496c1b9881adf6b36f26cc2779f3fc49"
+dependencies = [
+ "async-io",
+ "byteorder",
+ "derivative",
+ "enumflags2 0.6.4",
+ "fastrand",
+ "futures",
+ "nb-connect",
+ "nix 0.22.3",
+ "once_cell",
+ "polling",
+ "scoped-tls",
+ "serde",
+ "serde_repr",
+ "zbus_macros",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3959a7847cf95e3d51e312856617c5b1b77191176c65a79a5f14d778bbe0a6"
+dependencies = [
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8241,4 +8593,30 @@ checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "zvariant"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c7b55f2074489b7e8e07d2d0a6ee6b4f233867a653c664d8020ba53692525"
+dependencies = [
+ "byteorder",
+ "enumflags2 0.6.4",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ca5e22593eb4212382d60d26350065bf2a02c34b85bc850474a74b589a3de9"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,7 @@ wrappers = [
     # TODO(guswynn): switch to tracing in rdkafka
     "rdkafka",
     "reqwest",
+    "secret-service",
     "tokio-postgres",
     "tokio-tungstenite",
     "tokio-util",
@@ -100,6 +101,7 @@ wrappers = [
   "prost-build",
   "rayon-core",
   "reqwest",
+  "secret-service",
   "schannel",
   "sharded-slab",
   "tracing-core",

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -25,3 +25,4 @@ uuid = "1.2.2"
 url = "2.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 postgres-protocol = "0.6.4"
+keyring = "1.2.0"

--- a/src/mz/src/configuration.rs
+++ b/src/mz/src/configuration.rs
@@ -14,7 +14,6 @@ use std::{collections::BTreeMap, fmt::Display, fs, path::PathBuf};
 use anyhow::{bail, Context};
 use dirs::home_dir;
 use once_cell::sync::Lazy;
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -310,13 +309,8 @@ impl Profile<'_> {
     ) -> Result<ValidProfile<'_>, anyhow::Error> {
         let api_token: FronteggAPIToken = self.profile.app_password.as_str().try_into()?;
 
-        let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-
         let authentication_result = client
             .post(self.endpoint().api_token_auth_url())
-            .headers(headers)
             .json(&api_token)
             .send()
             .await

--- a/src/mz/src/configuration.rs
+++ b/src/mz/src/configuration.rs
@@ -115,6 +115,7 @@ impl fmt::Display for Endpoint {
 struct Profile0 {
     email: String,
     #[serde(rename(serialize = "app-password", deserialize = "app-password"))]
+    #[serde(default, skip_serializing_if = "Token::is_default")]
     app_password: Token,
     region: Option<CloudProviderRegion>,
     #[serde(default, skip_serializing_if = "Endpoint::is_default")]

--- a/src/mz/src/configuration.rs
+++ b/src/mz/src/configuration.rs
@@ -20,6 +20,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::region::CloudProviderRegion;
+use crate::vault::Token;
 
 pub const WEB_DOCS_URL: &str = "https://www.materialize.com/docs";
 
@@ -27,7 +28,7 @@ pub static DEFAULT_ENDPOINT: Lazy<Endpoint> =
     Lazy::new(|| "https://cloud.materialize.com".parse().unwrap());
 
 /// A Materialize Cloud API endpoint.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct Endpoint {
     url: Url,
@@ -114,7 +115,7 @@ impl fmt::Display for Endpoint {
 struct Profile0 {
     email: String,
     #[serde(rename(serialize = "app-password", deserialize = "app-password"))]
-    app_password: String,
+    app_password: Token,
     region: Option<CloudProviderRegion>,
     #[serde(default, skip_serializing_if = "Endpoint::is_default")]
     endpoint: Endpoint,
@@ -141,7 +142,7 @@ pub(crate) struct FronteggAuth {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct FronteggAPIToken {
+pub struct FronteggAPIToken {
     pub(crate) client_id: String,
     pub(crate) secret: String,
 }
@@ -149,6 +150,7 @@ pub(crate) struct FronteggAPIToken {
 pub(crate) struct ValidProfile<'a> {
     pub(crate) profile: &'a Profile<'a>,
     pub(crate) frontegg_auth: FronteggAuth,
+    pub(crate) app_password: String,
 }
 
 #[allow(dead_code)]
@@ -233,14 +235,14 @@ impl Configuration {
         endpoint: Endpoint,
         name: String,
         email: String,
-        api_token: FronteggAPIToken,
+        token: Token,
     ) {
         self.modified = true;
         self.profiles.insert(
             name,
             Profile0 {
                 email,
-                app_password: api_token.to_string(),
+                app_password: token,
                 region: None,
                 endpoint,
             },
@@ -290,10 +292,6 @@ impl Profile<'_> {
         &self.profile.email
     }
 
-    pub(crate) fn get_app_password(&self) -> &str {
-        &self.profile.app_password
-    }
-
     pub(crate) fn get_default_region(&self) -> Option<CloudProviderRegion> {
         self.profile.region
     }
@@ -303,11 +301,20 @@ impl Profile<'_> {
         self.profile.region = Some(region)
     }
 
+    pub fn get_frontegg_api_token(&self, name: &str) -> Result<FronteggAPIToken, anyhow::Error> {
+        self.profile
+            .app_password
+            .retrieve(name, &self.profile.email)?
+            .as_str()
+            .try_into()
+    }
+
     pub(crate) async fn validate(
         &self,
+        name: &str,
         client: &Client,
     ) -> Result<ValidProfile<'_>, anyhow::Error> {
-        let api_token: FronteggAPIToken = self.profile.app_password.as_str().try_into()?;
+        let api_token: FronteggAPIToken = self.get_frontegg_api_token(name)?;
 
         let authentication_result = client
             .post(self.endpoint().api_token_auth_url())
@@ -328,6 +335,7 @@ impl Profile<'_> {
         Ok(ValidProfile {
             profile: self,
             frontegg_auth: auth,
+            app_password: api_token.to_string(),
         })
     }
 }

--- a/src/mz/src/login.rs
+++ b/src/mz/src/login.rs
@@ -17,8 +17,9 @@ use axum::{extract::Query, response::IntoResponse, routing::get, Router};
 use reqwest::Client;
 use tokio::sync::broadcast::{channel, Sender};
 
-use crate::configuration::{Configuration, Endpoint, FronteggAPIToken, FronteggAuth};
+use crate::configuration::{Endpoint, FronteggAPIToken, FronteggAuth};
 use crate::utils::{trim_newline, RequestBuilderExt};
+
 use crate::BrowserAPIToken;
 
 /// Request handler for the server waiting the browser API token creation
@@ -44,10 +45,9 @@ async fn request(
 
 /// Log the user using the browser, generates an API token and saves the new profile data.
 pub(crate) async fn login_with_browser(
-    endpoint: Endpoint,
+    endpoint: &Endpoint,
     profile_name: &str,
-    config: &mut Configuration,
-) -> Result<()> {
+) -> Result<(String, FronteggAPIToken)> {
     // Open the browser to login user.
     let url = endpoint.web_login_url(profile_name).to_string();
     if let Err(err) = open::that(&url) {
@@ -68,17 +68,11 @@ pub(crate) async fn login_with_browser(
             .await
     });
 
-    match result
+    result
         .recv()
         .await
         .context("failed to retrive new profile")?
-    {
-        Some((email, api_token)) => {
-            config.create_or_update_profile(endpoint, profile_name.to_string(), email, api_token);
-            Ok(())
-        }
-        None => bail!("failed to login via browser"),
-    }
+        .context("failed to login via browser")
 }
 
 /// Generates an API token using an access token
@@ -130,12 +124,11 @@ async fn authenticate_user(
 }
 
 /// Log the user using the console, generates an API token and saves the new profile data.
+
 pub(crate) async fn login_with_console(
-    endpoint: Endpoint,
+    endpoint: &Endpoint,
     client: &Client,
-    profile_name: &String,
-    config: &mut Configuration,
-) -> Result<()> {
+) -> Result<(String, FronteggAPIToken)> {
     // Handle interactive user input
     let mut email = String::new();
 
@@ -148,18 +141,14 @@ pub(crate) async fn login_with_console(
     let _ = std::io::stdout().flush();
     let password = rpassword::read_password().unwrap();
 
-    // Check if there is a secret somewhere.
-    // If there is none save the api token someone on the root folder.
-    let auth_user = authenticate_user(&endpoint, client, &email, &password).await?;
+    let auth_user = authenticate_user(endpoint, client, &email, &password).await?;
     let api_token = generate_api_token(
-        &endpoint,
+        endpoint,
         client,
         auth_user,
         &String::from("App password for the CLI"),
     )
     .await?;
 
-    config.create_or_update_profile(endpoint, profile_name.to_string(), email, api_token);
-
-    Ok(())
+    Ok((email, api_token))
 }

--- a/src/mz/src/login.rs
+++ b/src/mz/src/login.rs
@@ -14,12 +14,11 @@ use std::net::SocketAddr;
 use anyhow::{bail, Context, Ok, Result};
 use axum::http::StatusCode;
 use axum::{extract::Query, response::IntoResponse, routing::get, Router};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
 use tokio::sync::broadcast::{channel, Sender};
 
 use crate::configuration::{Configuration, Endpoint, FronteggAPIToken, FronteggAuth};
-use crate::utils::trim_newline;
+use crate::utils::{trim_newline, RequestBuilderExt};
 use crate::BrowserAPIToken;
 
 /// Request handler for the server waiting the browser API token creation
@@ -89,21 +88,12 @@ pub(crate) async fn generate_api_token(
     access_token_response: FronteggAuth,
     description: &String,
 ) -> Result<FronteggAPIToken, reqwest::Error> {
-    let authorization: String = format!("Bearer {}", access_token_response.access_token);
-
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(authorization.as_str()).unwrap(),
-    );
     let mut body = HashMap::new();
     body.insert("description", description);
 
     client
         .post(endpoint.api_token_url())
-        .headers(headers)
+        .authenticate(&access_token_response)
         .json(&body)
         .send()
         .await?
@@ -122,13 +112,8 @@ async fn authenticate_user(
     access_token_request_body.insert("email", email);
     access_token_request_body.insert("password", password);
 
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-
     let response = client
         .post(endpoint.user_auth_url())
-        .headers(headers)
         .json(&access_token_request_body)
         .send()
         .await?;
@@ -147,6 +132,7 @@ async fn authenticate_user(
 /// Log the user using the console, generates an API token and saves the new profile data.
 pub(crate) async fn login_with_console(
     endpoint: Endpoint,
+    client: &Client,
     profile_name: &String,
     config: &mut Configuration,
 ) -> Result<()> {
@@ -162,14 +148,12 @@ pub(crate) async fn login_with_console(
     let _ = std::io::stdout().flush();
     let password = rpassword::read_password().unwrap();
 
-    let client = Client::new();
-
     // Check if there is a secret somewhere.
     // If there is none save the api token someone on the root folder.
-    let auth_user = authenticate_user(&endpoint, &client, &email, &password).await?;
+    let auth_user = authenticate_user(&endpoint, client, &email, &password).await?;
     let api_token = generate_api_token(
         &endpoint,
-        &client,
+        client,
         auth_user,
         &String::from("App password for the CLI"),
     )

--- a/src/mz/src/main.rs
+++ b/src/mz/src/main.rs
@@ -87,6 +87,7 @@ use clap::{Args, Parser, Subcommand};
 use secrets::SecretCommand;
 use serde::Deserialize;
 use utils::new_client;
+use vault::Vault;
 
 use crate::configuration::{Configuration, Endpoint, WEB_DOCS_URL};
 use crate::login::{generate_api_token, login_with_browser, login_with_console};
@@ -106,6 +107,7 @@ mod region;
 mod secrets;
 mod shell;
 mod utils;
+mod vault;
 
 /// Command-line interface for Materialize.
 #[derive(Debug, Parser)]
@@ -134,6 +136,9 @@ enum Commands {
         /// Force reauthentication for the profile
         #[clap(short, long)]
         force: bool,
+
+        #[clap(flatten)]
+        vault: Vault,
 
         /// Override the default API endpoint.
         #[clap(long, hide = true, default_value_t)]
@@ -251,12 +256,13 @@ async fn main() -> Result<()> {
     let args = Cli::parse();
     let client = new_client()?;
     let mut config = Configuration::load(args.profile.as_deref())?;
+    let profile_name = config.current_profile();
 
     match args.command {
         Commands::AppPassword(password_cmd) => {
             let profile = config.get_profile()?;
 
-            let valid_profile = profile.validate(&client).await?;
+            let valid_profile = profile.validate(&profile_name, &client).await?;
 
             match password_cmd.command {
                 AppPasswordSubommand::Create { name } => {
@@ -301,16 +307,20 @@ async fn main() -> Result<()> {
         Commands::Login {
             interactive,
             force,
+            vault,
             endpoint,
         } => {
             let profile = args.profile.unwrap_or_else(|| "default".into());
             config.update_current_profile(profile.clone());
             if config.get_profile().is_err() || force {
-                if interactive {
-                    login_with_console(endpoint, &client, &profile, &mut config).await?
+                let (email, api_token) = if interactive {
+                    login_with_console(&endpoint, &client).await?
                 } else {
-                    login_with_browser(endpoint, &profile, &mut config).await?
-                }
+                    login_with_browser(&endpoint, &profile).await?
+                };
+
+                let token = vault.store(&profile, &email, api_token)?;
+                config.create_or_update_profile(endpoint, profile, email, token)
             }
         }
 
@@ -323,7 +333,7 @@ async fn main() -> Result<()> {
                 let cloud_provider_region = CloudProviderRegion::from_str(&cloud_provider_region)?;
                 let mut profile = config.get_profile()?;
 
-                let valid_profile = profile.validate(&client).await?;
+                let valid_profile = profile.validate(&profile_name, &client).await?;
 
                 let loading_spinner = run_loading_spinner("Enabling region...".to_string());
                 let cloud_provider =
@@ -361,7 +371,7 @@ async fn main() -> Result<()> {
                 let cloud_provider_region = CloudProviderRegion::from_str(&cloud_provider_region)?;
                 let profile = config.get_profile()?;
 
-                let valid_profile = profile.validate(&client).await?;
+                let valid_profile = profile.validate(&profile_name, &client).await?;
 
                 let loading_spinner = run_loading_spinner("Disabling region...".to_string());
                 let cloud_provider =
@@ -379,7 +389,7 @@ async fn main() -> Result<()> {
             RegionCommand::List => {
                 let profile = config.get_profile()?;
 
-                let valid_profile = profile.validate(&client).await?;
+                let valid_profile = profile.validate(&profile_name, &client).await?;
 
                 let cloud_providers = list_cloud_providers(&client, &valid_profile)
                     .await
@@ -402,7 +412,7 @@ async fn main() -> Result<()> {
 
                 let profile = config.get_profile()?;
 
-                let valid_profile = profile.validate(&client).await?;
+                let valid_profile = profile.validate(&profile_name, &client).await?;
 
                 let environment = get_provider_region_environment(
                     &client,
@@ -432,7 +442,7 @@ async fn main() -> Result<()> {
                     .context("no region specified and no default region set")?,
             };
 
-            let valid_profile = profile.validate(&client).await?;
+            let valid_profile = profile.validate(&profile_name, &client).await?;
 
             command
                 .execute(valid_profile, cloud_provider_region, client)
@@ -453,7 +463,7 @@ async fn main() -> Result<()> {
                     .context("no region specified and no default region set")?,
             };
 
-            let valid_profile = profile.validate(&client).await?;
+            let valid_profile = profile.validate(&profile_name, &client).await?;
 
             shell(client, valid_profile, cloud_provider_region)
                 .await

--- a/src/mz/src/password.rs
+++ b/src/mz/src/password.rs
@@ -9,10 +9,9 @@
 
 use std::collections::HashMap;
 
-use crate::configuration::ValidProfile;
 use crate::FronteggAppPassword;
+use crate::{configuration::ValidProfile, utils::RequestBuilderExt};
 use anyhow::{Context, Result};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use reqwest::Client;
 
 /// Get Frontegg API tokens using an access token
@@ -20,21 +19,12 @@ pub(crate) async fn list_passwords(
     client: &Client,
     valid_profile: &ValidProfile<'_>,
 ) -> Result<Vec<FronteggAppPassword>> {
-    let authorization: String = format!("Bearer {}", valid_profile.frontegg_auth.access_token);
-
-    let mut headers = HeaderMap::new();
-    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    headers.insert(
-        AUTHORIZATION,
-        HeaderValue::from_str(authorization.as_str()).unwrap(),
-    );
     let mut body = HashMap::new();
     body.insert("description", &"App password for the CLI");
 
     client
         .get(valid_profile.profile.endpoint().api_token_url())
-        .headers(headers)
+        .authenticate(&valid_profile.frontegg_auth)
         .json(&body)
         .send()
         .await

--- a/src/mz/src/secrets.rs
+++ b/src/mz/src/secrets.rs
@@ -194,7 +194,7 @@ async fn execute_query(
         .post(url)
         .basic_auth(
             valid_profile.profile.get_email(),
-            Some(valid_profile.profile.get_app_password()),
+            Some(valid_profile.app_password.to_string()),
         )
         .json(&sql)
         .send()

--- a/src/mz/src/shell.rs
+++ b/src/mz/src/shell.rs
@@ -42,7 +42,7 @@ fn run_psql_shell(valid_profile: ValidProfile<'_>, environment: &Environment) ->
         .arg("-p")
         .arg(port)
         .arg("materialize")
-        .env("PGPASSWORD", valid_profile.profile.get_app_password())
+        .env("PGPASSWORD", valid_profile.app_password)
         .exec();
 
     Err(error).context("failed to spawn psql")
@@ -62,7 +62,7 @@ pub(crate) fn check_environment_health(
         .arg(host)
         .arg("-p")
         .arg(port)
-        .env("PGPASSWORD", valid_profile.profile.get_app_password())
+        .env("PGPASSWORD", valid_profile.app_password.clone())
         .arg("-d")
         .arg("materialize")
         .arg("-q")

--- a/src/mz/src/utils.rs
+++ b/src/mz/src/utils.rs
@@ -7,8 +7,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use reqwest::{Client, ClientBuilder, RequestBuilder};
 use std::time::Duration;
+
+use crate::configuration::FronteggAuth;
+
+/// Create a stanard client with common
+/// header values for all requests.
+pub fn new_client() -> Result<Client> {
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, HeaderValue::from_static("reqwest"));
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    ClientBuilder::new()
+        .default_headers(headers)
+        .build()
+        .context("failed to create client")
+}
+
+/// Extgension methods for building API requests
+pub(crate) trait RequestBuilderExt {
+    /// Authenticate the client with frontegg
+    fn authenticate(self, auth: &FronteggAuth) -> Self;
+}
+
+impl RequestBuilderExt for RequestBuilder {
+    fn authenticate(self, auth: &FronteggAuth) -> Self {
+        let authorization = format!("Bearer {}", auth.access_token);
+        self.header(AUTHORIZATION, &authorization)
+    }
+}
 
 /// Trim lines. Useful when reading input data.
 pub(crate) fn trim_newline(s: &mut String) {

--- a/src/mz/src/vault.rs
+++ b/src/mz/src/vault.rs
@@ -13,8 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{anyhow, bail, Result};
 use clap::Parser;
+use keyring::Entry;
 use serde::{de::Visitor, Deserialize, Serialize};
 
 use crate::configuration::FronteggAPIToken;
@@ -23,35 +24,67 @@ const INLINE_PREFIX: &str = "mzp_";
 
 /// A vault stores sensitive information and provides
 /// back a token than can be used for later retrieval.
-/// The default vault inlines values directly in the
-/// return token.
+/// By default, credentials are stored in the OS specific
+/// keychain if it exists.
 #[derive(Parser, Debug)]
 #[clap(group = clap::ArgGroup::new("vault").multiple(false))]
-pub struct Vault {}
+pub struct Vault {
+    /// Inline the credentials in the CLIs
+    /// configuration file.
+    #[clap(long, short, group = "vault")]
+    inline: bool,
+}
 
 impl Vault {
-    pub fn store(
-        &self,
-        _profile: &str,
-        _email: &str,
-        api_token: FronteggAPIToken,
-    ) -> Result<Token> {
+    pub fn store(&self, profile: &str, email: &str, api_token: FronteggAPIToken) -> Result<Token> {
         let password = api_token.to_string();
+        if self.inline {
+            return Ok(Token::Inline(password));
+        }
 
-        Ok(Token::Inline(password))
+        match Entry::new(&service_name(profile), email).set_password(&api_token.to_string()) {
+            Ok(_) => Ok(Token::Keychain),
+            Err(keyring::Error::NoEntry) => Ok(Token::Inline(password)),
+            Err(e) => bail!(e),
+        }
     }
 }
 
+#[derive(PartialEq, Eq)]
 pub enum Token {
     Inline(String),
+    Keychain,
+}
+
+impl Default for Token {
+    fn default() -> Self {
+        Token::Keychain
+    }
 }
 
 impl Token {
-    pub fn retrieve(&self, _profile: &str, _email: &str) -> Result<String> {
+    pub fn is_default(&self) -> bool {
+        *self == Token::Keychain
+    }
+
+    pub fn retrieve(&self, profile: &str, email: &str) -> Result<String> {
         match self {
             Token::Inline(app_password) => Ok(app_password.to_string()),
+            Token::Keychain => {
+                let entry = Entry::new(&service_name(profile), email);
+                entry.get_password().map_err(|e| match e {
+                    keyring::Error::NoEntry => anyhow!(
+                        "No credentials found in local keychain. Reauthenticate with mz login."
+                    ),
+                    _ => anyhow!(e),
+                })
+            }
         }
     }
+}
+
+fn service_name(profile: &str) -> String {
+    format!("Materialize CLI - Profile[{profile}]")
 }
 
 /// Custom debug implementation
@@ -60,6 +93,7 @@ impl std::fmt::Debug for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Inline(_) => write!(f, "Inline(_)"),
+            Self::Keychain => write!(f, "Keychain"),
         }
     }
 }
@@ -71,6 +105,7 @@ impl Serialize for Token {
     {
         match self {
             Token::Inline(app_password) => serializer.serialize_str(app_password),
+            Token::Keychain => unreachable!("keychain passwords should never be serialized"),
         }
     }
 }

--- a/src/mz/src/vault.rs
+++ b/src/mz/src/vault.rs
@@ -1,0 +1,106 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use clap::Parser;
+use serde::{de::Visitor, Deserialize, Serialize};
+
+use crate::configuration::FronteggAPIToken;
+
+const INLINE_PREFIX: &str = "mzp_";
+
+/// A vault stores sensitive information and provides
+/// back a token than can be used for later retrieval.
+/// The default vault inlines values directly in the
+/// return token.
+#[derive(Parser, Debug)]
+#[clap(group = clap::ArgGroup::new("vault").multiple(false))]
+pub struct Vault {}
+
+impl Vault {
+    pub fn store(
+        &self,
+        _profile: &str,
+        _email: &str,
+        api_token: FronteggAPIToken,
+    ) -> Result<Token> {
+        let password = api_token.to_string();
+
+        Ok(Token::Inline(password))
+    }
+}
+
+pub enum Token {
+    Inline(String),
+}
+
+impl Token {
+    pub fn retrieve(&self, _profile: &str, _email: &str) -> Result<String> {
+        match self {
+            Token::Inline(app_password) => Ok(app_password.to_string()),
+        }
+    }
+}
+
+/// Custom debug implementation
+/// to avoid leaking sensitive data.
+impl std::fmt::Debug for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Inline(_) => write!(f, "Inline(_)"),
+        }
+    }
+}
+
+impl Serialize for Token {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Token::Inline(app_password) => serializer.serialize_str(app_password),
+        }
+    }
+}
+
+struct TokenVisitor;
+
+impl<'de> Visitor<'de> for TokenVisitor {
+    type Value = Token;
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if v.starts_with(INLINE_PREFIX) {
+            return Ok(Token::Inline(v.to_string()));
+        }
+
+        Err(E::custom("unknown app password token"))
+    }
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("app password token")
+    }
+}
+
+impl<'de> Deserialize<'de> for Token {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(TokenVisitor)
+    }
+}


### PR DESCRIPTION
### Motivation

Adds the ability to store app passwords within your local keychain for more secure access. The CLI still retains the ability to store app passwords locally inline and is fully backwards compatible. 

### Tips for reviewer

This PR builds on top of #16853. Please skip the first commit. 

The primary two commits are best reviewed one at a time. 


mz: move app password behind vault abstraction

    Adds a new vault abstraction for storing app passwords. Vaults
    return tokens that can be used for later password retrieval. This
    commit contains a single vault type - Inline - which stores the app
    password inline within the configuration file for the CLI.

    This commit is primarily for threading the vaults and tokens
    through the code base. It does not modify any user-facing functionality.

    The vault is intended to be later extended to provide other variants
    such as keychains, 1password, etc.

mz: store app password in local keychain by default

    Adds a new vault type - Keychain - that stores the app password in the
    users local keychain. It also makes keychain the default vault type if
    a local keychain exists, otherwise it falls back to inline. Users
    may still manually specify inline with the new --inline flag.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
