### PR TITLE
persist: keep track of per-shard successful cmds in metrics

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -91,7 +91,7 @@ where
         let state = metrics
             .cmds
             .init_state
-            .run_cmd(|_cas_mismatch_metric| {
+            .run_cmd(&shard_metrics, |_cas_mismatch_metric| {
                 // No cas_mismatch retries because we just use the returned
                 // state on a mismatch.
                 state_versions.maybe_init_shard(&shard_metrics)
@@ -901,7 +901,8 @@ where
     ) -> Result<(SeqNo, Result<R, E>, RoutineMaintenance), Indeterminate> {
         let is_write = cmd.name == self.metrics.cmds.compare_and_append.name;
         let is_rollup = cmd.name == self.metrics.cmds.add_and_remove_rollups.name;
-        cmd.run_cmd(|cas_mismatch_metric| async move {
+        let shard_metrics = Arc::clone(&self.shard_metrics);
+        cmd.run_cmd(&shard_metrics, |cas_mismatch_metric| async move {
             let mut garbage_collection;
 
             loop {

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -461,7 +461,11 @@ pub struct CmdMetrics {
 }
 
 impl CmdMetrics {
-    pub async fn run_cmd<R, E, F, CmdFn>(&self, cmd_fn: CmdFn) -> Result<R, E>
+    pub async fn run_cmd<R, E, F, CmdFn>(
+        &self,
+        shard_metrics: &ShardMetrics,
+        cmd_fn: CmdFn,
+    ) -> Result<R, E>
     where
         F: std::future::Future<Output = Result<R, E>>,
         CmdFn: FnOnce(CmdCasMismatchMetric) -> F,
@@ -471,7 +475,10 @@ impl CmdMetrics {
         let res = cmd_fn(CmdCasMismatchMetric(self.cas_mismatch.clone())).await;
         self.seconds.inc_by(start.elapsed().as_secs_f64());
         match res.as_ref() {
-            Ok(_) => self.succeeded.inc(),
+            Ok(_) => {
+                self.succeeded.inc();
+                shard_metrics.cmd_succeeded.inc();
+            }
             Err(_) => self.failed.inc(),
         };
         res
@@ -971,6 +978,7 @@ pub struct ShardsMetrics {
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
     gc_finished: mz_ore::metrics::IntCounterVec,
     compaction_applied: mz_ore::metrics::IntCounterVec,
+    cmd_succeeded: mz_ore::metrics::IntCounterVec,
     // We hand out `Arc<ShardMetrics>` to read and write handles, but store it
     // here as `Weak`. This allows us to discover if it's no longer in use and
     // so we can remove it from the map.
@@ -1048,6 +1056,11 @@ impl ShardsMetrics {
                 help: "count of compactions applied to state by shard",
                 var_labels: ["shard"],
             )),
+            cmd_succeeded: registry.register(metric!(
+                name: "mz_persist_shard_cmd_succeeded",
+                help: "count of commands succeeded by shard",
+                var_labels: ["shard"],
+            )),
             shards,
         }
     }
@@ -1103,6 +1116,7 @@ pub struct ShardMetrics {
     // remove per-shard labels.
     pub gc_finished: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub compaction_applied: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub cmd_succeeded: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
 
 impl ShardMetrics {
@@ -1142,6 +1156,9 @@ impl ShardMetrics {
                 .get_delete_on_drop_counter(vec![shard.clone()]),
             compaction_applied: shards_metrics
                 .compaction_applied
+                .get_delete_on_drop_counter(vec![shard.clone()]),
+            cmd_succeeded: shards_metrics
+                .cmd_succeeded
                 .get_delete_on_drop_counter(vec![shard]),
         }
     }


### PR DESCRIPTION
This has come up in at least two debugging sessions now, so certainly seems worth the cost of a per-shard metric.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
