### PR TITLE
sql: fix aliasing of output of NATURAL joins

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2622,16 +2622,52 @@ fn plan_table_alias(mut scope: Scope, alias: Option<&TableAlias>) -> Result<Scop
 
         let table_name = normalize::ident(name.to_owned());
         for (i, item) in scope.items.iter_mut().enumerate() {
-            let column_name = columns
+            item.table_name = if item.allow_unqualified_references {
+                Some(PartialObjectName {
+                    database: None,
+                    schema: None,
+                    item: table_name.clone(),
+                })
+            } else {
+                // Columns that prohibit unqualified references are special
+                // columns from the output of a NATURAL or USING join that can
+                // only be referenced by their full, pre-join name. Applying an
+                // alias to the output of that join renders those columns
+                // inaccessible, which we accomplish here by setting the
+                // table name to `None`.
+                //
+                // Concretely, consider:
+                //
+                //      CREATE TABLE t1 (a int);
+                //      CREATE TABLE t2 (a int);
+                //  (1) SELECT ... FROM (t1 NATURAL JOIN t2);
+                //  (2) SELECT ... FROM (t1 NATURAL JOIN t2) AS t;
+                //
+                // In (1), the join has no alias. The underlying columns from
+                // either side of the join can be referenced as `t1.a` and
+                // `t2.a`, respectively, and the unqualified name `a` refers to
+                // a column whose value is `coalesce(t1.a, t2.a)`.
+                //
+                // In (2), the join is aliased as `t`. The columns from either
+                // side of the join (`t1.a` and `t2.a`) are inaccessible, and
+                // the coalesced column can be named as either `a` or `t.a`.
+                //
+                // We previously had a bug [0] that mishandled this subtle
+                // logic.
+                //
+                // NOTE(benesch): We could in theory choose to project away
+                // those inaccessible columns and drop them from the scope
+                // entirely, but that would require that this function also
+                // take and return the `HirRelationExpr` that is being aliased,
+                // which is a rather large refactor.
+                //
+                // [0]: https://github.com/MaterializeInc/materialize/issues/16920
+                None
+            };
+            item.column_name = columns
                 .get(i)
                 .map(|a| normalize::column_name(a.clone()))
                 .unwrap_or_else(|| item.column_name.clone());
-            item.table_name = Some(PartialObjectName {
-                database: None,
-                schema: None,
-                item: table_name.clone(),
-            });
-            item.column_name = column_name;
         }
     }
     Ok(scope)

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -45,6 +45,11 @@ query I
 SELECT t2.a FROM t1 NATURAL JOIN t2
 ----
 
+# Regression test for #16920.
+query I
+SELECT t.a FROM (t1 NATURAL JOIN t2) t
+----
+
 # Test sources with unnamed columns.
 
 statement ok

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -45,9 +45,13 @@ query I
 SELECT t2.a FROM t1 NATURAL JOIN t2
 ----
 
-# Regression test for #16920.
+# Regression tests for #16920.
 query I
 SELECT t.a FROM (t1 NATURAL JOIN t2) t
+----
+
+query I
+SELECT t.a FROM (t1 JOIN t2 USING (a)) t
 ----
 
 # Test sources with unnamed columns.


### PR DESCRIPTION
Given the following two tables:

    CREATE TABLE t1 (a int);
    CREATE TABLE t2 (a int);

Materialize was incorrectly producing an error with this query:

    SELECT y.a FROM (t1 NATURAL JOIN t2) AS y;
    ERROR:  table reference "y" is ambiguous

The above query is meant to be equivalent to the following query, which Materialize does correctly handle:

    SELECT a FROM (t1 NATURAL JOIN t2);

The bug was the result of the special handling of output join columns in NATURAL/USING joins. When the output is unaliased, the input columns remain available (in this example, as `t1.a` and `t2.a`). But when the output is aliased, those input columns become unnamable. Materialize was handling this correctly for `*` expansion, but not alias application.

Fix #16920.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

@jkosh44 I couldn't reproduce the panic you mentioned on Slack with the original patch. But I didn't run SLT locally in full, so there's a chance this panics in CI.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - (Needs wordsmithing.) Fix a bug where aliasing the output of a `NATURAL` or `USING` join and then referring to one of the joined columns by qualified reference would incorrectly produce a "table is ambiguous" error.
