### PR TITLE
mzcompose: Allow environmentd v0.38.0 to start

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -55,8 +55,8 @@ steps:
           - { value: checks-parallel-restart-redpanda }
           - { value: checks-upgrade-entire-mz }
           - { value: checks-upgrade-entire-mz-previous-version }
-          - { value: checks-upgrade-computed-first }
-          - { value: checks-upgrade-computed-last }
+          - { value: checks-upgrade-clusterd-compute-first }
+          - { value: checks-upgrade-clusterd-compute-last }
           - { value: cloudtest-upgrade }
           - { value: persist-maelstrom-single-node }
           - { value: persist-maelstrom-multi-node }

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -102,12 +102,16 @@ class StartClusterdCompute(MzcomposeAction):
 
         clusterd = Clusterd(name="clusterd_compute_1")
         if self.tag:
-            # TODO(benesch): remove this conditional once v0.38 ships.
-            if self.tag.startswith("v0.37"):
+            # TODO(benesch): remove this conditional once v0.39 ships.
+            if any(self.tag.startswith(version) for version in ["v0.37", "v0.38"]):
                 clusterd = Clusterd(
                     name="clusterd_compute_1",
                     image=f"materialize/computed:{self.tag}",
-                    options=["--controller-listen-addr=0.0.0.0:2101"],
+                    options=[
+                        "--controller-listen-addr=0.0.0.0:2101",
+                        "--secrets-reader=process",
+                        "--secrets-reader-process-dir=/mzdata/secrets",
+                    ],
                     storage_workers=None,
                 )
             else:

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -70,11 +70,12 @@ class Materialized(Service):
 
         command = ["--unsafe-mode"]
 
-        # TODO(benesch): remove this special case when v0.38 ships.
-        is_old_version = image is not None and (
-            image.endswith("v0.36.2") or image.endswith("v0.37.1")
-        )
-        if is_old_version:
+        # TODO(benesch): remove this special case when v0.39 ships.
+        # latest being 'v0.38.0' until then
+        if image is not None and any(
+            image.endswith(version)
+            for version in ["v0.36.2", "v0.37.1", "v0.38.0", "latest"]
+        ):
             persist_blob_url = "file:///mzdata/persist/blob"
             command.append("--orchestrator=process")
             command.append("--orchestrator-process-secrets-directory=/mzdata/secrets")


### PR DESCRIPTION
The change where --persist-blob-url is set in the entrypoint.sh did not make it into v0.38.0, so the variable needs to be set in services.py for that version.

### Motivation
  * This PR fixes a previously unreported bug.
The feature benchmark was failing with:

```
 error: The following required arguments were not provided:
feature-benchmark-materialized-1     |     --persist-blob-url <PERSIST_BLOB_URL>
```

when trying to run the "latest" version, that is, v0.38.0