### PR TITLE
ci/test: re-enable all restart tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -290,7 +290,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: restart
-          run: stash
     agents:
       queue: linux-x86_64
 

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -177,7 +177,7 @@ def workflow_storage_managed_collections(c: Composition) -> None:
 
 
 def workflow_default(c: Composition) -> None:
-    workflow_github_8021(c)
-    workflow_audit_log(c)
-    workflow_timelines(c)
-    workflow_stash(c)
+    c.workflow("github-8021")
+    c.workflow("audit-log")
+    c.workflow("timelines")
+    c.workflow("stash")


### PR DESCRIPTION
The non-stash tests accidentally got disabled in #16706.

h/t @philip-stoev

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR addresses post-merge review feedback.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
