### PR TITLE
doc/user: minor correction to SUBSCRIBE documentation

### DIFF
--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -25,7 +25,6 @@ You can use `SUBSCRIBE` to:
 
 -   Power event processors that react to every change to a relation or an arbitrary `SELECT` statement.
 -   Replicate the complete history of a relation while `SUBSCRIBE` is active.
--   Test a SQL `SELECT` statement over non-materialized views
 
 ## Syntax
 
@@ -131,7 +130,7 @@ A `SUBSCRIBE` whose `UP TO` is less than its "as of" timestamp (whether that tim
 
 ### Duration
 
-`SUBSCRIBE` will continue to run until canceled, session ends, the `UP TO` timestamp is reached, or all updates have been presented. The latter case typically occurs when
+`SUBSCRIBE` will continue to run until canceled, the session ends, the `UP TO` timestamp is reached, or all updates have been presented. The latter case typically occurs when
 tailing constant views (e.g. `CREATE VIEW v AS SELECT 1`).
 
 {{< warning >}}
@@ -167,8 +166,8 @@ distinguish between a stall in Materialize and a legitimate period of no
 updates.
 
 If the `PROGRESS` option is specified via `WITH (PROGRESS)`, an additional `mz_progressed` column appears in the output.
-When the column is `false` the rest of the row is a valid update.
-When the column is `true` the rest of the row is not a valid update and its content should be ignored;
+When the column is `false`, the rest of the row is a valid update.
+When the column is `true`m the rest of the row is not a valid update and its content should be ignored;
 the row exists only to communicate that timestamps have advanced.
 
 Not all timestamps that appear will have a corresponding row with `mz_progressed` set to `true`.


### PR DESCRIPTION
In nu Materialize, non-materialized views are queryable. Adjusting the `SUBSCRIBE` documentation page, which still referred to the old architecture.