### PR TITLE
adapter: allow pgwire to connect before coord acknowledges

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -119,8 +119,6 @@ pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponseUnary> + Send>>;
 /// The response to [`ConnClient::startup`](crate::ConnClient::startup).
 #[derive(Debug)]
 pub struct StartupResponse {
-    /// An opaque secret associated with this session.
-    pub secret_key: u32,
     /// Notifications associated with session startup.
     pub messages: Vec<StartupMessage>,
 }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -17,6 +17,7 @@ use std::mem;
 
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
+use rand::Rng;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::OwnedMutexGuard;
 use uuid::Uuid;
@@ -89,6 +90,7 @@ pub struct Session<T = mz_repr::Timestamp> {
     notices_tx: mpsc::UnboundedSender<AdapterNotice>,
     notices_rx: mpsc::UnboundedReceiver<AdapterNotice>,
     next_transaction_id: TransactionId,
+    secret_key: u32,
 }
 
 impl<T: TimestampManipulation> Session<T> {
@@ -124,12 +126,18 @@ impl<T: TimestampManipulation> Session<T> {
             notices_tx,
             notices_rx,
             next_transaction_id: 0,
+            secret_key: rand::thread_rng().gen(),
         }
     }
 
     /// Returns the connection ID associated with the session.
     pub fn conn_id(&self) -> ConnectionId {
         self.conn_id
+    }
+
+    /// Returns the secret key associated with the session.
+    pub fn secret_key(&self) -> ConnectionId {
+        self.secret_key
     }
 
     /// Returns the current transaction's PlanContext. Panics if there is not a


### PR DESCRIPTION
To improve the ability to meet our SLA guarantees, change the connection logic to acknowledge pgwire connections immediately and without waiting on the Coordinator. Delay sending the various startup messages until after, which is still in spec.

Keep the old API around and identical so that HTTP and other users that don't need this don't need to change.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
