### PR TITLE
upgrade: Fix the upgrade tests for 0.38

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -286,6 +286,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 60
     artifact_paths: junit_mzcompose_*.xml
+    inputs: [doc/user/content/releases]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: upgrade

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -106,9 +106,9 @@ class StartClusterdCompute(MzcomposeAction):
             if any(self.tag.startswith(version) for version in ["v0.37", "v0.38"]):
                 clusterd = Clusterd(
                     name="clusterd_compute_1",
-                    image=f"materialize/computed:{self.tag}",
+                    image=f"materialize/clusterd:{self.tag}",
                     options=[
-                        "--controller-listen-addr=0.0.0.0:2101",
+                        "--compute-controller-listen-addr=0.0.0.0:2101",
                         "--secrets-reader=process",
                         "--secrets-reader-process-dir=/mzdata/secrets",
                     ],
@@ -117,12 +117,12 @@ class StartClusterdCompute(MzcomposeAction):
             else:
                 clusterd = Clusterd(
                     name="clusterd_compute_1",
-                    image=f"materialize/computed:{self.tag}",
+                    image=f"materialize/clusterd:{self.tag}",
                 )
         print(f"Starting Compute using image {clusterd.config.get('image')}")
 
         with c.override(clusterd):
-            c.up("clusterd_compute_1")
+            c.start_and_wait_for_tcp(services=["clusterd_compute_1"])
 
 
 class RestartRedpandaDebezium(MzcomposeAction):

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -74,7 +74,7 @@ class Materialized(Service):
         # latest being 'v0.38.0' until then
         if image is not None and any(
             image.endswith(version)
-            for version in ["v0.36.2", "v0.37.1", "v0.38.0", "latest"]
+            for version in ["v0.36.2", "v0.37.3", "v0.38.0", "latest"]
         ):
             persist_blob_url = "file:///mzdata/persist/blob"
             command.append("--orchestrator=process")


### PR DESCRIPTION
- Have any changes to the doc/user/content/releases dir cause the upgrade tests to run
- Fix the Checks-based upgrade test to use clusterd and not computed
- Fix the legacy upgrade test to use a file glob that contains all patch versions, not just the latest one
- fix services.py to provide the proper command line options when starting a v0.37.3 instance for upgrade purposes

### Motivation
  * This PR fixes a previously unreported bug.
CI upgrade jobs were failing.