### PR TITLE
zippy: Use a separate storage clusterd

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -259,7 +259,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=1000]
+          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=2000]
 
   - id: zippy-user-tables
     label: "Zippy User Tables"
@@ -279,7 +279,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=PostgresCdc, --actions=1000]
+          args: [--scenario=PostgresCdc, --actions=3000]
 
   - id: zippy-debezium-postgres
     label: "Zippy Debezium Postgres"

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -21,6 +21,7 @@ from materialize.zippy.debezium_capabilities import (
 from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.kafka_capabilities import KafkaRunning
 from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.storaged_capabilities import StoragedRunning
 
 
 class DebeziumStart(Action):
@@ -52,7 +53,7 @@ class CreateDebeziumSource(Action):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, KafkaRunning, PostgresTableExists}
+        return {MzIsRunning, StoragedRunning, KafkaRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         # To avoid conflicts, we make sure the postgres table and the debezium source have matching names
@@ -122,6 +123,9 @@ class CreateDebeziumSource(Action):
                       FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.{self.postgres_table.name}')
                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                       ENVELOPE DEBEZIUM
+                      WITH (
+                        REMOTE 'storaged:2100'
+                      )
                     """
                 )
             )

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -17,6 +17,7 @@ from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
+from materialize.zippy.storaged_capabilities import StoragedRunning
 
 
 class CreatePostgresCdcTable(Action):
@@ -24,7 +25,7 @@ class CreatePostgresCdcTable(Action):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, PostgresRunning, PostgresTableExists}
+        return {MzIsRunning, StoragedRunning, PostgresRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
@@ -75,6 +76,9 @@ class CreatePostgresCdcTable(Action):
                     > CREATE SOURCE {name}_source
                       FROM POSTGRES CONNECTION {name}_connection (PUBLICATION '{name}_publication')
                       FOR TABLES ({self.postgres_cdc_table.postgres_table.name} AS {name})
+                      WITH (
+                        REMOTE 'storaged:2100'
+                      )
                     """
                 )
             )

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -15,6 +15,7 @@ from materialize.mzcompose import Composition
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.sink_capabilities import SinkExists
+from materialize.zippy.storaged_capabilities import StoragedRunning
 from materialize.zippy.view_capabilities import ViewExists
 
 
@@ -23,7 +24,7 @@ class CreateSinkParameterized(ActionFactory):
 
     @classmethod
     def requires(self) -> List[Set[Type[Capability]]]:
-        return [{MzIsRunning, ViewExists}]
+        return [{MzIsRunning, StoragedRunning, ViewExists}]
 
     def __init__(self, max_sinks: int = 10) -> None:
         self.max_sinks = max_sinks
@@ -108,6 +109,9 @@ class CreateSink(Action):
                   FROM KAFKA CONNECTION {self.sink.name}_kafka_conn (TOPIC 'sink-{self.sink.name}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn
                   ENVELOPE NONE
+                  WITH (
+                    REMOTE 'storaged:2100'
+                  )
             """
             )
             + dest_view_sql

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -16,6 +16,7 @@ from materialize.zippy.framework import Action, ActionFactory, Capabilities, Cap
 from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.source_capabilities import SourceExists
+from materialize.zippy.storaged_capabilities import StoragedRunning
 
 
 class CreateSourceParameterized(ActionFactory):
@@ -23,7 +24,7 @@ class CreateSourceParameterized(ActionFactory):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, KafkaRunning, TopicExists}
+        return {MzIsRunning, StoragedRunning, KafkaRunning, TopicExists}
 
     def __init__(self, max_sources: int = 10) -> None:
         self.max_sources = max_sources
@@ -68,6 +69,9 @@ class CreateSource(Action):
                   (TOPIC 'testdrive-{self.source.topic.name}-${{testdrive.seed}}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.source.name}_csr_conn
                   ENVELOPE {envelope}
+                  WITH (
+                    REMOTE 'storaged:2100'
+                  )
                 """
             )
         )

--- a/misc/python/materialize/zippy/storaged_actions.py
+++ b/misc/python/materialize/zippy/storaged_actions.py
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.crdb_capabilities import CockroachIsRunning
+from materialize.zippy.framework import Action, Capability
+from materialize.zippy.minio_capabilities import MinioIsRunning
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.storaged_capabilities import StoragedRunning
+
+
+class StoragedStart(Action):
+    """Starts a storaged clusterd instance."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {CockroachIsRunning, MinioIsRunning}
+
+    def run(self, c: Composition) -> None:
+        c.start_and_wait_for_tcp(services=["storaged"])
+
+    def provides(self) -> List[Capability]:
+        return [StoragedRunning()]
+
+
+class StoragedRestart(Action):
+    """Restarts the entire storaged clusterd instance."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, StoragedRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("storaged")
+        c.start_and_wait_for_tcp(services=["storaged"])
+
+
+class StoragedKill(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, StoragedRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("storaged")
+
+    def withholds(self) -> Set[Type[Capability]]:
+        return {StoragedRunning}

--- a/misc/python/materialize/zippy/storaged_capabilities.py
+++ b/misc/python/materialize/zippy/storaged_capabilities.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+
+
+class StoragedRunning(Capability):
+    pass

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -17,6 +17,7 @@ from materialize.zippy.framework import Action, ActionFactory, Capabilities, Cap
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.source_capabilities import SourceExists
+from materialize.zippy.storaged_capabilities import StoragedRunning
 from materialize.zippy.table_capabilities import TableExists
 from materialize.zippy.view_capabilities import ViewExists, WatermarkedObjects
 
@@ -126,7 +127,7 @@ class ValidateView(Action):
 
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, ViewExists}
+        return {MzIsRunning, StoragedRunning, ViewExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.view = random.choice(capabilities.get(ViewExists))

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
+    Clusterd,
     Cockroach,
     Debezium,
     Kafka,
@@ -37,6 +38,7 @@ SERVICES = [
     MinioMc(),
     # Those two are overriden below
     Materialized(),
+    Clusterd(name="storaged", storage_workers=4),
     Testdrive(),
 ]
 


### PR DESCRIPTION
Spawn a separate clusterd for sources and sinks so that Zippy can kill and start it separately.

This provides additional event interleavings not possible before, as the following events can happen while the storaged cluster is down:
- environmentd restarts
- Kafka events and table inserts
- materialized views creation

### Motivation

  * This PR fixes a previously unreported bug.
After the unfication under `clusterd`, Zippy lost the ability to kill storaged selectively.