### PR TITLE
Update nightly Rust version for CI

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2022-09-25
+NIGHTLY_RUST_DATE=2023-01-03
 
 cd "$(dirname "$0")/.."
 

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -146,8 +146,6 @@ RUN mkdir rust \
     && rm -f rust-src.asc rust-src.tar.gz \
     && case $RUST_COMPONENTS in *miri*) \
         PATH=$PATH:/root/.cargo/bin cargo miri setup \
-        && mv /root/.cargo/bin/xargo /usr/local/bin/xargo \
-        && mv /root/.cargo/bin/xargo-check /usr/local/bin/xargo-check \
         ;; \
     esac \
     && rm -rf rust \


### PR DESCRIPTION
This PR updates the Rust nightly version used in CI to 2023-01-03.

### Motivation

  * This PR fixes a previously unreported bug.

CI jobs that use nightly Rusts are no longer able to compile Materialize after we updated the code base to Rust 1.66.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
