### PR TITLE
testdrive: Fortify csv-sources.td

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -171,7 +171,7 @@ dollars,category
   FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM bad_text_csv
-contains:Decode error: Text: CSV error at record number 2: invalid UTF-8
+contains:invalid UTF-8
 
 # Declare a key constraint (PRIMARY KEY NOT ENFORCED)
 


### PR DESCRIPTION
In order to work around #16048, do not expect a specific record number in the error message. Instead, zero in on the part of the error message that is relevant to the test at hand.


### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI with 4 partitions was failing.