### PR TITLE
materialized: document the Docker image

### DIFF
--- a/misc/images/materialized/README.md
+++ b/misc/images/materialized/README.md
@@ -1,0 +1,43 @@
+# `materialized` Docker image
+
+This directory builds an all-in-one Docker image of Materialize for our internal
+development and testing.
+
+> ⚠️ **WARNING** ⚠️
+>
+> This Docker image is not officially supported by Materialize. We do not
+> offer support for this Docker image. Do not run production deployments using
+> this Docker image.
+
+> ⚠️ **WARNING** ⚠️
+>
+> The performance characteristics of this Docker image are not representative
+> of the performance characteristics of our hosted offering. This image bundles
+> several services into the same container, while in our hosted offering we
+> run these services scaled across many machines.
+
+## Usage
+
+To launch the Docker container:
+
+```
+docker run -v mzdata:/mzdata -p 6875:6875 -p 6876:6876 materialize/materialized
+```
+
+After running this command...
+
+  * Materialize logs will be emitted to the stderr stream.
+  * The SQL interface will be available on port 6875.
+  * The HTTP interface will be available on port 6876.
+
+To connect to the SQL interface using `psql`:
+
+```
+psql postgres://materialize@localhost:6875/materialize
+```
+
+To view logs for the embedded CockroachDB server:
+
+```
+docker exec <CONTAINER-ID> cat /mzdata/cockroach/logs/cockroach.log
+```

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -11,6 +11,17 @@
 
 set -euo pipefail
 
+cat <<EOF >/dev/stderr
+WARNING: This Docker image is not officially supported by Materialize. We do not
+offer support for this Docker image. Do not run production deployments using
+this Docker image.
+
+WARNING: The performance characteristics of this Docker image are not
+representative of the performance characteristics of our hosted offering. This
+image bundles several services into the same container, while in our hosted
+offering we run these services scaled across many machines.
+EOF
+
 COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true cockroach start-single-node \
     --insecure \
     --background


### PR DESCRIPTION
Add a README for the Docker image that has the most basic usage instructions, but also disclaims all support and warns users not to run the Docker image in production. The warning is also emitted to stderr when the Docker image boots.

### Motivation

  * This PR fixes a previously unreported bug: the Docker image had stopped being runnable with `docker run`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
