### PR TITLE
release qualification: Adjust the running time of the KafkaSourcesLar…

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -50,7 +50,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaSourcesLarge, --actions=100000]
+          args: [--scenario=KafkaSourcesLarge, --actions=40000]
 
   - id: zippy-dataflows-large
     label: "Long running Zippy with complex dataflows"


### PR DESCRIPTION
…ge Zippy scenario

With the conversion to clusterd, all kill actions in the Zippy scenario now kill both compute and storage clusters. This has caused the execution time of the test to increase significantly, causing CI timeouts.

### Motivation

  * This PR fixes a previously unreported bug.
The Release Qualification CI job was failing.