### PR TITLE
sql: implement numrange

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1107,6 +1107,30 @@ pub const TYPE_DATE_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
     },
 };
 
+pub const TYPE_NUM_RANGE: BuiltinType<NameReference> = BuiltinType {
+    name: "numrange",
+    schema: PG_CATALOG_SCHEMA,
+    oid: mz_pgrepr::oid::TYPE_NUMRANGE_OID,
+    details: CatalogTypeDetails {
+        typ: CatalogType::Range {
+            element_reference: TYPE_NUMERIC.name,
+        },
+        array_id: None,
+    },
+};
+
+pub const TYPE_NUM_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
+    name: "_numrange",
+    schema: PG_CATALOG_SCHEMA,
+    oid: mz_pgrepr::oid::TYPE_NUMRANGE_ARRAY_OID,
+    details: CatalogTypeDetails {
+        typ: CatalogType::Array {
+            element_reference: TYPE_NUM_RANGE.name,
+        },
+        array_id: None,
+    },
+};
+
 pub const MZ_DATAFLOW_OPERATORS: BuiltinLog = BuiltinLog {
     name: "mz_dataflow_operators",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2993,6 +3017,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Type(&TYPE_INT8_RANGE_ARRAY),
         Builtin::Type(&TYPE_DATE_RANGE),
         Builtin::Type(&TYPE_DATE_RANGE_ARRAY),
+        Builtin::Type(&TYPE_NUM_RANGE),
+        Builtin::Type(&TYPE_NUM_RANGE_ARRAY),
     ];
     for (schema, funcs) in &[
         (PG_CATALOG_SCHEMA, &*mz_sql::func::PG_CATALOG_BUILTINS),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 use ::encoding::label::encoding_from_whatwg_label;
 use ::encoding::DecoderTrap;
 use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, Timelike, Utc};
+use dec::OrderedDecimal;
 use fallible_iterator::FallibleIterator;
 use hmac::{Hmac, Mac};
 use itertools::Itertools;
@@ -2206,6 +2207,9 @@ impl BinaryFunc {
                 ScalarType::Int32 => eager!(contains_range_elem::<i32>),
                 ScalarType::Int64 => eager!(contains_range_elem::<i64>),
                 ScalarType::Date => eager!(contains_range_elem::<Date>),
+                ScalarType::Numeric { .. } => {
+                    eager!(contains_range_elem::<OrderedDecimal<Numeric>>)
+                }
                 _ => unreachable!(),
             }),
         }
@@ -6520,6 +6524,7 @@ impl fmt::Display for VariadicFunc {
                 ScalarType::Int32 => "int4range",
                 ScalarType::Int64 => "int8range",
                 ScalarType::Date => "daterange",
+                ScalarType::Numeric { .. } => "numrange",
                 _ => unreachable!(),
             }),
         }

--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -78,6 +78,8 @@ pub const TYPE_INT8RANGE_OID: u32 = 3926;
 pub const TYPE_INT8RANGE_ARRAY_OID: u32 = 3927;
 pub const TYPE_DATERANGE_OID: u32 = 3912;
 pub const TYPE_DATERANGE_ARRAY_OID: u32 = 3913;
+pub const TYPE_NUMRANGE_OID: u32 = 3906;
+pub const TYPE_NUMRANGE_ARRAY_OID: u32 = 3907;
 
 /// The first OID in PostgreSQL's system catalog that is not pinned during
 /// bootstrapping.

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -14,16 +14,19 @@ use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 
 use bitflags::bitflags;
+use dec::OrderedDecimal;
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
 use mz_lowertest::MzReflect;
 use mz_ore::soft_assert;
 use mz_proto::{RustType, TryFromProtoError};
-use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
 
 use crate::scalar::DatumKind;
 use crate::Datum;
 
 use super::date::Date;
+use super::numeric::Numeric;
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.range.rs"));
 
@@ -157,6 +160,12 @@ impl<'a> RangeOps<'a> for Date {
 
     fn err_type_name() -> &'static str {
         "date"
+    }
+}
+
+impl<'a> RangeOps<'a> for OrderedDecimal<Numeric> {
+    fn err_type_name() -> &'static str {
+        "numeric"
     }
 }
 
@@ -417,6 +426,7 @@ impl<'a, const UPPER: bool> RangeBound<Datum<'a>, UPPER> {
                 d @ Datum::Int32(_) => self.canonicalize_inner::<i32>(d)?,
                 d @ Datum::Int64(_) => self.canonicalize_inner::<i64>(d)?,
                 d @ Datum::Date(_) => self.canonicalize_inner::<Date>(d)?,
+                Datum::Numeric(..) => {}
                 d => unreachable!("{d:?} not yet supported in ranges"),
             },
         })

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -380,6 +380,27 @@ impl TryFrom<Datum<'_>> for Date {
     }
 }
 
+impl TryFrom<Datum<'_>> for OrderedDecimal<Numeric> {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Numeric(n) => Ok(n),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<Datum<'_>> for Option<OrderedDecimal<Numeric>> {
+    type Error = ();
+    fn try_from(from: Datum<'_>) -> Result<Self, Self::Error> {
+        match from {
+            Datum::Null => Ok(None),
+            Datum::Numeric(n) => Ok(Some(n)),
+            _ => Err(()),
+        }
+    }
+}
+
 impl<'a> Datum<'a> {
     /// Reports whether this datum is null (i.e., is [`Datum::Null`]).
     pub fn is_null(&self) -> bool {
@@ -932,6 +953,12 @@ impl<'a> From<u128> for Datum<'a> {
 impl<'a> From<Numeric> for Datum<'a> {
     fn from(n: Numeric) -> Datum<'a> {
         Datum::Numeric(OrderedDecimal(n))
+    }
+}
+
+impl<'a> From<OrderedDecimal<Numeric>> for Datum<'a> {
+    fn from(n: OrderedDecimal<Numeric>) -> Datum<'a> {
+        Datum::Numeric(n)
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2167,6 +2167,21 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
         "now" => Scalar {
             params!() => UnmaterializableFunc::CurrentTimestamp, 1299;
         },
+        "numrange" => Scalar {
+            params!(Numeric, Numeric) => Operation::variadic(|_ecx, mut exprs| {
+                exprs.push(HirScalarExpr::literal(Datum::String("[)"), ScalarType::String));
+                Ok(HirScalarExpr::CallVariadic {
+                    func: VariadicFunc::RangeCreate { elem_type: ScalarType::Numeric { max_scale: None } },
+                    exprs
+                })
+            }) => ScalarType::Range { element_type: Box::new(ScalarType::Int32)}, 3844;
+            params!(Numeric, Numeric, String) => Operation::variadic(|_ecx, exprs| {
+                Ok(HirScalarExpr::CallVariadic {
+                    func: VariadicFunc::RangeCreate { elem_type: ScalarType::Numeric { max_scale: None } },
+                    exprs
+                })
+            }) => ScalarType::Range { element_type: Box::new(ScalarType::Numeric { max_scale: None })}, 3845;
+        },
         "octet_length" => Scalar {
             params!(Bytes) => UnaryFunc::ByteLengthBytes(func::ByteLengthBytes), 720;
             params!(String) => UnaryFunc::ByteLengthString(func::ByteLengthString), 1374;

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -1841,3 +1841,705 @@ empty
 false
 false
 false
+
+#
+# numrange
+
+query T
+select '[0,100)'::numrange::text;
+----
+[0,100)
+
+query T
+select pg_typeof('[0,100)'::numrange);
+----
+numrange
+
+query T
+select 'empty'::numrange::text;
+----
+empty
+
+query T
+select pg_typeof('empty'::numrange);
+----
+numrange
+
+query T
+select null::numrange::text
+----
+NULL
+
+# Parameterized input on
+#   xjoin(["(","["],
+#       xjoin([null,-1,0,1],
+#           xjoin(
+#               [null,-1,0,1],
+#               ["),"]"]
+#           )
+#       )
+#   )
+
+query T
+SELECT '(,)'::numrange::text;
+----
+(,)
+
+query T
+SELECT '(,-1)'::numrange::text;
+----
+(,-1)
+
+query T
+SELECT '(,0)'::numrange::text;
+----
+(,0)
+
+query T
+SELECT '(,1)'::numrange::text;
+----
+(,1)
+
+query T
+SELECT '(,]'::numrange::text;
+----
+(,)
+
+query T
+SELECT '(,-1]'::numrange::text;
+----
+(,-1]
+
+query T
+SELECT '(,0]'::numrange::text;
+----
+(,0]
+
+query T
+SELECT '(,1]'::numrange::text;
+----
+(,1]
+
+query T
+SELECT '(-1,)'::numrange::text;
+----
+(-1,)
+
+query T
+SELECT '(-1,-1)'::numrange::text;
+----
+empty
+
+query T
+SELECT '(-1,0)'::numrange::text;
+----
+(-1,0)
+
+query T
+SELECT '(-1,1)'::numrange::text;
+----
+(-1,1)
+
+query T
+SELECT '(-1,]'::numrange::text;
+----
+(-1,)
+
+query T
+SELECT '(-1,-1]'::numrange::text;
+----
+empty
+
+query T
+SELECT '(-1,0]'::numrange::text;
+----
+(-1,0]
+
+query T
+SELECT '(-1,1]'::numrange::text;
+----
+(-1,1]
+
+query T
+SELECT '(0,)'::numrange::text;
+----
+(0,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '(0,-1)'::numrange::text;
+
+query T
+SELECT '(0,0)'::numrange::text;
+----
+empty
+
+query T
+SELECT '(0,1)'::numrange::text;
+----
+(0,1)
+
+query T
+SELECT '(0,]'::numrange::text;
+----
+(0,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '(0,-1]'::numrange::text;
+
+query T
+SELECT '(0,0]'::numrange::text;
+----
+empty
+
+query T
+SELECT '(0,1]'::numrange::text;
+----
+(0,1]
+
+query T
+SELECT '(1,)'::numrange::text;
+----
+(1,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '(1,-1)'::numrange::text;
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '(1,0)'::numrange::text;
+
+query T
+SELECT '(1,1)'::numrange::text;
+----
+empty
+
+query T
+SELECT '(1,]'::numrange::text;
+----
+(1,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '(1,-1]'::numrange::text;
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '(1,0]'::numrange::text;
+
+query T
+SELECT '(1,1]'::numrange::text;
+----
+empty
+
+query T
+SELECT '[,)'::numrange::text;
+----
+(,)
+
+query T
+SELECT '[,-1)'::numrange::text;
+----
+(,-1)
+
+query T
+SELECT '[,0)'::numrange::text;
+----
+(,0)
+
+query T
+SELECT '[,1)'::numrange::text;
+----
+(,1)
+
+query T
+SELECT '[,]'::numrange::text;
+----
+(,)
+
+query T
+SELECT '[,-1]'::numrange::text;
+----
+(,-1]
+
+query T
+SELECT '[,0]'::numrange::text;
+----
+(,0]
+
+query T
+SELECT '[,1]'::numrange::text;
+----
+(,1]
+
+query T
+SELECT '[-1,)'::numrange::text;
+----
+[-1,)
+
+query T
+SELECT '[-1,-1)'::numrange::text;
+----
+empty
+
+query T
+SELECT '[-1,0)'::numrange::text;
+----
+[-1,0)
+
+query T
+SELECT '[-1,1)'::numrange::text;
+----
+[-1,1)
+
+query T
+SELECT '[-1,]'::numrange::text;
+----
+[-1,)
+
+query T
+SELECT '[-1,-1]'::numrange::text;
+----
+[-1,-1]
+
+query T
+SELECT '[-1,0]'::numrange::text;
+----
+[-1,0]
+
+query T
+SELECT '[-1,1]'::numrange::text;
+----
+[-1,1]
+
+query T
+SELECT '[0,)'::numrange::text;
+----
+[0,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '[0,-1)'::numrange::text;
+
+query T
+SELECT '[0,0)'::numrange::text;
+----
+empty
+
+query T
+SELECT '[0,1)'::numrange::text;
+----
+[0,1)
+
+query T
+SELECT '[0,]'::numrange::text;
+----
+[0,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '[0,-1]'::numrange::text;
+
+query T
+SELECT '[0,0]'::numrange::text;
+----
+[0,0]
+
+query T
+SELECT '[0,1]'::numrange::text;
+----
+[0,1]
+
+query T
+SELECT '[1,)'::numrange::text;
+----
+[1,)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '[1,-1)'::numrange::text;
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '[1,0)'::numrange::text;
+
+query T
+SELECT '[1,1)'::numrange::text;
+----
+empty
+
+query T
+SELECT '[1,]'::numrange::text;
+----
+[1,)
+
+# Range bound errors
+query error range lower bound must be less than or equal to range upper bound
+SELECT '[1,-1]'::numrange::text;
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT '[1,0]'::numrange::text;
+
+# Whitespace handling
+query T
+SELECT
+	DISTINCT column1::numrange::text
+FROM
+	(
+		VALUES
+			('   empty'),
+			('empty  '),
+			('  [1,)'),
+			('[  1,)'),
+			('[1  ,)'),
+			('[  1  ,)'),
+            ('[1,  2)'),
+			('[1,2  )'),
+			('[1,  2  )'),
+			('[1,)  '),
+			('  (,1)'),
+			('(,  1)'),
+			('  (,)  ')
+	) t;
+----
+(,)
+(,1)
+[1,)
+[1,2)
+empty
+
+# Input errors
+query error invalid input syntax for type range
+SELECT '[1,  )'::numrange
+
+query error invalid input syntax for type range
+SELECT '(  ,1)'::numrange
+
+query error invalid input syntax for type range
+SELECT '(  ,  )'::numrange
+
+query error invalid input syntax for type range
+SELECT 'emptyy'::numrange;
+
+query error invalid input syntax for type range
+SELECT ''::numrange;
+
+query error invalid input syntax for type range
+SELECT '1'::numrange;
+
+query error invalid input syntax for type range
+SELECT 'd'::numrange;
+
+query error invalid input syntax for type range
+SELECT ','::numrange;
+
+query error invalid input syntax for type range
+SELECT ')'::numrange;
+
+query error invalid input syntax for type range
+SELECT '{'::numrange;
+
+query error invalid input syntax for type range
+SELECT '('::numrange;
+
+query error invalid input syntax for type range
+SELECT '['::numrange;
+
+query error invalid input syntax for type range
+SELECT '(1)'::numrange;
+
+query error invalid input syntax for type range
+SELECT '[1]'::numrange;
+
+query error invalid input syntax for type range
+SELECT '(1,'::numrange;
+
+query error invalid input syntax for type range
+SELECT '[1,'::numrange;
+
+query error invalid input syntax for type range
+SELECT '(1,1'::numrange;
+
+query error invalid input syntax for type range
+SELECT '[1,1'::numrange;
+
+query error invalid input syntax for type range
+SELECT '(1,1]1'::numrange;
+
+query error invalid input syntax for type range
+SELECT '[1,1]a'::numrange;
+
+query error invalid input syntax for type range
+SELECT '(1,1]]'::numrange;
+
+query error invalid input syntax for type range
+SELECT '[1,1]}'::numrange;
+
+query error invalid input syntax for type range
+SELECT '(1,1]  ]'::numrange;
+
+query error invalid input syntax for type range
+SELECT '[1,1]  }'::numrange;
+
+statement ok
+CREATE TABLE numrange_values (a numrange);
+
+statement ok
+INSERT INTO numrange_values VALUES
+    (null),
+    ('[,1)'::numrange),
+    ('[,1]'::numrange),
+    ('[,)'::numrange),
+    ('[,]'::numrange),
+    ('(,1)'::numrange),
+    ('(,1]'::numrange),
+    ('(,)'::numrange),
+    ('(,]'::numrange),
+    ('[-1,1)'::numrange),
+    ('[-1,1]'::numrange),
+    ('(-1,1)'::numrange),
+    ('(-1,1]'::numrange),
+    ('[0,0)'::numrange),
+    ('[0,0]'::numrange),
+    ('(0,0)'::numrange),
+    ('(0,0]'::numrange),
+    ('[1,)'::numrange),
+    ('[1,]'::numrange),
+    ('(1,)'::numrange),
+    ('(1,]'::numrange);
+
+query T
+SELECT a::text AS t FROM numrange_values ORDER BY a;
+----
+empty
+empty
+empty
+(,1)
+(,1)
+(,1]
+(,1]
+(,)
+(,)
+(,)
+(,)
+[-1,1)
+[-1,1]
+(-1,1)
+(-1,1]
+[0,0]
+[1,)
+[1,)
+(1,)
+(1,)
+NULL
+
+query T
+SELECT a::text AS t FROM numrange_values EXCEPT SELECT column1::text FROM (VALUES
+    (numrange(null,1)),
+    (numrange(null,1, '[]')),
+    (numrange(null,null)),
+    (numrange(null,null, '[]')),
+    (numrange(null,1, '()')),
+    (numrange(null,1, '(]')),
+    (numrange(null,null, '()')),
+    (numrange(null,null,'(]')),
+    (numrange(-1,1)),
+    (numrange(-1,1, '[]')),
+    (numrange(-1,1, '()')),
+    (numrange(-1,1,'(]')),
+    (numrange(0,0)),
+    (numrange(0,0, '[]')),
+    (numrange(0,0,'()')),
+    (numrange(0,0,'(]')),
+    (numrange(1,null)),
+    (numrange(1,null, '[]')),
+    (numrange(1,null,'()')),
+    (numrange(1,null,'(]'))
+) t;
+----
+NULL
+
+query error invalid range bound flags
+SELECT numrange(null,null,' (]');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'(] ');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'( ]');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'(,]');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'a()');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'(a)');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'()a');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'(()');
+
+query error invalid range bound flags
+SELECT numrange(null,null,'())');
+
+# Test range in list
+query T
+SELECT (LIST['(,)', 'empty', '[-1,1]']::numrange list)::text;
+----
+{(,),empty,[-1,1]}
+
+query T
+SELECT ('{"(,)","empty","[-1,1]"}'::numrange list)::text;
+----
+{(,),empty,[-1,1]}
+
+# Test range in array
+query T
+SELECT (ARRAY['(,)', 'empty', '[-1,1]']::_numrange)::text;
+----
+{(,),empty,[-1,1]}
+
+query T
+SELECT ('{"(,)","empty","[-1,1]"}'::_numrange)::text;
+----
+{(,),empty,[-1,1]}
+
+# Test builtin functions
+
+query B
+select '(,)'::numrange = '(,)'::numrange;
+----
+true
+
+query B
+select '(,)'::numrange != 'empty'::numrange;
+----
+false
+
+query B
+select '(,)'::numrange > 'empty'::numrange;
+----
+false
+
+query B
+select '(,)'::numrange >= 'empty'::numrange;
+----
+false
+
+query B
+select '(,)'::numrange < 'empty'::numrange;
+----
+false
+
+query B
+select '(,)'::numrange <= 'empty'::numrange;
+----
+false
+
+# Results from PG
+# (,)|t|t|t
+# [0,0]|f|t|f
+# (,1)|t|t|f
+# (,1]|t|t|t
+# (1,)|f|f|f
+# [1,)|f|f|t
+# (-1,1)|f|t|f
+# (-1,1]|f|t|t
+# [-1,1)|t|t|f
+# [-1,1]|t|t|t
+# empty|f|f|f
+# Note that the predicate also ensures equality between @> and <@
+query TTTT
+SELECT
+	DISTINCT
+	a::TEXT,
+	a @> -1::numeric AS contains_neg_1,
+	a @> 0::numeric AS contains_0,
+	a @> 1::numeric AS contains_1
+FROM
+	numrange_values
+WHERE
+	(a @> -1::numeric = -1::numeric <@ a)
+	AND (a @> 0::numeric = 0::numeric <@ a)
+	AND (a @> 1::numeric = 1::numeric <@ a)
+ORDER BY
+	a;
+----
+(,)
+true
+true
+true
+(,1)
+true
+true
+false
+(,1]
+true
+true
+true
+(-1,1)
+false
+true
+false
+(-1,1]
+false
+true
+true
+(1,)
+false
+false
+false
+[-1,1)
+true
+true
+false
+[-1,1]
+true
+true
+true
+[0,0]
+false
+true
+false
+[1,)
+false
+false
+true
+empty
+false
+false
+false
+
+query T
+SELECT '[1.1,1.1]'::numrange::text;
+----
+[1.1,1.1]
+
+query T
+SELECT '[1.1,1.2]'::numrange::text;
+----
+[1.1,1.2]
+
+query T
+SELECT '[1.1,1.1)'::numrange::text;
+----
+empty
+
+query T
+SELECT numrange(1.1::numeric(38,1),1.2::numeric(38,2))::text;
+----
+[1.1,1.2)
+
+query T
+SELECT numrange(1.1::numeric(38,2),1.2::numeric(38,1))::text;
+----
+[1.1,1.2)
+
+query T
+SELECT numrange(-1.1::numeric(38,10),1.2::numeric(38,0))::text;
+----
+[-1.1,1)
+
+query T
+SELECT numrange(-1.1::numeric(38,0),1.2::numeric(38,10))::text;
+----
+[-1,1.2)
+
+query error range lower bound must be less than or equal to range upper bound
+SELECT numrange(1.1::numeric(38,2),1.2::numeric(38,0))::text;

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -38,6 +38,7 @@ _interval
 _jsonb
 _mz_timestamp
 _numeric
+_numrange
 _oid
 _record
 _regclass
@@ -83,6 +84,7 @@ list
 map
 mz_timestamp
 numeric
+numrange
 oid
 regclass
 regproc


### PR DESCRIPTION
Implements `numrange`, which we need for handling remap migrations.

### Motivation

 This PR adds a known-desirable feature.

### Tips for reviewer

Mostly just need a rubberstamp; these implementations are all basically identical.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a