### PR TITLE
cloudtest: Run kind export kubeconfig as part of setup

### DIFF
--- a/test/cloudtest/setup
+++ b/test/cloudtest/setup
@@ -19,6 +19,11 @@ if ! kind get clusters | grep -q cloudtest; then
     run kind create cluster --name=cloudtest --config=misc/kind/cluster.yaml --wait=60s
 fi
 
+# Make sure a kubeconfig file is generated and placed in $KUBECONFIG
+# of the ci-builder container, as defined in its Dockerfile
+
+run kind export kubeconfig --name cloudtest
+
 for f in misc/kind/configmaps/*; do
     run kubectl --context=kind-cloudtest apply -f "$f"
 done


### PR DESCRIPTION
Run `kind export kubeconfig` as part of setup to ensure that the kubeconfig file is properly populated regardless of whether the cluster existed previously or was newly-created.

### Motivation

  * This PR fixes a previously unreported bug.
Cloudtest was failing because of a missing kubeconfig.
### Tips for reviewer


@benesch this line was present before your refactoring but was removed as part of it.

Apparently for some reason, it needs to run otherwise CI fails as follows:

```
Running plugin cloudtest command hook | 0s
-- | --
  | kind: Make sure kind is running... | 8s
  | $ kubectl --context=kind-cloudtest apply -f misc/kind/configmaps/coredns.yaml
  | W0104 11:01:15.574339      52 loader.go:221] Config not found: kubeconfig
```

In other words:
1. `kind get clusters` reports a cluster exists on the given CI machine
2. still, kubeconfig is not present on that same CI machine
I have no explanation for this except that buildkite may be cleaning up the home directory between runs.

