### PR TITLE
bump sysinfo version and fix how we refresh CPU info in the process orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7010,9 +7010,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb297c0afb439440834b4bcf02c5c9da8ec2e808e70f36b0d8e815ff403bd24"
+checksum = "17351d0e9eb8841897b14e9669378f3c69fb57779cc04f8ca9a9d512edfb2563"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0.147"
 serde_json = "1.0.89"
 scopeguard = "1.1.0"
 sha1 = "0.10.5"
-sysinfo = "0.27.1"
+sysinfo = "0.27.2"
 tokio = { version = "1.23.0", features = [ "fs", "process", "time" ] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -289,18 +289,11 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
 
         let mut system = self.system.lock().expect("lock poisoned");
         let mut metrics = vec![];
-        // Refresh all processes, even though it's slightly wasteful to do so,
-        // to work around https://github.com/GuillaumeGomez/sysinfo/issues/898 .
-        system.refresh_processes_specifics(ProcessRefreshKind::new().with_cpu());
         for pid in pids {
             let (cpu_nano_cores, memory_bytes) = match pid {
                 None => (None, None),
                 Some(pid) => {
-                    // TODO[btv] Uncomment this, and remove the call to `refresh_process_specifics`
-                    // outside the loop, if https://github.com/GuillaumeGomez/sysinfo/issues/898
-                    // is ever fixed.
-                    //
-                    // system.refresh_process_specifics(pid, ProcessRefreshKind::new().with_cpu());
+                    system.refresh_process_specifics(pid, ProcessRefreshKind::new().with_cpu());
                     match system.process(pid) {
                         None => (None, None),
                         Some(process) => {

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -24,7 +24,7 @@ mz-ore = { path = "../ore" }
 once_cell = "1.16.0"
 os_info = "3.5.1"
 semver = "1.0.16"
-sysinfo = "0.27.1"
+sysinfo = "0.27.2"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.23.0"
 tokio-stream = "0.1.11"


### PR DESCRIPTION
This is basically just a revert of #16861, which worked around [a bug](https://github.com/GuillaumeGomez/sysinfo/issues/898) in the sysinfo crate.

That bug has been fixed in the latest version of sysinfo (in [this](https://github.com/GuillaumeGomez/sysinfo/pull/900) PR), so we can back out the workaround.

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None