### PR TITLE
storage: various timestamp related changes

### DIFF
--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -11,12 +11,12 @@
 //! timestamps
 
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::sync::Arc;
 
 use anyhow::Context;
 use differential_dataflow::lattice::Lattice;
 use futures::{stream::LocalBoxStream, StreamExt};
-use mz_persist_client::error::UpperMismatch;
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp;
@@ -27,6 +27,7 @@ use mz_ore::halt;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::critical::SinceHandle;
+use mz_persist_client::error::UpperMismatch;
 use mz_persist_client::read::ListenEvent;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::PersistClient;
@@ -43,7 +44,7 @@ use crate::source::reclock::{ReclockBatch, ReclockError, ReclockFollower, Recloc
 impl<FromTime, IntoTime> ReclockFollower<FromTime, IntoTime>
 where
     FromTime: SourceTimestamp,
-    IntoTime: Timestamp + Lattice + TotalOrder,
+    IntoTime: Timestamp + Lattice + TotalOrder + Display,
 {
     pub fn reclock_compat<'a, M>(
         &'a self,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1270,6 +1270,12 @@ where
 
     let bytes_read_counter = base_metrics.bytes_read.clone();
 
+    // TODO(petrosagg): figure out what this operator's read requirements are. The code currently
+    // relies on the other handle that is present in the source operator to not over compact, which
+    // is currently true since it's driven by the resumption frontier. Nevertheless, we should fix
+    // this and reason locally instead of globally.
+    timestamper.compact(Antichain::new());
+
     let operator_name = format!("reclock({})", id);
     let mut reclock_op = OperatorBuilder::new(operator_name, scope.clone());
     let (mut reclocked_output, reclocked_stream) = reclock_op.new_output();

--- a/src/timely-util/src/antichain.rs
+++ b/src/timely-util/src/antichain.rs
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::{Display, Error, Formatter};
+
+use timely::progress::frontier::AntichainRef;
+
+pub trait AntichainExt {
+    type Pretty: Display;
+
+    fn pretty(&self) -> Self::Pretty;
+}
+
+impl<'a, T: Display> AntichainExt for AntichainRef<'a, T> {
+    type Pretty = FrontierPrinter<Self>;
+
+    fn pretty(&self) -> Self::Pretty {
+        FrontierPrinter(*self)
+    }
+}
+
+pub struct FrontierPrinter<F>(F);
+
+impl<'a, T: Display> Display for FrontierPrinter<AntichainRef<'a, T>> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.write_str("{")?;
+        let mut time_iter = self.0.iter();
+        if let Some(t) = time_iter.next() {
+            t.fmt(f)?;
+        }
+        for t in time_iter {
+            f.write_str(", ")?;
+            t.fmt(f)?;
+        }
+        f.write_str("}")?;
+        Ok(())
+    }
+}

--- a/src/timely-util/src/capture.rs
+++ b/src/timely-util/src/capture.rs
@@ -1,0 +1,27 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use timely::dataflow::operators::capture::{EventCore, EventPusherCore};
+use tokio::sync::mpsc::UnboundedSender;
+
+pub struct UnboundedTokioCapture<T, D>(pub UnboundedSender<EventCore<T, D>>);
+
+impl<T, D> EventPusherCore<T, D> for UnboundedTokioCapture<T, D> {
+    fn push(&mut self, event: EventCore<T, D>) {
+        // NOTE: An Err(x) result just means "data not accepted" most likely
+        //       because the receiver is gone. No need to panic.
+        let _ = self.0.send(event);
+    }
+}

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -83,6 +83,7 @@
 //! Utilities for working with Timely.
 
 pub mod activator;
+pub mod antichain;
 pub mod builder_async;
 pub mod event;
 pub mod operator;

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -85,6 +85,7 @@
 pub mod activator;
 pub mod antichain;
 pub mod builder_async;
+pub mod capture;
 pub mod event;
 pub mod operator;
 pub mod order;

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -20,7 +20,7 @@ use std::fmt;
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use timely::order::Product;
-use timely::progress::{PathSummary, Timestamp};
+use timely::progress::timestamp::{PathSummary, Refines, Timestamp};
 use timely::PartialOrder;
 
 /// A partially ordered timestamp that is partitioned by an arbitrary number of partitions
@@ -145,6 +145,16 @@ impl<P: Partition, T: Timestamp> Timestamp for Partitioned<P, T> {
     fn minimum() -> Self {
         Self(Timestamp::minimum())
     }
+}
+
+impl<P: Partition, T: Timestamp> Refines<()> for Partitioned<P, T> {
+    fn to_inner(_other: ()) -> Self {
+        Self::minimum()
+    }
+
+    fn to_outer(self) {}
+
+    fn summarize(_path: Self::Summary) {}
 }
 
 impl<P: Eq, T: PartialOrder> PartialOrder for Partitioned<P, T>

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -95,7 +95,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     random.seed(args.seed)
 
-    environment_extra = ["MZ_LOG_FILTER=warn"]
+    environment_extra = ["MZ_LOG_FILTER=info"]
     mz_options = [
         "--adapter-stash-url=postgres://root@cockroach:26257?options=--search_path=adapter",
         "--storage-stash-url=postgres://root@cockroach:26257?options=--search_path=storage",


### PR DESCRIPTION
### Motivation

This PR contains a few changes that I broke off from a bigger PR that are easy to review in isolation. The most complex change is the reclock commit whose commit description I reproduce here:


#### Reclock changes

This commit implements two changes in the ReclockFollower.

The first and simpler of the two is per-handle read holds so that each user of a `ReclockFollower` can independently compact the in-memory trace while having the trace be compaced that the minimum of all the handles.

The second one is removing explicit tracking of the source since frontier which was used to generate the `NotBeyondSince` error when reclocking. It turns out that this breaks a useful property of the reclock operator which is to commute with compaction. Specifically the property that breaks is that:

```
compact(reclock(collection, trace)) == reclock(collection, compact(trace))`
```

Beyond just fixing the property for purity's sake, there is also a practical aspect which is that it is incorrect to even attempt to filter source timestamps using the calculated `source_since` frontier. Imagine that we are reclocking this partial order:

```
  ,B---...
 /
A
 \
  `C---...
```

With the remap trace being:

```
(A, 0, +1)
(A, 1, -1)
(B, 1, +1)
(C, 1, +1)
... more bindings
```

Now suppose we compact the remap trace to `{1}`, which results in:

```
(B, 1, +1)
(C, 1, +1)
... more bindings
```

And we would naturally calculate the `source_since` to be `{B, C}`. If we use this frontier to reject reclock requests that are not beyond it, we have lost the ability to reclock events that happened at `A`!. And there is no other timestamp that events at `A` could have because advancing `A` by `{B, C}` yields just `A`. In other words, the code was incorrectly assuming that after compaction all timestamps are beyond the compaction frontier, which is not true.
### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
