### PR TITLE
sql: implement misc.range functions

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -405,6 +405,7 @@ message ProtoUnaryFunc {
         google.protobuf.Empty cast_uint64_to_int16 = 280;
         google.protobuf.Empty range_lower = 283;
         google.protobuf.Empty range_upper = 284;
+        google.protobuf.Empty range_empty = 285;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -408,6 +408,8 @@ message ProtoUnaryFunc {
         google.protobuf.Empty range_empty = 285;
         google.protobuf.Empty range_lower_inc = 286;
         google.protobuf.Empty range_upper_inc = 287;
+        google.protobuf.Empty range_lower_inf = 288;
+        google.protobuf.Empty range_upper_inf = 289;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -403,6 +403,8 @@ message ProtoUnaryFunc {
         google.protobuf.Empty cast_uint16_to_int16 = 278;
         google.protobuf.Empty cast_uint32_to_int16 = 279;
         google.protobuf.Empty cast_uint64_to_int16 = 280;
+        google.protobuf.Empty range_lower = 283;
+        google.protobuf.Empty range_upper = 284;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -406,6 +406,8 @@ message ProtoUnaryFunc {
         google.protobuf.Empty range_lower = 283;
         google.protobuf.Empty range_upper = 284;
         google.protobuf.Empty range_empty = 285;
+        google.protobuf.Empty range_lower_inc = 286;
+        google.protobuf.Empty range_upper_inc = 287;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3871,7 +3871,9 @@ derive_unary!(
     PgColumnSize,
     MzRowSize,
     MzTypeName,
-    StepMzTimestamp
+    StepMzTimestamp,
+    RangeLower,
+    RangeUpper
 );
 
 impl UnaryFunc {
@@ -4256,6 +4258,8 @@ impl Arbitrary for UnaryFunc {
             PgColumnSize::arbitrary().prop_map_into().boxed(),
             MzRowSize::arbitrary().prop_map_into().boxed(),
             MzTypeName::arbitrary().prop_map_into().boxed(),
+            RangeLower::arbitrary().prop_map_into().boxed(),
+            RangeUpper::arbitrary().prop_map_into().boxed(),
         ])
     }
 }
@@ -4588,6 +4592,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::CastTimestampToMzTimestamp(_) => CastTimestampToMzTimestamp(()),
             UnaryFunc::CastTimestampTzToMzTimestamp(_) => CastTimestampTzToMzTimestamp(()),
             UnaryFunc::StepMzTimestamp(_) => StepMzTimestamp(()),
+            UnaryFunc::RangeLower(_) => RangeLower(()),
+            UnaryFunc::RangeUpper(_) => RangeUpper(()),
         };
         ProtoUnaryFunc { kind: Some(kind) }
     }
@@ -4987,6 +4993,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 CastTimestampToMzTimestamp(()) => Ok(impls::CastTimestampToMzTimestamp.into()),
                 CastTimestampTzToMzTimestamp(()) => Ok(impls::CastTimestampTzToMzTimestamp.into()),
                 StepMzTimestamp(()) => Ok(impls::StepMzTimestamp.into()),
+                RangeLower(()) => Ok(impls::RangeLower.into()),
+                RangeUpper(()) => Ok(impls::RangeUpper.into()),
             }
         } else {
             Err(TryFromProtoError::missing_field("ProtoUnaryFunc::kind"))

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3874,7 +3874,9 @@ derive_unary!(
     StepMzTimestamp,
     RangeLower,
     RangeUpper,
-    RangeEmpty
+    RangeEmpty,
+    RangeLowerInc,
+    RangeUpperInc
 );
 
 impl UnaryFunc {
@@ -4262,6 +4264,8 @@ impl Arbitrary for UnaryFunc {
             RangeLower::arbitrary().prop_map_into().boxed(),
             RangeUpper::arbitrary().prop_map_into().boxed(),
             RangeEmpty::arbitrary().prop_map_into().boxed(),
+            RangeLowerInc::arbitrary().prop_map_into().boxed(),
+            RangeUpperInc::arbitrary().prop_map_into().boxed(),
         ])
     }
 }
@@ -4597,6 +4601,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::RangeLower(_) => RangeLower(()),
             UnaryFunc::RangeUpper(_) => RangeUpper(()),
             UnaryFunc::RangeEmpty(_) => RangeEmpty(()),
+            UnaryFunc::RangeLowerInc(_) => RangeLowerInc(()),
+            UnaryFunc::RangeUpperInc(_) => RangeUpperInc(()),
         };
         ProtoUnaryFunc { kind: Some(kind) }
     }
@@ -4999,6 +5005,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 RangeLower(()) => Ok(impls::RangeLower.into()),
                 RangeUpper(()) => Ok(impls::RangeUpper.into()),
                 RangeEmpty(()) => Ok(impls::RangeEmpty.into()),
+                RangeLowerInc(_) => Ok(impls::RangeLowerInc.into()),
+                RangeUpperInc(_) => Ok(impls::RangeUpperInc.into()),
             }
         } else {
             Err(TryFromProtoError::missing_field("ProtoUnaryFunc::kind"))

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3873,7 +3873,8 @@ derive_unary!(
     MzTypeName,
     StepMzTimestamp,
     RangeLower,
-    RangeUpper
+    RangeUpper,
+    RangeEmpty
 );
 
 impl UnaryFunc {
@@ -4260,6 +4261,7 @@ impl Arbitrary for UnaryFunc {
             MzTypeName::arbitrary().prop_map_into().boxed(),
             RangeLower::arbitrary().prop_map_into().boxed(),
             RangeUpper::arbitrary().prop_map_into().boxed(),
+            RangeEmpty::arbitrary().prop_map_into().boxed(),
         ])
     }
 }
@@ -4594,6 +4596,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::StepMzTimestamp(_) => StepMzTimestamp(()),
             UnaryFunc::RangeLower(_) => RangeLower(()),
             UnaryFunc::RangeUpper(_) => RangeUpper(()),
+            UnaryFunc::RangeEmpty(_) => RangeEmpty(()),
         };
         ProtoUnaryFunc { kind: Some(kind) }
     }
@@ -4995,6 +4998,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 StepMzTimestamp(()) => Ok(impls::StepMzTimestamp.into()),
                 RangeLower(()) => Ok(impls::RangeLower.into()),
                 RangeUpper(()) => Ok(impls::RangeUpper.into()),
+                RangeEmpty(()) => Ok(impls::RangeEmpty.into()),
             }
         } else {
             Err(TryFromProtoError::missing_field("ProtoUnaryFunc::kind"))

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3876,7 +3876,9 @@ derive_unary!(
     RangeUpper,
     RangeEmpty,
     RangeLowerInc,
-    RangeUpperInc
+    RangeUpperInc,
+    RangeLowerInf,
+    RangeUpperInf
 );
 
 impl UnaryFunc {
@@ -4266,6 +4268,8 @@ impl Arbitrary for UnaryFunc {
             RangeEmpty::arbitrary().prop_map_into().boxed(),
             RangeLowerInc::arbitrary().prop_map_into().boxed(),
             RangeUpperInc::arbitrary().prop_map_into().boxed(),
+            RangeLowerInf::arbitrary().prop_map_into().boxed(),
+            RangeUpperInf::arbitrary().prop_map_into().boxed(),
         ])
     }
 }
@@ -4603,6 +4607,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::RangeEmpty(_) => RangeEmpty(()),
             UnaryFunc::RangeLowerInc(_) => RangeLowerInc(()),
             UnaryFunc::RangeUpperInc(_) => RangeUpperInc(()),
+            UnaryFunc::RangeLowerInf(_) => RangeLowerInf(()),
+            UnaryFunc::RangeUpperInf(_) => RangeUpperInf(()),
         };
         ProtoUnaryFunc { kind: Some(kind) }
     }
@@ -5007,6 +5013,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 RangeEmpty(()) => Ok(impls::RangeEmpty.into()),
                 RangeLowerInc(_) => Ok(impls::RangeLowerInc.into()),
                 RangeUpperInc(_) => Ok(impls::RangeUpperInc.into()),
+                RangeLowerInf(_) => Ok(impls::RangeLowerInf.into()),
+                RangeUpperInf(_) => Ok(impls::RangeUpperInf.into()),
             }
         } else {
             Err(TryFromProtoError::missing_field("ProtoUnaryFunc::kind"))

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -202,3 +202,23 @@ sqlfunc!(
         }
     }
 );
+
+sqlfunc!(
+    #[sqlname = "range_lower_inf"]
+    fn range_lower_inf(a: Range<Datum<'a>>) -> bool {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.lower.bound.is_none(),
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "range_upper_inf"]
+    fn range_upper_inf(a: Range<Datum<'a>>) -> bool {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.upper.bound.is_none(),
+        }
+    }
+);

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -9,6 +9,7 @@
 
 use std::fmt;
 
+use mz_repr::adt::range::Range;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -174,3 +175,10 @@ impl fmt::Display for RangeUpper {
         f.write_str("rangeupper")
     }
 }
+
+sqlfunc!(
+    #[sqlname = "range_empty"]
+    fn range_empty(a: Range<Datum<'a>>) -> bool {
+        a.inner.is_none()
+    }
+);

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -182,3 +182,23 @@ sqlfunc!(
         a.inner.is_none()
     }
 );
+
+sqlfunc!(
+    #[sqlname = "range_lower_inc"]
+    fn range_lower_inc(a: Range<Datum<'a>>) -> bool {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.lower.inclusive,
+        }
+    }
+);
+
+sqlfunc!(
+    #[sqlname = "range_upper_inc"]
+    fn range_upper_inc(a: Range<Datum<'a>>) -> bool {
+        match a.inner {
+            None => false,
+            Some(inner) => inner.upper.inclusive,
+        }
+    }
+);

--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -68,3 +68,109 @@ impl fmt::Display for CastRangeToString {
         f.write_str("rangetostr")
     }
 }
+
+#[derive(
+    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+)]
+pub struct RangeLower;
+
+impl LazyUnaryFunc for RangeLower {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+        let r = a.unwrap_range();
+        Ok(Datum::from(
+            r.inner.map(|inner| inner.lower.bound).flatten(),
+        ))
+    }
+
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        input_type
+            .scalar_type
+            .unwrap_range_element_type()
+            .clone()
+            .nullable(input_type.nullable)
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+}
+
+impl fmt::Display for RangeLower {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("rangelower")
+    }
+}
+
+#[derive(
+    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+)]
+pub struct RangeUpper;
+
+impl LazyUnaryFunc for RangeUpper {
+    fn eval<'a>(
+        &'a self,
+        datums: &[Datum<'a>],
+        temp_storage: &'a RowArena,
+        a: &'a MirScalarExpr,
+    ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, temp_storage)?;
+        if a.is_null() {
+            return Ok(Datum::Null);
+        }
+        let r = a.unwrap_range();
+        Ok(Datum::from(
+            r.inner.map(|inner| inner.upper.bound).flatten(),
+        ))
+    }
+
+    fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        input_type
+            .scalar_type
+            .unwrap_range_element_type()
+            .clone()
+            .nullable(input_type.nullable)
+    }
+
+    fn propagates_nulls(&self) -> bool {
+        true
+    }
+
+    fn introduces_nulls(&self) -> bool {
+        true
+    }
+
+    fn preserves_uniqueness(&self) -> bool {
+        false
+    }
+
+    fn inverse(&self) -> Option<crate::UnaryFunc> {
+        None
+    }
+}
+
+impl fmt::Display for RangeUpper {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("rangeupper")
+    }
+}

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2136,6 +2136,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
             params!(String) => UnaryFunc::Lower(func::Lower), 870;
             params!(RangeAny) => UnaryFunc::RangeLower(func::RangeLower) => AnyElement, 3848;
         },
+        "lower_inc" => Scalar {
+            params!(RangeAny) => UnaryFunc::RangeLowerInc(func::RangeLowerInc) => Bool, 3851;
+        },
         "lpad" => Scalar {
             params!(String, Int64) => VariadicFunc::PadLeading, 879;
             params!(String, Int64, String) => VariadicFunc::PadLeading, 873;
@@ -2515,6 +2518,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
         "upper" => Scalar {
             params!(String) => UnaryFunc::Upper(func::Upper), 871;
             params!(RangeAny) => UnaryFunc::RangeUpper(func::RangeUpper) => AnyElement, 3849;
+        },
+        "upper_inc" => Scalar {
+            params!(RangeAny) => UnaryFunc::RangeUpperInc(func::RangeUpperInc) => Bool, 3852;
         },
         "variance" => Scalar {
             params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("variance")) => Float64, 2151;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2060,6 +2060,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
                 })
             }) => ScalarType::Range { element_type: Box::new(ScalarType::Int64)}, 3946;
         },
+        "isempty" => Scalar {
+            params!(RangeAny) => UnaryFunc::RangeEmpty(func::RangeEmpty) => Bool, 3850;
+        },
         "jsonb_array_length" => Scalar {
             params!(Jsonb) => UnaryFunc::JsonbArrayLength(func::JsonbArrayLength) => Int32, 3207;
         },

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2131,6 +2131,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
         },
         "lower" => Scalar {
             params!(String) => UnaryFunc::Lower(func::Lower), 870;
+            params!(RangeAny) => UnaryFunc::RangeLower(func::RangeLower) => AnyElement, 3848;
         },
         "lpad" => Scalar {
             params!(String, Int64) => VariadicFunc::PadLeading, 879;
@@ -2510,6 +2511,7 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
         },
         "upper" => Scalar {
             params!(String) => UnaryFunc::Upper(func::Upper), 871;
+            params!(RangeAny) => UnaryFunc::RangeUpper(func::RangeUpper) => AnyElement, 3849;
         },
         "variance" => Scalar {
             params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("variance")) => Float64, 2151;
@@ -3764,8 +3766,8 @@ static OP_IMPLS: Lazy<HashMap<&'static str, Func>> = Lazy::new(|| {
             params!(Jsonb, Jsonb) => BinaryFunc::NotEq, 3241;
             params!(ArrayAny, ArrayAny) => BinaryFunc::NotEq => Bool, 1071;
             params!(RecordAny, RecordAny) => BinaryFunc::NotEq => Bool, 2989;
-            params!(MzTimestamp, MzTimestamp) => BinaryFunc::NotEq=>Bool, oid::FUNC_MZ_TIMESTAMP_NOT_EQ_MZ_TIMESTAMP_OID;
-            params!(RangeAny, RangeAny) => BinaryFunc::Eq => Bool, 3883;
+            params!(MzTimestamp, MzTimestamp) => BinaryFunc::NotEq => Bool, oid::FUNC_MZ_TIMESTAMP_NOT_EQ_MZ_TIMESTAMP_OID;
+            params!(RangeAny, RangeAny) => BinaryFunc::NotEq => Bool, 3883;
         }
     }
 });

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2139,6 +2139,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
         "lower_inc" => Scalar {
             params!(RangeAny) => UnaryFunc::RangeLowerInc(func::RangeLowerInc) => Bool, 3851;
         },
+        "lower_inf" => Scalar {
+            params!(RangeAny) => UnaryFunc::RangeLowerInf(func::RangeLowerInf) => Bool, 3853;
+        },
         "lpad" => Scalar {
             params!(String, Int64) => VariadicFunc::PadLeading, 879;
             params!(String, Int64, String) => VariadicFunc::PadLeading, 873;
@@ -2521,6 +2524,9 @@ pub static PG_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
         },
         "upper_inc" => Scalar {
             params!(RangeAny) => UnaryFunc::RangeUpperInc(func::RangeUpperInc) => Bool, 3852;
+        },
+        "upper_inf" => Scalar {
+            params!(RangeAny) => UnaryFunc::RangeUpperInf(func::RangeUpperInf) => Bool, 3854;
         },
         "variance" => Scalar {
             params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("variance")) => Float64, 2151;

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -536,8 +536,26 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM int4range_values WHERE (NOT isempty(a)) AND (a <> int4range(lower(a), upper(a)));
+SELECT
+	a::STRING
+FROM
+	int4range_values
+WHERE
+	(NOT isempty(a))
+	AND (
+			a
+			!= int4range(
+					lower(a),
+					upper(a),
+					CASE
+					WHEN lower_inc(a) THEN '['
+					ELSE '('
+					END
+					|| CASE WHEN upper_inc(a) THEN ']' ELSE ')' END
+				)
+		);
 ----
+
 
 
 query error invalid range bound flags
@@ -1181,7 +1199,24 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM int8range_values WHERE (NOT isempty(a)) AND (a <> int8range(lower(a), upper(a)));
+SELECT
+	a::STRING
+FROM
+	int8range_values
+WHERE
+	(NOT isempty(a))
+	AND (
+			a
+			!= int8range(
+					lower(a),
+					upper(a),
+					CASE
+					WHEN lower_inc(a) THEN '['
+					ELSE '('
+					END
+					|| CASE WHEN upper_inc(a) THEN ']' ELSE ')' END
+				)
+		);
 ----
 
 
@@ -1720,7 +1755,24 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM daterange_values WHERE (NOT isempty(a)) AND (a <> daterange(lower(a), upper(a)));
+SELECT
+	a::STRING
+FROM
+	daterange_values
+WHERE
+	(NOT isempty(a))
+	AND (
+			a
+			!= daterange(
+					lower(a),
+					upper(a),
+					CASE
+					WHEN lower_inc(a) THEN '['
+					ELSE '('
+					END
+					|| CASE WHEN upper_inc(a) THEN ']' ELSE ')' END
+				)
+		);
 ----
 
 
@@ -2378,16 +2430,25 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM numrange_values WHERE (NOT isempty(a)) AND (a <> numrange(lower(a), upper(a)));
+SELECT
+	a::STRING
+FROM
+	numrange_values
+WHERE
+	(NOT isempty(a))
+	AND (
+			a
+			!= numrange(
+					lower(a),
+					upper(a),
+					CASE
+					WHEN lower_inc(a) THEN '['
+					ELSE '('
+					END
+					|| CASE WHEN upper_inc(a) THEN ']' ELSE ')' END
+				)
+		);
 ----
-(,1]
-(,1]
-(1,)
-(1,)
-[0,0]
-(-1,1)
-(-1,1]
-[-1,1]
 
 query error invalid range bound flags
 SELECT numrange(null,null,' (]');

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -557,6 +557,10 @@ WHERE
 ----
 
 
+query T
+SELECT DISTINCT a::text FROM int4range_values WHERE lower_inf(a) AND upper_inf(a);
+----
+(,)
 
 query error invalid range bound flags
 SELECT int4range(null,null,' (]');
@@ -1220,6 +1224,11 @@ WHERE
 ----
 
 
+query T
+SELECT DISTINCT a::text FROM int8range_values WHERE lower_inf(a) AND upper_inf(a);
+----
+(,)
+
 # Test range in list
 query T
 SELECT (LIST['(,)', 'empty', '[-1,1]']::int8range list)::text;
@@ -1775,6 +1784,11 @@ WHERE
 		);
 ----
 
+
+query T
+SELECT DISTINCT a::text FROM daterange_values WHERE lower_inf(a) AND upper_inf(a);
+----
+(,)
 
 query T
 SELECT a::text AS t FROM daterange_values EXCEPT SELECT column1::text FROM (VALUES
@@ -2449,6 +2463,12 @@ WHERE
 				)
 		);
 ----
+
+
+query T
+SELECT DISTINCT a::text FROM numrange_values WHERE lower_inf(a) AND upper_inf(a);
+----
+(,)
 
 query error invalid range bound flags
 SELECT numrange(null,null,' (]');

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -460,6 +460,7 @@ CREATE TABLE int4range_values (a int4range);
 statement ok
 INSERT INTO int4range_values VALUES
     (null),
+    ('empty'),
     ('[,1)'::int4range),
     ('[,1]'::int4range),
     ('[,)'::int4range),
@@ -484,6 +485,7 @@ INSERT INTO int4range_values VALUES
 query T
 SELECT a::text AS t FROM int4range_values ORDER BY a;
 ----
+empty
 empty
 empty
 empty
@@ -531,6 +533,12 @@ SELECT a::text AS t FROM int4range_values EXCEPT SELECT column1::text FROM (VALU
 ) t;
 ----
 NULL
+
+# test that lower and upper roundtrip through range constructor function
+query T
+SELECT a::text FROM int4range_values WHERE (a::text <> 'empty') AND (a <> int4range(lower(a), upper(a)));
+----
+
 
 query error invalid range bound flags
 SELECT int4range(null,null,' (]');
@@ -591,7 +599,7 @@ true
 query B
 select '(,)'::int4range != 'empty'::int4range;
 ----
-false
+true
 
 query B
 select '(,)'::int4range > 'empty'::int4range;
@@ -1097,6 +1105,7 @@ CREATE TABLE int8range_values (a int8range);
 statement ok
 INSERT INTO int8range_values VALUES
     (null),
+    ('empty'),
     ('[,1)'::int8range),
     ('[,1]'::int8range),
     ('[,)'::int8range),
@@ -1121,6 +1130,7 @@ INSERT INTO int8range_values VALUES
 query T
 SELECT a::text AS t FROM int8range_values ORDER BY a;
 ----
+empty
 empty
 empty
 empty
@@ -1169,6 +1179,11 @@ SELECT a::text AS t FROM int8range_values EXCEPT SELECT column1::text FROM (VALU
 ----
 NULL
 
+# test that lower and upper roundtrip through range constructor function
+query T
+SELECT a::text FROM int8range_values WHERE (a::text <> 'empty') AND (a <> int8range(lower(a), upper(a)));
+----
+
 
 # Test range in list
 query T
@@ -1202,7 +1217,7 @@ true
 query B
 select '(,)'::int8range != 'empty'::int8range;
 ----
-false
+true
 
 query B
 select '(,)'::int8range > 'empty'::int8range;
@@ -1663,6 +1678,7 @@ CREATE TABLE daterange_values (a daterange);
 statement ok
 INSERT INTO daterange_values VALUES
     (null),
+    ('empty'),
     ('[,)'::daterange),
     ('[,1970-01-01]'::daterange),
     ('[,)'::daterange),
@@ -1684,6 +1700,7 @@ query T
 SELECT a::text AS t FROM daterange_values ORDER BY a;
 ----
 empty
+empty
 (,1970-01-01)
 (,1970-01-02)
 (,1970-01-02)
@@ -1700,6 +1717,12 @@ empty
 [1970-01-02,)
 [1970-01-02,)
 NULL
+
+# test that lower and upper roundtrip through range constructor function
+query T
+SELECT a::text FROM daterange_values WHERE (a::text <> 'empty') AND (a <> daterange(lower(a), upper(a)));
+----
+
 
 query T
 SELECT a::text AS t FROM daterange_values EXCEPT SELECT column1::text FROM (VALUES
@@ -1756,7 +1779,7 @@ true
 query B
 select '(,)'::daterange != 'empty'::daterange;
 ----
-false
+true
 
 query B
 select '(,)'::daterange > 'empty'::daterange;
@@ -2279,6 +2302,7 @@ CREATE TABLE numrange_values (a numrange);
 statement ok
 INSERT INTO numrange_values VALUES
     (null),
+    ('empty'),
     ('[,1)'::numrange),
     ('[,1]'::numrange),
     ('[,)'::numrange),
@@ -2303,6 +2327,7 @@ INSERT INTO numrange_values VALUES
 query T
 SELECT a::text AS t FROM numrange_values ORDER BY a;
 ----
+empty
 empty
 empty
 empty
@@ -2350,6 +2375,19 @@ SELECT a::text AS t FROM numrange_values EXCEPT SELECT column1::text FROM (VALUE
 ) t;
 ----
 NULL
+
+# test that lower and upper roundtrip through range constructor function
+query T
+SELECT a::text FROM numrange_values WHERE (a::text <> 'empty') AND (a <> numrange(lower(a), upper(a)));
+----
+(,1]
+(,1]
+(1,)
+(1,)
+[0,0]
+(-1,1)
+(-1,1]
+[-1,1]
 
 query error invalid range bound flags
 SELECT numrange(null,null,' (]');
@@ -2410,7 +2448,7 @@ true
 query B
 select '(,)'::numrange != 'empty'::numrange;
 ----
-false
+true
 
 query B
 select '(,)'::numrange > 'empty'::numrange;

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -536,7 +536,7 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM int4range_values WHERE (a::text <> 'empty') AND (a <> int4range(lower(a), upper(a)));
+SELECT a::text FROM int4range_values WHERE (NOT isempty(a)) AND (a <> int4range(lower(a), upper(a)));
 ----
 
 
@@ -1181,7 +1181,7 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM int8range_values WHERE (a::text <> 'empty') AND (a <> int8range(lower(a), upper(a)));
+SELECT a::text FROM int8range_values WHERE (NOT isempty(a)) AND (a <> int8range(lower(a), upper(a)));
 ----
 
 
@@ -1720,7 +1720,7 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM daterange_values WHERE (a::text <> 'empty') AND (a <> daterange(lower(a), upper(a)));
+SELECT a::text FROM daterange_values WHERE (NOT isempty(a)) AND (a <> daterange(lower(a), upper(a)));
 ----
 
 
@@ -2378,7 +2378,7 @@ NULL
 
 # test that lower and upper roundtrip through range constructor function
 query T
-SELECT a::text FROM numrange_values WHERE (a::text <> 'empty') AND (a <> numrange(lower(a), upper(a)));
+SELECT a::text FROM numrange_values WHERE (NOT isempty(a)) AND (a <> numrange(lower(a), upper(a)));
 ----
 (,1]
 (,1]


### PR DESCRIPTION
Also includes a fix for `range <> range`, which was inadvertently planning as `range = range`

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  -n/a