### PR TITLE
Expecting elements takes closure

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -160,10 +160,12 @@ pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
 }
 
 pub fn upsert_format(dps: Vec<DiffPair<Row>>, sink_id: GlobalId, from: GlobalId) -> Option<Row> {
-    let dp = dps.expect_element(format!(
-        "primary key error: expected at most one update per key and timestamp \
+    let dp = dps.expect_element(|| {
+        format!(
+            "primary key error: expected at most one update per key and timestamp \
           This can happen when the configured sink key is not a primary key of \
           the sinked relation: sink {sink_id} created from {from}."
-    ));
+        )
+    });
     dp.after
 }

--- a/src/ore/src/collections.rs
+++ b/src/ore/src/collections.rs
@@ -39,13 +39,14 @@ where
     ///
     /// This method panics if the collection does not have exactly one element.
     fn into_element(self) -> T::Item {
-        self.expect_element("into_element called on collection with more than one element")
+        self.expect_element(|| "into_element called on collection with more than one element")
     }
 
     /// Consumes the collection and returns its only element.
     ///
-    /// This method panics with the given error message if the collection does not have exactly one element.
-    fn expect_element<Err: Display>(self, msg: Err) -> T::Item;
+    /// This method panics with the given error function's return value if the collection does not
+    /// have exactly one element.
+    fn expect_element<Err: Display>(self, msg_fn: impl FnOnce() -> Err) -> T::Item;
 }
 
 impl<T> CollectionExt<T> for T
@@ -60,11 +61,11 @@ where
         self.into_iter().last().unwrap()
     }
 
-    fn expect_element<Err: Display>(self, msg: Err) -> T::Item {
+    fn expect_element<Err: Display>(self, msg_fn: impl FnOnce() -> Err) -> T::Item {
         let mut iter = self.into_iter();
         match (iter.next(), iter.next()) {
             (Some(el), None) => el,
-            _ => panic!("{}", msg),
+            _ => panic!("{}", msg_fn()),
         }
     }
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -397,7 +397,7 @@ fn sql_impl_table_func_inner(
 ) -> Operation<TableFuncPlan> {
     let query = match mz_sql_parser::parser::parse_statements(sql)
         .expect("static function definition failed to parse")
-        .expect_element("static function definition must have exactly one statement")
+        .expect_element(|| "static function definition must have exactly one statement")
     {
         Statement::Select(SelectStatement { query, as_of: None }) => query,
         _ => panic!("static function definition expected SELECT statement"),


### PR DESCRIPTION
Previously, expect_element would accept a fully-formed message, which meant the message would need to be fully computed when calling the function. For specialized messages, this would cause an allocation and string interpolation.

With this change, expect_element takes a closure that is used in the error case to generate a message. This avoids pre-generating error messages at the expense of some additional syntactic noise.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
