### PR TITLE
environmentd: use auth message instead of headers for websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,6 +7635,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "sha1",
  "thiserror",

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -52,13 +52,18 @@ The WebSocket API provides two modes with slightly different transactional seman
 ### Endpoint
 
 ```
-https://<MZ host address>/api/experimental/sql
+wss://<MZ host address>/api/experimental/sql
 ```
 
-Accessing the endpoint requires [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme). Reuse the same credentials as with `psql`:
+To authenticate, send an initial text or binary message containing a JSON object with keys:
 
-* **User ID:** Your email to access Materialize.
-* **Password:** Your app password.
+- `user`: Your email to access Materialize.
+- `password`: Your app password.
+
+Successful authentication will result in an initial `ReadyForQuery` response from the server.
+Otherwise an error is indicated by a websocket Close message.
+
+HTTP `Authorization` headers are ignored.
 
 ### Messages
 
@@ -161,6 +166,11 @@ The payload is an array of JSON values corresponding to the columns from the `Ro
 You can model these with the following TypeScript definitions:
 
 ```typescript
+interface Auth {
+    user: string;
+    password: string;
+}
+
 interface Simple {
     query: string;
 }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -78,6 +78,7 @@ tokio-stream = { version = "0.1.11", features = ["net"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
+tungstenite = { version = "0.18.0", features = ["native-tls"] }
 url = "2.3.1"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -110,7 +111,6 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4"] }
-tungstenite = "0.18.0"
 
 [build-dependencies]
 anyhow = "1.0.66"

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -120,7 +120,7 @@ mod http;
 mod server;
 mod telemetry;
 
-pub use crate::http::{SqlResponse, WebSocketResponse};
+pub use crate::http::{SqlResponse, WebSocketAuth, WebSocketResponse};
 
 pub const BUILD_INFO: BuildInfo = build_info!();
 

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -106,7 +106,7 @@ tower-http = { version = "0.3.5", features = ["auth", "base64", "cors", "map-res
 tracing = { version = "0.1.37", features = ["attributes", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.30", features = ["once_cell", "std"] }
 tracing-subscriber = { version = "0.3.16", features = ["alloc", "ansi", "env-filter", "fmt", "json", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "serde", "serde_json", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log", "tracing-serde"] }
-tungstenite = { version = "0.18.0", features = ["base64", "handshake", "http", "httparse", "sha1", "url"] }
+tungstenite = { version = "0.18.0", features = ["base64", "handshake", "http", "httparse", "native-tls", "native-tls-crate", "sha1", "url"] }
 uncased = { version = "0.9.7", features = ["alloc"] }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["getrandom", "rng", "serde", "std", "v4"] }
@@ -207,7 +207,7 @@ tower-http = { version = "0.3.5", features = ["auth", "base64", "cors", "map-res
 tracing = { version = "0.1.37", features = ["attributes", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.30", features = ["once_cell", "std"] }
 tracing-subscriber = { version = "0.3.16", features = ["alloc", "ansi", "env-filter", "fmt", "json", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "serde", "serde_json", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log", "tracing-serde"] }
-tungstenite = { version = "0.18.0", features = ["base64", "handshake", "http", "httparse", "sha1", "url"] }
+tungstenite = { version = "0.18.0", features = ["base64", "handshake", "http", "httparse", "native-tls", "native-tls-crate", "sha1", "url"] }
 uncased = { version = "0.9.7", features = ["alloc"] }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["getrandom", "rng", "serde", "std", "v4"] }


### PR DESCRIPTION
The javascript websocket API doesn't support specifying headers. We thus need to implement a separate way for websocket clients to authenticate. Use an initial message to do that.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a