### PR TITLE
ci-builder: mount the host kubeconfig

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -134,7 +134,7 @@ case "$cmd" in
         docker push materialize/ci-builder:"$cache_tag"
         ;;
     run)
-        mkdir -p target-xcompile
+        mkdir -p target-xcompile ~/.kube
         args=(
             --cidfile "$cid_file"
             --rm --interactive
@@ -158,6 +158,20 @@ case "$cmd" in
         done
         if [[ -t 1 ]]; then
             args+=(--tty)
+        fi
+        # Forward the host's Kubernetes config.
+        args+=(
+            # Need to forward the entire directory to allow creation and
+            # deletion of config.lock.
+            --volume "$HOME/.kube:/kube"
+            --env "KUBECONFIG=/kube/config"
+        )
+        # Forward the host's SSH agent, if available.
+        if [[ "${SSH_AUTH_SOCK:-}" ]]; then
+            args+=(
+                --volume "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock"
+                --env "SSH_AUTH_SOCK=/tmp/ssh-agent.sock"
+            )
         fi
         if [[ "$(uname -s)" = Linux ]]; then
             # Allow Docker-in-Docker by mounting the Docker socket in the
@@ -193,14 +207,6 @@ case "$cmd" in
             export DOCKER_HOST=${MZ_DEV_CI_BUILDER_DOCKER_HOST-${DOCKER_HOST-}}
             export DOCKER_TLS_VERIFY=${MZ_DEV_CI_BUILDER_DOCKER_TLS_VERIFY-${DOCKER_TLS_VERIFY-}}
             export DOCKER_CERT_PATH=${MZ_DEV_CI_BUILDER_DOCKER_CERT_PATH-${DOCKER_CERT_PATH-}}
-
-            # Forward the host's SSH agent, if available.
-            if [[ "${SSH_AUTH_SOCK:-}" ]]; then
-                args+=(
-                    --volume "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock"
-                    --env "SSH_AUTH_SOCK=/tmp/ssh-agent.sock"
-                )
-            fi
 
             # Forward the host's buildkite-agent binary, if available.
             if command -v buildkite-agent > /dev/null 2>&1; then


### PR DESCRIPTION
So that any kind clusters that are created outlive the ci-builder container that is used to create them.

Alternative to #16930.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
