### PR TITLE
persist: small cleanups

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -1044,8 +1044,8 @@ where
                     Ok(()) => {
                         cap_set.downgrade(batch_upper);
                     }
-                    Err(current_upper) => {
-                        cap_set.downgrade(current_upper.0.iter());
+                    Err(mismatch) => {
+                        cap_set.downgrade(mismatch.current.iter());
 
                         // Clean up in case we didn't manage to append the
                         // batches to persist.
@@ -1061,7 +1061,7 @@ where
                             sink_id,
                             batch_lower,
                             batch_upper,
-                            current_upper
+                            mismatch.current,
                         );
                     }
                 }

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -81,6 +81,7 @@ use criterion::{criterion_group, criterion_main, Bencher, BenchmarkGroup, Benchm
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_persist_client::metrics::Metrics;
 use tempfile::TempDir;
 use timely::progress::{Antichain, Timestamp};
 use tokio::runtime::Runtime;
@@ -93,7 +94,7 @@ use mz_persist::s3::{S3Blob, S3BlobConfig};
 use mz_persist::workload::DataGenerator;
 use mz_persist_client::async_runtime::CpuHeavyRuntime;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{Metrics, PersistClient, PersistConfig};
+use mz_persist_client::{PersistClient, PersistConfig};
 use mz_persist_types::Codec64;
 
 // The "plumbing" and "porcelain" names are from git [1]. Our "plumbing"

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -19,6 +19,7 @@ use anyhow::bail;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::metrics::Metrics;
 use prometheus::Encoder;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::Barrier;
@@ -27,7 +28,7 @@ use tracing::{debug, error, info, info_span, trace, Instrument};
 
 use mz_ore::cast::CastFrom;
 use mz_persist::workload::DataGenerator;
-use mz_persist_client::{Metrics, PersistConfig, PersistLocation, ShardId};
+use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
 
 use crate::open_loop::api::{BenchmarkReader, BenchmarkWriter};
 use crate::BUILD_INFO;

--- a/src/storage-client/src/controller/remap_migration.rs
+++ b/src/storage-client/src/controller/remap_migration.rs
@@ -17,6 +17,7 @@ use anyhow::Context;
 use differential_dataflow::consolidation;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
+use mz_persist_client::error::UpperMismatch;
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp;
@@ -27,7 +28,7 @@ use mz_expr::PartitionId;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::read::Subscribe;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{ShardId, Upper};
+use mz_persist_client::ShardId;
 use mz_persist_types::Codec64;
 use mz_repr::{Datum, Diff, GlobalId};
 use mz_timely_util::order::Partitioned;
@@ -314,7 +315,7 @@ where
         &mut self,
         updates: Vec<(FromTime, IntoTime, Diff)>,
         new_upper: Antichain<IntoTime>,
-    ) -> Result<(), Upper<IntoTime>> {
+    ) -> Result<(), UpperMismatch<IntoTime>> {
         let row_updates = updates.into_iter().map(|(from_ts, ts, diff)| {
             (
                 (SourceData(Ok(FromTime::encode_row(&from_ts))), ()),

--- a/src/storage-client/src/util/remap_handle.rs
+++ b/src/storage-client/src/util/remap_handle.rs
@@ -10,10 +10,10 @@
 //! Reclocking compatibility code until the whole ingestion pipeline is transformed to native
 //! timestamps
 
+use mz_persist_client::error::UpperMismatch;
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp;
 
-use mz_persist_client::Upper;
 use mz_repr::Diff;
 
 /// A handle that can produce the data expressing the translation of FromTime to
@@ -49,7 +49,7 @@ pub trait RemapHandle: RemapHandleReader {
         updates: Vec<(Self::FromTime, Self::IntoTime, Diff)>,
         upper: Antichain<Self::IntoTime>,
         new_upper: Antichain<Self::IntoTime>,
-    ) -> Result<(), Upper<Self::IntoTime>>;
+    ) -> Result<(), UpperMismatch<Self::IntoTime>>;
 
     async fn compact(&mut self, since: Antichain<Self::IntoTime>);
 

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -14,7 +14,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_ore::now::NowFn;
 use timely::progress::Antichain;
 
-use mz_persist_client::{PersistClient, ShardId, Upper};
+use mz_persist_client::{PersistClient, ShardId};
 use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_storage_client::types::sources::SourceData;
 
@@ -73,8 +73,8 @@ pub async fn write_to_persist(
             .await;
         match cas_result {
             Ok(Ok(())) => break 'retry_loop,
-            Ok(Err(Upper(upper))) => {
-                recent_upper = upper;
+            Ok(Err(mismatch)) => {
+                recent_upper = mismatch.current;
             }
             Err(e) => {
                 panic!("Invalid usage of the persist client for collection {collection_id} status history shard: {e:?}");

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -159,14 +159,14 @@ impl Healthchecker {
                         self.current_status = status_update.status;
                         break;
                     }
-                    Ok(Err(actual_upper)) => {
+                    Ok(Err(mismatch)) => {
                         trace!(
                             "Had to retry updating status, old upper {:?}, new upper {:?}",
                             &self.upper,
-                            &actual_upper
+                            &mismatch.current
                         );
                         // Sync to the new upper, go to the loop again
-                        self.sync(&actual_upper.0).await;
+                        self.sync(&mismatch.current).await;
                         // If we can't transition to the new status after the sync, no need to do anything else
                         if !self.current_status.can_transition(&status_update.status) {
                             break;

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use differential_dataflow::lattice::Lattice;
 use futures::{stream::LocalBoxStream, StreamExt};
+use mz_persist_client::error::UpperMismatch;
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp;
@@ -28,7 +29,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::read::ListenEvent;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{PersistClient, Upper};
+use mz_persist_client::PersistClient;
 use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId};
 use mz_storage_client::controller::CollectionMetadata;
@@ -253,7 +254,7 @@ where
         updates: Vec<(Self::FromTime, Self::IntoTime, Diff)>,
         upper: Antichain<Self::IntoTime>,
         new_upper: Antichain<Self::IntoTime>,
-    ) -> Result<(), Upper<Self::IntoTime>> {
+    ) -> Result<(), UpperMismatch<Self::IntoTime>> {
         let row_updates = updates.into_iter().map(|(from_ts, into_ts, diff)| {
             ((SourceData(Ok(from_ts.encode_row())), ()), into_ts, diff)
         });


### PR DESCRIPTION
- Remove PersistLocation::open_locations method only used by the persistcli source_example
- Include both expected and actual in the error returned for an upper mismatch
- Get rid of a few `pub use`s

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
