### PR TITLE
ci-builder: remove KUBECONFIG from Dockerfile

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -243,10 +243,6 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnu-cc
 ENV CARGO_TARGET_DIR=/mnt/build
 ENV CARGO_INCREMENTAL=0
 
-# The kubeconfig file needs to be in the working directory so that it can be shared
-# across invocations of the container
-ENV KUBECONFIG=kubeconfig
-
 # Set a environment variable that tools can check to see if they're in the
 # builder or not.
 


### PR DESCRIPTION
We've switched to mounting the Kubernetes configuration from the host's home directory in #16934. This is more resilient than the old approach of storing the Kubernetes configuring in the current working directory, which did not persist across builds, just across mutiple invocations of the container in the same build.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR removes dead code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a