### PR TITLE
UpdateConfiguration compute command

### DIFF
--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -41,6 +41,10 @@ message ProtoComputeCommand {
         ProtoComputeStartupEpoch epoch = 2;
     }
 
+    message ProtoUpdateConfiguration {
+        repeated ProtoComputeParameter params = 1;
+    }
+
     oneof kind {
         ProtoCreateTimely create_timely = 1;
         ProtoInstanceConfig create_instance = 2;
@@ -49,7 +53,7 @@ message ProtoComputeCommand {
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
         google.protobuf.Empty initialization_complete = 7;
-        ProtoUpdateMaxResultSize update_max_result_size = 8;
+        ProtoUpdateConfiguration update_configuration = 8;
     }
 }
 
@@ -74,6 +78,8 @@ message ProtoPeek {
     map<string, string> otel_ctx = 7;
 }
 
-message ProtoUpdateMaxResultSize {
-    uint32 max_result_size = 1;
+message ProtoComputeParameter {
+    oneof kind {
+        uint32 max_result_size = 1;
+    }
 }

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -47,7 +47,7 @@ message ProtoComputeCommand {
 
     oneof kind {
         ProtoCreateTimely create_timely = 1;
-        ProtoInstanceConfig create_instance = 2;
+        logging.ProtoLoggingConfig create_instance = 2;
         ProtoCreateDataflows create_dataflows = 3;
         mz_storage_client.client.ProtoAllowCompaction allow_compaction = 4;
         ProtoPeek peek = 5;
@@ -55,11 +55,6 @@ message ProtoComputeCommand {
         google.protobuf.Empty initialization_complete = 7;
         ProtoUpdateConfiguration update_configuration = 8;
     }
-}
-
-message ProtoInstanceConfig {
-    logging.ProtoLoggingConfig logging = 1;
-    uint32 max_result_size = 2;
 }
 
 message ProtoCommunicationConfig {

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -624,6 +624,10 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         if let Some(create_inst_command) = create_inst_command {
             self.commands.push(create_inst_command);
         }
+        if !final_configuration.is_empty() {
+            self.commands
+                .push(ComputeCommand::UpdateConfiguration(final_configuration));
+        }
         self.dataflow_count = live_dataflows.len();
         if !live_dataflows.is_empty() {
             self.commands
@@ -644,10 +648,6 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         }
         if initialization_complete {
             self.commands.push(ComputeCommand::InitializationComplete);
-        }
-        if !final_configuration.is_empty() {
-            self.commands
-                .push(ComputeCommand::UpdateConfiguration(final_configuration));
         }
 
         self.reduced_count = command_count;

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -27,7 +27,8 @@ use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::{ReadPolicy, StorageController};
 
 use crate::command::{
-    ComputeCommand, ComputeCommandHistory, ComputeStartupEpoch, InstanceConfig, Peek,
+    ComputeCommand, ComputeCommandHistory, ComputeParameter, ComputeStartupEpoch, InstanceConfig,
+    Peek,
 };
 use crate::logging::{LogVariant, LoggingConfig};
 use crate::response::{ComputeResponse, PeekResponse, SubscribeBatch, SubscribeResponse};
@@ -751,8 +752,9 @@ where
 
     /// Update the max size in bytes of any result.
     pub fn update_max_result_size(&mut self, max_result_size: u32) {
+        let params = [ComputeParameter::MaxResultSize(max_result_size)].into();
         self.compute
-            .send(ComputeCommand::UpdateMaxResultSize(max_result_size))
+            .send(ComputeCommand::UpdateConfiguration(params));
     }
 
     /// Validate that a collection exists for all identifiers, and error if any do not.

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -27,8 +27,7 @@ use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::{ReadPolicy, StorageController};
 
 use crate::command::{
-    ComputeCommand, ComputeCommandHistory, ComputeParameter, ComputeStartupEpoch, InstanceConfig,
-    Peek,
+    ComputeCommand, ComputeCommandHistory, ComputeParameter, ComputeStartupEpoch, Peek,
 };
 use crate::logging::{LogVariant, LoggingConfig};
 use crate::response::{ComputeResponse, PeekResponse, SubscribeBatch, SubscribeResponse};
@@ -198,10 +197,12 @@ where
             comm_config: Default::default(),
             epoch: ComputeStartupEpoch::new(envd_epoch, 0),
         });
-        instance.send(ComputeCommand::CreateInstance(InstanceConfig {
-            logging: Default::default(),
-            max_result_size,
-        }));
+
+        let dummy_logging_config = Default::default();
+        instance.send(ComputeCommand::CreateInstance(dummy_logging_config));
+
+        let params = [ComputeParameter::MaxResultSize(max_result_size)].into();
+        instance.send(ComputeCommand::UpdateConfiguration(params));
 
         instance
     }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -307,14 +307,13 @@ struct CommandSpecialization {
 }
 
 impl CommandSpecialization {
-    /// Specialize a command for the given `Replica` and `ReplicaId`.
+    /// Specialize a command for the given replica configuration.
     ///
     /// Most `ComputeCommand`s are independent of the target replica, but some
     /// contain replica-specific fields that must be adjusted before sending.
     fn specialize_command<T>(&self, command: &mut ComputeCommand<T>) {
-        // Set new replica ID and obtain set the sinked logs specific to this replica
-        if let ComputeCommand::CreateInstance(config) = command {
-            config.logging = self.logging_config.clone();
+        if let ComputeCommand::CreateInstance(logging) = command {
+            *logging = self.logging_config.clone();
         }
 
         if let ComputeCommand::CreateTimely { comm_config, epoch } = command {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -27,9 +27,7 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, Mutex};
 use uuid::Uuid;
 
-use mz_compute_client::command::{
-    ComputeCommand, ComputeCommandHistory, ComputeParameter, InstanceConfig, Peek,
-};
+use mz_compute_client::command::{ComputeCommand, ComputeCommandHistory, ComputeParameter, Peek};
 use mz_compute_client::logging::LoggingConfig;
 use mz_compute_client::metrics::ComputeMetrics;
 use mz_compute_client::plan::Plan;
@@ -131,7 +129,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         );
         match cmd {
             CreateTimely { .. } => panic!("CreateTimely must be captured before"),
-            CreateInstance(config) => self.handle_create_instance(config),
+            CreateInstance(logging) => self.handle_create_instance(logging),
             InitializationComplete => (),
             UpdateConfiguration(params) => self.handle_update_configuration(params),
             CreateDataflows(dataflows) => self.handle_create_dataflows(dataflows),
@@ -144,8 +142,8 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         }
     }
 
-    fn handle_create_instance(&mut self, config: InstanceConfig) {
-        self.initialize_logging(&config.logging);
+    fn handle_create_instance(&mut self, logging: LoggingConfig) {
+        self.initialize_logging(&logging);
     }
 
     fn handle_update_configuration(&mut self, params: BTreeSet<ComputeParameter>) {


### PR DESCRIPTION
This PR introduces an `UpdateConfiguration` compute command to configure the `max_result_size` config option, replacing the existing `UpdateMaxResultSize` command.

This is done to prepare for the introduction of additional dynamic compute configuration parameters, like the persist configuration (https://github.com/MaterializeInc/materialize/issues/16753).

### Motivation

  * This PR adds a known-desirable feature.

Closes #16273.

### Tips for reviewer

Look at the commits and their messages separately!

~~I'm not clear about how sane changing the maximum result size is in general. It might have unexpected effects if different replicas know different values for this parameter at the same time (maybe find for peeks, but probably not for subscribes). In this PR I didn't attempt to solve this issue and simply kept the existing functionality. But we should look into this as a follow-up.~~ [It's probably fine.](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1672756702068429)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
