### PR TITLE
storage,compute: simplify thread/operator activation by relying on async activation

### DIFF
--- a/src/service/src/local.rs
+++ b/src/service/src/local.rs
@@ -10,56 +10,33 @@
 //! Process-local transport for the [client](crate::client) module.
 
 use std::fmt;
-use std::thread::Thread;
 
 use async_trait::async_trait;
-use crossbeam_channel::Sender;
 use itertools::Itertools;
-use timely::scheduling::SyncActivator;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::client::{GenericClient, Partitionable, Partitioned};
-
-pub trait Activatable {
-    fn activate(&self);
-}
-
-impl Activatable for SyncActivator {
-    fn activate(&self) {
-        self.activate().unwrap()
-    }
-}
-
-impl Activatable for Thread {
-    fn activate(&self) {
-        self.unpark()
-    }
-}
 
 /// A client to a thread in the same process.
 ///
 /// The thread is unparked on every call to [`send`](LocalClient::send) and on
 /// `Drop`.
 #[derive(Debug)]
-pub struct LocalClient<C, R, A: Activatable> {
+pub struct LocalClient<C, R> {
     rx: UnboundedReceiver<R>,
-    tx: Sender<C>,
-    tx_activator: A,
+    tx: UnboundedSender<C>,
 }
 
 #[async_trait]
-impl<C, R, A> GenericClient<C, R> for LocalClient<C, R, A>
+impl<C, R> GenericClient<C, R> for LocalClient<C, R>
 where
     C: fmt::Debug + Send,
     R: fmt::Debug + Send,
-    A: fmt::Debug + Activatable + Send,
 {
     async fn send(&mut self, cmd: C) -> Result<(), anyhow::Error> {
         self.tx
             .send(cmd)
             .expect("worker command receiver should not drop first");
-
-        self.tx_activator.activate();
 
         Ok(())
     }
@@ -69,21 +46,16 @@ where
     }
 }
 
-impl<C, R, A: Activatable> LocalClient<C, R, A> {
+impl<C, R> LocalClient<C, R> {
     /// Create a new instance of [`LocalClient`] from its parts.
-    pub fn new(rx: UnboundedReceiver<R>, tx: Sender<C>, tx_activator: A) -> Self {
-        Self {
-            rx,
-            tx,
-            tx_activator,
-        }
+    pub fn new(rx: UnboundedReceiver<R>, tx: UnboundedSender<C>) -> Self {
+        Self { rx, tx }
     }
 
     /// Create a new partitioned local client from parts for each client.
     pub fn new_partitioned(
         rxs: Vec<UnboundedReceiver<R>>,
-        txs: Vec<Sender<C>>,
-        tx_activators: Vec<A>,
+        txs: Vec<UnboundedSender<C>>,
     ) -> Partitioned<Self, C, R>
     where
         (C, R): Partitionable<C, R>,
@@ -91,8 +63,7 @@ impl<C, R, A: Activatable> LocalClient<C, R, A> {
         let clients = rxs
             .into_iter()
             .zip_eq(txs)
-            .zip_eq(tx_activators)
-            .map(|((rx, tx), tx_activator)| LocalClient::new(rx, tx, tx_activator))
+            .map(|(rx, tx)| LocalClient::new(rx, tx))
             .collect();
         Partitioned::new(clients)
     }
@@ -100,13 +71,10 @@ impl<C, R, A: Activatable> LocalClient<C, R, A> {
 
 // We implement `Drop` so that we can wake each of the threads and have them
 // notice the drop.
-impl<C, R, A: Activatable> Drop for LocalClient<C, R, A> {
+impl<C, R> Drop for LocalClient<C, R> {
     fn drop(&mut self) {
         // Drop the thread handle.
-        let (tx, _rx) = crossbeam_channel::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         self.tx = tx;
-        // Unpark the thread once the handle is dropped, so that it can observe
-        // the emptiness.
-        self.tx_activator.activate();
     }
 }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -407,7 +407,11 @@ where
     fn split_command(&mut self, command: StorageCommand<T>) -> Vec<Option<StorageCommand<T>>> {
         self.observe_command(&command);
 
-        vec![Some(command); usize::cast_from(self.parts)]
+        // Only send command to the first worker, which distributes it within
+        // the replica/timely cluster.
+        let mut res = vec![None; usize::cast_from(self.parts)];
+        res[0] = Some(command);
+        res
     }
 
     fn absorb_response(


### PR DESCRIPTION
Before, we were handing around Activators, so that we can activate
either the receiving thread or operator when sending compute/storage
commands.

Now, we use a tokio channel and use an async operator as the command
pump. This gives us activation of the timely operator "for free" and we
can get rid of the manual activators.

This requires that storage also adopt an internal control
dataflow/fabric for pumping commands, which in turns makes the
reconciliation logic a tiny smidge more complicated. We want to move in
this direction anyways, for supporting the distribution of internal
storage commands.

The motivation for this refactoring is that I want to add a way of
distributing replica-internal (internal to the timely cluster) commands,
for example for suspending and restarting a dataflow. One approach for
this would be to distribute commands using a timely-internal fabric,
similar to what this PR does. The subtle part is that we have to make
sure that the interleaving of internal and controller-issued commands is
the same on all workers, so they have to go through the same command
dataflow. And it seemed easier to work with tokio/async channels
compared to using "regular" channels and manually passing around
Activators.

We can also do that change (the internal command dataflow) without this
refactoring, it will just require more code around handling Activators
and the operator code that reads from both channels (internal and
external commands) will likely be more complicated.

### Tips for reviewer

I came across this while working on https://github.com/MaterializeInc/materialize/pull/16875, where I have to sent both internal and external commands through the same internal dataflow/fabric.

I thought it's simpler to use async/tokio channels, because we don't have to pass around activators anymore, but I understand this is a sensitive part of the code base. So I'm happy to work around it and also use activators in my work on the storage-internal control flow. This is also why I included a rather large number of reviewers.

Refefences:
 - https://github.com/MaterializeInc/materialize/pull/16875: Draft PR that adds replica-internal commands to storage.
 - https://github.com/MaterializeInc/materialize/issues/16773: A comment where I explain why the interleaving of internal and external commands needs some care to get right.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
