### PR TITLE
adapter: change audit log timestamp to use oracle

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -33,7 +33,7 @@ Field           | Type                         | Meaning
 `object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `connection`, `database`, `function`, `index`, `materialized-view`, `role`, `schema`, `secret`, `sink`, `source`, `table`, `type`, or `view`.
 `details`       | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
 `user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
-`occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
+`occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred. Guaranteed to be in order of event creation. Events created in the same transaction will have identical values.
 
 ### `mz_aws_privatelink_connections`
 

--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -125,7 +125,7 @@ fn bench_transact(c: &mut Criterion) {
                     public_schema_oid: id,
                 }];
                 catalog
-                    .transact(Some(mz_repr::Timestamp::MIN), None, ops, |_| Ok(()))
+                    .transact(mz_repr::Timestamp::MIN, None, ops, |_| Ok(()))
                     .await
                     .unwrap();
             })

--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -124,7 +124,10 @@ fn bench_transact(c: &mut Criterion) {
                     oid: id,
                     public_schema_oid: id,
                 }];
-                catalog.transact(None, ops, |_| Ok(())).await.unwrap();
+                catalog
+                    .transact(Some(mz_repr::Timestamp::MIN), None, ops, |_| Ok(()))
+                    .await
+                    .unwrap();
             })
         })
     });

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -234,7 +234,7 @@ impl<S: Append + 'static> Coordinator<S> {
             result,
         } = self
             .catalog
-            .transact(Some(oracle_write_ts), session, ops, |catalog| {
+            .transact(oracle_write_ts, session, ops, |catalog| {
                 f(CatalogTxn {
                     dataflow_client: &self.controller,
                     catalog,

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -139,6 +139,7 @@ async fn datadriven() {
                             .clone();
                         catalog
                             .transact(
+                                Some(mz_repr::Timestamp::MIN),
                                 None,
                                 vec![Op::CreateItem {
                                     id,

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -139,7 +139,7 @@ async fn datadriven() {
                             .clone();
                         catalog
                             .transact(
-                                Some(mz_repr::Timestamp::MIN),
+                                mz_repr::Timestamp::MIN,
                                 None,
                                 vec![Op::CreateItem {
                                     id,


### PR DESCRIPTION
Use the oracle timestamp instead of system clock for the audit events table. The system clock was used because (at the time) the oracle ts didn't have a firm bound on being off from the system clock, so using it to determine when a thing happened was not safe. For example, we once had a bug where the oracle ts was days ahead due to a fast loop. We've improved the logic enough that we have enough confidence that won't happen again (due to the use of write groups) that we'd now prefer to have the guarantee of always goes up, and believe that the audit log timestamps will be within a 10s margin of error.

See: https://github.com/MaterializeInc/cloud/issues/4907#issuecomment-1370474874

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a