### PR TITLE
bin/sqllogictest: don't remove clusterd processes

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -164,7 +164,6 @@ def main() -> int:
                 *args.args,
             ]
         elif args.program == "sqllogictest":
-            _handle_lingering_services(kill=True)
             command += [f"--postgres-url={args.postgres}"]
     elif args.program == "test":
         build_retcode = _build(args)


### PR DESCRIPTION
Since the switch to the new process orchestrator, the clusterd processes created by `bin/environmentd` no longer complete with the clusterd processes created bin `bin/sqllogictest`, so `bin/sqllogictest` no longer needs to delete lingering clusterd processes.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
