### PR TITLE
zippy: Disable sql.stats.forecasts.enabled in CRDB

### DIFF
--- a/misc/python/materialize/zippy/crdb_actions.py
+++ b/misc/python/materialize/zippy/crdb_actions.py
@@ -29,6 +29,12 @@ class CockroachStart(Action):
                 user="root",
             )
 
+        c.sql(
+            "SET CLUSTER SETTING sql.stats.forecasts.enabled = false",
+            service="cockroach",
+            user="root",
+        )
+
     def provides(self) -> List[Capability]:
         return [CockroachIsRunning()]
 


### PR DESCRIPTION
Due to #16726 and the related upstream issue, CRDB needs to run with

SET CLUSTER SETTING sql.stats.forecasts.enabled = false;

in order for long Zippy tests to have a fighting chance of completing successfully.

### Motivation

  * This PR fixes a previously unreported bug.

The entire Release Qualification Test is failing.