### PR TITLE
zippy: Always generate the expected number of actions

### DIFF
--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -154,7 +154,7 @@ class Test:
         for action_or_factory in self._scenario.bootstrap():
             self.append_actions(action_or_factory)
 
-        for i in range(0, actions):
+        while len(self._actions) < actions:
             action_or_factory = self._pick_action_or_factory()
             self.append_actions(action_or_factory)
 


### PR DESCRIPTION
Always generate the expected number of actions regardless of whether a particular Factory produces no action or more than one actions.

### Motivation

  * This PR fixes a previously unreported bug.

Zippy execution time was sometimes shorter than expected.