### PR TITLE
orchestrator-process: remove debugging println

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -305,7 +305,6 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                             // 100.0 * num_of_cores, this will be true whenever there
                             // are less than 2^53 / 10^9 logical cores, or about
                             // 9 million.
-                            println!("Usage is {}", process.cpu_usage());
                             let cpu = u64::try_cast_from(
                                 (f64::from(process.cpu_usage()) * 10_000_000.0).trunc(),
                             )


### PR DESCRIPTION
Remove a debugging println that was inadvertently merged in 650f40313.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
