### PR TITLE
Re-enable coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ junit_*.xml
 perf.data*
 **/*.rej
 **/*.orig
+**/*.profraw
+**/*.profdata
 
 # This is un-orthodox, but adding it to the repo would "tie" it to each users
 # local version of nixpkgs. This way, we can all use the flake and have a

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -60,7 +60,7 @@ arch_go=$(arch_go "$arch_gcc")
 
 cid_file=ci/builder/.${channel%%-*}.cidfile
 
-rust_components=rustc,cargo,rust-std-$arch_gcc-unknown-linux-gnu
+rust_components=rustc,cargo,rust-std-$arch_gcc-unknown-linux-gnu,llvm-tools-preview
 if [[ $rust_version = nightly ]]; then
     rust_components+=,miri-preview
 else

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -158,7 +158,8 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version "=0.9.44" cargo-nextest \
     && `: Until https://github.com/est31/cargo-udeps/pull/147 is released in cargo-udeps` \
     && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked  cargo-udeps --features=vendored-openssl \
-    && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache
+    && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
+    && cargo install --root /usr/local --version "=0.3.6" cargo-binutils
 
 # Link the system lld into the cross-compiling sysroot.
 

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -97,10 +97,10 @@ steps:
   - id: coverage
     label: Code coverage
     timeout_in_minutes: 240
-    command: bin/ci-builder run nightly bin/pyactivate -m ci.nightly.coverage
+    command: bin/ci-builder run stable bin/pyactivate -m ci.nightly.coverage
+    artifact_paths: coverage-*.json
     agents:
       queue: linux-x86_64
-    skip: Disabled due to persistent OOMs when linking
 
   - id: kafka-matrix
     label: Kafka smoke test against previous Kafka versions

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -114,6 +114,11 @@ def main() -> int:
         help="Disables the limited codesigning we do on macOS to support Instruments",
         action="store_true",
     )
+    parser.add_argument(
+        "--coverage",
+        help="Build with coverage",
+        action="store_true",
+    )
     args = parser.parse_intermixed_args()
 
     # Handle `+toolchain` like rustup.
@@ -262,6 +267,8 @@ def _build(args: argparse.Namespace, extra_programs: list[str] = []) -> int:
     if args.tokio_console:
         features += ["tokio-console"]
         env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " --cfg=tokio_unstable"
+    if args.coverage:
+        env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " -Cinstrument-coverage"
     if args.features:
         features.extend(args.features.split(","))
     if features:

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -231,14 +231,8 @@ class CargoBuild(CargoPreImage):
         self.channel = None
         if rd.coverage:
             self.rustflags += [
-                "-Zinstrument-coverage",
-                # Nix generates some unresolved symbols that -Zinstrument-coverage
-                # somehow causes the linker to complain about, so just disable
-                # warnings about unresolved symbols and hope it all works out.
-                # See: https://github.com/nix-rust/nix/issues/1116
-                "-Clink-arg=-Wl,--warn-unresolved-symbols",
+                "-Cinstrument-coverage",
             ]
-            self.channel = "nightly"
         if len(self.bins) == 0 and len(self.examples) == 0:
             raise ValueError("mzbuild config is missing pre-build target")
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -185,16 +185,19 @@ class Composition:
             if "allow_host_ports" in config:
                 config.pop("allow_host_ports")
 
-            if self.repo.rd.coverage:
+            coverage_volume = "./coverage:/coverage"
+            if self.repo.rd.coverage and coverage_volume not in config.get(
+                "volumes", []
+            ):
                 # Emit coverage information to a file in a directory that is
                 # bind-mounted to the "coverage" directory on the host. We
                 # inject the configuration to all services for simplicity, but
                 # this only have an effect if the service runs instrumented Rust
                 # binaries.
+                config.setdefault("volumes", []).append(coverage_volume)
                 config.setdefault("environment", []).append(
                     f"LLVM_PROFILE_FILE=/coverage/{name}-%m.profraw"
                 )
-                config.setdefault("volumes", []).append("./coverage:/coverage")
 
         # Determine mzbuild specs and inject them into services accordingly.
         deps = self.repo.resolve_dependencies(images)

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -196,7 +196,7 @@ class Composition:
                 # binaries.
                 config.setdefault("volumes", []).append(coverage_volume)
                 config.setdefault("environment", []).append(
-                    f"LLVM_PROFILE_FILE=/coverage/{name}-%m.profraw"
+                    f"LLVM_PROFILE_FILE=/coverage/{name}-%p-%9m.profraw"
                 )
 
         # Determine mzbuild specs and inject them into services accordingly.


### PR DESCRIPTION
This has been languishing for a bit, and the "hard part" is figuring out exactly what llvm-cov invocations we want to best present the information, what tests should run in nightly to get useful coverage information, and so on.  So I'm going to punt on these bits and aim to get the rest merged, which enables using mzcompose with --coverage and does demonstrate adding the fast sqllogictests with coverage to nightly, which is useful as a starting point to experiment with that coverage data.  We can iterate on the rest.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

 * This PR adds a known-desirable feature, see #16511.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
