### PR TITLE
mz: Add the ability to store app passwords within the local keychain for more secure storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3318,6 +3318,7 @@ dependencies = [
  "postgres-protocol",
  "reqwest",
  "rpassword",
+ "security-framework",
  "serde",
  "tokio",
  "toml",
@@ -6412,9 +6413,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6425,9 +6426,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -25,3 +25,6 @@ uuid = "1.2.2"
 url = "2.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 postgres-protocol = "0.6.4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "2.7.0"

--- a/src/mz/src/login.rs
+++ b/src/mz/src/login.rs
@@ -17,8 +17,9 @@ use axum::{extract::Query, response::IntoResponse, routing::get, Router};
 use reqwest::Client;
 use tokio::sync::broadcast::{channel, Sender};
 
-use crate::configuration::{Configuration, Endpoint, FronteggAPIToken, FronteggAuth};
+use crate::configuration::{Endpoint, FronteggAPIToken, FronteggAuth};
 use crate::utils::{trim_newline, RequestBuilderExt};
+
 use crate::BrowserAPIToken;
 
 /// Request handler for the server waiting the browser API token creation
@@ -44,10 +45,9 @@ async fn request(
 
 /// Log the user using the browser, generates an API token and saves the new profile data.
 pub(crate) async fn login_with_browser(
-    endpoint: Endpoint,
+    endpoint: &Endpoint,
     profile_name: &str,
-    config: &mut Configuration,
-) -> Result<()> {
+) -> Result<(String, FronteggAPIToken)> {
     // Open the browser to login user.
     let url = endpoint.web_login_url(profile_name).to_string();
     if let Err(err) = open::that(&url) {
@@ -68,17 +68,11 @@ pub(crate) async fn login_with_browser(
             .await
     });
 
-    match result
+    result
         .recv()
         .await
         .context("failed to retrive new profile")?
-    {
-        Some((email, api_token)) => {
-            config.create_or_update_profile(endpoint, profile_name.to_string(), email, api_token);
-            Ok(())
-        }
-        None => bail!("failed to login via browser"),
-    }
+        .context("failed to login via browser")
 }
 
 /// Generates an API token using an access token
@@ -130,12 +124,11 @@ async fn authenticate_user(
 }
 
 /// Log the user using the console, generates an API token and saves the new profile data.
+
 pub(crate) async fn login_with_console(
-    endpoint: Endpoint,
+    endpoint: &Endpoint,
     client: &Client,
-    profile_name: &String,
-    config: &mut Configuration,
-) -> Result<()> {
+) -> Result<(String, FronteggAPIToken)> {
     // Handle interactive user input
     let mut email = String::new();
 
@@ -148,18 +141,14 @@ pub(crate) async fn login_with_console(
     let _ = std::io::stdout().flush();
     let password = rpassword::read_password().unwrap();
 
-    // Check if there is a secret somewhere.
-    // If there is none save the api token someone on the root folder.
-    let auth_user = authenticate_user(&endpoint, client, &email, &password).await?;
+    let auth_user = authenticate_user(endpoint, client, &email, &password).await?;
     let api_token = generate_api_token(
-        &endpoint,
+        endpoint,
         client,
         auth_user,
         &String::from("App password for the CLI"),
     )
     .await?;
 
-    config.create_or_update_profile(endpoint, profile_name.to_string(), email, api_token);
-
-    Ok(())
+    Ok((email, api_token))
 }

--- a/src/mz/src/secrets.rs
+++ b/src/mz/src/secrets.rs
@@ -194,7 +194,7 @@ async fn execute_query(
         .post(url)
         .basic_auth(
             valid_profile.profile.get_email(),
-            Some(valid_profile.profile.get_app_password()),
+            Some(valid_profile.app_password.to_string()),
         )
         .json(&sql)
         .send()

--- a/src/mz/src/shell.rs
+++ b/src/mz/src/shell.rs
@@ -42,7 +42,7 @@ fn run_psql_shell(valid_profile: ValidProfile<'_>, environment: &Environment) ->
         .arg("-p")
         .arg(port)
         .arg("materialize")
-        .env("PGPASSWORD", valid_profile.profile.get_app_password())
+        .env("PGPASSWORD", valid_profile.app_password)
         .exec();
 
     Err(error).context("failed to spawn psql")
@@ -62,7 +62,7 @@ pub(crate) fn check_environment_health(
         .arg(host)
         .arg("-p")
         .arg(port)
-        .env("PGPASSWORD", valid_profile.profile.get_app_password())
+        .env("PGPASSWORD", valid_profile.app_password.clone())
         .arg("-d")
         .arg("materialize")
         .arg("-q")

--- a/src/mz/src/vault.rs
+++ b/src/mz/src/vault.rs
@@ -1,0 +1,142 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use clap::Parser;
+use serde::{de::Visitor, Deserialize, Serialize};
+
+use crate::configuration::FronteggAPIToken;
+
+const INLINE_PREFIX: &str = "mzp_";
+
+/// A vault stores sensitive information and provides
+/// back a token than can be used for later retrieval.
+/// By default, credentials are stored in the OS specific
+/// keychain if it exists.
+#[derive(Parser, Debug)]
+#[clap(group = clap::ArgGroup::new("vault").multiple(false))]
+pub struct Vault {
+    /// Inline the credentials in the CLIs
+    /// configuration file.
+    #[clap(long, group = "vault")]
+    inline: bool,
+}
+
+impl Vault {
+    pub fn store(&self, profile: &str, email: &str, api_token: FronteggAPIToken) -> Result<Token> {
+        if self.inline {
+            let password = api_token.to_string();
+            return Ok(Token::Inline(password));
+        }
+
+        keychain::set_app_password(profile, email, api_token)
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum Token {
+    Inline(String),
+    Keychain,
+}
+
+impl Default for Token {
+    fn default() -> Self {
+        Token::Keychain
+    }
+}
+
+impl Token {
+    pub fn is_default(&self) -> bool {
+        *self == Token::Keychain
+    }
+
+    pub fn retrieve(&self, profile: &str, email: &str) -> Result<String> {
+        match self {
+            Token::Inline(app_password) => Ok(app_password.to_string()),
+            Token::Keychain => keychain::get_app_password(profile, email),
+        }
+    }
+}
+
+mod keychain {
+    use crate::configuration::FronteggAPIToken;
+
+    use super::Token;
+    use anyhow::{bail, Result};
+
+    pub fn get_app_password(_: &str, _: &str) -> Result<String> {
+        bail!("no credentials set. authenticate using mz login")
+    }
+
+    pub fn set_app_password(_: &str, _: &str, api_token: FronteggAPIToken) -> Result<Token> {
+        // The platform does not support local keychains.
+        // Fall back to inline credential management.
+        let password = api_token.to_string();
+        Ok(Token::Inline(password))
+    }
+}
+
+/// Custom debug implementation
+/// to avoid leaking sensitive data.
+impl std::fmt::Debug for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Inline(_) => write!(f, "Inline(_)"),
+            Self::Keychain => write!(f, "Keychain"),
+        }
+    }
+}
+
+impl Serialize for Token {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Token::Inline(app_password) => serializer.serialize_str(app_password),
+            Token::Keychain => unreachable!("keychain passwords should never be serialized"),
+        }
+    }
+}
+
+struct TokenVisitor;
+
+impl<'de> Visitor<'de> for TokenVisitor {
+    type Value = Token;
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        if v.starts_with(INLINE_PREFIX) {
+            return Ok(Token::Inline(v.to_string()));
+        }
+
+        Err(E::custom("unknown app password token"))
+    }
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("app password token")
+    }
+}
+
+impl<'de> Deserialize<'de> for Token {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(TokenVisitor)
+    }
+}

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -230,11 +230,11 @@ tikv-jemalloc-sys = { version = "0.4.3+5.2.1-patched.2", features = ["background
 [target.x86_64-apple-darwin.dependencies]
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
-security-framework = { version = "2.0.0", features = ["OSX_10_9", "alpn"] }
+security-framework = { version = "2.7.0", features = ["OSX_10_9", "alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
-security-framework = { version = "2.0.0", features = ["OSX_10_9", "alpn"] }
+security-framework = { version = "2.7.0", features = ["OSX_10_9", "alpn"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
### Motivation

Adds the ability to store app passwords within your local keychain for more secure access. The CLI still retains the ability to store app passwords locally inline and is fully backwards compatible. 

### Tips for reviewer

This PR builds on top of #16853. Please skip the first commit. 

The primary two commits are best reviewed one at a time. 


mz: move app password behind vault abstraction

    Adds a new vault abstraction for storing app passwords. Vaults
    return tokens that can be used for later password retrieval. This
    commit contains a single vault type - Inline - which stores the app
    password inline within the configuration file for the CLI.

    This commit is primarily for threading the vaults and tokens
    through the code base. It does not modify any user-facing functionality.

    The vault is intended to be later extended to provide other variants
    such as keychains, 1password, etc.

mz: store app password in local keychain by default

    Adds a new vault type - Keychain - that stores the app password in the
    users local keychain. It also makes keychain the default vault type if
    a local keychain exists, otherwise it falls back to inline. Users
    may still manually specify inline with the new --inline flag.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
