### PR TITLE
Partition `LetRec` correctly

### DIFF
--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1746,7 +1746,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
                         .collect()
                 }
                 Plan::LetRec { ids, values, body } => {
-                    let mut values_parts: Vec<Vec<Self>> = Vec::with_capacity(parts);
+                    let mut values_parts: Vec<Vec<Self>> = vec![Vec::new(); parts];
                     for value in values.into_iter() {
                         for (index, part) in value.partition_among(parts).into_iter().enumerate() {
                             values_parts[index].push(part);


### PR DESCRIPTION
LIR expressions need to be partitioned across workers, and this was not happening correctly for `LetRec` which would just crash when this is attempted. For some reason we aren't seeing this in SLT, perhaps because it only has one worker? (I thought it had three, but .. idk). 

But, attempting to use `WITH MUTUALLY RECURSIVE` on replicas with more than one worker panics without this fix, which makes sense.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
