### PR TITLE
sql: Use consistent col ordering for natural join

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2915,12 +2915,11 @@ fn plan_join(
             kind,
         )?,
         JoinConstraint::Natural => {
-            let left_column_names: HashSet<_> = left_scope.column_names().collect();
+            let left_column_names = left_scope.column_names();
             let right_column_names: HashSet<_> = right_scope.column_names().collect();
             let column_names: Vec<_> = left_column_names
-                .intersection(&right_column_names)
-                .into_iter()
-                .map(|n| (*n).clone())
+                .filter(|col| right_column_names.contains(col))
+                .cloned()
                 .collect();
             plan_using_constraint(
                 &column_names,

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -997,6 +997,6 @@ query error column "a" specified in USING clause does not exist in right table
 SELECT (SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (a)) FROM (SELECT 3 a) s3
 
 query II colnames
-SELECT * FROM l NATURAL JOIN l AS a
+SELECT * FROM l NATURAL JOIN l AS a LIMIT 0
 ----
 la  lb

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -995,3 +995,8 @@ SELECT (SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (c)) FROM (SELE
 # USING column missing from the right table only but existing in the outer scope.
 query error column "a" specified in USING clause does not exist in right table
 SELECT (SELECT * FROM (SELECT 1 a) s1 JOIN (SELECT 2 b) s2 USING (a)) FROM (SELECT 3 a) s3
+
+query II colnames
+SELECT * FROM l NATURAL JOIN l AS a
+----
+la  lb


### PR DESCRIPTION
Previously we were iterating over a HashSet to determine the column order of natural joins, which resulted in a random column order. This commit fixes this issue by using a Vec for deterministic column order.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A