### PR TITLE
doc/user: Fix function indexing logic in docs

### DIFF
--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -27,7 +27,7 @@
     {{/*  Extract the function's name from its signature and use it as the ID
           to facilitate deeplinking. The `docsearch_l3` class is a special
           class that is scraped by our Algolia DocSearch configuration.  */}}
-    <td {{ if (ne ($.Get 0) .type "JSON") }} class="docsearch_l3" id="{{ index (split .signature "(") 0 | urlize }}" {{end}}>
+    <td {{ if (not (isset $.Params 0)) }} class="docsearch_l3" id="{{ index (split .signature "(") 0 | urlize }}" {{end}}>
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}


### PR DESCRIPTION
This makes a change in template logic to only render `class="docsearch_l3" id="urlized-function-name"` on materialize.com/docs/sql/functions/ and NOT on any of the other three pages that use the template:

materialize.com/docs/sql/types/list/
materialize.com/docs/sql/types/jsonb/
materialize.com/docs/sql/types/map/

**Change in user-facing behavior:** _(only after reindex in prod)_
1. Typing `log` in search should show a result for the log function and clicking it should take you to the sql/functions page with log row in table highlighted: https://materialize.com/docs/sql/functions/#log
2. Typing  `jsonb_array_elements_text` should show a result for https://materialize.com/docs/sql/types/jsonb/#jsonb_array_elements_text first
3. Clicking the docs links in [jsonb entries](https://materialize.com/docs/sql/functions/#json-func) on the sql/functions page should take you to the example section on the jsonb page (not the table at the top of the page).

**Why?** 

Every function is already rendered in tables on materialize.com/docs/sql/functions/ so indexing them on the types pages would cause duplicate entries in the index. Additionally, on the JSONB page, there are entire subsections dedicated to functions (like  https://materialize.com/docs/sql/types/jsonb/#jsonb_array_elements_text) that should take precedence.

The only way to evaluate that this is working is to deploy and reindex.

There might be a way to add a proper staging index in Algolia to allow us to test these changes before deploying to production, but it would require a change to the deploy script.

fixes #16912 