### PR TITLE
mzcompose: Protect --persist-blob-url from the shell

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -85,7 +85,7 @@ class Materialized(Service):
         command += [f"--environment-id={environment_id}"]
 
         if persist_blob_url:
-            command.append(f"--persist-blob-url={persist_blob_url}")
+            command.append(f"--persist-blob-url='{persist_blob_url}'")
 
         if propagate_crashes:
             command += ["--orchestrator-process-propagate-crashes"]


### PR DESCRIPTION
previously, the --persist-blob-url option was passed as an environment variable. Now it is passed on the command line, which means it needs to be single-quoted in case it contains special shell characters.

For example, if the --persist-blob-url was pointing to a Minio instance, the URL will contain the string '&region=minio' . The ampresand in this string would cause the rest of the command line to be disregarded.

### Motivation

  * This PR fixes a previously unreported bug.

Zippy was failing / not testing the right thing because most of the environmentd command line was disregarded.

@benesch FYI