### PR TITLE
*: remove some unnecessary mz_persist_types::Codec impls

### DIFF
--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -11,9 +11,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::Error;
-use bytes::BufMut;
 use proptest_derive::Arbitrary;
-use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
@@ -196,25 +194,6 @@ impl RustType<ProtoPartitionId> for PartitionId {
             Option::Some(None(_)) => Ok(PartitionId::None),
             Option::None => Err(TryFromProtoError::missing_field("ProtoPartitionId::kind")),
         }
-    }
-}
-
-impl mz_persist_types::Codec for PartitionId {
-    fn codec_name() -> String {
-        "protobuf[PartitionId]".into()
-    }
-
-    fn encode<B: BufMut>(&self, buf: &mut B) {
-        self.into_proto()
-            .encode(buf)
-            .expect("provided buffer had sufficient capacity")
-    }
-
-    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
-        ProtoPartitionId::decode(buf)
-            .map_err(|err| err.to_string())?
-            .into_rust()
-            .map_err(|err: TryFromProtoError| err.to_string())
     }
 }
 

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -26,7 +26,6 @@ use mz_persist::indexed::encoding::BlobTraceBatchPart;
 use mz_persist::location::{Atomicity, Blob, Consensus, ExternalError, SeqNo, VersionedData};
 use mz_persist::workload::{self, DataGenerator};
 use mz_persist_client::ShardId;
-use mz_persist_types::Codec;
 
 use crate::{bench_all_blob, bench_all_consensus};
 

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -206,11 +206,14 @@ impl StateVersions {
             new_state.seqno(),
             new_state
         );
-        let new = self
-            .metrics
-            .codecs
-            .state_diff
-            .encode(|| VersionedData::from((new_state.seqno(), diff)));
+        let new = self.metrics.codecs.state_diff.encode(|| {
+            let mut buf = Vec::new();
+            diff.encode(&mut buf);
+            VersionedData {
+                seqno: new_state.seqno(),
+                data: Bytes::from(buf),
+            }
+        });
         assert_eq!(new.seqno, diff.seqno_to);
 
         let payload_len = new.data.len();

--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -11,15 +11,12 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
-use bytes::BufMut;
-use mz_persist_types::Codec;
 use proptest_derive::Arbitrary;
-use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 
-use mz_proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.global_id.rs"));
 
@@ -116,21 +113,5 @@ impl RustType<ProtoGlobalId> for GlobalId {
             Some(Explain(_)) => Ok(GlobalId::Explain),
             None => Err(TryFromProtoError::missing_field("ProtoGlobalId::kind")),
         }
-    }
-}
-
-impl Codec for GlobalId {
-    fn codec_name() -> String {
-        "GlobalId".into()
-    }
-
-    fn encode<B: BufMut>(&self, buf: &mut B) {
-        let proto: ProtoGlobalId = self.into_proto();
-        Message::encode(&proto, buf).expect("provided buffer had sufficient capacity")
-    }
-
-    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
-        let proto: ProtoGlobalId = Message::decode(buf).map_err(|err| err.to_string())?;
-        proto.into_rust().map_err(|err| err.to_string())
     }
 }

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -18,7 +18,6 @@ use prost::Message;
 use uuid::Uuid;
 
 use mz_ore::cast::CastFrom;
-use mz_persist_types::Codec;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 use crate::adt::array::ArrayDimension;
@@ -32,17 +31,13 @@ use crate::row::{
 };
 use crate::{Datum, Row, RowPacker};
 
-impl Codec for Row {
-    fn codec_name() -> String {
-        "protobuf[Row]".into()
-    }
-
+impl Row {
     /// Encodes a row into the permanent storage format.
     ///
     /// This perfectly round-trips through [Row::decode]. It's guaranteed to be
     /// readable by future versions of Materialize through v(TODO: Figure out
     /// our policy).
-    fn encode<B>(&self, buf: &mut B)
+    pub fn encode<B>(&self, buf: &mut B)
     where
         B: BufMut,
     {
@@ -56,7 +51,7 @@ impl Codec for Row {
     /// This perfectly round-trips through [Row::encode]. It can read rows
     /// encoded by historical versions of Materialize back to v(TODO: Figure out
     /// our policy).
-    fn decode(buf: &[u8]) -> Result<Row, String> {
+    pub fn decode(buf: &[u8]) -> Result<Row, String> {
         let proto_row = ProtoRow::decode(buf).map_err(|err| err.to_string())?;
         Row::try_from(&proto_row)
     }
@@ -333,7 +328,6 @@ impl RustType<ProtoRow> for Row {
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
-    use mz_persist_types::Codec;
     use uuid::Uuid;
 
     use crate::adt::array::ArrayDimension;

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -48,7 +48,7 @@ use mz_ore::now::{EpochMillis, NowFn};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::{PersistClient, PersistLocation, ShardId};
-use mz_persist_types::{Codec, Codec64, Opaque};
+use mz_persist_types::{Codec64, Opaque};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
 use mz_stash::{self, PostgresFactory, StashError, TypedCollection};
@@ -451,23 +451,6 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
     }
 }
 
-impl Codec for CollectionMetadata {
-    fn codec_name() -> String {
-        "protobuf[CollectionMetadata]".into()
-    }
-
-    fn encode<B: BufMut>(&self, buf: &mut B) {
-        self.into_proto()
-            .encode(buf)
-            .expect("no required fields means no initialization errors");
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, String> {
-        let proto = ProtoCollectionMetadata::decode(buf).map_err(|err| err.to_string())?;
-        proto.into_rust().map_err(|err| err.to_string())
-    }
-}
-
 /// A trait that is used to calculate safe _resumption frontiers_ for a source.
 ///
 /// Use [`ResumptionFrontierCalculator::initialize_state`] for creating an
@@ -518,23 +501,6 @@ impl RustType<ProtoDurableCollectionMetadata> for DurableCollectionMetadata {
     }
 }
 
-impl Codec for DurableCollectionMetadata {
-    fn codec_name() -> String {
-        "protobuf[DurableCollectionMetadata]".into()
-    }
-
-    fn encode<B: BufMut>(&self, buf: &mut B) {
-        self.into_proto()
-            .encode(buf)
-            .expect("no required fields means no initialization errors");
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, String> {
-        let proto = ProtoDurableCollectionMetadata::decode(buf).map_err(|err| err.to_string())?;
-        proto.into_rust().map_err(|err| err.to_string())
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DurableExportMetadata<T> {
     pub initial_as_of: SinkAsOf<T>,
@@ -572,18 +538,14 @@ impl RustType<ProtoDurableExportMetadata> for DurableExportMetadata<mz_repr::Tim
     }
 }
 
-impl Codec for DurableExportMetadata<mz_repr::Timestamp> {
-    fn codec_name() -> String {
-        "protobuf[DurableExportMetadata]".into()
-    }
-
-    fn encode<B: BufMut>(&self, buf: &mut B) {
+impl DurableExportMetadata<mz_repr::Timestamp> {
+    pub fn encode<B: BufMut>(&self, buf: &mut B) {
         self.into_proto()
             .encode(buf)
             .expect("no required fields means no initialization errors");
     }
 
-    fn decode(buf: &[u8]) -> Result<Self, String> {
+    pub fn decode(buf: &[u8]) -> Result<Self, String> {
         let proto = ProtoDurableExportMetadata::decode(buf).map_err(|err| err.to_string())?;
         proto.into_rust().map_err(|err| err.to_string())
     }

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use mz_expr::EvalError;
-use mz_persist_types::Codec;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, Row};
 
@@ -51,12 +50,8 @@ impl RustType<ProtoDecodeError> for DecodeError {
     }
 }
 
-impl Codec for DecodeError {
-    fn codec_name() -> String {
-        "protobuf[DecodeError]".into()
-    }
-
-    fn encode<B>(&self, buf: &mut B)
+impl DecodeError {
+    pub fn encode<B>(&self, buf: &mut B)
     where
         B: BufMut,
     {
@@ -65,7 +60,7 @@ impl Codec for DecodeError {
             .expect("no required fields means no initialization errors")
     }
 
-    fn decode(buf: &[u8]) -> Result<Self, String> {
+    pub fn decode(buf: &[u8]) -> Result<Self, String> {
         let proto = ProtoDecodeError::decode(buf).map_err(|err| err.to_string())?;
         proto.into_rust().map_err(|err| err.to_string())
     }
@@ -388,23 +383,6 @@ impl RustType<ProtoDataflowError> for DataflowError {
     }
 }
 
-impl Codec for DataflowError {
-    fn codec_name() -> String {
-        "protobuf[DataflowError]".into()
-    }
-
-    fn encode<B: BufMut>(&self, buf: &mut B) {
-        self.into_proto()
-            .encode(buf)
-            .expect("no required fields means no initialization errors");
-    }
-
-    fn decode(buf: &[u8]) -> Result<Self, String> {
-        let proto = ProtoDataflowError::decode(buf).map_err(|err| err.to_string())?;
-        proto.into_rust().map_err(|err| err.to_string())
-    }
-}
-
 impl Display for DataflowError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -442,8 +420,6 @@ impl From<EnvelopeError> for DataflowError {
 
 #[cfg(test)]
 mod tests {
-    use mz_persist_types::Codec;
-
     use crate::types::errors::DecodeErrorKind;
 
     use super::DecodeError;


### PR DESCRIPTION
The only types that need to impl Codec are ones uses as the key or value of a persist shard. It's been fine so far for other things to impl Codec, but when we add structure to persist, a Codec impl will be more involved. So, remove the unnecessary impls to avoid the complexity.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
