### PR TITLE
Fix a lint issue for links in doc comments

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1140,7 +1140,7 @@ impl MirScalarExpr {
                         } else if *func == VariadicFunc::ListIndex && is_list_create_call(&exprs[0])
                         {
                             // We are looking for ListIndex(ListCreate, literal), and eliminate
-                            // both the ListIndex and the ListCreate. E.g.: LIST[f1,f2][2] --> f2
+                            // both the ListIndex and the ListCreate. E.g.: `LIST[f1,f2][2]` --> `f2`
                             let ind_exprs = exprs.split_off(1);
                             let top_list_create = exprs.swap_remove(0);
                             *e = reduce_list_create_list_index_literal(top_list_create, ind_exprs);
@@ -1249,10 +1249,10 @@ impl MirScalarExpr {
         ///
         /// # Examples
         ///
-        /// LIST[f1,f2][2] --> f2.
+        /// `LIST[f1,f2][2]` --> `f2`.
         ///
         /// A multi-dimensional list, with only some of the indexes being literals:
-        /// LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [2][n][2] --> LIST[f6, f8] [n]
+        /// `LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [2][n][2]` --> `LIST[f6, f8] [n]`
         ///
         /// See more examples in list.slt.
         fn reduce_list_create_list_index_literal(


### PR DESCRIPTION
Philip reported that some new lint is having
```
error: unresolved link to `2`
    --> src/expr/src/scalar/mod.rs:1252:25
     |
1252 |         /// LIST[f1,f2][2] --> f2.
     |                         ^ no item named `2` in scope
     |
     = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
     = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
```
I guess this is because the [] was trying to be resolved as a link. This PR adds backticks around the relevant parts.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Draft for now until I can make the CI run the relevant lint to check that the PR is solving the problem.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
