### PR TITLE
doc/user: document mz_dependencies

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -243,6 +243,16 @@ Field      | Type       | Meaning
 `index_id` | [`text`]   | The ID of the index the peek is targeting.
 `time`     | [`mz_timestamp`] | The timestamp the peek has requested.
 
+### `mz_object_dependencies`
+
+The `mz_object_dependencies` table describes the dependency structure between
+all database objects in the system.
+
+Field                  | Type       | Meaning
+-----------------------|------------|--------
+`object_id`            | [`text`]   | The ID of the dependent object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).
+`referenced_object_id` | [`text`]   | The ID of the referenced object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).
+
 ### `mz_raw_peek_durations`
 
 The `mz_raw_peek_durations` source describes a histogram of the duration in
@@ -547,6 +557,7 @@ Field         | Type                          | Meaning
 `status`      | [`text`]                      | The status of the sink: one of `created`, `starting`, `running`, `stalled`, `failed`, or `dropped`.
 `error`       | [`text`]                      | If the sink is in an error state, the error message.
 `details`     | [`jsonb`]                     | Additional metadata provided by the sink.
+
 
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list


### PR DESCRIPTION
Documenting: https://github.com/MaterializeInc/materialize/pull/16923

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add mz_internal.mz_dependencies`
