### PR TITLE
sql: temporarily allow "mzcompose" pseudo cloud provider

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -29,7 +29,8 @@ DEFAULT_MZ_VOLUMES = [
     "tmp:/share/tmp",
 ]
 
-DEFAULT_MZ_ENVIRONMENT_ID = "docker-mzcompose-00000000-0000-0000-0000-000000000000-0"
+# TODO(benesch): change to `docker-mzcompose` once v0.39 ships.
+DEFAULT_MZ_ENVIRONMENT_ID = "mzcompose-test-00000000-0000-0000-0000-000000000000-0"
 
 
 class Materialized(Service):
@@ -79,10 +80,7 @@ class Materialized(Service):
             command.append("--orchestrator-process-secrets-directory=/mzdata/secrets")
 
         if not environment_id:
-            if is_old_version:
-                environment_id = "mzcompose-test-00000000-0000-0000-0000-000000000000-0"
-            else:
-                environment_id = DEFAULT_MZ_ENVIRONMENT_ID
+            environment_id = DEFAULT_MZ_ENVIRONMENT_ID
         command += [f"--environment-id={environment_id}"]
 
         if persist_blob_url:

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -685,6 +685,9 @@ pub enum CloudProvider {
     Local,
     /// A pseudo-provider value used by Docker.
     Docker,
+    /// A deprecated psuedo-provider value used by mzcompose.
+    // TODO(benesch): remove once v0.39 ships.
+    MzCompose,
     /// A pseudo-provider value used by cloudtest.
     Cloudtest,
     /// Amazon Web Services.
@@ -696,6 +699,7 @@ impl fmt::Display for CloudProvider {
         match self {
             CloudProvider::Local => f.write_str("local"),
             CloudProvider::Docker => f.write_str("docker"),
+            CloudProvider::MzCompose => f.write_str("mzcompose"),
             CloudProvider::Cloudtest => f.write_str("cloudtest"),
             CloudProvider::Aws => f.write_str("aws"),
         }
@@ -709,6 +713,7 @@ impl FromStr for CloudProvider {
         match s {
             "local" => Ok(CloudProvider::Local),
             "docker" => Ok(CloudProvider::Docker),
+            "mzcompose" => Ok(CloudProvider::MzCompose),
             "cloudtest" => Ok(CloudProvider::Cloudtest),
             "aws" => Ok(CloudProvider::Aws),
             _ => Err(InvalidCloudProviderError),


### PR DESCRIPTION
fbb31a61 attempted to replace the "mzcompose" pseudo cloud provider with a "docker" psuedo cloud provider. The motivation is to have a single cloud provider for use when running the Docker image directly, via `docker run` and when running via mzcompose.

Unfortunately, changing the environment ID conditionally based on the version of the Materialize in use breaks the upgrade tests (see #16902). So instead we'll need to do this over two releases. In the next release, we'll add support for the "docker" provider without removing support for the "mzcompose" provider; in the *following* release,  we'll remove support for the "mzcompose" provider.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
