### PR TITLE
Simplify some code in the Testdrive parser

### DIFF
--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -426,12 +426,7 @@ impl<'a> Iterator for LineReader<'a> {
         while let Some((i, c)) = chars.next() {
             if c == '\n' {
                 self.src_line += 1;
-                if fold_newlines
-                    && i + 3 < self.inner.len()
-                    && self.inner.is_char_boundary(i + 1)
-                    && self.inner.is_char_boundary(i + 3)
-                    && &self.inner[i + 1..i + 3] == "  "
-                {
+                if fold_newlines && self.inner.get(i + 1..i + 3) == Some("  ") {
                     // Chomp the newline and one space. This ensures a SQL query
                     // that is split over two lines does not become invalid.
                     chars.next();


### PR DESCRIPTION
It seems like we were just inlining the [`get` function](https://doc.rust-lang.org/std/primitive.str.html#method.get). I found that this logic took a bit of effort to understand, so let's make it easier for the next person by using the library function.