### PR TITLE
bin/cargo-test: set COCKROACH_URL, not POSTGRES_URL

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -178,7 +178,7 @@ def main() -> int:
             command += ["--test", test]
         command += args.args
         command += ["--", "--nocapture"]
-        os.environ["POSTGRES_URL"] = args.postgres
+        os.environ["COCKROACH_URL"] = args.postgres
     else:
         raise UIError(f"unknown program {args.program}")
 


### PR DESCRIPTION
Since transitioning our development environment to CockroachDB, the Rust tests now require the COCKROACH_URL environment variable, rather than the POSTGRES_URL environment variable. Update the bin/cargo-test script accordingly. This script is only run by developers locally, not in CI, which is why this went unnoticed until now.

h/t @umanwizard

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
