### PR TITLE
testdrive: Fortify system-functions.td

### DIFF
--- a/test/testdrive/system-functions.td
+++ b/test/testdrive/system-functions.td
@@ -22,8 +22,8 @@ true
 > SELECT now() - pg_postmaster_start_time() > interval '1 second' AND now() - pg_postmaster_start_time() < interval '1 year';
 true
 
-> SELECT length(cast(mz_environment_id() as text));
-55
+> SELECT length(cast(mz_environment_id() as text)) > 36;
+true
 
 > SELECT length(cast(mz_internal.mz_session_id() as text));
 36


### PR DESCRIPTION
The length of the environment_id is variable, so do not assume a specific length in the .td test.

### Motivation

  * This PR fixes a previously unreported bug.
Nigtly testdrive in K8s was failing.