### PR TITLE
doc/developer: recommend `cargo install --locked`

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -316,7 +316,7 @@ If you add or remove dependencies on crates, you will likely need to regenerate
 the `workspace-hack` crate. You can do this by running:
 
 ```
-cargo install cargo-hakari
+cargo install --locked cargo-hakari
 cargo hakari generate
 cargo hakari manage-deps
 ```


### PR DESCRIPTION
Apparently one of cargo-hakari's dependencies made a backwards incompatible change, and `cargo install cargo-hakari` no longer works as expected.

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
