### PR TITLE
test/cloudtest: handle setup failures

### DIFF
--- a/test/cloudtest/setup
+++ b/test/cloudtest/setup
@@ -15,7 +15,9 @@ cd "$(dirname "$0")/../.."
 
 . misc/shlib/shlib.bash
 
-run kind create cluster --name=cloudtest --config=misc/kind/cluster.yaml --wait=60s || true
+if ! kind get clusters | grep -q cloudtest; then
+    run kind create cluster --name=cloudtest --config=misc/kind/cluster.yaml --wait=60s
+fi
 
 for f in misc/kind/configmaps/*; do
     run kubectl --context=kind-cloudtest apply -f "$f"


### PR DESCRIPTION
@philip-stoev I feel like this will be slightly less confusing in the case that kind fails to create the cluster when running locally. That way you'll see the cluster creation failure, rather than whatever goes wrong later when you try to use kubectl with a partially-created cluster.

Use slightly different create-if-not-exists logic in cloudtest, so that we can distinguish between "cluster already exists" and "cluster failed to set up.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported hypothetical bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
