### PR TITLE
persist: understand structure of persisted data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ dependencies = [
  "mz-expr",
  "mz-ore",
  "mz-persist-client",
+ "mz-persist-types",
  "mz-pid-file",
  "mz-repr",
  "mz-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8092,6 +8092,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
+ "getrandom",
  "globset",
  "hashbrown",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,6 +4205,8 @@ dependencies = [
 name = "mz-persist-types"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "arrow2",
  "bytes",
  "workspace-hack",
 ]
@@ -4383,6 +4385,7 @@ dependencies = [
  "itertools",
  "mz-lowertest",
  "mz-ore",
+ "mz-persist",
  "mz-persist-types",
  "mz-proto",
  "num-traits",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -21,6 +21,7 @@ mz-compute-client = { path = "../compute-client" }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
+mz-persist-types = { path = "../persist-types" }
 mz-pid-file = { path = "../pid-file" }
 mz-repr = { path = "../repr" }
 mz-service = { path = "../service" }

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -33,6 +33,7 @@ use mz_ore::cast::CastFrom;
 use mz_persist_client::batch::Batch;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriterEnrichedHollowBatch;
+use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
@@ -307,10 +308,11 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff, _>(
+            .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
                 &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
-                target_relation_desc,
+                Arc::new(target_relation_desc),
+                Arc::new(UnitSchema),
             )
             .await
             .expect("could not open persist shard");
@@ -576,10 +578,11 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff, _>(
+            .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
                 &format!("compute::persist_sink::write_batches {}", sink_id),
-                target_relation_desc,
+                Arc::new(target_relation_desc),
+                Arc::new(UnitSchema),
             )
             .await
             .expect("could not open persist shard");
@@ -897,10 +900,11 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff,_>(
+            .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
                 &format!("persist_sink::append_batches {}", sink_id),
-                target_relation_desc,
+                Arc::new(target_relation_desc),
+                Arc::new(UnitSchema)
             )
             .await
             .expect("could not open persist shard");

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -7,9 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use criterion::{black_box, Criterion, Throughput};
+use mz_persist_types::codec_impls::VecU8Schema;
 use timely::progress::Antichain;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
@@ -64,10 +66,11 @@ async fn bench_writes_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let mut write = client
-        .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+        .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
             ShardId::new(),
             "bench",
-            PersistClient::TEST_SCHEMA,
+            Arc::new(VecU8Schema),
+            Arc::new(VecU8Schema),
         )
         .await?;
 
@@ -117,7 +120,12 @@ async fn bench_write_to_listen_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let (mut write, read) = client
-        .open::<Vec<u8>, Vec<u8>, u64, i64, _>(ShardId::new(), "bench", PersistClient::TEST_SCHEMA)
+        .open::<Vec<u8>, Vec<u8>, u64, i64>(
+            ShardId::new(),
+            "bench",
+            Arc::new(VecU8Schema),
+            Arc::new(VecU8Schema),
+        )
         .await?;
 
     // Start the listener in a task before the write so it can't "cheat" by
@@ -203,10 +211,11 @@ pub fn bench_snapshot(
         let shard_id = ShardId::new();
         let (_, as_of) = runtime.block_on(async {
             let mut write = client
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
                     shard_id,
                     "bench",
-                    PersistClient::TEST_SCHEMA,
+                    Arc::new(VecU8Schema),
+                    Arc::new(VecU8Schema),
                 )
                 .await
                 .expect("failed to open shard");
@@ -227,10 +236,11 @@ async fn bench_snapshot_one_iter(
     as_of: &Antichain<u64>,
 ) -> Result<(), anyhow::Error> {
     let mut read = client
-        .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64, _>(
+        .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64>(
             *shard_id,
             "bench",
-            PersistClient::TEST_SCHEMA,
+            Arc::new(VecU8Schema),
+            Arc::new(VecU8Schema),
         )
         .await?;
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -20,6 +20,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::metrics::Metrics;
+use mz_persist_types::codec_impls::TodoSchema;
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -134,7 +135,12 @@ impl Transactor {
             .expect("maelstrom node_id should be n followed by an integer");
 
         let (mut write, mut read) = client
-            .open(shard_id, "maelstrom long-lived", PersistClient::TEST_SCHEMA)
+            .open(
+                shard_id,
+                "maelstrom long-lived",
+                Arc::new(TodoSchema::<MaelstromKey>::default()),
+                Arc::new(TodoSchema::<MaelstromVal>::default()),
+            )
             .await?;
         // Use the CONTROLLER_CRITICAL_SINCE id for all nodes so we get coverage
         // of contending traffic.
@@ -262,7 +268,8 @@ impl Transactor {
                 .open_leased_reader(
                     self.shard_id,
                     "maelstrom short-lived",
-                    PersistClient::TEST_SCHEMA,
+                    Arc::new(TodoSchema::<MaelstromKey>::default()),
+                    Arc::new(TodoSchema::<MaelstromVal>::default()),
                 )
                 .await
                 .expect("codecs should match");

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -692,11 +692,14 @@ impl Service for TransactorService {
 }
 
 mod codec_impls {
+    use mz_persist_types::codec_impls::TodoSchema;
     use mz_persist_types::Codec;
 
     use crate::maelstrom::txn::{MaelstromKey, MaelstromVal};
 
     impl Codec for MaelstromKey {
+        type Schema = TodoSchema<MaelstromKey>;
+
         fn codec_name() -> String {
             "MaelstromKey".into()
         }
@@ -717,6 +720,8 @@ mod codec_impls {
     }
 
     impl Codec for MaelstromVal {
+        type Schema = TodoSchema<MaelstromVal>;
+
         fn codec_name() -> String {
             "MaelstromVal".into()
         }

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -472,7 +472,10 @@ mod api {
 }
 
 mod raw_persist_benchmark {
+    use std::sync::Arc;
+
     use async_trait::async_trait;
+    use mz_persist_types::codec_impls::VecU8Schema;
     use timely::progress::Antichain;
     use tokio::sync::mpsc::Sender;
 
@@ -508,7 +511,12 @@ mod raw_persist_benchmark {
         let mut readers = vec![];
         for _ in 0..num_readers {
             let (_writer, reader) = persist
-                .open::<Vec<u8>, Vec<u8>, u64, i64, _>(id, "open loop", PersistClient::TEST_SCHEMA)
+                .open::<Vec<u8>, Vec<u8>, u64, i64>(
+                    id,
+                    "open loop",
+                    Arc::new(VecU8Schema),
+                    Arc::new(VecU8Schema),
+                )
                 .await?;
 
             let listen = reader
@@ -538,10 +546,11 @@ mod raw_persist_benchmark {
             let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel(10);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
                     id,
                     "open loop",
-                    PersistClient::TEST_SCHEMA,
+                    Arc::new(VecU8Schema),
+                    Arc::new(VecU8Schema),
                 )
                 .await?;
 
@@ -586,10 +595,11 @@ mod raw_persist_benchmark {
             handles.push(handle);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(
                     id,
                     "open loop",
-                    PersistClient::TEST_SCHEMA,
+                    Arc::new(VecU8Schema),
+                    Arc::new(VecU8Schema),
                 )
                 .await?;
 

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -381,6 +381,7 @@ mod api {
 mod types {
     use bytes::BufMut;
     use differential_dataflow::lattice::Lattice;
+    use mz_persist_types::codec_impls::TodoSchema;
     use serde::{Deserialize, Serialize};
     use timely::progress::PathSummary;
 
@@ -399,6 +400,8 @@ mod types {
     }
 
     impl Codec for PartitionOffset {
+        type Schema = TodoSchema<PartitionOffset>;
+
         fn codec_name() -> String {
             "partition_offset[u64,u64]".to_owned()
         }
@@ -467,6 +470,8 @@ mod types {
     }
 
     impl Codec for Timestamp {
+        type Schema = TodoSchema<Timestamp>;
+
         fn codec_name() -> String {
             "timestamp[u64]".to_owned()
         }

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -18,6 +18,7 @@ use anyhow::anyhow;
 use bytes::BufMut;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::trace::Description;
+use mz_persist_types::codec_impls::TodoSchema;
 use prost::Message;
 
 use mz_build_info::BuildInfo;
@@ -619,6 +620,8 @@ pub(crate) static KVTD_CODECS: Mutex<(String, String, String, String)> =
     Mutex::new((String::new(), String::new(), String::new(), String::new()));
 
 impl Codec for K {
+    type Schema = TodoSchema<K>;
+
     fn codec_name() -> String {
         KVTD_CODECS.lock().expect("lockable").0.clone()
     }
@@ -635,6 +638,8 @@ impl Codec for K {
 }
 
 impl Codec for V {
+    type Schema = TodoSchema<V>;
+
     fn codec_name() -> String {
         KVTD_CODECS.lock().expect("lockable").1.clone()
     }
@@ -651,6 +656,8 @@ impl Codec for V {
 }
 
 impl Codec for T {
+    type Schema = TodoSchema<T>;
+
     fn codec_name() -> String {
         KVTD_CODECS.lock().expect("lockable").2.clone()
     }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1179,6 +1179,7 @@ pub mod datadriven {
     use differential_dataflow::consolidation::consolidate_updates;
     use differential_dataflow::trace::Description;
     use mz_build_info::DUMMY_BUILD_INFO;
+    use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 
     use crate::batch::{validate_truncate_batch, BatchBuilder};
     use crate::fetch::fetch_batch_part;
@@ -1608,10 +1609,11 @@ pub mod datadriven {
         let as_of = args.expect_antichain("as_of");
         let read = datadriven
             .client
-            .open_leased_reader::<String, (), u64, i64, _>(
+            .open_leased_reader::<String, (), u64, i64>(
                 datadriven.shard_id,
                 "",
-                PersistClient::TEST_SCHEMA,
+                Arc::new(StringSchema),
+                Arc::new(UnitSchema),
             )
             .await
             .expect("invalid shard types");

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -438,12 +438,13 @@ impl ConsensusKnobs for PersistConfig {
 /// [tokio::time::timeout_at].
 ///
 /// ```rust,no_run
+/// # use std::sync::Arc;
 /// # use mz_persist_types::codec_impls::StringSchema;
 /// # let client: mz_persist_client::PersistClient = unimplemented!();
 /// # let timeout: std::time::Duration = unimplemented!();
 /// # let id = mz_persist_client::ShardId::new();
 /// # async {
-/// tokio::time::timeout(timeout, client.open::<String, String, u64, i64, _>(id, "desc",
+/// tokio::time::timeout(timeout, client.open::<String, String, u64, i64>(id, "desc",
 ///     Arc::new(StringSchema),Arc::new(StringSchema))).await
 /// # };
 /// ```

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 # NB: This is meant to be a strong, independent abstraction boundary. Please
 # don't leak in dependencies on other Materialize packages.
 [dependencies]
+anyhow = { version = "1.0.66", features = ["backtrace"] }
+arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", features = ["io_ipc", "io_parquet"] }
 bytes = "1.3.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -31,7 +31,7 @@ use crate::part::{ColumnsMut, ColumnsRef};
 use crate::{Codec, Codec64, Opaque};
 
 /// An implementation of [Schema] for [()].
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct UnitSchema;
 
 impl PartEncoder<'_, ()> for UnitSchema {
@@ -108,7 +108,7 @@ impl<'a, T: Data> PartDecoder<'a, T> for SimpleDecoder<'a, T> {
 }
 
 /// An implementation of [Schema] for [String].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StringSchema;
 
 // TODO: Feels like it should be possible to write a single impl of Schema to
@@ -172,7 +172,7 @@ impl Codec for String {
 }
 
 /// An implementation of [Schema] for [`Vec<u8>`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct VecU8Schema;
 
 impl Schema<Vec<u8>> for VecU8Schema {
@@ -624,6 +624,12 @@ impl ColumnPush<Option<String>> for MutableUtf8Array<i32> {
 /// A placeholder for a [Codec] impl that hasn't yet gotten a real [Schema].
 #[derive(Debug)]
 pub struct TodoSchema<T>(PhantomData<T>);
+
+impl<T> Default for TodoSchema<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 
 impl<T> PartEncoder<'_, T> for TodoSchema<T> {
     fn encode(&mut self, _val: &T) {

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -9,11 +9,61 @@
 
 //! Implementations of [Codec] for stdlib types.
 
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use arrow2::array::{
+    Array, BinaryArray, BooleanArray, MutableArray, MutableBinaryArray, MutableBooleanArray,
+    MutablePrimitiveArray, MutableUtf8Array, PrimitiveArray, Utf8Array,
+};
+use arrow2::bitmap::{Bitmap, MutableBitmap};
+use arrow2::buffer::Buffer;
+use arrow2::datatypes::DataType as ArrowLogicalType;
+use arrow2::io::parquet::write::Encoding;
+use arrow2::types::NativeType;
 use bytes::BufMut;
 
+use crate::columnar::sealed::ColumnRef;
+use crate::columnar::{
+    ColumnFormat, ColumnGet, ColumnPush, Data, DataType, PartDecoder, PartEncoder, Schema,
+};
+use crate::part::{ColumnsMut, ColumnsRef};
 use crate::{Codec, Codec64, Opaque};
 
+/// An implementation of [Schema] for [()].
+#[derive(Debug)]
+pub struct UnitSchema;
+
+impl PartEncoder<'_, ()> for UnitSchema {
+    fn encode(&mut self, _val: &()) {}
+}
+
+impl PartDecoder<'_, ()> for UnitSchema {
+    fn decode(&self, _idx: usize, _val: &mut ()) {}
+}
+
+impl Schema<()> for UnitSchema {
+    type Encoder<'a> = Self;
+    type Decoder<'a> = Self;
+
+    fn columns(&self) -> Vec<(String, DataType)> {
+        Vec::new()
+    }
+
+    fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        let () = cols.finish()?;
+        Ok(UnitSchema)
+    }
+
+    fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        let () = cols.finish()?;
+        Ok(UnitSchema)
+    }
+}
+
 impl Codec for () {
+    type Schema = UnitSchema;
+
     fn codec_name() -> String {
         "()".into()
     }
@@ -33,7 +83,78 @@ impl Codec for () {
     }
 }
 
+/// An implementation of [PartEncoder] for a single column.
+pub struct SimpleEncoder<'a, T: Data> {
+    col: &'a mut T::Mut,
+    encode: fn(&mut T::Mut, &T),
+}
+
+impl<'a, T: Data> PartEncoder<'a, T> for SimpleEncoder<'a, T> {
+    fn encode(&mut self, val: &T) {
+        (self.encode)(self.col, val);
+    }
+}
+
+/// An implementation of [PartDecoder] for a single column.
+pub struct SimpleDecoder<'a, T: Data> {
+    col: &'a T::Col,
+    decode: fn(&T::Col, usize, &mut T),
+}
+
+impl<'a, T: Data> PartDecoder<'a, T> for SimpleDecoder<'a, T> {
+    fn decode(&self, idx: usize, val: &mut T) {
+        (self.decode)(self.col, idx, val)
+    }
+}
+
+/// An implementation of [Schema] for [String].
+#[derive(Debug, Clone)]
+pub struct StringSchema;
+
+// TODO: Feels like it should be possible to write a single impl of Schema to
+// cover StringSchema, VecU8Schema, MaelstromKeySchema, etc in terms of
+// ColumnRef and ColumnMut. We might have to pull in the rust experts though,
+// the lifetimes get tricky.
+impl Schema<String> for StringSchema {
+    type Encoder<'a> = SimpleEncoder<'a, String>;
+
+    type Decoder<'a> = SimpleDecoder<'a, String>;
+
+    fn columns(&self) -> Vec<(String, DataType)> {
+        let data_type = DataType {
+            optional: false,
+            format: ColumnFormat::String,
+        };
+        vec![("".to_owned(), data_type)]
+    }
+
+    fn decoder<'a>(&self, mut cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        let col = cols.col::<String>("")?;
+        let () = cols.finish()?;
+        Ok(SimpleDecoder {
+            col,
+            decode: |col, idx, val| {
+                val.clear();
+                val.push_str(col.value(idx));
+            },
+        })
+    }
+
+    fn encoder<'a>(&self, mut cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        let col = cols.col::<String>("")?;
+        let () = cols.finish()?;
+        Ok(SimpleEncoder {
+            col,
+            encode: |col, val| {
+                col.push(Some(val));
+            },
+        })
+    }
+}
+
 impl Codec for String {
+    type Schema = StringSchema;
+
     fn codec_name() -> String {
         "String".into()
     }
@@ -50,7 +171,50 @@ impl Codec for String {
     }
 }
 
+/// An implementation of [Schema] for [`Vec<u8>`].
+#[derive(Debug, Clone)]
+pub struct VecU8Schema;
+
+impl Schema<Vec<u8>> for VecU8Schema {
+    type Encoder<'a> = SimpleEncoder<'a, Vec<u8>>;
+
+    type Decoder<'a> = SimpleDecoder<'a, Vec<u8>>;
+
+    fn columns(&self) -> Vec<(String, DataType)> {
+        let data_type = DataType {
+            optional: false,
+            format: ColumnFormat::Bytes,
+        };
+        vec![("".to_owned(), data_type)]
+    }
+
+    fn decoder<'a>(&self, mut cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        let col = cols.col::<Vec<u8>>("")?;
+        let () = cols.finish()?;
+        Ok(SimpleDecoder {
+            col,
+            decode: |col, idx, val| {
+                val.clear();
+                val.extend_from_slice(col.value(idx));
+            },
+        })
+    }
+
+    fn encoder<'a>(&self, mut cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        let col = cols.col::<Vec<u8>>("")?;
+        let () = cols.finish()?;
+        Ok(SimpleEncoder {
+            col,
+            encode: |col, val| {
+                col.push(Some(val));
+            },
+        })
+    }
+}
+
 impl Codec for Vec<u8> {
+    type Schema = VecU8Schema;
+
     fn codec_name() -> String {
         "Vec<u8>".into()
     }
@@ -106,5 +270,386 @@ impl Opaque for u64 {
 impl Opaque for i64 {
     fn initial() -> Self {
         i64::MIN
+    }
+}
+
+impl Data for bool {
+    const TYPE: DataType = DataType {
+        optional: false,
+        format: ColumnFormat::Bool,
+    };
+    type Ref<'a> = bool;
+    type Col = Bitmap;
+    type Mut = MutableBitmap;
+}
+
+impl Data for Option<bool> {
+    const TYPE: DataType = DataType {
+        optional: true,
+        format: ColumnFormat::Bool,
+    };
+    type Ref<'a> = Option<bool>;
+    type Col = BooleanArray;
+    type Mut = MutableBooleanArray;
+}
+
+macro_rules! data_primitive {
+    ($data:ident, $format:expr) => {
+        impl Data for $data {
+            const TYPE: DataType = DataType {
+                optional: false,
+                format: $format,
+            };
+            type Ref<'a> = $data;
+            type Col = Buffer<$data>;
+            type Mut = Vec<$data>;
+        }
+
+        impl Data for Option<$data> {
+            const TYPE: DataType = DataType {
+                optional: true,
+                format: $format,
+            };
+            type Ref<'a> = Option<$data>;
+            type Col = PrimitiveArray<$data>;
+            type Mut = MutablePrimitiveArray<$data>;
+        }
+    };
+}
+
+data_primitive!(u8, ColumnFormat::U8);
+data_primitive!(u16, ColumnFormat::U16);
+data_primitive!(u32, ColumnFormat::U32);
+data_primitive!(u64, ColumnFormat::U64);
+data_primitive!(i8, ColumnFormat::I8);
+data_primitive!(i16, ColumnFormat::I16);
+data_primitive!(i32, ColumnFormat::I32);
+data_primitive!(i64, ColumnFormat::I64);
+data_primitive!(f32, ColumnFormat::F32);
+data_primitive!(f64, ColumnFormat::F64);
+
+impl Data for Vec<u8> {
+    const TYPE: DataType = DataType {
+        optional: false,
+        format: ColumnFormat::Bytes,
+    };
+    type Ref<'a> = &'a [u8];
+    // TODO: Something that more obviously isn't optional.
+    type Col = BinaryArray<i32>;
+    type Mut = MutableBinaryArray<i32>;
+}
+
+impl Data for Option<Vec<u8>> {
+    const TYPE: DataType = DataType {
+        optional: true,
+        format: ColumnFormat::Bytes,
+    };
+    type Ref<'a> = Option<&'a [u8]>;
+    type Col = BinaryArray<i32>;
+    type Mut = MutableBinaryArray<i32>;
+}
+
+impl Data for String {
+    const TYPE: DataType = DataType {
+        optional: false,
+        format: ColumnFormat::String,
+    };
+    type Ref<'a> = &'a str;
+    // TODO: Something that more obviously isn't optional.
+    type Col = Utf8Array<i32>;
+    type Mut = MutableUtf8Array<i32>;
+}
+
+impl Data for Option<String> {
+    const TYPE: DataType = DataType {
+        optional: true,
+        format: ColumnFormat::String,
+    };
+    type Ref<'a> = Option<&'a str>;
+    type Col = Utf8Array<i32>;
+    type Mut = MutableUtf8Array<i32>;
+}
+
+impl ColumnRef for Bitmap {
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+        let array = BooleanArray::new(ArrowLogicalType::Boolean, self.clone(), None);
+        (Encoding::Plain, Box::new(array))
+    }
+    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
+        let array = array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| format!("expected BooleanArray but was {:?}", array.data_type()))?;
+        if array.validity().is_some() {
+            return Err("unexpected validity for non-optional bool".to_owned());
+        }
+        Ok(array.values().clone())
+    }
+}
+
+impl ColumnGet<bool> for Bitmap {
+    fn get<'a>(&'a self, idx: usize) -> bool {
+        self.get_bit(idx)
+    }
+}
+
+impl ColumnPush<bool> for MutableBitmap {
+    fn push<'a>(&mut self, val: bool) {
+        <MutableBitmap>::push(self, val)
+    }
+}
+
+impl ColumnRef for BooleanArray {
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+        (Encoding::Plain, Box::new(self.clone()))
+    }
+    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
+        let array = array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| format!("expected BooleanArray but was {:?}", array.data_type()))?;
+        Ok(array.clone())
+    }
+}
+
+impl ColumnGet<Option<bool>> for BooleanArray {
+    fn get<'a>(&'a self, idx: usize) -> Option<bool> {
+        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+            Some(self.value(idx))
+        } else {
+            None
+        }
+    }
+}
+
+impl ColumnPush<Option<bool>> for MutableBooleanArray {
+    fn push<'a>(&mut self, val: Option<bool>) {
+        <MutableBooleanArray>::push(self, val)
+    }
+}
+
+macro_rules! arrowable_primitive {
+    ($data:ident, $encoding:expr) => {
+        impl ColumnRef for Buffer<$data> {
+            fn len(&self) -> usize {
+                self.len()
+            }
+            fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+                let array = PrimitiveArray::new($data::PRIMITIVE.into(), self.clone(), None);
+                ($encoding, Box::new(array.clone()))
+            }
+            fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
+                let array = array
+                    .as_any()
+                    .downcast_ref::<PrimitiveArray<$data>>()
+                    .ok_or_else(|| {
+                        format!(
+                            "expected {} but was {:?}",
+                            std::any::type_name::<PrimitiveArray<$data>>(),
+                            array.data_type()
+                        )
+                    })?;
+                if array.validity().is_some() {
+                    return Err(format!(
+                        "unexpected validity for non-optional {}",
+                        std::any::type_name::<$data>()
+                    ));
+                }
+                Ok(array.values().clone())
+            }
+        }
+
+        impl ColumnGet<$data> for Buffer<$data> {
+            fn get<'a>(&'a self, idx: usize) -> $data {
+                self[idx]
+            }
+        }
+
+        impl ColumnPush<$data> for Vec<$data> {
+            fn push<'a>(&mut self, val: $data) {
+                <Vec<$data>>::push(self, val)
+            }
+        }
+
+        impl ColumnRef for PrimitiveArray<$data> {
+            fn len(&self) -> usize {
+                self.len()
+            }
+            fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+                ($encoding, Box::new(self.clone()))
+            }
+            fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
+                let array = array
+                    .as_any()
+                    .downcast_ref::<PrimitiveArray<$data>>()
+                    .ok_or_else(|| {
+                        format!(
+                            "expected {} but was {:?}",
+                            std::any::type_name::<PrimitiveArray<$data>>(),
+                            array.data_type()
+                        )
+                    })?;
+                Ok(array.clone())
+            }
+        }
+
+        impl ColumnGet<Option<$data>> for PrimitiveArray<$data> {
+            fn get<'a>(&'a self, idx: usize) -> Option<$data> {
+                if self.validity().map_or(true, |x| x.get_bit(idx)) {
+                    Some(self.value(idx))
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl ColumnPush<Option<$data>> for MutablePrimitiveArray<$data> {
+            fn push<'a>(&mut self, val: Option<$data>) {
+                <MutablePrimitiveArray<$data>>::push(self, val)
+            }
+        }
+    };
+}
+
+arrowable_primitive!(u8, Encoding::Plain);
+arrowable_primitive!(u16, Encoding::Plain);
+arrowable_primitive!(u32, Encoding::Plain);
+arrowable_primitive!(u64, Encoding::Plain);
+arrowable_primitive!(i8, Encoding::Plain);
+arrowable_primitive!(i16, Encoding::Plain);
+arrowable_primitive!(i32, Encoding::Plain);
+arrowable_primitive!(i64, Encoding::Plain);
+arrowable_primitive!(f32, Encoding::Plain);
+arrowable_primitive!(f64, Encoding::Plain);
+
+impl ColumnRef for BinaryArray<i32> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+        (Encoding::Plain, Box::new(self.clone()))
+    }
+    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
+        let array = array
+            .as_any()
+            .downcast_ref::<BinaryArray<i32>>()
+            .ok_or_else(|| format!("expected BinaryArray<i32> but was {:?}", array.data_type()))?;
+        Ok(array.clone())
+    }
+}
+
+impl ColumnGet<Vec<u8>> for BinaryArray<i32> {
+    fn get<'a>(&'a self, idx: usize) -> &'a [u8] {
+        assert!(self.validity().is_none());
+        self.value(idx)
+    }
+}
+
+impl ColumnGet<Option<Vec<u8>>> for BinaryArray<i32> {
+    fn get<'a>(&'a self, idx: usize) -> Option<&'a [u8]> {
+        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+            Some(self.value(idx))
+        } else {
+            None
+        }
+    }
+}
+
+impl ColumnPush<Vec<u8>> for MutableBinaryArray<i32> {
+    fn push<'a>(&mut self, val: &'a [u8]) {
+        assert!(self.validity().is_none());
+        <MutableBinaryArray<i32>>::push(self, Some(val))
+    }
+}
+
+impl ColumnPush<Option<Vec<u8>>> for MutableBinaryArray<i32> {
+    fn push<'a>(&mut self, val: Option<&'a [u8]>) {
+        assert!(self.validity().is_none());
+        <MutableBinaryArray<i32>>::push(self, val)
+    }
+}
+
+impl ColumnRef for Utf8Array<i32> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+        (Encoding::Plain, Box::new(self.clone()))
+    }
+    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
+        let array = array
+            .as_any()
+            .downcast_ref::<Utf8Array<i32>>()
+            .ok_or_else(|| format!("expected Utf8Array<i32> but was {:?}", array.data_type()))?;
+        Ok(array.clone())
+    }
+}
+
+impl ColumnGet<String> for Utf8Array<i32> {
+    fn get<'a>(&'a self, idx: usize) -> &'a str {
+        assert!(self.validity().is_none());
+        self.value(idx)
+    }
+}
+
+impl ColumnGet<Option<String>> for Utf8Array<i32> {
+    fn get<'a>(&'a self, idx: usize) -> Option<&'a str> {
+        if self.validity().map_or(true, |x| x.get_bit(idx)) {
+            Some(self.value(idx))
+        } else {
+            None
+        }
+    }
+}
+
+impl ColumnPush<String> for MutableUtf8Array<i32> {
+    fn push<'a>(&mut self, val: &'a str) {
+        assert!(self.validity().is_none());
+        <MutableUtf8Array<i32>>::push(self, Some(val))
+    }
+}
+
+impl ColumnPush<Option<String>> for MutableUtf8Array<i32> {
+    fn push<'a>(&mut self, val: Option<&'a str>) {
+        <MutableUtf8Array<i32>>::push(self, val)
+    }
+}
+
+/// A placeholder for a [Codec] impl that hasn't yet gotten a real [Schema].
+#[derive(Debug)]
+pub struct TodoSchema<T>(PhantomData<T>);
+
+impl<T> PartEncoder<'_, T> for TodoSchema<T> {
+    fn encode(&mut self, _val: &T) {
+        panic!("TODO")
+    }
+}
+
+impl<T> PartDecoder<'_, T> for TodoSchema<T> {
+    fn decode(&self, _idx: usize, _val: &mut T) {
+        panic!("TODO")
+    }
+}
+
+impl<T: Debug> Schema<T> for TodoSchema<T> {
+    type Encoder<'a> = Self;
+    type Decoder<'a> = Self;
+
+    fn columns(&self) -> Vec<(String, DataType)> {
+        panic!("TODO")
+    }
+
+    fn decoder<'a>(&self, _cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        panic!("TODO")
+    }
+
+    fn encoder<'a>(&self, _cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        panic!("TODO")
     }
 }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -1,0 +1,251 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Columnar understanding of persisted data
+//!
+//! For efficiency/performance, we directly expose the columnar structure of
+//! persist's internal encoding to users during encoding and decoding. For
+//! ergonomics, we wrap the arrow2 crate we use to read and write parquet data.
+//!
+//! Some of the requirements that led to this design:
+//! - Support a separation of data and schema because Row is not
+//!   self-describing: e.g. a Datum::Null can be one of many possible column
+//!   types. A RelationDesc is necessary to describe a Row schema.
+//! - Narrow down arrow2::data_types::DataType (the arrow "logical" types) to a
+//!   set we want to support in persist.
+//! - Associate an arrow2::io::parquet::write::Encoding with each of those
+//!   types.
+//! - Do `dyn Any` downcasting of columns once per part, not once per update.
+//! - Unlike arrow2, be precise about whether each column is optional or not.
+//!
+//! The primary presentation of this abstraction is a sealed trait [Data], which
+//! is implemented for the owned version of each type of data that can be stored
+//! in persist: `int64`, `Option<String>`, etc.
+//!
+//! Under the hood, it's necessary to store something like a map of `name ->
+//! column`. A natural instinct is to make Data object safe, but I couldn't
+//! figure out a way to make that work without severe limitations. As a result,
+//! the DataType enum is introduced with a 1:1 relationship between variants and
+//! implementations of Data. This allows for easy type erasure and guardrails
+//! when downcasting the types back.
+//!
+//! Note: The "Data" strategy is roughly how columnation works and the
+//! "DataType" strategy is roughly how arrow2 works. Doing both of them gets us
+//! the benefits of both, while the downside is code duplication and cognitive
+//! overhead.
+//!
+//! The Data trait has associated types for the exclusive "builder" type for the
+//! column and for the shared "reader" type. These implement also implement some
+//! common traits to make relationships between types more structured.
+//!
+//! Finally, the [Schema] trait maps an implementor of [Codec] to the underlying
+//! column structure. It also provides a [PartEncoder] and [PartDecoder] for
+//! amortizing any downcasting that does need to happen.
+
+use std::fmt::Debug;
+
+use crate::codec_impls::UnitSchema;
+use crate::columnar::sealed::ColumnRef;
+use crate::part::{ColumnsMut, ColumnsRef, PartBuilder};
+use crate::Codec;
+
+/// A type understood by persist.
+///
+/// The equality and sorting of the encoded column matches those of this rust
+/// type.
+///
+/// This trait is implemented for owned types. However, for efficiency the
+/// columns themselves don't store the owned types, so instead we read and write
+/// in terms of the associated [Self::Ref]. This is not simply `&Self` because
+/// e.g. it's sometimes not possible for us to present the column as something
+/// like `&Option<T>` but we can always produce a `Option<&T>`. Tuples have a
+/// similar restriction.
+///
+/// This trait is intentionally "sealed" via the unexported Column trait.
+///
+/// There is a 1:1 mapping between implementors of [Data] and variants of the
+/// [DataType] enum. The parallel hierarchy exists so that Data can be ergonomic
+/// while DataType is object-safe and has exhaustiveness checking. A Data impl
+/// can be mapped to it's corresponding DataType via [Data::TYPE] and back via
+/// DataType::data_fn.
+pub trait Data: Debug + Send + Sync + Sized + 'static {
+    /// The DataType variant corresponding to this data type.
+    const TYPE: DataType;
+
+    /// The associated reference type of [Self] used for reads and writes on
+    /// columns of this type.
+    ///
+    /// TODO: We may want to eventually separate this into In and Out types
+    /// because one wants to be covariant and the other wants to be
+    /// contravariant.
+    type Ref<'a>
+    where
+        Self: 'a;
+
+    /// The shared reference of columns of this type of data.
+    type Col: ColumnGet<Self> + From<Self::Mut>;
+
+    /// The exclusive builder of columns of this type of data.
+    type Mut: ColumnPush<Self> + Default;
+}
+
+/// A type that may be retrieved from a column of [T].
+pub trait ColumnGet<T: Data>: ColumnRef {
+    /// Retrieves the value at index.
+    fn get<'a>(&'a self, idx: usize) -> T::Ref<'a>;
+}
+
+/// A type that may be added into a column of [T].
+pub trait ColumnPush<T: Data> {
+    /// Pushes a new value into this column.
+    fn push<'a>(&mut self, val: T::Ref<'a>);
+}
+
+pub(crate) mod sealed {
+    use arrow2::array::Array;
+    use arrow2::io::parquet::write::Encoding;
+
+    /// A common trait implemented by all [Data::Col] types.
+    pub trait ColumnRef: Sized {
+        /// Returns the number of elements in this column.
+        fn len(&self) -> usize;
+
+        /// Returns this column as an arrow2 Array.
+        fn to_arrow(&self) -> (Encoding, Box<dyn Array>);
+
+        /// Constructs the column from an arrow2 Array.
+        #[allow(clippy::borrowed_box)]
+        fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String>;
+    }
+}
+
+/// A description of a type understood by persist.
+///
+/// There is a 1:1 mapping between implementors of [Data] and variants of the
+/// [DataType] enum. The parallel hierarchy exists so that Data can be ergonomic
+/// while DataType is object-safe and has exhaustiveness checking. A Data impl
+/// can be mapped to it's corresponding DataType via [Data::TYPE] and back via
+/// DataType::data_fn.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DataType {
+    /// Whether this type is optional.
+    pub optional: bool,
+    /// The in-memory rust type of a column of data.
+    pub format: ColumnFormat,
+}
+
+/// The in-memory rust type of a column of data.
+///
+/// The equality and sorting of the encoded column matches those of this rust
+/// type. Because of this, the variants are named after the rust type.
+///
+/// NB: This intentionally exists as a subset of [arrow2::datatypes::DataType].
+/// It also represents slightly different semantics. The arrow2 DataType always
+/// indicates an optional field, where as these all indicate non-optional fields
+/// (which may be made optional via [DataType]).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ColumnFormat {
+    /// A column of type [bool].
+    Bool,
+    /// A column of type [i8].
+    I8,
+    /// A column of type [i16].
+    I16,
+    /// A column of type [i32].
+    I32,
+    /// A column of type [i64].
+    I64,
+    /// A column of type [u8].
+    U8,
+    /// A column of type [u16].
+    U16,
+    /// A column of type [u32].
+    U32,
+    /// A column of type [u64].
+    U64,
+    /// A column of type [f32].
+    F32,
+    /// A column of type [f64].
+    F64,
+    /// A column of type [`Vec<u8>`].
+    Bytes,
+    /// A column of type [String].
+    String,
+    // TODO: FixedSizedBytes for UUIDs?
+    // TODO: Struct?
+}
+
+/// An encoder for values of a fixed schema
+///
+/// This allows us to amortize the cost of downcasting columns into concrete
+/// types.
+pub trait PartEncoder<'a, T> {
+    /// Encodes the given value into the Part being constructed.
+    fn encode(&mut self, val: &T);
+}
+
+/// A decoder for values of a fixed schema.
+///
+/// This allows us to amortize the cost of downcasting columns into concrete
+/// types.
+pub trait PartDecoder<'a, T> {
+    /// Decodes the value at the given index.
+    ///
+    /// Implementations of this should reuse allocations within the passed value
+    /// whenever possible.
+    fn decode(&self, idx: usize, val: &mut T);
+}
+
+/// A description of the structure of a [crate::Codec] implementor.
+pub trait Schema<T>: Debug {
+    /// The associated [PartEncoder] implementor.
+    type Encoder<'a>: PartEncoder<'a, T>;
+    /// The associated [PartDecoder] implementor.
+    type Decoder<'a>: PartDecoder<'a, T>;
+
+    /// Returns the name and types of the columns in this type.
+    ///
+    /// TODO: This is the only place where DataType leaks externally. We could
+    /// tighten up the abstraction by instead passing into this method some
+    /// object with a method like `fn add<T: Data>(name: String)`. If we decide
+    /// to support struct columns, a hypothetical StructSchemaBuilder would look
+    /// very much like this. Decide if this is better/worth it.
+    fn columns(&self) -> Vec<(String, DataType)>;
+
+    /// Returns a [Self::Decoder<'a>] for the given columns.
+    fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String>;
+
+    /// Returns a [Self::Encoder<'a>] for the given columns.
+    fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String>;
+}
+
+/// A helper for writing tests that validate that a piece of data roundtrips
+/// through the columnar format.
+pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
+    schema: &T::Schema,
+    val: &T,
+) -> Result<(), String> {
+    let mut part = PartBuilder::new(schema, &UnitSchema);
+    schema.encoder(part.key_mut())?.encode(val);
+    part.push_ts_diff(1, 1);
+    let part = part.finish()?;
+
+    let mut actual = T::default();
+    assert_eq!(part.len(), 1);
+    let part = part.key_ref();
+    schema.decoder(part)?.decode(0, &mut actual);
+    if &actual != val {
+        Err(format!(
+            "validate_roundtrip expected {:?} but got {:?}",
+            val, actual
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -95,14 +95,14 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
     type Mut: ColumnPush<Self> + Default;
 }
 
-/// A type that may be retrieved from a column of [T].
+/// A type that may be retrieved from a column of `[T]`.
 pub trait ColumnGet<T: Data>: ColumnRef {
     /// Retrieves the value at index.
     fn get<'a>(&'a self, idx: usize) -> T::Ref<'a>;
 }
 
-/// A type that may be added into a column of [T].
-pub trait ColumnPush<T: Data> {
+/// A type that may be added into a column of `[T]`.
+pub trait ColumnPush<T: Data>: Send + Sync {
     /// Pushes a new value into this column.
     fn push<'a>(&mut self, val: T::Ref<'a>);
 }
@@ -111,8 +111,8 @@ pub(crate) mod sealed {
     use arrow2::array::Array;
     use arrow2::io::parquet::write::Encoding;
 
-    /// A common trait implemented by all [Data::Col] types.
-    pub trait ColumnRef: Sized {
+    /// A common trait implemented by all `Data::Col` types.
+    pub trait ColumnRef: Sized + Send + Sync {
         /// Returns the number of elements in this column.
         fn len(&self) -> usize;
 

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -85,11 +85,23 @@
 
 use bytes::BufMut;
 
-mod codec_impls;
+use crate::columnar::Schema;
+
+pub mod codec_impls;
+pub mod columnar;
+pub mod parquet;
+pub mod part;
 
 /// Encoding and decoding operations for a type usable as a persisted key or
 /// value.
 pub trait Codec: Sized + 'static {
+    /// The type of the associated schema for [Self].
+    ///
+    /// This is a separate type because Row is not self-describing. For Row, you
+    /// need a RelationDesc to determine the types of any columns that are
+    /// Datum::Null.
+    type Schema: Schema<Self>;
+
     /// Name of the codec.
     ///
     /// This name is stored for the key and value when a stream is first created

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -1,0 +1,103 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Parquet serialization and deserialization for persist data.
+//!
+//! TODO: Move this into mz_persist_client::internal once we don't need
+//! [validate_roundtrip].
+
+use std::fmt::Debug;
+use std::io::{Read, Seek, Write};
+
+use anyhow::anyhow;
+use arrow2::datatypes::Schema as ArrowSchema;
+use arrow2::io::parquet::read::{infer_schema, read_metadata, FileReader};
+use arrow2::io::parquet::write::{
+    CompressionOptions, FileWriter, RowGroupIterator, Version, WriteOptions,
+};
+
+use crate::codec_impls::UnitSchema;
+use crate::columnar::{PartDecoder, PartEncoder, Schema};
+use crate::part::{Part, PartBuilder};
+
+/// Encodes the given part into our parquet-based serialization format.
+pub fn encode_part<W: Write>(w: &mut W, part: &Part) -> Result<(), anyhow::Error> {
+    let metadata = Vec::new();
+    let (fields, encodings, chunk) = part.to_arrow();
+
+    let schema = ArrowSchema::from(fields);
+    let options = WriteOptions {
+        write_statistics: false,
+        compression: CompressionOptions::Uncompressed,
+        version: Version::V2,
+    };
+    let mut writer = FileWriter::try_new(w, schema.clone(), options)?;
+
+    let row_groups =
+        RowGroupIterator::try_new(std::iter::once(Ok(chunk)), &schema, options, encodings)?;
+    for row_group in row_groups {
+        writer.write(row_group?)?;
+    }
+    writer.end(Some(metadata))?;
+    Ok(())
+}
+
+/// Decodes a part with the given schema from our parquet-based serialization
+/// format.
+pub fn decode_part<R: Read + Seek, K, KS: Schema<K>, V, VS: Schema<V>>(
+    r: &mut R,
+    key_schema: &KS,
+    val_schema: &VS,
+) -> Result<Part, anyhow::Error> {
+    let metadata = read_metadata(r)?;
+    let schema = infer_schema(&metadata)?;
+    let mut reader = FileReader::new(r, metadata.row_groups, schema, None, None, None);
+
+    let chunk = reader
+        .next()
+        .ok_or_else(|| anyhow!("not enough chunks in part"))?
+        .map_err(anyhow::Error::new)?;
+    let part = Part::from_arrow(key_schema, val_schema, chunk).map_err(anyhow::Error::msg)?;
+
+    if let Some(_) = reader.next() {
+        return Err(anyhow!("too many chunks in part"));
+    }
+
+    Ok(part)
+}
+
+/// A helper for writing tests that validate that a piece of data roundtrips
+/// through the parquet serialization format.
+pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
+    schema: &S,
+    val: &T,
+) -> Result<(), String> {
+    let mut part = PartBuilder::new(schema, &UnitSchema);
+    schema.encoder(part.key_mut())?.encode(val);
+    part.push_ts_diff(1, 1);
+    let part = part.finish()?;
+
+    let mut encoded = Vec::new();
+    let () = encode_part(&mut encoded, &part).map_err(|err| err.to_string())?;
+    let part = decode_part(&mut std::io::Cursor::new(&encoded), schema, &UnitSchema)
+        .map_err(|err| err.to_string())?;
+
+    let mut actual = T::default();
+    assert_eq!(part.len(), 1);
+    let part = part.key_ref();
+    schema.decoder(part)?.decode(0, &mut actual);
+    if &actual != val {
+        Err(format!(
+            "validate_roundtrip expected {:?} but got {:?}",
+            val, actual
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -1,0 +1,551 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A columnar representation of one blob's worth of data
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow2::array::{Array, NullArray, PrimitiveArray, StructArray};
+use arrow2::buffer::Buffer;
+use arrow2::chunk::Chunk;
+use arrow2::datatypes::{DataType as ArrowLogicalType, Field};
+use arrow2::io::parquet::write::Encoding;
+
+use crate::columnar::sealed::ColumnRef;
+use crate::columnar::{ColumnFormat, Data, DataType, Schema};
+
+/// A columnar representation of one blob's worth of data.
+#[derive(Debug, Default)]
+pub struct Part {
+    len: usize,
+    key: Vec<(String, DynColumnRef)>,
+    val: Vec<(String, DynColumnRef)>,
+    ts: Buffer<i64>,
+    diff: Buffer<i64>,
+}
+
+impl Part {
+    /// The number of updates contained.
+    pub fn len(&self) -> usize {
+        debug_assert_eq!(self.validate(), Ok(()));
+        self.len
+    }
+
+    /// Returns a [Columns] for the key columns.
+    pub fn key_ref<'a>(&'a self) -> ColumnsRef<'a> {
+        ColumnsRef {
+            cols: self
+                .key
+                .iter()
+                .map(|(name, col)| (name.as_str(), col))
+                .collect(),
+        }
+    }
+
+    /// Returns a [Columns] for the val columns.
+    pub fn val_ref<'a>(&'a self) -> ColumnsRef<'a> {
+        ColumnsRef {
+            cols: self
+                .val
+                .iter()
+                .map(|(name, col)| (name.as_str(), col))
+                .collect(),
+        }
+    }
+
+    pub(crate) fn to_arrow(&self) -> (Vec<Field>, Vec<Vec<Encoding>>, Chunk<Box<dyn Array>>) {
+        let (mut fields, mut encodings, mut arrays) =
+            (Vec::new(), Vec::new(), Vec::<Box<dyn Array>>::new());
+
+        {
+            let (mut key_fields, mut key_encodings, mut key_arrays) =
+                (Vec::new(), Vec::new(), Vec::new());
+            for (name, col) in self.key.iter() {
+                let (encoding, array) = col.to_arrow();
+                key_fields.push(Field::new(name, array.data_type().clone(), col.0.optional));
+                key_encodings.push(encoding);
+                key_arrays.push(array);
+            }
+            if key_arrays.is_empty() {
+                // arrow2 doesn't allow empty struct arrays
+                let key = NullArray::new(ArrowLogicalType::Null, self.ts.len());
+                fields.push(Field::new("k", key.data_type().clone(), false));
+                encodings.push(vec![Encoding::Plain]);
+                arrays.push(Box::new(key));
+            } else {
+                let key = StructArray::new(ArrowLogicalType::Struct(key_fields), key_arrays, None);
+                fields.push(Field::new("k", key.data_type().clone(), false));
+                encodings.push(key_encodings);
+                arrays.push(Box::new(key));
+            }
+        }
+
+        {
+            let (mut val_fields, mut val_encodings, mut val_arrays) =
+                (Vec::new(), Vec::new(), Vec::new());
+            for (name, col) in self.val.iter() {
+                let (encoding, array) = col.to_arrow();
+                val_fields.push(Field::new(name, array.data_type().clone(), col.0.optional));
+                val_encodings.push(encoding);
+                val_arrays.push(array);
+            }
+            if val_arrays.is_empty() {
+                // arrow2 doesn't allow empty struct arrays
+                let val = NullArray::new(ArrowLogicalType::Null, self.ts.len());
+                fields.push(Field::new("v", val.data_type().clone(), false));
+                encodings.push(vec![Encoding::Plain]);
+                arrays.push(Box::new(val));
+            } else {
+                let val = StructArray::new(ArrowLogicalType::Struct(val_fields), val_arrays, None);
+                fields.push(Field::new("v", val.data_type().clone(), false));
+                encodings.push(val_encodings);
+                arrays.push(Box::new(val));
+            }
+        }
+
+        {
+            let ts = PrimitiveArray::new(ArrowLogicalType::Int64, self.ts.clone(), None);
+            fields.push(Field::new("t", ts.data_type().clone(), false));
+            encodings.push(vec![Encoding::Plain]);
+            arrays.push(Box::new(ts));
+        }
+
+        {
+            let diff = PrimitiveArray::new(ArrowLogicalType::Int64, self.diff.clone(), None);
+            fields.push(Field::new("d", diff.data_type().clone(), false));
+            encodings.push(vec![Encoding::Plain]);
+            arrays.push(Box::new(diff));
+        }
+
+        (fields, encodings, Chunk::new(arrays))
+    }
+
+    pub(crate) fn from_arrow<K, KS: Schema<K>, V, VS: Schema<V>>(
+        key_schema: &KS,
+        val_schema: &VS,
+        chunk: Chunk<Box<dyn Array>>,
+    ) -> Result<Self, String> {
+        let key_schema = key_schema.columns();
+        let val_schema = val_schema.columns();
+
+        let len = chunk.len();
+        let chunk = chunk.into_arrays();
+        if chunk.len() != 4 {
+            return Err(format!("expected 4 columns got {}", chunk.len()));
+        }
+        let (key, val, ts, diff) = (&chunk[0], &chunk[1], &chunk[2], &chunk[3]);
+
+        let key = if let Some(_) = key.as_any().downcast_ref::<NullArray>() {
+            Vec::new()
+        } else if let Some(key_array) = key.as_any().downcast_ref::<StructArray>() {
+            assert!(key_array.validity().is_none());
+            assert_eq!(key_schema.len(), key_array.values().len());
+            let mut key = Vec::new();
+            for ((name, typ), array) in key_schema.iter().zip(key_array.values()) {
+                let col = DynColumnRef::from_arrow(typ, array)?;
+                key.push((name.clone(), col));
+            }
+            key
+        } else {
+            return Err(format!(
+                "expected key to be Null or Struct array got {:?}",
+                key.data_type()
+            ));
+        };
+
+        let val = if let Some(_) = val.as_any().downcast_ref::<NullArray>() {
+            Vec::new()
+        } else if let Some(val_array) = val.as_any().downcast_ref::<StructArray>() {
+            assert!(val_array.validity().is_none());
+            assert_eq!(val_schema.len(), val_array.values().len());
+            let mut val = Vec::new();
+            for ((name, typ), array) in val_schema.iter().zip(val_array.values()) {
+                let col = DynColumnRef::from_arrow(typ, array)?;
+                val.push((name.clone(), col));
+            }
+            val
+        } else {
+            return Err(format!(
+                "expected val to be Null or Struct array got {:?}",
+                val.data_type()
+            ));
+        };
+
+        let diff = diff
+            .as_any()
+            .downcast_ref::<PrimitiveArray<i64>>()
+            .ok_or_else(|| {
+                format!(
+                    "expected diff to be PrimitiveArray<i64> got {:?}",
+                    diff.data_type()
+                )
+            })?;
+        assert!(diff.validity().is_none());
+        let diff = diff.values().clone();
+
+        let ts = ts
+            .as_any()
+            .downcast_ref::<PrimitiveArray<i64>>()
+            .ok_or_else(|| {
+                format!(
+                    "expected ts to be PrimitiveArray<i64> got {:?}",
+                    ts.data_type()
+                )
+            })?;
+        assert!(ts.validity().is_none());
+        let ts = ts.values().clone();
+
+        let part = Part {
+            len,
+            key,
+            val,
+            ts,
+            diff,
+        };
+        let () = part.validate()?;
+        Ok(part)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        for (name, col) in self.key.iter() {
+            if self.len != col.len() {
+                return Err(format!(
+                    "key col {} len {} didn't match part len {}",
+                    name,
+                    col.len(),
+                    self.len()
+                ));
+            }
+        }
+        for (name, col) in self.val.iter() {
+            if self.len != col.len() {
+                return Err(format!(
+                    "val col {} len {} didn't match part len {}",
+                    name,
+                    col.len(),
+                    self.len()
+                ));
+            }
+        }
+        if self.len != self.ts.len() {
+            return Err(format!(
+                "ts col len {} didn't match part len {}",
+                self.ts.len(),
+                self.len()
+            ));
+        }
+        if self.len != self.diff.len() {
+            return Err(format!(
+                "diff col len {} didn't match part len {}",
+                self.diff.len(),
+                self.len()
+            ));
+        }
+        // TODO: Also validate the col types match schema.
+        Ok(())
+    }
+}
+
+/// An in-progress columnar constructor for one blob's worth of data.
+#[derive(Debug, Default)]
+pub struct PartBuilder {
+    key: Vec<(String, DynColumnMut)>,
+    val: Vec<(String, DynColumnMut)>,
+    ts: Vec<i64>,
+    diff: Vec<i64>,
+}
+
+impl PartBuilder {
+    /// Returns a new PartBuilder with the given schema.
+    pub fn new<K, KS: Schema<K>, V, VS: Schema<V>>(key_schema: &KS, val_schema: &VS) -> Self {
+        let key = key_schema
+            .columns()
+            .into_iter()
+            .map(|(name, data_type)| (name, DynColumnMut::new_untyped(&data_type)))
+            .collect();
+        let val = val_schema
+            .columns()
+            .into_iter()
+            .map(|(name, data_type)| (name, DynColumnMut::new_untyped(&data_type)))
+            .collect();
+        let ts = Vec::new();
+        let diff = Vec::new();
+        PartBuilder { key, val, ts, diff }
+    }
+
+    /// Returns a [ColumnsMut] for the key columns.
+    pub fn key_mut<'a>(&'a mut self) -> ColumnsMut<'a> {
+        ColumnsMut {
+            cols: self
+                .key
+                .iter_mut()
+                .map(|(name, col)| (name.as_str(), col))
+                .collect(),
+        }
+    }
+
+    /// Returns a [ColumnsMut] for the val columns.
+    pub fn val_mut<'a>(&'a mut self) -> ColumnsMut<'a> {
+        ColumnsMut {
+            cols: self
+                .val
+                .iter_mut()
+                .map(|(name, col)| (name.as_str(), col))
+                .collect(),
+        }
+    }
+
+    /// Adds a single timestamp and diff.
+    ///
+    /// TODO: Feels like there's some better way to model this.
+    pub fn push_ts_diff(&mut self, ts: i64, diff: i64) {
+        self.ts.push(ts);
+        self.diff.push(diff);
+    }
+
+    /// Completes construction of the [Part].
+    pub fn finish(self) -> Result<Part, String> {
+        let key = self
+            .key
+            .into_iter()
+            .map(|(name, col)| (name, col.finish_untyped()))
+            .collect();
+        let val = self
+            .val
+            .into_iter()
+            .map(|(name, col)| (name, col.finish_untyped()))
+            .collect();
+        let ts = Buffer::from(self.ts);
+        let diff = Buffer::from(self.diff);
+
+        let len = diff.len();
+        let part = Part {
+            len,
+            key,
+            val,
+            ts,
+            diff,
+        };
+        let () = part.validate()?;
+        Ok(part)
+    }
+}
+
+/// Hack to make things work with `Arc<dyn Any>::downcast_ref`.
+#[derive(Debug)]
+struct DynColumnRef(DataType, Arc<dyn Any>);
+
+impl DynColumnRef {
+    pub fn new<T: Data>(col: T::Col) -> Self {
+        DynColumnRef(T::TYPE.clone(), Arc::new(col))
+    }
+
+    pub fn downcast<T: Data>(&self) -> Result<&T::Col, String> {
+        let col = self
+            .1
+            .downcast_ref::<T::Col>()
+            .ok_or_else(|| format!("expected {} col", std::any::type_name::<T::Col>()))?;
+        Ok(col)
+    }
+
+    pub fn len(&self) -> usize {
+        struct LenDataFn<'a>(&'a DynColumnRef);
+        impl DataFn<Result<usize, String>> for LenDataFn<'_> {
+            fn call<T: Data>(self) -> Result<usize, String> {
+                self.0.downcast::<T>().map(|x| x.len())
+            }
+        }
+        self.0
+            .data_fn(LenDataFn(self))
+            .expect("DynColumnRef DataType should have internally consistent")
+    }
+
+    #[allow(clippy::borrowed_box)]
+    pub(crate) fn from_arrow(data_type: &DataType, array: &Box<dyn Array>) -> Result<Self, String> {
+        struct FromArrowDataFn<'a>(&'a Box<dyn Array>);
+        impl DataFn<Result<DynColumnRef, String>> for FromArrowDataFn<'_> {
+            fn call<T: Data>(self) -> Result<DynColumnRef, String> {
+                let typ = T::TYPE.clone();
+                let col = T::Col::from_arrow(self.0)?;
+                let col: Arc<dyn Any> = Arc::new(col);
+                Ok(DynColumnRef(typ, col))
+            }
+        }
+        let col = data_type.data_fn(FromArrowDataFn(array))?;
+        debug_assert_eq!(&col.0, data_type);
+        Ok(col)
+    }
+
+    pub(crate) fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
+        struct ToArrowDataFn<'a>(&'a DynColumnRef);
+        impl DataFn<Result<(Encoding, Box<dyn Array>), String>> for ToArrowDataFn<'_> {
+            fn call<T: Data>(self) -> Result<(Encoding, Box<dyn Array>), String> {
+                Ok(self.0.downcast::<T>()?.to_arrow())
+            }
+        }
+        self.0
+            .data_fn(ToArrowDataFn(self))
+            .expect("DynColumnRef DataType should have internally consistent")
+    }
+}
+
+/// Hack to make things work with `Box<dyn Any>::downcast_mut`.
+#[derive(Debug)]
+struct DynColumnMut(DataType, Box<dyn Any>);
+
+impl DynColumnMut {
+    pub fn new<T: Data>(col: T::Mut) -> Self {
+        DynColumnMut(T::TYPE.clone(), Box::new(col))
+    }
+
+    pub fn new_untyped(typ: &DataType) -> Self {
+        struct NewUntypedDataFn;
+        impl DataFn<DynColumnMut> for NewUntypedDataFn {
+            fn call<T: Data>(self) -> DynColumnMut {
+                DynColumnMut::new::<T>(T::Mut::default())
+            }
+        }
+        typ.data_fn(NewUntypedDataFn)
+    }
+
+    pub fn downcast<T: Data>(&mut self) -> Result<&mut T::Mut, String> {
+        let col = self
+            .1
+            .downcast_mut::<T::Mut>()
+            .ok_or_else(|| format!("expected {} col", std::any::type_name::<T::Col>()))?;
+        Ok(col)
+    }
+
+    pub fn finish<T: Data>(self) -> Result<DynColumnRef, String> {
+        let col = self
+            .1
+            .downcast::<T::Mut>()
+            .map_err(|_| format!("expected {} col", std::any::type_name::<T::Col>()))?;
+        let col = T::Col::from(*col);
+        let col = DynColumnRef::new::<T>(col);
+        debug_assert_eq!(self.0, col.0);
+        Ok(col)
+    }
+
+    fn finish_untyped(self) -> DynColumnRef {
+        let typ = self.0.clone();
+        struct FinishUntypedDataFn(DynColumnMut);
+        impl DataFn<Result<DynColumnRef, String>> for FinishUntypedDataFn {
+            fn call<T: Data>(self) -> Result<DynColumnRef, String> {
+                self.0.finish::<T>()
+            }
+        }
+        let col = typ
+            .data_fn(FinishUntypedDataFn(self))
+            .expect("DynColumnMut DataType should have internally consistent");
+        assert_eq!(typ, col.0);
+        col
+    }
+}
+
+/// A set of shared references to named columns.
+///
+/// This type implements a "builder"-esque pattern to help [Schema::decoder]
+/// impls. All columns should be removed via [Self::col] and the [Self::finish]
+/// called to verify that all columns have been accounted for.
+#[derive(Debug)]
+pub struct ColumnsRef<'a> {
+    cols: HashMap<&'a str, &'a DynColumnRef>,
+}
+
+impl<'a> ColumnsRef<'a> {
+    /// Removes the named column from the set.
+    pub fn col<T: Data>(&mut self, name: &str) -> Result<&'a T::Col, String> {
+        let col = self
+            .cols
+            .remove(name)
+            .ok_or_else(|| format!("no col named {}", name))?;
+        col.downcast::<T>()
+    }
+
+    /// Verifies that all columns in the set have been removed.
+    pub fn finish(self) -> Result<(), String> {
+        if self.cols.is_empty() {
+            Ok(())
+        } else {
+            let names = self.cols.iter().map(|(x, _)| *x).collect::<Vec<_>>();
+            Err(format!("unused cols: {}", names.join(" ")))
+        }
+    }
+}
+
+/// A set of exclusive references to named columns.
+///
+/// This type implements a "builder"-esque pattern to help [Schema::encoder]
+/// impls. All columns should be removed via [Self::col] and the [Self::finish]
+/// called to verify that all columns have been accounted for.
+#[derive(Debug)]
+pub struct ColumnsMut<'a> {
+    cols: HashMap<&'a str, &'a mut DynColumnMut>,
+}
+
+impl<'a> ColumnsMut<'a> {
+    /// Removes the named column from the set.
+    pub fn col<T: Data>(&mut self, name: &str) -> Result<&'a mut T::Mut, String> {
+        let col = self
+            .cols
+            .remove(name)
+            .ok_or_else(|| format!("no col named {}", name))?;
+        col.downcast::<T>()
+    }
+
+    /// Verifies that all columns in the set have been removed.
+    pub fn finish(self) -> Result<(), String> {
+        if self.cols.is_empty() {
+            Ok(())
+        } else {
+            let names = self.cols.iter().map(|(x, _)| *x).collect::<Vec<_>>();
+            Err(format!("unused cols: {}", names.join(" ")))
+        }
+    }
+}
+
+trait DataFn<R> {
+    fn call<T: Data>(self) -> R;
+}
+
+impl DataType {
+    fn data_fn<R, F: DataFn<R>>(&self, logic: F) -> R {
+        match (self.optional, self.format) {
+            (false, ColumnFormat::Bool) => logic.call::<bool>(),
+            (true, ColumnFormat::Bool) => logic.call::<Option<bool>>(),
+            (false, ColumnFormat::U8) => logic.call::<u8>(),
+            (true, ColumnFormat::U8) => logic.call::<Option<u8>>(),
+            (false, ColumnFormat::U16) => logic.call::<u16>(),
+            (true, ColumnFormat::U16) => logic.call::<Option<u16>>(),
+            (false, ColumnFormat::U32) => logic.call::<u32>(),
+            (true, ColumnFormat::U32) => logic.call::<Option<u32>>(),
+            (false, ColumnFormat::U64) => logic.call::<u64>(),
+            (true, ColumnFormat::U64) => logic.call::<Option<u64>>(),
+            (false, ColumnFormat::I8) => logic.call::<i8>(),
+            (true, ColumnFormat::I8) => logic.call::<Option<i8>>(),
+            (false, ColumnFormat::I16) => logic.call::<i16>(),
+            (true, ColumnFormat::I16) => logic.call::<Option<i16>>(),
+            (false, ColumnFormat::I32) => logic.call::<i32>(),
+            (true, ColumnFormat::I32) => logic.call::<Option<i32>>(),
+            (false, ColumnFormat::I64) => logic.call::<i64>(),
+            (true, ColumnFormat::I64) => logic.call::<Option<i64>>(),
+            (false, ColumnFormat::F32) => logic.call::<f32>(),
+            (true, ColumnFormat::F32) => logic.call::<Option<f32>>(),
+            (false, ColumnFormat::F64) => logic.call::<f64>(),
+            (true, ColumnFormat::F64) => logic.call::<Option<f64>>(),
+            (false, ColumnFormat::Bytes) => logic.call::<Vec<u8>>(),
+            (true, ColumnFormat::Bytes) => logic.call::<Option<Vec<u8>>>(),
+            (false, ColumnFormat::String) => logic.call::<String>(),
+            (true, ColumnFormat::String) => logic.call::<Option<String>>(),
+        }
+    }
+}

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -56,6 +56,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0" }
+mz-persist = { path = "../persist" }
 rand = "0.8.5"
 
 [build-dependencies]

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -75,10 +75,17 @@
 // END LINT CONFIG
 
 use std::cmp::Ordering;
+use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsBuilder};
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::columnar::{PartDecoder, PartEncoder, Schema};
+use mz_persist_types::part::{Part, PartBuilder};
+use mz_persist_types::Codec;
 use mz_repr::adt::date::Date;
-use mz_repr::{Datum, Row};
+use mz_repr::{ColumnType, Datum, RelationDesc, Row, ScalarType};
+use rand::distributions::{Alphanumeric, DistString};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
@@ -307,5 +314,117 @@ fn bench_filter(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_sort, bench_pack, bench_filter);
+fn encode_legacy(rows: &[Row]) -> ColumnarRecords {
+    let mut buf = ColumnarRecordsBuilder::default();
+    let mut key_buf = Vec::new();
+    for row in rows.iter() {
+        key_buf.clear();
+        row.encode(&mut key_buf);
+        assert!(buf.push(((&key_buf, &[]), 1i64.to_le_bytes(), 1i64.to_le_bytes())));
+    }
+    buf.finish()
+}
+
+fn decode_legacy(part: &ColumnarRecords) -> Vec<Row> {
+    let mut rows = Vec::new();
+    for ((key, _val), _ts, _diff) in part.iter() {
+        rows.push(Row::decode(key).unwrap());
+    }
+    rows
+}
+
+fn encode_structured(schema: &RelationDesc, rows: &[Row]) -> Part {
+    let mut part = PartBuilder::new(schema, &UnitSchema);
+    let mut encoder = schema.encoder(part.key_mut()).unwrap();
+    for row in rows.iter() {
+        encoder.encode(row);
+    }
+    drop(encoder);
+    for _ in rows.iter() {
+        part.push_ts_diff(1, 1);
+    }
+    part.finish().unwrap()
+}
+
+fn decode_structured(schema: &RelationDesc, part: &Part, len: usize) -> Row {
+    let decoder = schema.decoder(part.key_ref()).unwrap();
+    let mut row = Row::default();
+    for idx in 0..len {
+        decoder.decode(idx, &mut row);
+        black_box(&row);
+    }
+    row
+}
+
+fn bench_roundtrip(c: &mut Criterion) {
+    let num_rows = 10_000;
+    let mut rng = seeded_rng();
+    let rows = (0..num_rows)
+        .map(|_| {
+            let str_len = rng.gen_range(0..10);
+            Row::pack(vec![
+                Datum::from(rng.gen::<bool>()),
+                Datum::from(rng.gen::<Option<bool>>()),
+                Datum::from(Alphanumeric.sample_string(&mut rng, str_len).as_str()),
+                Datum::from(
+                    Some(Alphanumeric.sample_string(&mut rng, str_len).as_str())
+                        .filter(|_| rng.gen::<bool>()),
+                ),
+            ])
+        })
+        .collect::<Vec<_>>();
+    let schema = RelationDesc::from_names_and_types(vec![
+        (
+            "a",
+            ColumnType {
+                nullable: false,
+                scalar_type: ScalarType::Bool,
+            },
+        ),
+        (
+            "b",
+            ColumnType {
+                nullable: true,
+                scalar_type: ScalarType::Bool,
+            },
+        ),
+        (
+            "c",
+            ColumnType {
+                nullable: false,
+                scalar_type: ScalarType::String,
+            },
+        ),
+        (
+            "d",
+            ColumnType {
+                nullable: true,
+                scalar_type: ScalarType::String,
+            },
+        ),
+    ]);
+
+    c.bench_function("roundtrip_encode_legacy", |b| {
+        b.iter(|| std::hint::black_box(encode_legacy(&rows)));
+    });
+    c.bench_function("roundtrip_encode_structured", |b| {
+        b.iter(|| std::hint::black_box(encode_structured(&schema, &rows)));
+    });
+    let legacy = encode_legacy(&rows);
+    let structured = encode_structured(&schema, &rows);
+    c.bench_function("roundtrip_decode_legacy", |b| {
+        b.iter(|| std::hint::black_box(decode_legacy(&legacy)));
+    });
+    c.bench_function("roundtrip_decode_structured", |b| {
+        b.iter(|| std::hint::black_box(decode_structured(&schema, &structured, rows.len())));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_sort,
+    bench_pack,
+    bench_filter,
+    bench_roundtrip
+);
 criterion_main!(benches);

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -31,6 +31,7 @@ use bytes::BufMut;
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
+use mz_persist_types::codec_impls::UnitSchema;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
@@ -931,7 +932,8 @@ where
                     .open_writer(
                         metadata.data_shard,
                         &purpose,
-                        metadata.relation_desc.clone(),
+                        Arc::new(metadata.relation_desc.clone()),
+                        Arc::new(UnitSchema),
                     )
                     .await
                     .expect("invalid persist usage");
@@ -1388,10 +1390,11 @@ where
         // heartbeat continously. The assumption is that calls to snapshot are rare and therefore
         // worth it to always create a new handle.
         let mut read_handle = persist_client
-            .open_leased_reader::<SourceData, (), _, _, _>(
+            .open_leased_reader::<SourceData, (), _, _>(
                 metadata.data_shard,
                 &format!("snapshot {}", id),
-                metadata.relation_desc.clone(),
+                Arc::new(metadata.relation_desc.clone()),
+                Arc::new(UnitSchema),
             )
             .await
             .expect("invalid persist usage");
@@ -1976,12 +1979,13 @@ where
 
         for (shard_id, shard_purpose) in shards {
             let (mut write, mut read) = persist_client
-                .open::<crate::types::sources::SourceData, (), T, Diff, _>(
+                .open::<crate::types::sources::SourceData, (), T, Diff>(
                     *shard_id,
                     shard_purpose.as_str(),
                     // We have to _read_ the shard to figure out if its been migrated or not, so we
                     // hedge on setting a `RelationDesc`.
-                    PersistClient::TO_REPLACE_SCHEMA,
+                    Arc::new(RelationDesc::empty()),
+                    Arc::new(UnitSchema),
                 )
                 .await
                 .expect("invalid persist usage");

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use mz_persist_client::operators::shard_source::shard_source;
+use mz_persist_types::codec_impls::UnitSchema;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::{Scope, Stream};
@@ -127,7 +128,8 @@ where
         as_of,
         until.clone(),
         flow_control,
-        metadata.relation_desc,
+        Arc::new(metadata.relation_desc),
+        Arc::new(UnitSchema),
     );
     let rows = decode_and_mfp(&fetched, &name, until, map_filter_project, yield_fn);
     (rows, token)

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -22,6 +22,7 @@ use dec::OrderedDecimal;
 use differential_dataflow::lattice::Lattice;
 use globset::{Glob, GlobBuilder};
 use itertools::Itertools;
+use mz_persist_types::codec_impls::TodoSchema;
 use once_cell::sync::Lazy;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
@@ -2514,6 +2515,8 @@ impl RustType<ProtoSourceData> for SourceData {
 }
 
 impl Codec for SourceData {
+    type Schema = TodoSchema<SourceData>;
+
     fn codec_name() -> String {
         "protobuf[SourceData]".into()
     }

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -9,8 +9,11 @@
 
 //! Healthcheck common
 
+use std::sync::Arc;
+
 use differential_dataflow::lattice::Lattice;
 use mz_ore::now::NowFn;
+use mz_persist_types::codec_impls::UnitSchema;
 use timely::progress::Antichain;
 
 use mz_persist_client::{PersistClient, ShardId};
@@ -38,7 +41,8 @@ pub async fn write_to_persist(
         .open_writer(
             status_shard,
             &format!("healthcheck::write_to_persist {}", collection_id),
-            relation_desc.clone(),
+            Arc::new(relation_desc.clone()),
+            Arc::new(UnitSchema),
         )
         .await
         .expect(

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{Collection, Hashable};
+use mz_persist_types::codec_impls::UnitSchema;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::Scope;
 use timely::progress::frontier::Antichain;
@@ -110,10 +111,11 @@ where
             .open(metadata.persist_location)
             .await
             .expect("could not open persist client")
-            .open_writer::<SourceData, (), Timestamp, Diff, _>(
+            .open_writer::<SourceData, (), Timestamp, Diff>(
                 metadata.data_shard,
                 &format!("storage::persist_sink {}", src_id),
-                metadata.relation_desc.clone(),
+                Arc::new(metadata.relation_desc.clone()),
+                Arc::new(UnitSchema),
             )
             .await
             .expect("could not open persist shard");

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -169,6 +169,7 @@ mod tests {
     use std::time::Duration;
 
     use itertools::Itertools;
+    use mz_persist_types::codec_impls::UnitSchema;
     use mz_repr::Row;
     use timely::progress::Antichain;
 
@@ -472,7 +473,8 @@ mod tests {
             .open(
                 shard_id,
                 "tests::dump_storage_collection",
-                MZ_SINK_STATUS_HISTORY_DESC.clone(),
+                Arc::new(MZ_SINK_STATUS_HISTORY_DESC.clone()),
+                Arc::new(UnitSchema),
             )
             .await
             .unwrap();

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -612,6 +612,7 @@ mod tests {
 
     use futures::Stream;
     use itertools::Itertools;
+    use mz_persist_types::codec_impls::UnitSchema;
     use once_cell::sync::Lazy;
     use timely::progress::Timestamp as _;
     use tokio::sync::Mutex;
@@ -1347,10 +1348,11 @@ mod tests {
         drop(persist_clients);
 
         let read_handle = persist_client
-            .open_leased_reader::<SourceData, (), Timestamp, Diff, _>(
+            .open_leased_reader::<SourceData, (), Timestamp, Diff>(
                 binding_shard,
                 "test_since_hold",
-                mz_storage_client::types::sources::KAFKA_PROGRESS_DESC.clone(),
+                Arc::new(mz_storage_client::types::sources::KAFKA_PROGRESS_DESC.clone()),
+                Arc::new(UnitSchema),
             )
             .await
             .expect("error opening persist shard");

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use differential_dataflow::lattice::Lattice;
 use futures::{stream::LocalBoxStream, StreamExt};
+use mz_persist_types::codec_impls::UnitSchema;
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp;
@@ -165,7 +166,8 @@ where
             .open(
                 metadata.remap_shard.clone(),
                 &format!("reclock {}", id),
-                remap_relation_desc,
+                Arc::new(remap_relation_desc),
+                Arc::new(UnitSchema),
             )
             .await
             .context("error opening persist shard")?;

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -75,6 +75,7 @@ use std::thread;
 
 use crossbeam_channel::TryRecvError;
 use differential_dataflow::lattice::Lattice;
+use mz_persist_types::codec_impls::UnitSchema;
 use timely::communication::Allocate;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
@@ -222,7 +223,8 @@ impl SinkHandle {
                 .open_leased_reader(
                     shard_id,
                     &format!("sink::since {}", sink_id),
-                    from_relation_desc,
+                    Arc::new(from_relation_desc),
+                    Arc::new(UnitSchema),
                 )
                 .await
                 .expect("opening reader for shard");

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -85,6 +85,7 @@ use std::thread;
 use std::time::Duration;
 
 use mz_ore::halt;
+use mz_persist_types::codec_impls::UnitSchema;
 use mz_storage::internal_control::{InternalCommandSender, InternalStorageCommand};
 use timely::progress::{Antichain, Timestamp as _};
 
@@ -306,12 +307,13 @@ where
                 (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
                     loop {
                         let (mut data_write_handle, data_read_handle) = persist_client
-                            .open::<SourceData, (), Timestamp, Diff, _>(
+                            .open::<SourceData, (), Timestamp, Diff>(
                                 data_shard.clone(),
                                 "tests::check_loop",
                                 // TODO(guswynn|danhhz): replace this with a real desc when persist requires a
                                 // schema.
-                                RelationDesc::empty(),
+                                Arc::new(RelationDesc::empty()),
+                                Arc::new(UnitSchema),
                             )
                             .await
                             .unwrap();

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -211,22 +211,26 @@ zeroize = { version = "1.5.7", features = ["serde"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
+getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
+getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 tikv-jemalloc-sys = { version = "0.5.2", features = ["background_threads", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-apple-darwin.dependencies]
+getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
+getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["unstable"] }
 security-framework = { version = "2.7.0", features = ["alpn"] }


### PR DESCRIPTION
For efficiency/performance, we directly expose the columnar structure of persist's internal encoding to users during encoding and decoding. For ergonomics, we wrap the arrow2 crate we use to read and write parquet data.

Some of the requirements that led to this design:
- Support a separation of data and schema because Row is not self-describing: e.g. a Datum::Null can be one of many possible column types. A RelationDesc is necessary to describe a Row schema.
- Narrow down arrow2::data_types::DataType (the arrow "logical" types) to a set we want to support in persist.
- Associate an arrow2::io::parquet::write::Encoding with each of those types.
- Do `dyn Any` downcasting of columns once per part, not once per update.
- Unlike arrow2, be precise about whether each column is optional or not.

The primary presentation of this abstraction is a sealed trait [Data], which is implemented for the owned version of each type of data that can be stored in persist: `int64`, `Option<String>`, etc.

Under the hood, it's necessary to store something like a map of `name -> column`. A natural instinct is to make Data object safe, but I couldn't figure out a way to make that work without severe limitations. As a result, the DataType enum is introduced with a 1:1 relationship between variants and implementations of Data. This allows for easy type erasure and guardrails when downcasting the types back.

Note: The "Data" strategy is roughly how columnation works and the "DataType" strategy is roughly how arrow2 works. Doing both of them gets us the benefits of both, while the downside is code duplication and cognitive overhead.

The Data trait has associated types for the exclusive "builder" type for the column and for the shared "reader" type. These implement also implement some common traits to make relationships between types more structured.

Finally, the [Schema] trait maps an implementor of [Codec] to the underlying column structure. It also provides a [PartEncoder] and [PartDecoder] for amortizing any downcasting that does need to happen.

Initial benchmarks compared to the previous Protobuf based encoding for Row (specifically, 1000 of them each with one bool and one string):

    roundtrip_encode_legacy time:   [1.5251 ms 1.5267 ms 1.5285 ms]
    roundtrip_encode_structured
                            time:   [852.47 µs 852.99 µs 853.65 µs]
    roundtrip_decode_legacy time:   [1.9244 ms 1.9314 ms 1.9376 ms]
    roundtrip_decode_structured
                            time:   [619.88 µs 620.12 µs 620.40 µs]


### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Rough timeline I'm imagining:

- Hash out this PR and get it merged with the code completely unused.
- In a separate PR, figure out the full mapping for SourceData -> parquet. Hook this up in some sort of checks mode (ideally in CI, maybe behind soft assert?) to sanity check that data we see in practice does in fact faithfully roundtrip.
- In a final PR, turn this on an introduce a migration codepath to handle existing pre-strutured data.

There's quite a bit of boilerplate in row/encoding.rs. I don't think it's fundamental (seems like DatumType and AsColumnType already most of the work once we can talk rust into it), but I'm hesitant to spend too much time on that before we figure out the full SourceData -> parquet mapping.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
