### PR TITLE
zippy: Add a secenario that restarts CRDB and Minio

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -37,6 +37,7 @@ steps:
           - { value: zippy-debezium-postgres }
           - { value: zippy-postgres-cdc }
           - { value: zippy-cluster-replicas }
+          - { value: zippy-crdb-minio-restart }
           - { value: secrets }
           - { value: checks-oneatatime-drop-create-default-replica }
           - { value: checks-oneatatime-restart-clusterd-compute }
@@ -299,6 +300,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=ClusterReplicas, --actions=1000]
+
+  - id: zippy-crdb-minio-restart
+    label: "Zippy CRDB/Minio restarts"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=CrdbMinioRestart, --actions=1000]
 
   - id: secrets
     label: "Secrets"

--- a/misc/python/materialize/zippy/crdb_actions.py
+++ b/misc/python/materialize/zippy/crdb_actions.py
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import time
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.crdb_capabilities import CockroachIsRunning
+from materialize.zippy.framework import Action, Capability
+
+
+class CockroachStart(Action):
+    """Starts a CockroachDB instance."""
+
+    def run(self, c: Composition) -> None:
+        c.start_and_wait_for_tcp(services=["cockroach"])
+        c.wait_for_cockroach()
+
+        for schema in ["adapter", "storage", "consensus"]:
+            c.sql(
+                f"CREATE SCHEMA IF NOT EXISTS {schema}",
+                service="cockroach",
+                user="root",
+            )
+
+    def provides(self) -> List[Capability]:
+        return [CockroachIsRunning()]
+
+
+class CockroachRestart(Action):
+    """Restart the CockroachDB instance."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {CockroachIsRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("cockroach")
+        time.sleep(1)
+        c.up("cockroach")

--- a/misc/python/materialize/zippy/crdb_capabilities.py
+++ b/misc/python/materialize/zippy/crdb_capabilities.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+
+
+class CockroachIsRunning(Capability):
+    pass

--- a/misc/python/materialize/zippy/minio_actions.py
+++ b/misc/python/materialize/zippy/minio_actions.py
@@ -1,0 +1,57 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import time
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capability
+from materialize.zippy.minio_capabilities import MinioIsRunning
+
+
+class MinioStart(Action):
+    """Starts a Minio instance."""
+
+    def run(self, c: Composition) -> None:
+        c.start_and_wait_for_tcp(services=["minio"])
+
+        # Minio is managed using a dedicated container
+        c.up("minio_mc", persistent=True)
+
+        # Create user
+        c.exec(
+            "minio_mc",
+            "mc",
+            "config",
+            "host",
+            "add",
+            "myminio",
+            "http://minio:9000",
+            "minioadmin",
+            "minioadmin",
+        )
+
+        # Create bucket
+        c.exec("minio_mc", "mc", "mb", "myminio/persist"),
+
+    def provides(self) -> List[Capability]:
+        return [MinioIsRunning()]
+
+
+class MinioRestart(Action):
+    """Restart the Minio instance."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MinioIsRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("minio")
+        time.sleep(1)
+        c.up("minio")

--- a/misc/python/materialize/zippy/minio_capabilities.py
+++ b/misc/python/materialize/zippy/minio_capabilities.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+
+
+class MinioIsRunning(Capability):
+    pass


### PR DESCRIPTION
Previously, Zippy relied on file storage and the built-in CRDB from the Materialize container. This make testing unrealistic and prevented testing disruptions of those two services.

- Make Minio and CRDB stand-alone containers and require their use in Zippy
- Implement Actions that restart Minio and CRDB
- Install a separate Scenario that uses those actions

Relates to #15573

### Motivation

A test was needed that introduces heavy disruptions of the underlying services Mz relies on - object storage and a back-end database.