### PR TITLE
adapter: implement mz_internal.mz_dependencies

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1289,6 +1289,14 @@ pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable 
         .with_column("sink_progress_topic", ScalarType::String.nullable(false)),
     is_retained_metrics_relation: false,
 });
+pub static MZ_OBJECT_DEPENDENCIES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_object_dependencies",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("object_id", ScalarType::String.nullable(false))
+        .with_column("referenced_object_id", ScalarType::String.nullable(false)),
+    is_retained_metrics_relation: false,
+});
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_databases",
     schema: MZ_CATALOG_SCHEMA,
@@ -2994,6 +3002,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_VIEW_FOREIGN_KEYS),
         Builtin::Table(&MZ_KAFKA_SINKS),
         Builtin::Table(&MZ_KAFKA_CONNECTIONS),
+        Builtin::Table(&MZ_OBJECT_DEPENDENCIES),
         Builtin::Table(&MZ_DATABASES),
         Builtin::Table(&MZ_SCHEMAS),
         Builtin::Table(&MZ_COLUMNS),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -37,9 +37,9 @@ use crate::catalog::builtin::{
     MZ_CLUSTER_REPLICA_FRONTIERS, MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_METRICS,
     MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS, MZ_DATABASES, MZ_EGRESS_IPS,
     MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS,
-    MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS,
-    MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD,
-    MZ_TABLES, MZ_TYPES, MZ_VIEWS,
+    MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS, MZ_OBJECT_DEPENDENCIES, MZ_PSEUDO_TYPES,
+    MZ_ROLES, MZ_SCHEMAS, MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS,
+    MZ_STORAGE_USAGE_BY_SHARD, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
     CatalogItem, CatalogState, Connection, Database, Error, ErrorKind, Func, Index,
@@ -63,6 +63,22 @@ pub struct BuiltinTableUpdate {
 }
 
 impl CatalogState {
+    pub(super) fn pack_depends_update(
+        &self,
+        depender: GlobalId,
+        dependee: GlobalId,
+        diff: Diff,
+    ) -> BuiltinTableUpdate {
+        BuiltinTableUpdate {
+            id: self.resolve_builtin_table(&MZ_OBJECT_DEPENDENCIES),
+            row: Row::pack_slice(&[
+                Datum::String(&depender.to_string()),
+                Datum::String(&dependee.to_string()),
+            ]),
+            diff,
+        }
+    }
+
     pub(super) fn pack_database_update(
         &self,
         database: &Database,

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -513,6 +513,10 @@ mz_message_counts_sent_internal_3
 SOURCE
 materialize
 mz_internal
+mz_object_dependencies
+BASE TABLE
+materialize
+mz_internal
 mz_peek_durations
 VIEW
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -537,6 +537,7 @@ mz_storage_host_sizes
 mz_storage_usage_by_shard
 mz_view_foreign_keys
 mz_view_keys
+mz_object_dependencies
 
 > SHOW VIEWS FROM mz_internal
 name
@@ -580,7 +581,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-37
+38
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/mz-depends.td
+++ b/test/testdrive/mz-depends.td
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test `mz_internal.mz_object_dependencies`.
+
+> CREATE SOURCE with_subsources FROM LOAD GENERATOR AUCTION FOR ALL TABLES;
+
+> SELECT
+  top_level_s.name as source,
+  s.name AS subsource
+  FROM mz_internal.mz_object_dependencies AS d
+  JOIN mz_sources AS s ON s.id = d.referenced_object_id
+  JOIN mz_sources AS top_level_s ON top_level_s.id = d.object_id
+  WHERE top_level_s.name = 'with_subsources';
+source          subsource
+-------------------------
+with_subsources accounts
+with_subsources auctions
+with_subsources bids
+with_subsources organizations
+with_subsources users
+
+# make sure dropping works
+> DROP SOURCE with_subsources CASCADE
+> SELECT
+  top_level_s.name as source,
+  s.name AS subsource
+  FROM mz_internal.mz_object_dependencies AS d
+  JOIN mz_sources AS s ON s.id = d.referenced_object_id
+  JOIN mz_sources AS top_level_s ON top_level_s.id = d.object_id
+  WHERE top_level_s.name = 'with_subsources';
+source          subsource
+-------------------------
+
+# Make sure other objects work as well.
+# TODO(guswynn): determine if we need to test all object types exhaustively
+> CREATE CONNECTION ssh_conn TO SSH TUNNEL (
+    HOST 'unused',
+    USER 'mz',
+    PORT 22
+  );
+> CREATE CONNECTION pg_conn TO POSTGRES (
+    HOST unused,
+    DATABASE unused,
+    USER unused,
+    SSH TUNNEL ssh_conn
+  );
+
+> SELECT
+  top_level_c.name as conn,
+  c.name AS dep_conn
+  FROM mz_internal.mz_object_dependencies AS d
+  JOIN mz_connections AS c ON c.id = d.referenced_object_id
+  JOIN mz_connections AS top_level_c ON top_level_c.id = d.object_id
+conn     dep_conn
+-----------------
+pg_conn ssh_conn


### PR DESCRIPTION
This pr adds `mz_internal.mz_depends`.

- It also adds a simple set of testdrive tests, as I felt it was unnecessary to test all `depends_on` users exhaustively.
- I don't know if it should be in `mz_internal`
- I opted to only mark deps for user objects, and skip system objects entirely. This may be the wrong choice

### Motivation

  * This PR adds a known-desirable feature.

Closes https://github.com/MaterializeInc/materialize/issues/12390

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add `mz_internal.mz_dependencies`
