### PR TITLE
storage: in workers, add cluster-internal control dataflow

### DIFF
--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -1,0 +1,95 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Types for cluster-internal control messages that can be broadcast to all
+//! workers from individual operators/workers.
+
+use serde::{Deserialize, Serialize};
+use timely::communication::Allocate;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::{Broadcast, Operator};
+
+use mz_repr::GlobalId;
+use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
+
+use crate::storage_state::Worker;
+
+/// Internal commands that can be sent by individual operators/workers that will
+/// be broadcast to all workers. The worker main loop will receive those and act
+/// on them.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum InternalStorageCommand {
+    /// For testing.
+    Message(String),
+    /// Suspend and restart the dataflow identified by the `GlobalId`.
+    SuspendAndRestart(GlobalId),
+}
+
+// TODO(aljoscha): Should these be bounded?
+/// And unbounded receiver of internal storage commands.
+pub type InternalCommandReceiver = tokio::sync::mpsc::UnboundedReceiver<InternalStorageCommand>;
+/// And unbounded receiver of internal storage commands.
+pub type InternalCommandSender = tokio::sync::mpsc::UnboundedSender<InternalStorageCommand>;
+
+impl<'w, A: Allocate> Worker<'w, A> {
+    /// Sets up an internal dataflow that will receive worker-local commands on
+    /// the given receiver and broadcast them to all workers. The returned
+    /// receiver should be used to receive all broadcast commands.
+    pub fn setup_internal_command_pump(
+        &mut self,
+        mut internal_cmd_rx: InternalCommandReceiver,
+    ) -> crossbeam_channel::Receiver<InternalStorageCommand> {
+        let (forwarding_command_tx, forwarding_command_rx) = crossbeam_channel::unbounded();
+
+        self.timely_worker.dataflow::<u64, _, _>(move |scope| {
+            let mut pump_op =
+                AsyncOperatorBuilder::new("InternalStorageCmdPump".to_string(), scope.clone());
+
+            let (mut cmd_output, cmd_stream) = pump_op.new_output();
+
+            let _shutdown_button = pump_op.build(move |mut capabilities| async move {
+                let mut cap = capabilities.pop().expect("missing capability");
+
+                while let Some(cmd) = internal_cmd_rx.recv().await {
+                    let time = cap.time().clone();
+                    let mut cmd_output = cmd_output.activate();
+                    let mut session = cmd_output.session(&cap);
+                    session.give(cmd);
+
+                    cap.downgrade(&(time + 1));
+                }
+            });
+
+            cmd_stream.broadcast().unary_frontier::<Vec<()>, _, _, _>(
+                Pipeline,
+                "InternalStorageCmdForwarder",
+                |_cap, _info| {
+                    let mut container = Default::default();
+                    move |input, _output| {
+                        while let Some((_, data)) = input.next() {
+                            data.swap(&mut container);
+                            for cmd in container.drain(..) {
+                                let res = forwarding_command_tx.send(cmd);
+                                match res {
+                                    Ok(_) => {
+                                        // All's well!
+                                        //
+                                    }
+                                    Err(_send_err) => {
+                                        // The subscribe loop dropped, meaning
+                                        // we're probably shutting down. Seems
+                                        // fine to ignore.
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            );
+        });
+
+        forwarding_command_rx
+    }
+}

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -58,6 +58,17 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     let mut session = cmd_output.session(&cap);
                     session.give(cmd);
 
+                    // TODO(aljoscha): This will not work when we have more than
+                    // one worker. They will have to use something like
+                    // wall-clock time, which advances roughly in lock-step on
+                    // all workers instead of workers just counting the number
+                    // of commands.
+                    //
+                    // Also, though, the above is only true if we care about
+                    // frontiers. Which I think we do because we will need to
+                    // get commands into a deterministic order before working
+                    // them off. And we can only do this once we know that we
+                    // have seen all commands before a certain time.
                     cap.downgrade(&(time + 1));
                 }
             });

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -78,6 +78,7 @@
 //! Materialize's storage layer.
 
 pub mod decode;
+pub mod internal_control;
 pub mod render;
 pub mod server;
 pub mod sink;

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -116,6 +116,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                storage_state.internal_cmd_tx.clone(),
             );
             let oks: Vec<_> = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)
@@ -127,6 +128,7 @@ where
                 DelimitedValueSourceConnection(connection),
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                storage_state.internal_cmd_tx.clone(),
             );
             let oks = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)
@@ -138,6 +140,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                storage_state.internal_cmd_tx.clone(),
             );
             let oks = oks.into_iter().map(SourceType::ByteStream).collect();
             ((oks, err), cap)
@@ -149,6 +152,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                storage_state.internal_cmd_tx.clone(),
             );
             let oks = oks.into_iter().map(SourceType::Row).collect();
             ((oks, err), cap)
@@ -160,6 +164,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                storage_state.internal_cmd_tx.clone(),
             );
             let oks = oks.into_iter().map(SourceType::Row).collect();
             ((oks, err), cap)
@@ -171,6 +176,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                storage_state.internal_cmd_tx.clone(),
             );
             let oks: Vec<_> = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -84,6 +84,9 @@ pub fn serve(
             .unwrap();
         let (source_metrics, sink_metrics, decode_metrics) = metrics_bundle.clone();
         let persist_clients = Arc::clone(&config.persist_clients);
+
+        let (internal_cmd_tx, internal_cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+
         Worker {
             timely_worker,
             client_rx,
@@ -105,6 +108,8 @@ pub fn serve(
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
                 dropped_ids: Vec::new(),
+                internal_cmd_tx,
+                internal_cmd_rx: Some(internal_cmd_rx),
             },
         }
         .run()

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -209,6 +209,8 @@ where
 
             let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_cache));
 
+            let (internal_cmd_tx, internal_cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+
             let storage_state = mz_storage::storage_state::StorageState {
                 source_uppers: HashMap::new(),
                 source_tokens: HashMap::new(),
@@ -231,6 +233,8 @@ where
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
                 dropped_ids: Vec::new(),
+                internal_cmd_tx,
+                internal_cmd_rx: Some(internal_cmd_rx),
             };
 
             let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);


### PR DESCRIPTION
### Motivation

Partially resolves #16773


### Tips for reviewer

Left some explanatory comments. This is **not** yet meant for merging!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
