### PR TITLE
IDLE ARRANGEMENT MERGE EFFORT option

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2501,6 +2501,7 @@ impl<S: Append> Catalog<S> {
             let config = ComputeReplicaConfig {
                 location: catalog.concretize_replica_location(serialized_config.location)?,
                 logging,
+                idle_arrangement_merge_effort: serialized_config.idle_arrangement_merge_effort,
             };
 
             // And write the allocated sources back to storage
@@ -5766,13 +5767,15 @@ impl From<ComputeReplicaLogging> for SerializedComputeReplicaLogging {
 pub struct SerializedComputeReplicaConfig {
     pub location: SerializedComputeReplicaLocation,
     pub logging: SerializedComputeReplicaLogging,
+    pub idle_arrangement_merge_effort: Option<u32>,
 }
 
 impl From<ComputeReplicaConfig> for SerializedComputeReplicaConfig {
-    fn from(ComputeReplicaConfig { location, logging }: ComputeReplicaConfig) -> Self {
+    fn from(config: ComputeReplicaConfig) -> Self {
         SerializedComputeReplicaConfig {
-            location: location.into(),
-            logging: logging.into(),
+            location: config.location.into(),
+            logging: config.logging.into(),
+            idle_arrangement_merge_effort: config.idle_arrangement_merge_effort,
         }
     }
 }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -488,6 +488,7 @@ fn default_compute_replica_config(
             az_user_specified: false,
         },
         logging: default_logging_config(),
+        idle_arrangement_merge_effort: None,
     }
 }
 
@@ -501,6 +502,7 @@ fn builtin_compute_replica_config(
             az_user_specified: false,
         },
         logging: default_logging_config(),
+        idle_arrangement_merge_effort: None,
     }
 }
 

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -356,6 +356,16 @@ async fn migrate<S: Append>(
         |_, _| Ok(()),
         |_, _| Ok(()),
         |_, _| Ok(()),
+        // An optional field, `idle_arrangement_merge_effort`, was added to replica configs, which
+        // should default to `None` for existing configs. The deserialization is able deserialize
+        // the missing values as `None`. This migration updates the on-disk version to explicitly
+        // have a `None` value instead of a missing value.
+        //
+        // Introduced in v0.39.0
+        |txn: &mut Transaction<'_, S>, _bootstrap_args| {
+            txn.compute_replicas.update(|_k, v| Some(v.clone()))?;
+            Ok(())
+        },
         // Add new migrations above.
         //
         // Migrations should be preceded with a comment of the following form:

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -37,7 +37,7 @@ message ProtoComputeCommand {
     }
 
     message ProtoCreateTimely {
-        ProtoCommunicationConfig comm_config = 1;
+        ProtoTimelyConfig config = 1;
         ProtoComputeStartupEpoch epoch = 2;
     }
 
@@ -57,7 +57,7 @@ message ProtoComputeCommand {
     }
 }
 
-message ProtoCommunicationConfig {
+message ProtoTimelyConfig {
     uint64 workers = 1;
     uint64 process = 2;
     repeated string addresses = 3;

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -61,6 +61,7 @@ message ProtoTimelyConfig {
     uint64 workers = 1;
     uint64 process = 2;
     repeated string addresses = 3;
+    uint32 idle_arrangement_merge_effort = 4;
 }
 
 message ProtoPeek {

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -56,8 +56,8 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.command.rs"));
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Create the timely runtime according to the supplied CommunicationConfig. Must be the first
-    /// command sent to a clusterd. This is the only command that is broadcasted by
-    /// ActiveReplication to all clusterd processes within a replica.
+    /// command sent to a clusterd. This is the only command that is broadcasted to all clusterd
+    /// processes within a replica.
     CreateTimely {
         config: TimelyConfig,
         epoch: ComputeStartupEpoch,
@@ -312,6 +312,10 @@ pub struct TimelyConfig {
     pub process: usize,
     /// Addresses of all processes
     pub addresses: Vec<String>,
+    /// The amount of effort to be spent on arrangement compaction during idle times.
+    ///
+    /// See [`differential_dataflow::Config::idle_merge_effort`].
+    pub idle_arrangement_merge_effort: u32,
 }
 
 impl RustType<ProtoTimelyConfig> for TimelyConfig {
@@ -320,6 +324,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             workers: self.workers.into_proto(),
             addresses: self.addresses.into_proto(),
             process: self.process.into_proto(),
+            idle_arrangement_merge_effort: self.idle_arrangement_merge_effort,
         }
     }
 
@@ -328,6 +333,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             process: proto.process.into_rust()?,
             workers: proto.workers.into_rust()?,
             addresses: proto.addresses.into_rust()?,
+            idle_arrangement_merge_effort: proto.idle_arrangement_merge_effort,
         })
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -163,6 +163,10 @@ pub enum ComputeControllerResponse<T> {
 pub struct ComputeReplicaConfig {
     pub location: ComputeReplicaLocation,
     pub logging: ComputeReplicaLogging,
+    /// The amount of effort to be spent on arrangement compaction during idle times.
+    ///
+    /// See [`differential_dataflow::Config::idle_merge_effort`].
+    pub idle_arrangement_merge_effort: Option<u32>,
 }
 
 /// Size or location of a replica

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -68,7 +68,7 @@ use self::error::{
 };
 use self::instance::{ActiveInstance, Instance};
 use self::orchestrator::ComputeOrchestrator;
-use self::replica::ReplicaResponse;
+use self::replica::{ReplicaConfig, ReplicaResponse};
 
 mod instance;
 mod orchestrator;
@@ -557,6 +557,10 @@ impl<T> ActiveComputeController<'_, T> {
     }
 }
 
+/// Default value for `idle_arrangement_merge_effort` if none is supplied.
+// TODO(#16906): Test if 1000 is a good default.
+const DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: u32 = 1000;
+
 impl<T> ActiveComputeController<'_, T>
 where
     T: Timestamp + Lattice,
@@ -585,16 +589,24 @@ where
             sink_logs.insert(variant, (id, storage_meta));
         }
 
-        let logging_config = LoggingConfig {
-            interval,
-            enable_logging,
-            log_logging: config.logging.log_logging,
-            index_logs: Default::default(),
-            sink_logs,
+        let idle_arrangement_merge_effort = config
+            .idle_arrangement_merge_effort
+            .unwrap_or(DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT);
+
+        let replica_config = ReplicaConfig {
+            location: config.location,
+            logging: LoggingConfig {
+                interval,
+                enable_logging,
+                log_logging: config.logging.log_logging,
+                index_logs: Default::default(),
+                sink_logs,
+            },
+            idle_arrangement_merge_effort,
         };
 
         self.instance(instance_id)?
-            .add_replica(replica_id, config.location, logging_config)?;
+            .add_replica(replica_id, replica_config)?;
         Ok(())
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -194,7 +194,7 @@ where
         };
 
         instance.send(ComputeCommand::CreateTimely {
-            comm_config: Default::default(),
+            config: Default::default(),
             epoch: ComputeStartupEpoch::new(envd_epoch, 0),
         });
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -29,7 +29,7 @@ use mz_storage_client::controller::{ReadPolicy, StorageController};
 use crate::command::{
     ComputeCommand, ComputeCommandHistory, ComputeParameter, ComputeStartupEpoch, Peek,
 };
-use crate::logging::{LogVariant, LoggingConfig};
+use crate::logging::LogVariant;
 use crate::response::{ComputeResponse, PeekResponse, SubscribeBatch, SubscribeResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 use crate::types::dataflows::DataflowDescription;
@@ -38,7 +38,7 @@ use crate::types::sources::SourceInstanceDesc;
 
 use super::error::CollectionMissing;
 use super::orchestrator::ComputeOrchestrator;
-use super::replica::{Replica, ReplicaResponse};
+use super::replica::{Replica, ReplicaConfig, ReplicaResponse};
 use super::{
     CollectionState, ComputeControllerResponse, ComputeInstanceId, ComputeReplicaLocation,
     ReplicaId,
@@ -293,22 +293,21 @@ where
     pub fn add_replica(
         &mut self,
         id: ReplicaId,
-        location: ComputeReplicaLocation,
-        mut logging_config: LoggingConfig,
+        mut config: ReplicaConfig,
     ) -> Result<(), ReplicaExists> {
         if self.compute.replicas.contains_key(&id) {
             return Err(ReplicaExists(id));
         }
 
         // Initialize state for per-replica log collections.
-        for (log_id, _) in logging_config.sink_logs.values() {
+        for (log_id, _) in config.logging.sink_logs.values() {
             self.compute
                 .collections
                 .insert(*log_id, CollectionState::new_log_collection());
         }
 
-        logging_config.index_logs = self.compute.arranged_logs.clone();
-        let maintained_logs: BTreeSet<_> = logging_config.log_identifiers().collect();
+        config.logging.index_logs = self.compute.arranged_logs.clone();
+        let maintained_logs: BTreeSet<_> = config.logging.log_identifiers().collect();
 
         // Initialize frontier tracking for the new replica
         // and clean up any dropped collections that we can
@@ -330,8 +329,7 @@ where
             id,
             self.compute.instance_id,
             self.compute.build_info,
-            location,
-            logging_config,
+            config,
             self.compute.orchestrator.clone(),
             ComputeStartupEpoch::new(self.compute.envd_epoch, *replica_epoch),
         );
@@ -372,7 +370,10 @@ where
         // If the replica is managed we have to remove it from the orchestrator. We spawn
         // a background task that waits until the termination of the message handler task and
         // then removes it from the orchestrator.
-        if matches!(replica.location, ComputeReplicaLocation::Managed { .. }) {
+        if matches!(
+            replica.config.location,
+            ComputeReplicaLocation::Managed { .. }
+        ) {
             let replica_task = replica.replica_task.take().unwrap();
             let instance_id = self.compute.instance_id;
             let orchestrator = self.compute.orchestrator.clone();
@@ -433,10 +434,9 @@ where
     }
 
     fn rehydrate_replica(&mut self, id: ReplicaId) {
-        let location = self.compute.replicas[&id].location.clone();
-        let logging_config = self.compute.replicas[&id].logging_config.clone();
+        let config = self.compute.replicas[&id].config.clone();
         self.remove_replica_state(id);
-        let result = self.add_replica(id, location, logging_config);
+        let result = self.add_replica(id, config);
 
         match result {
             Ok(()) => (),

--- a/src/compute-client/src/controller/orchestrator.rs
+++ b/src/compute-client/src/controller/orchestrator.rs
@@ -21,7 +21,7 @@ use mz_orchestrator::{
     ServiceEvent, ServicePort, ServiceProcessMetrics,
 };
 
-use crate::command::CommunicationConfig;
+use crate::command::TimelyConfig;
 
 use super::{
     ComputeInstanceEvent, ComputeInstanceId, ComputeReplicaAllocation, ComputeReplicaLocation,
@@ -52,7 +52,7 @@ impl ComputeOrchestrator {
         instance_id: ComputeInstanceId,
         replica_id: ReplicaId,
         location: ComputeReplicaLocation,
-    ) -> Result<(Vec<String>, CommunicationConfig), anyhow::Error> {
+    ) -> Result<(Vec<String>, TimelyConfig), anyhow::Error> {
         match location {
             ComputeReplicaLocation::Remote {
                 addrs,
@@ -60,12 +60,12 @@ impl ComputeOrchestrator {
                 workers,
             } => {
                 let addrs = addrs.into_iter().collect();
-                let comm_config = CommunicationConfig {
+                let timely_config = TimelyConfig {
                     workers: workers.get(),
                     process: 0,
                     addresses: compute_addrs.into_iter().collect(),
                 };
-                Ok((addrs, comm_config))
+                Ok((addrs, timely_config))
             }
             ComputeReplicaLocation::Managed {
                 allocation,
@@ -77,14 +77,13 @@ impl ComputeOrchestrator {
                     .await?;
 
                 let addrs = service.addresses("computectl");
-                let comm_config = CommunicationConfig {
+                let timely_config = TimelyConfig {
                     workers: allocation.workers.get(),
                     process: 0,
                     addresses: service.addresses("compute"),
                 };
 
-                tracing::debug!("Obtained comm_config: {:?}", comm_config);
-                Ok((addrs, comm_config))
+                Ok((addrs, timely_config))
             }
         }
     }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -27,7 +27,7 @@ use mz_build_info::BuildInfo;
 use mz_ore::retry::Retry;
 use mz_service::client::GenericClient;
 
-use crate::command::{CommunicationConfig, ComputeCommand, ComputeStartupEpoch};
+use crate::command::{ComputeCommand, ComputeStartupEpoch, TimelyConfig};
 use crate::logging::LoggingConfig;
 use crate::response::ComputeResponse;
 use crate::service::{ComputeClient, ComputeGrpcClient};
@@ -194,10 +194,10 @@ where
 
         let result = orchestrator
             .ensure_replica_location(instance_id, replica_id, location)
-            .and_then(|(addrs, comm_config)| {
+            .and_then(|(addrs, timely_config)| {
                 let cmd_spec = CommandSpecialization {
                     logging_config,
-                    comm_config,
+                    timely_config,
                     epoch,
                 };
                 let metrics = metrics_stream(orchestrator.clone(), instance_id, replica_id);
@@ -302,7 +302,7 @@ where
 
 struct CommandSpecialization {
     logging_config: LoggingConfig,
-    comm_config: CommunicationConfig,
+    timely_config: TimelyConfig,
     epoch: ComputeStartupEpoch,
 }
 
@@ -316,8 +316,8 @@ impl CommandSpecialization {
             *logging = self.logging_config.clone();
         }
 
-        if let ComputeCommand::CreateTimely { comm_config, epoch } = command {
-            *comm_config = self.comm_config.clone();
+        if let ComputeCommand::CreateTimely { config, epoch } = command {
+            *config = self.timely_config.clone();
             *epoch = self.epoch;
         }
     }

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -29,7 +29,7 @@ use mz_repr::{Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_service::grpc::{BidiProtoClient, ClientTransport, GrpcClient, GrpcServer, ResponseStream};
 
-use crate::command::{CommunicationConfig, ComputeCommand, ProtoComputeCommand};
+use crate::command::{ComputeCommand, ProtoComputeCommand, TimelyConfig};
 use crate::response::{
     ComputeResponse, PeekResponse, ProtoComputeResponse, SubscribeBatch, SubscribeResponse,
 };
@@ -188,13 +188,13 @@ where
     fn split_command(&mut self, command: ComputeCommand<T>) -> Vec<Option<ComputeCommand<T>>> {
         self.observe_command(&command);
         match command {
-            ComputeCommand::CreateTimely { comm_config, epoch } => (0..self.parts)
+            ComputeCommand::CreateTimely { config, epoch } => (0..self.parts)
                 .into_iter()
                 .map(|part| {
                     Some(ComputeCommand::CreateTimely {
-                        comm_config: CommunicationConfig {
+                        config: TimelyConfig {
                             process: part,
-                            ..comm_config.clone()
+                            ..config.clone()
                         },
                         epoch,
                     })

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -46,16 +46,16 @@ use timely::communication::allocator::zero_copy::initialize::initialize_networki
 use timely::communication::allocator::GenericBuilder;
 use tracing::{debug, info, warn};
 
-use mz_compute_client::command::{CommunicationConfig, ComputeStartupEpoch};
+use mz_compute_client::command::{ComputeStartupEpoch, TimelyConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::{Listener, Stream};
 
 /// Creates communication mesh from cluster config
 pub async fn initialize_networking(
-    config: &CommunicationConfig,
+    config: &TimelyConfig,
     epoch: ComputeStartupEpoch,
 ) -> Result<(Vec<GenericBuilder>, Box<dyn Any + Send>), anyhow::Error> {
-    let CommunicationConfig {
+    let TimelyConfig {
         workers,
         process,
         addresses,

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -32,8 +32,8 @@ use timely::WorkerConfig;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
-use mz_compute_client::command::{CommunicationConfig, ComputeStartupEpoch};
 use mz_compute_client::command::{ComputeCommand, ComputeCommandHistory};
+use mz_compute_client::command::{ComputeStartupEpoch, TimelyConfig};
 use mz_compute_client::metrics::ComputeMetrics;
 use mz_compute_client::response::ComputeResponse;
 use mz_compute_client::service::ComputeClient;
@@ -78,8 +78,8 @@ struct ClusterClient<C> {
 
 /// Metadata about timely workers in this process.
 pub struct TimelyContainer {
-    /// The current communication config in use
-    comm_config: CommunicationConfig,
+    /// The current timely config in use
+    config: TimelyConfig,
     /// Channels over which to send endpoints for wiring up a new Client
     client_txs: Vec<
         crossbeam_channel::Sender<(
@@ -143,20 +143,20 @@ impl ClusterClient<PartitionedClient> {
     }
 
     async fn build_timely(
-        comm_config: CommunicationConfig,
+        config: TimelyConfig,
         epoch: ComputeStartupEpoch,
         trace_metrics: TraceMetrics,
         compute_metrics: ComputeMetrics,
         persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
         tokio_executor: Handle,
     ) -> Result<TimelyContainer, Error> {
-        info!("Building timely container with config {comm_config:?}");
-        let (client_txs, client_rxs): (Vec<_>, Vec<_>) = (0..comm_config.workers)
+        info!("Building timely container with config {config:?}");
+        let (client_txs, client_rxs): (Vec<_>, Vec<_>) = (0..config.workers)
             .map(|_| crossbeam_channel::unbounded())
             .unzip();
         let client_rxs: Mutex<Vec<_>> = Mutex::new(client_rxs.into_iter().map(Some).collect());
 
-        let (builders, other) = initialize_networking(&comm_config, epoch).await?;
+        let (builders, other) = initialize_networking(&config, epoch).await?;
 
         let mut worker_config = WorkerConfig::default();
         differential_dataflow::configure(
@@ -166,7 +166,7 @@ impl ClusterClient<PartitionedClient> {
             },
         );
 
-        let workers = comm_config.workers;
+        let workers = config.workers;
         let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {
             let timely_worker_index = timely_worker.index();
             let _tokio_guard = tokio_executor.enter();
@@ -189,7 +189,7 @@ impl ClusterClient<PartitionedClient> {
         .map_err(|e| anyhow!("{e}"))?;
 
         Ok(TimelyContainer {
-            comm_config,
+            config,
             client_txs,
             _worker_guards: worker_guards,
         })
@@ -197,17 +197,16 @@ impl ClusterClient<PartitionedClient> {
 
     async fn build(
         &mut self,
-        comm_config: CommunicationConfig,
+        config: TimelyConfig,
         epoch: ComputeStartupEpoch,
     ) -> Result<(), Error> {
-        let workers = comm_config.workers;
+        let workers = config.workers;
 
         // Check if we can reuse the existing timely instance.
-        // We currently do not support reinstantiating timely, we simply panic
-        // if another communication config is requested. This
-        // code must panic before dropping the worker guards contained in timely_container.
-        // As we don't terminate timely workers, the thread join would hang forever, possibly
-        // creating a fair share of confusion in the orchestrator.
+        // We currently do not support reinstantiating timely, we simply panic if another config is
+        // requested. This code must panic before dropping the worker guards contained in
+        // timely_container. As we don't terminate timely workers, the thread join would hang
+        // forever, possibly creating a fair share of confusion in the orchestrator.
 
         let trace_metrics = self.trace_metrics.clone();
         let compute_metrics = self.compute_metrics.clone();
@@ -217,11 +216,11 @@ impl ClusterClient<PartitionedClient> {
         let mut timely_lock = self.timely_container.lock().await;
         let timely = match timely_lock.take() {
             Some(existing) => {
-                if comm_config != existing.comm_config {
+                if config != existing.config {
                     halt!(
                         "new timely configuration does not match existing timely configuration:\n{:?}\nvs\n{:?}",
-                        comm_config,
-                        existing.comm_config,
+                        config,
+                        existing.config,
                     );
                 }
                 info!("Timely already initialized; re-using.",);
@@ -229,7 +228,7 @@ impl ClusterClient<PartitionedClient> {
             }
             None => {
                 let build_timely_result = Self::build_timely(
-                    comm_config,
+                    config,
                     epoch,
                     trace_metrics,
                     compute_metrics,
@@ -293,9 +292,7 @@ impl GenericClient<ComputeCommand, ComputeResponse> for ClusterClient<Partitione
         // Changing this debug statement requires changing the replica-isolation test
         tracing::debug!("ClusterClient send={:?}", &cmd);
         match cmd {
-            ComputeCommand::CreateTimely { comm_config, epoch } => {
-                self.build(comm_config, epoch).await
-            }
+            ComputeCommand::CreateTimely { config, epoch } => self.build(config, epoch).await,
             _ => self.inner.as_mut().expect("intialized").send(cmd).await,
         }
     }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1185,7 +1185,7 @@ pub enum ReplicaOptionName {
     Remote,
     /// The `SIZE [[=] <size>]` option.
     Size,
-    /// The `AVAILABILITY ZONE [[=] <size>]` option.
+    /// The `AVAILABILITY ZONE [[=] <id>]` option.
     AvailabilityZone,
     /// The `WORKERS [[=] <workers>]` option
     Workers,
@@ -1195,6 +1195,8 @@ pub enum ReplicaOptionName {
     IntrospectionInterval,
     /// The `INTROSPECTION DEBUGGING [[=] <enabled>]` option.
     IntrospectionDebugging,
+    /// The `IDLE ARRANGEMENT MERGE EFFORT [=] <value>` option.
+    IdleArrangementMergeEffort,
 }
 
 impl AstDisplay for ReplicaOptionName {
@@ -1207,6 +1209,9 @@ impl AstDisplay for ReplicaOptionName {
             ReplicaOptionName::Compute => f.write_str("COMPUTE"),
             ReplicaOptionName::IntrospectionInterval => f.write_str("INTROSPECTION INTERVAL"),
             ReplicaOptionName::IntrospectionDebugging => f.write_str("INTROSPECTION DEBUGGING"),
+            ReplicaOptionName::IdleArrangementMergeEffort => {
+                f.write_str("IDLE ARRANGEMENT MERGE EFFORT")
+            }
         }
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -109,6 +109,7 @@ Distinct
 Dot
 Double
 Drop
+Effort
 Element
 Else
 Enable
@@ -153,6 +154,7 @@ Hour
 Hours
 Id
 Idempotence
+Idle
 If
 Ignore
 Ilike
@@ -200,6 +202,7 @@ Materialize
 Materialized
 Max
 Mechanisms
+Merge
 Message
 Metadata
 Minute

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3095,6 +3095,7 @@ impl<'a> Parser<'a> {
         let name = match self.expect_one_of_keywords(&[
             AVAILABILITY,
             COMPUTE,
+            IDLE,
             INTROSPECTION,
             REMOTE,
             SIZE,
@@ -3105,6 +3106,10 @@ impl<'a> Parser<'a> {
                 ReplicaOptionName::AvailabilityZone
             }
             COMPUTE => ReplicaOptionName::Compute,
+            IDLE => {
+                self.expect_keywords(&[ARRANGEMENT, MERGE, EFFORT])?;
+                ReplicaOptionName::IdleArrangementMergeEffort
+            }
             INTROSPECTION => match self.expect_one_of_keywords(&[DEBUGGING, INTERVAL])? {
                 DEBUGGING => ReplicaOptionName::IntrospectionDebugging,
                 INTERVAL => ReplicaOptionName::IntrospectionInterval,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1037,6 +1037,13 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), INTROSPECTION INTERVAL =
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(String("1s"))) }, ReplicaOption { name: IntrospectionDebugging, value: Some(Value(Boolean(true))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Number("0"))) }] }])) }] })
 
 parse-statement
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE '1', IDLE ARRANGEMENT MERGE EFFORT 0))
+----
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), IDLE ARRANGEMENT MERGE EFFORT = 100), b (SIZE = '1', IDLE ARRANGEMENT MERGE EFFORT = 0))
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [ClusterOption { name: Replicas, value: Some(ClusterReplicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("100"))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }, ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("0"))) }] }])) }] })
+
+parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE = ('host1'), SIZE = '1'))
@@ -1119,6 +1126,20 @@ CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], INTROSPECTION INTERVAL 
 CREATE CLUSTER REPLICA default.replica REMOTE = ('host1'), INTROSPECTION INTERVAL = NULL
 =>
 CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IntrospectionInterval, value: Some(Value(Null)) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], IDLE ARRANGEMENT MERGE EFFORT = 100
+----
+CREATE CLUSTER REPLICA default.replica REMOTE = ('host1'), IDLE ARRANGEMENT MERGE EFFORT = 100
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("100"))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], IDLE ARRANGEMENT MERGE EFFORT 0
+----
+CREATE CLUSTER REPLICA default.replica REMOTE = ('host1'), IDLE ARRANGEMENT MERGE EFFORT = 0
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Sequence([Value(String("host1"))])) }, ReplicaOption { name: IdleArrangementMergeEffort, value: Some(Value(Number("0"))) }] } })
 
 parse-statement
 DROP CLUSTER cluster

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -277,28 +277,43 @@ pub enum ComputeReplicaConfig {
         compute_addrs: BTreeSet<String>,
         workers: NonZeroUsize,
         introspection: Option<ComputeReplicaIntrospectionConfig>,
+        idle_arrangement_merge_effort: Option<u32>,
     },
     Managed {
         size: String,
         availability_zone: Option<String>,
         introspection: Option<ComputeReplicaIntrospectionConfig>,
+        idle_arrangement_merge_effort: Option<u32>,
     },
 }
 
 impl ComputeReplicaConfig {
     pub fn get_az(&self) -> Option<&str> {
         match self {
-            ComputeReplicaConfig::Remote {
-                addrs: _,
-                compute_addrs: _,
-                workers: _,
-                introspection: _,
-            } => None,
+            ComputeReplicaConfig::Remote { .. } => None,
             ComputeReplicaConfig::Managed {
-                size: _,
-                availability_zone,
-                introspection: _,
+                availability_zone, ..
             } => availability_zone.as_deref(),
+        }
+    }
+
+    pub fn get_introspection(&self) -> Option<&ComputeReplicaIntrospectionConfig> {
+        match self {
+            ComputeReplicaConfig::Remote { introspection, .. } => introspection.as_ref(),
+            ComputeReplicaConfig::Managed { introspection, .. } => introspection.as_ref(),
+        }
+    }
+
+    pub fn get_idle_arrangement_merge_effort(&self) -> Option<u32> {
+        match self {
+            ComputeReplicaConfig::Remote {
+                idle_arrangement_merge_effort,
+                ..
+            } => *idle_arrangement_merge_effort,
+            ComputeReplicaConfig::Managed {
+                idle_arrangement_merge_effort,
+                ..
+            } => *idle_arrangement_merge_effort,
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2470,7 +2470,8 @@ generate_extracted_config!(
     (Compute, Vec<String>),
     (Workers, u16),
     (IntrospectionInterval, OptionalInterval),
-    (IntrospectionDebugging, bool, Default(false))
+    (IntrospectionDebugging, bool, Default(false)),
+    (IdleArrangementMergeEffort, u32)
 );
 
 fn plan_replica_config(
@@ -2485,6 +2486,7 @@ fn plan_replica_config(
         compute,
         introspection_interval,
         introspection_debugging,
+        idle_arrangement_merge_effort,
         ..
     }: ReplicaOptionExtracted = options.try_into()?;
 
@@ -2537,6 +2539,7 @@ fn plan_replica_config(
                 compute_addrs,
                 workers,
                 introspection,
+                idle_arrangement_merge_effort,
             })
         }
         (Some(size), None) => {
@@ -2551,6 +2554,7 @@ fn plan_replica_config(
                 size,
                 availability_zone,
                 introspection,
+                idle_arrangement_merge_effort,
             })
         }
         (_, _) => {

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -317,6 +317,26 @@ impl ImpliedValue for u16 {
     }
 }
 
+impl TryFromValue<Value> for u32 {
+    fn try_from_value(v: Value) -> Result<Self, PlanError> {
+        match v {
+            Value::Number(v) => v
+                .parse::<u32>()
+                .map_err(|e| sql_err!("invalid numeric value: {e}")),
+            _ => sql_bail!("cannot use value as number"),
+        }
+    }
+    fn name() -> String {
+        "uint4".to_string()
+    }
+}
+
+impl ImpliedValue for u32 {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide an integer value")
+    }
+}
+
 impl TryFromValue<Value> for u64 {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         match v {

--- a/test/testdrive/idle_arrangement_merge_effort.td
+++ b/test/testdrive/idle_arrangement_merge_effort.td
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that specifying an idle arrangement merge effort has an effect.
+#
+# The idea is to create an arrangement with some records in it, then send retractions for all those
+# records and watch what happens. Without further updates arriving at the arrangement, its batches
+# should only be merged if a positive idle merge effort is configured.
+
+> CREATE CLUSTER test REPLICAS (
+    eager (SIZE '1', IDLE ARRANGEMENT MERGE EFFORT = 100),
+    lazy (SIZE '1', IDLE ARRANGEMENT MERGE EFFORT = 0)
+  )
+> SET cluster = test
+
+# Create the arrangement used in this test.
+# Set the minimal compaction window, to ensure the most aggressive compaction.
+> CREATE TABLE t (a int)
+> CREATE DEFAULT INDEX ON t WITH (LOGICAL COMPACTION WINDOW = '1ms')
+
+# Fill the arrangement with some records.
+> INSERT INTO t SELECT generate_series(1, 100)
+
+# Retract all the records from the arrangement.
+> DELETE FROM t
+
+# This is subtle: DD's idle_merge_effort is only applied to in-progress merges of batches, but
+# doesn't itself cause new merges to start. Thus, we need to send another update to trigger a batch
+# merge in the arrangement. We only insert a single record, which is not enough to complete a full
+# merge of the relatively larger batches (unless we exert idle merge effort).
+> INSERT INTO t VALUES (1)
+
+# The arrangement should now be compacted on the eager replica, but not on the lazy one.
+
+> SET cluster_replica = eager
+> SELECT records, batches FROM mz_internal.mz_arrangement_sizes
+records  batches
+----------------
+1        1
+
+> SET cluster_replica = lazy
+> SELECT records, batches FROM mz_internal.mz_arrangement_sizes
+records  batches
+----------------
+201      4
+
+# Clean up.
+> DROP CLUSTER test CASCADE


### PR DESCRIPTION
This PR adds an `IDLE ARRANGEMENT MERGE EFFORT` option to the `CREATE CLUSTER REPLICA` statement, to enable changing the default value of the [`idle_merge_effort`] configuration passed to differential dataflow.

[`idle_merge_effort`]: https://docs.rs/differential-dataflow/latest/differential_dataflow/struct.Config.html#structfield.idle_merge_effort

### Motivation

  * This PR adds a known-desirable feature.

Implements #16794.

(I'll open a separate PR to update the user docs.)

### Tips for reviewer

I separated the work into sensible commits:
* Commit 1: Makes the necessary changes to SQL parsing, planning and the catalog.
* Commit 2: Renames the `CommunicationConfig` type to `TimelyConfig`, in anticipation of the first non-communication config field.
* Commit 3: Implements the rest of the plumbing inside compute.
* Commit 4: Adds a testdrive test.

Surfaces folk will be interested in commits 1 and 4, Compute folk will be interested in commits 2, 3, and 4.

Note that this PR includes a change to the catalog format, but it only adds an optional field and our deserialization is smart enough to fill in `None` for missing optional fields. ~~So I don't believe there is a migration necessary, and I've tested locally that the upgrade works, but let me know if I missed something.~~ Added one now anyway, to test our migration machinery.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add a new `IDLE ARRANGEMENT MERGE EFFORT` option to the `CREATE CLUSTER REPLICA` statement, to enable configuring the amount of effort a replica exerts on compacting arrangements during idle periods.
