### PR TITLE
storage: add mod to track persist shards

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -51,7 +51,7 @@ use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_persist_types::{Codec, Codec64, Opaque};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
-use mz_stash::{self, PostgresFactory, StashError, TypedCollection};
+use mz_stash::{self, Append, PostgresFactory, StashError, TypedCollection};
 
 use crate::client::{
     CreateSinkCommand, CreateSourceCommand, ProtoStorageCommand, ProtoStorageResponse,
@@ -81,7 +81,11 @@ pub static METADATA_COLLECTION: TypedCollection<GlobalId, DurableCollectionMetad
 pub static METADATA_EXPORT: TypedCollection<GlobalId, DurableExportMetadata<mz_repr::Timestamp>> =
     TypedCollection::new("storage-export-metadata-u64");
 
-pub static ALL_COLLECTIONS: &[&str] = &[METADATA_COLLECTION.name(), METADATA_EXPORT.name()];
+pub static ALL_COLLECTIONS: &[&str] = &[
+    METADATA_COLLECTION.name(),
+    METADATA_EXPORT.name(),
+    shard_wal::SHARD_WAL.name(),
+];
 
 // Do this dance so that we keep the storage controller expressed in terms of a generic timestamp `T`.
 struct MetadataExportFetcher;
@@ -765,7 +769,26 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
             .open(postgres_url, None, tls)
             .await
             .expect("could not connect to postgres storage stash");
-        let stash = mz_stash::Cache::new(stash);
+        let mut stash = mz_stash::Cache::new(stash);
+
+        // Inserts empty values into all new collections, so the collections are readable.
+        let mut batches = Vec::new();
+        macro_rules! init_collections {
+            ($($collection:expr),*) => {
+                $(if let Some(batch) = $collection.make_initializing_batch(&mut stash).await.expect("stash operation must succeed") {
+                    batches.push(batch);
+                })*
+            }
+        }
+        init_collections!(
+            &METADATA_COLLECTION,
+            &METADATA_EXPORT,
+            &shard_wal::SHARD_WAL
+        );
+        stash
+            .append(&batches)
+            .await
+            .expect("initializing collections must succeed");
 
         let persist_write_handles = persist_handles::PersistWriteWorker::new(tx);
         let collection_manager_write_handle = persist_write_handles.clone();

--- a/src/storage-client/src/controller/shard_wal.rs
+++ b/src/storage-client/src/controller/shard_wal.rs
@@ -1,0 +1,183 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Handles tracking persist shards. Currently only identifies shards we might
+//! reap but does nothing to actually reclaim their resources.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Debug;
+
+use differential_dataflow::lattice::Lattice;
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+use timely::order::TotalOrder;
+use timely::progress::Timestamp;
+
+use mz_ore::now::EpochMillis;
+use mz_persist_client::ShardId;
+use mz_persist_types::Codec64;
+use mz_proto::RustType;
+use mz_repr::TimestampManipulation;
+use mz_stash::{self, TypedCollection};
+
+use crate::client::{StorageCommand, StorageResponse};
+use crate::controller::{ProtoStorageCommand, ProtoStorageResponse};
+
+use super::Controller;
+
+/// Metadata about retired shards
+#[derive(Arbitrary, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize, Hash)]
+pub struct ReapableShardMetadata {
+    pub desc: String,
+    pub first_seen: u64,
+    // We use `REAPABLE_SHARDS` like a WAL, if you expect all shards to be
+    // reclaimed in the fullness of time.
+    pub reapable: bool,
+}
+
+pub static SHARD_WAL: TypedCollection<ShardId, ReapableShardMetadata> =
+    TypedCollection::new("storage-retired-shards");
+
+impl<T> Controller<T>
+where
+    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis> + TimestampManipulation,
+
+    // Required to setup grpc clients for new storaged instances.
+    StorageCommand<T>: RustType<ProtoStorageCommand>,
+    StorageResponse<T>: RustType<ProtoStorageResponse>,
+{
+    pub(super) async fn register_shards<I>(&mut self, entries: I)
+    where
+        I: IntoIterator<Item = (ShardId, String)>,
+    {
+        let ts = (self.now)();
+        SHARD_WAL
+            .insert_without_overwrite(
+                &mut self.state.stash,
+                entries.into_iter().map(|(shard_id, desc)| {
+                    (
+                        shard_id,
+                        ReapableShardMetadata {
+                            desc,
+                            first_seen: ts,
+                            reapable: false,
+                        },
+                    )
+                }),
+            )
+            .await
+            .expect("must be able to write to stash");
+    }
+
+    // Eagerly marking shards reapable currently does nothing, but makes us feel
+    // like it might one day.
+    pub(super) async fn mark_shards_reapable(&mut self, reapable_shards: &BTreeSet<ShardId>) {
+        SHARD_WAL
+            .update(
+                &mut self.state.stash,
+                |k, v| {
+                    if reapable_shards.contains(k) {
+                        Some(ReapableShardMetadata {
+                            reapable: true,
+                            ..v.clone()
+                        })
+                    } else {
+                        None
+                    }
+                },
+                |_, _| false,
+            )
+            .await
+            .expect("must be able to write to stash");
+    }
+
+    /// Reconcile the state of `REAPABLE_SHARDS` on boot.
+    pub(super) async fn reconcile_shards(&mut self) {
+        if super::METADATA_COLLECTION
+            .upper(&mut self.state.stash)
+            .await
+            .expect("must be able to connect to stash")
+            .elements()
+            == [mz_stash::Timestamp::MIN]
+        {
+            // No metadata yet.
+            return;
+        }
+        // Get all shards we're aware of from stash.
+        let all_shard_data: BTreeMap<_, _> = super::METADATA_COLLECTION
+            .peek_one(&mut self.state.stash)
+            .await
+            .expect("must be able to read from stash")
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    super::DurableCollectionMetadata {
+                        remap_shard,
+                        data_shard,
+                    },
+                )| {
+                    [
+                        (id, (remap_shard, format!("{:?} remap shard", id))),
+                        (id, (data_shard, format!("{:?} data shard", id))),
+                    ]
+                },
+            )
+            .flatten()
+            .collect();
+
+        // Remove all shards not in collections or with dropped read
+        // capabilities.
+        let in_use_shards: BTreeSet<_> = all_shard_data
+            .iter()
+            .filter_map(|(id, (shard_id, _desc))| {
+                self.state
+                    .collections
+                    .get(id)
+                    .map(|c| {
+                        if c.implied_capability.is_empty() {
+                            None
+                        } else {
+                            Some(*shard_id)
+                        }
+                    })
+                    .flatten()
+            })
+            .collect();
+
+        // Register all shards to ensure they're in the shard WAL (this should
+        // not write any new values).
+        self.register_shards(
+            all_shard_data
+                .into_iter()
+                .map(|(_id, (shard_id, desc))| (shard_id, desc)),
+        )
+        .await;
+
+        // Get all shard IDs we've ever seen that we haven't already determined
+        // are reapable.
+        let all_shards: BTreeSet<_> = SHARD_WAL
+            .peek_one(&mut self.state.stash)
+            .await
+            .expect("must be able to read from stash")
+            .into_iter()
+            .filter_map(|(shard_id, metadata)| {
+                if metadata.reapable {
+                    None
+                } else {
+                    Some(shard_id)
+                }
+            })
+            .collect();
+
+        // Mark all shards reapable that are no longer in use.
+        self.mark_shards_reapable(&all_shards.difference(&in_use_shards).cloned().collect())
+            .await;
+    }
+}

--- a/src/storage-client/src/controller/shard_wal.rs
+++ b/src/storage-client/src/controller/shard_wal.rs
@@ -41,7 +41,7 @@ pub struct ReapableShardMetadata {
     pub reapable: bool,
 }
 
-pub static SHARD_WAL: TypedCollection<ShardId, ReapableShardMetadata> =
+pub(super) static SHARD_WAL: TypedCollection<ShardId, ReapableShardMetadata> =
     TypedCollection::new("storage-retired-shards");
 
 impl<T> Controller<T>
@@ -99,16 +99,6 @@ where
 
     /// Reconcile the state of `REAPABLE_SHARDS` on boot.
     pub(super) async fn reconcile_shards(&mut self) {
-        if super::METADATA_COLLECTION
-            .upper(&mut self.state.stash)
-            .await
-            .expect("must be able to connect to stash")
-            .elements()
-            == [mz_stash::Timestamp::MIN]
-        {
-            // No metadata yet.
-            return;
-        }
         // Get all shards we're aware of from stash.
         let all_shard_data: BTreeMap<_, _> = super::METADATA_COLLECTION
             .peek_one(&mut self.state.stash)


### PR DESCRIPTION
Eventually, we'd like a subsystem to reap unused persist shards; as part of that development, this commit introduces a stash collection which holds all shards that it's seen, and identifies those which it no longer sees on reboot or whose read handles have been truncated.

We currently don't do anything with this identification, so it isn't very aggressive in marking shards as reapable.

@philip-stoev Do you have any suggestions for testing this? Unsure if we have a framework that drives the storage controller and can read from stash.

### Motivation

This PR adds a known-desirable feature. Discussed with @danhhz 

### Tips for reviewer

@mjibson Can you review the changes to [src/stash/src/lib.rs](https://github.com/MaterializeInc/materialize/compare/main...sploiselle:materialize:shard-wal#diff-30fd38e01a123ae13b3eff2854656fe65bd686e5141d31b2c5aa52c7185e1809)?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
