### PR TITLE
Pre-tidy planner output

### DIFF
--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1744,15 +1744,8 @@ fn apply_existential_subquery(
                 .applied_to(id_gen, get_inner.clone(), col_map, cte_map)
                 // throw away actual values and just remember whether or not there were __any__ rows
                 .distinct_by((0..get_inner.arity()).collect())
-                // Append true to anything that returned any rows. This
-                // join is logically equivalent to
-                // `.map(vec![Datum::True])`, but using a join allows
-                // for potential predicate pushdown and elision in the
-                // optimizer.
-                .product(mz_expr::MirRelationExpr::constant(
-                    vec![vec![Datum::True]],
-                    RelationType::new(vec![ScalarType::Bool.nullable(false)]),
-                ));
+                // Append true to anything that returned any rows.
+                .map(vec![mz_expr::MirScalarExpr::literal_true()]);
             // append False to anything that didn't return any rows
             get_inner.lookup(id_gen, exists, vec![(Datum::False, ScalarType::Bool)])
         },

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1341,9 +1341,26 @@ fn plan_set_expr(
                     ),
                 }
             }
-            let project_key: Vec<_> = (left_type.arity()..left_type.arity() * 2).collect();
-            let lhs = left_expr.map(left_casts).project(project_key.clone());
-            let rhs = right_expr.map(right_casts).project(project_key);
+            let lhs = if left_casts
+                .iter()
+                .enumerate()
+                .any(|(i, e)| e != &HirScalarExpr::column(i))
+            {
+                let project_key: Vec<_> = (left_type.arity()..left_type.arity() * 2).collect();
+                left_expr.map(left_casts).project(project_key)
+            } else {
+                left_expr
+            };
+            let rhs = if right_casts
+                .iter()
+                .enumerate()
+                .any(|(i, e)| e != &HirScalarExpr::column(i))
+            {
+                let project_key: Vec<_> = (right_type.arity()..right_type.arity() * 2).collect();
+                right_expr.map(right_casts).project(project_key)
+            } else {
+                right_expr
+            };
 
             let relation_expr = match op {
                 SetOperator::Union => {

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -1229,41 +1229,23 @@ digraph G {
     labeljust = l
     label = "(select true as a) union (select false as b);"
     node [ shape = box ]
-    subgraph cluster9 {
-        label = "Box9:Select"
-        boxhead9 [ shape = record, label = "{ Distinct: Enforce| 0: Q8.C0 }" ]
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label = "{ Distinct: Enforce| 0: Q4.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q8 [ label = "Q8(F)" ]
+            Q4 [ label = "Q4(F)" ]
         }
     }
-    subgraph cluster8 {
-        label = "Box8:Union"
-        boxhead8 [ shape = record, label = "{ Distinct: Preserve| 0: Q6.C0 }" ]
-        {
-            rank = same
-            node [ shape = circle ]
-            Q6 [ label = "Q6(F)" ]
-            Q7 [ label = "Q7(F)" ]
-        }
-    }
-    subgraph cluster3 {
-        label = "Box3:Select"
-        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C1 }" ]
+    subgraph cluster4 {
+        label = "Box4:Union"
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C0 }" ]
         {
             rank = same
             node [ shape = circle ]
             Q2 [ label = "Q2(F)" ]
-        }
-    }
-    subgraph cluster2 {
-        label = "Box2:Select"
-        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C0 }" ]
-        {
-            rank = same
-            node [ shape = circle ]
-            Q1 [ label = "Q1(F)" ]
+            Q3 [ label = "Q3(F)" ]
         }
     }
     subgraph cluster1 {
@@ -1282,50 +1264,28 @@ digraph G {
             rank = same
         }
     }
-    subgraph cluster7 {
-        label = "Box7:Select"
-        boxhead7 [ shape = record, label = "{ Distinct: Preserve| 0: Q5.C1 }" ]
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: false }" ]
         {
             rank = same
             node [ shape = circle ]
-            Q5 [ label = "Q5(F)" ]
+            Q1 [ label = "Q1(F)" ]
         }
     }
-    subgraph cluster6 {
-        label = "Box6:Select"
-        boxhead6 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0| 1: Q4.C0 }" ]
-        {
-            rank = same
-            node [ shape = circle ]
-            Q4 [ label = "Q4(F)" ]
-        }
-    }
-    subgraph cluster5 {
-        label = "Box5:Select"
-        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: false }" ]
-        {
-            rank = same
-            node [ shape = circle ]
-            Q3 [ label = "Q3(F)" ]
-        }
-    }
-    subgraph cluster4 {
-        label = "Box4:Values"
-        boxhead4 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+    subgraph cluster2 {
+        label = "Box2:Values"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
         {
             rank = same
         }
     }
     edge [ arrowhead = none, style = dashed ]
-    Q8 -> boxhead8 [ lhead = cluster8 ]
-    Q6 -> boxhead3 [ lhead = cluster3 ]
-    Q7 -> boxhead7 [ lhead = cluster7 ]
-    Q2 -> boxhead2 [ lhead = cluster2 ]
-    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q4 -> boxhead4 [ lhead = cluster4 ]
+    Q2 -> boxhead1 [ lhead = cluster1 ]
+    Q3 -> boxhead3 [ lhead = cluster3 ]
     Q0 -> boxhead0 [ lhead = cluster0 ]
-    Q5 -> boxhead6 [ lhead = cluster6 ]
-    Q4 -> boxhead5 [ lhead = cluster5 ]
-    Q3 -> boxhead4 [ lhead = cluster4 ]
+    Q1 -> boxhead2 [ lhead = cluster2 ]
 }
 
 build

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -160,277 +160,138 @@ EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
     "body": {
       "Union": {
         "base": {
-          "Project": {
-            "input": {
-              "Map": {
+          "Union": {
+            "base": {
+              "Project": {
                 "input": {
-                  "Let": {
-                    "id": 3,
-                    "value": {
-                      "Union": {
-                        "base": {
-                          "Project": {
-                            "input": {
-                              "Map": {
-                                "input": {
-                                  "Let": {
-                                    "id": 1,
-                                    "value": {
-                                      "Project": {
-                                        "input": {
-                                          "Map": {
-                                            "input": {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 0
-                                                },
-                                                "typ": {
-                                                  "column_types": [],
-                                                  "keys": [
-                                                    []
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            "scalars": [
-                                              {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        4,
-                                                        1,
-                                                        0,
-                                                        0,
-                                                        0
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        4,
-                                                        2,
-                                                        0,
-                                                        0,
-                                                        0
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "Int32",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "outputs": [
-                                          0,
-                                          1
-                                        ]
-                                      }
-                                    },
-                                    "body": {
-                                      "Get": {
-                                        "id": {
-                                          "Local": 1
-                                        },
-                                        "typ": {
-                                          "column_types": [
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": false
-                                            },
-                                            {
-                                              "scalar_type": "Int32",
-                                              "nullable": false
-                                            }
-                                          ],
-                                          "keys": [
-                                            []
-                                          ]
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "scalars": [
-                                  {
-                                    "Column": 0
-                                  },
-                                  {
-                                    "Column": 1
-                                  }
-                                ]
-                              }
-                            },
-                            "outputs": [
-                              2,
-                              3
-                            ]
-                          }
+                  "Map": {
+                    "input": {
+                      "Get": {
+                        "id": {
+                          "Local": 0
                         },
-                        "inputs": [
+                        "typ": {
+                          "column_types": [],
+                          "keys": [
+                            []
+                          ]
+                        }
+                      }
+                    },
+                    "scalars": [
+                      {
+                        "Literal": [
                           {
-                            "Project": {
-                              "input": {
-                                "Map": {
-                                  "input": {
-                                    "Let": {
-                                      "id": 2,
-                                      "value": {
-                                        "Project": {
-                                          "input": {
-                                            "Map": {
-                                              "input": {
-                                                "Get": {
-                                                  "id": {
-                                                    "Local": 0
-                                                  },
-                                                  "typ": {
-                                                    "column_types": [],
-                                                    "keys": [
-                                                      []
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              "scalars": [
-                                                {
-                                                  "Literal": [
-                                                    {
-                                                      "Ok": {
-                                                        "data": [
-                                                          4,
-                                                          1,
-                                                          0,
-                                                          0,
-                                                          0
-                                                        ]
-                                                      }
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    }
-                                                  ]
-                                                },
-                                                {
-                                                  "Literal": [
-                                                    {
-                                                      "Ok": {
-                                                        "data": [
-                                                          4,
-                                                          2,
-                                                          0,
-                                                          0,
-                                                          0
-                                                        ]
-                                                      }
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "outputs": [
-                                            0,
-                                            1
-                                          ]
-                                        }
-                                      },
-                                      "body": {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 2
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": false
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": false
-                                              }
-                                            ],
-                                            "keys": [
-                                              []
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "scalars": [
-                                    {
-                                      "Column": 0
-                                    },
-                                    {
-                                      "Column": 1
-                                    }
-                                  ]
-                                }
-                              },
-                              "outputs": [
-                                2,
-                                3
+                            "Ok": {
+                              "data": [
+                                4,
+                                1,
+                                0,
+                                0,
+                                0
                               ]
                             }
+                          },
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": false
+                          }
+                        ]
+                      },
+                      {
+                        "Literal": [
+                          {
+                            "Ok": {
+                              "data": [
+                                4,
+                                2,
+                                0,
+                                0,
+                                0
+                              ]
+                            }
+                          },
+                          {
+                            "scalar_type": "Int32",
+                            "nullable": false
                           }
                         ]
                       }
-                    },
-                    "body": {
-                      "Get": {
-                        "id": {
-                          "Local": 3
-                        },
-                        "typ": {
-                          "column_types": [
+                    ]
+                  }
+                },
+                "outputs": [
+                  0,
+                  1
+                ]
+              }
+            },
+            "inputs": [
+              {
+                "Project": {
+                  "input": {
+                    "Map": {
+                      "input": {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
+                            ]
+                          }
+                        }
+                      },
+                      "scalars": [
+                        {
+                          "Literal": [
                             {
-                              "scalar_type": "Int32",
-                              "nullable": false
+                              "Ok": {
+                                "data": [
+                                  4,
+                                  1,
+                                  0,
+                                  0,
+                                  0
+                                ]
+                              }
                             },
                             {
                               "scalar_type": "Int32",
                               "nullable": false
                             }
-                          ],
-                          "keys": []
+                          ]
+                        },
+                        {
+                          "Literal": [
+                            {
+                              "Ok": {
+                                "data": [
+                                  4,
+                                  2,
+                                  0,
+                                  0,
+                                  0
+                                ]
+                              }
+                            },
+                            {
+                              "scalar_type": "Int32",
+                              "nullable": false
+                            }
+                          ]
                         }
-                      }
+                      ]
                     }
-                  }
-                },
-                "scalars": [
-                  {
-                    "Column": 0
                   },
-                  {
-                    "Column": 1
-                  }
-                ]
+                  "outputs": [
+                    0,
+                    1
+                  ]
+                }
               }
-            },
-            "outputs": [
-              2,
-              3
             ]
           }
         },
@@ -440,110 +301,63 @@ EXPLAIN DECORRELATED PLAN WITH(raw) AS JSON FOR
               "input": {
                 "Map": {
                   "input": {
-                    "Let": {
-                      "id": 4,
-                      "value": {
-                        "Project": {
-                          "input": {
-                            "Map": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 0
-                                  },
-                                  "typ": {
-                                    "column_types": [],
-                                    "keys": [
-                                      []
-                                    ]
-                                  }
-                                }
-                              },
-                              "scalars": [
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          4,
-                                          3,
-                                          0,
-                                          0,
-                                          0
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ]
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          4,
-                                          4,
-                                          0,
-                                          0,
-                                          0
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          },
-                          "outputs": [
-                            0,
-                            1
-                          ]
-                        }
+                    "Get": {
+                      "id": {
+                        "Local": 0
                       },
-                      "body": {
-                        "Get": {
-                          "id": {
-                            "Local": 4
-                          },
-                          "typ": {
-                            "column_types": [
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": false
-                              },
-                              {
-                                "scalar_type": "Int32",
-                                "nullable": false
-                              }
-                            ],
-                            "keys": [
-                              []
-                            ]
-                          }
-                        }
+                      "typ": {
+                        "column_types": [],
+                        "keys": [
+                          []
+                        ]
                       }
                     }
                   },
                   "scalars": [
                     {
-                      "Column": 0
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              4,
+                              3,
+                              0,
+                              0,
+                              0
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
                     },
                     {
-                      "Column": 1
+                      "Literal": [
+                        {
+                          "Ok": {
+                            "data": [
+                              4,
+                              4,
+                              0,
+                              0,
+                              0
+                            ]
+                          }
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": false
+                        }
+                      ]
                     }
                   ]
                 }
               },
               "outputs": [
-                2,
-                3
+                0,
+                1
               ]
             }
           }
@@ -998,87 +812,50 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                 "input": {
                   "Project": {
                     "input": {
-                      "Map": {
-                        "input": {
-                          "Let": {
-                            "id": 1,
-                            "value": {
-                              "Project": {
-                                "input": {
-                                  "Join": {
-                                    "inputs": [
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Local": 0
-                                          },
-                                          "typ": {
-                                            "column_types": [],
-                                            "keys": [
-                                              []
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Get": {
-                                          "id": {
-                                            "Global": {
-                                              "User": 1
-                                            }
-                                          },
-                                          "typ": {
-                                            "column_types": [
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              },
-                                              {
-                                                "scalar_type": "Int32",
-                                                "nullable": true
-                                              }
-                                            ],
-                                            "keys": []
-                                          }
-                                        }
-                                      }
-                                    ],
-                                    "equivalences": [],
-                                    "implementation": "Unimplemented"
-                                  }
-                                },
-                                "outputs": [
-                                  0
+                      "Join": {
+                        "inputs": [
+                          {
+                            "Get": {
+                              "id": {
+                                "Local": 0
+                              },
+                              "typ": {
+                                "column_types": [],
+                                "keys": [
+                                  []
                                 ]
                               }
-                            },
-                            "body": {
-                              "Get": {
-                                "id": {
-                                  "Local": 1
-                                },
-                                "typ": {
-                                  "column_types": [
-                                    {
-                                      "scalar_type": "Int32",
-                                      "nullable": true
-                                    }
-                                  ],
-                                  "keys": []
+                            }
+                          },
+                          {
+                            "Get": {
+                              "id": {
+                                "Global": {
+                                  "User": 1
                                 }
+                              },
+                              "typ": {
+                                "column_types": [
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  },
+                                  {
+                                    "scalar_type": "Int32",
+                                    "nullable": true
+                                  }
+                                ],
+                                "keys": []
                               }
                             }
                           }
-                        },
-                        "scalars": [
-                          {
-                            "Column": 0
-                          }
-                        ]
+                        ],
+                        "equivalences": [],
+                        "implementation": "Unimplemented"
                       }
                     },
                     "outputs": [
-                      1
+                      0
                     ]
                   }
                 },
@@ -1100,83 +877,46 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                       "input": {
                         "Project": {
                           "input": {
-                            "Map": {
-                              "input": {
-                                "Let": {
-                                  "id": 2,
-                                  "value": {
-                                    "Project": {
-                                      "input": {
-                                        "Join": {
-                                          "inputs": [
-                                            {
-                                              "Get": {
-                                                "id": {
-                                                  "Local": 0
-                                                },
-                                                "typ": {
-                                                  "column_types": [],
-                                                  "keys": [
-                                                    []
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "Get": {
-                                                "id": {
-                                                  "Global": {
-                                                    "User": 5
-                                                  }
-                                                },
-                                                "typ": {
-                                                  "column_types": [
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": false
-                                                    },
-                                                    {
-                                                      "scalar_type": "Int32",
-                                                      "nullable": true
-                                                    }
-                                                  ],
-                                                  "keys": []
-                                                }
-                                              }
-                                            }
-                                          ],
-                                          "equivalences": [],
-                                          "implementation": "Unimplemented"
-                                        }
-                                      },
-                                      "outputs": [
-                                        1
+                            "Join": {
+                              "inputs": [
+                                {
+                                  "Get": {
+                                    "id": {
+                                      "Local": 0
+                                    },
+                                    "typ": {
+                                      "column_types": [],
+                                      "keys": [
+                                        []
                                       ]
                                     }
-                                  },
-                                  "body": {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 2
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
+                                  }
+                                },
+                                {
+                                  "Get": {
+                                    "id": {
+                                      "Global": {
+                                        "User": 5
                                       }
+                                    },
+                                    "typ": {
+                                      "column_types": [
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": false
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ],
+                                      "keys": []
                                     }
                                   }
                                 }
-                              },
-                              "scalars": [
-                                {
-                                  "Column": 0
-                                }
-                              ]
+                              ],
+                              "equivalences": [],
+                              "implementation": "Unimplemented"
                             }
                           },
                           "outputs": [
@@ -1238,87 +978,50 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
             "base": {
               "Project": {
                 "input": {
-                  "Map": {
-                    "input": {
-                      "Let": {
-                        "id": 1,
-                        "value": {
-                          "Project": {
-                            "input": {
-                              "Join": {
-                                "inputs": [
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Local": 0
-                                      },
-                                      "typ": {
-                                        "column_types": [],
-                                        "keys": [
-                                          []
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Get": {
-                                      "id": {
-                                        "Global": {
-                                          "User": 1
-                                        }
-                                      },
-                                      "typ": {
-                                        "column_types": [
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          },
-                                          {
-                                            "scalar_type": "Int32",
-                                            "nullable": true
-                                          }
-                                        ],
-                                        "keys": []
-                                      }
-                                    }
-                                  }
-                                ],
-                                "equivalences": [],
-                                "implementation": "Unimplemented"
-                              }
-                            },
-                            "outputs": [
-                              0
+                  "Join": {
+                    "inputs": [
+                      {
+                        "Get": {
+                          "id": {
+                            "Local": 0
+                          },
+                          "typ": {
+                            "column_types": [],
+                            "keys": [
+                              []
                             ]
                           }
-                        },
-                        "body": {
-                          "Get": {
-                            "id": {
-                              "Local": 1
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
+                        }
+                      },
+                      {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
                             }
+                          },
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ],
+                            "keys": []
                           }
                         }
                       }
-                    },
-                    "scalars": [
-                      {
-                        "Column": 0
-                      }
-                    ]
+                    ],
+                    "equivalences": [],
+                    "implementation": "Unimplemented"
                   }
                 },
                 "outputs": [
-                  1
+                  0
                 ]
               }
             },
@@ -1328,83 +1031,46 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                   "input": {
                     "Project": {
                       "input": {
-                        "Map": {
-                          "input": {
-                            "Let": {
-                              "id": 2,
-                              "value": {
-                                "Project": {
-                                  "input": {
-                                    "Join": {
-                                      "inputs": [
-                                        {
-                                          "Get": {
-                                            "id": {
-                                              "Local": 0
-                                            },
-                                            "typ": {
-                                              "column_types": [],
-                                              "keys": [
-                                                []
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "Get": {
-                                            "id": {
-                                              "Global": {
-                                                "User": 5
-                                              }
-                                            },
-                                            "typ": {
-                                              "column_types": [
-                                                {
-                                                  "scalar_type": "Int32",
-                                                  "nullable": false
-                                                },
-                                                {
-                                                  "scalar_type": "Int32",
-                                                  "nullable": true
-                                                }
-                                              ],
-                                              "keys": []
-                                            }
-                                          }
-                                        }
-                                      ],
-                                      "equivalences": [],
-                                      "implementation": "Unimplemented"
-                                    }
-                                  },
-                                  "outputs": [
-                                    1
+                        "Join": {
+                          "inputs": [
+                            {
+                              "Get": {
+                                "id": {
+                                  "Local": 0
+                                },
+                                "typ": {
+                                  "column_types": [],
+                                  "keys": [
+                                    []
                                   ]
                                 }
-                              },
-                              "body": {
-                                "Get": {
-                                  "id": {
-                                    "Local": 2
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
+                              }
+                            },
+                            {
+                              "Get": {
+                                "id": {
+                                  "Global": {
+                                    "User": 5
                                   }
+                                },
+                                "typ": {
+                                  "column_types": [
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": false
+                                    },
+                                    {
+                                      "scalar_type": "Int32",
+                                      "nullable": true
+                                    }
+                                  ],
+                                  "keys": []
                                 }
                               }
                             }
-                          },
-                          "scalars": [
-                            {
-                              "Column": 0
-                            }
-                          ]
+                          ],
+                          "equivalences": [],
+                          "implementation": "Unimplemented"
                         }
                       },
                       "outputs": [
@@ -2304,115 +1970,103 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                             "Let": {
                                               "id": 3,
                                               "value": {
-                                                "Join": {
-                                                  "inputs": [
-                                                    {
-                                                      "Reduce": {
-                                                        "input": {
-                                                          "Filter": {
-                                                            "input": {
-                                                              "Join": {
-                                                                "inputs": [
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Local": 2
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": [
-                                                                          [
-                                                                            0
-                                                                          ]
-                                                                        ]
-                                                                      }
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "Get": {
-                                                                      "id": {
-                                                                        "Global": {
-                                                                          "User": 5
+                                                "Map": {
+                                                  "input": {
+                                                    "Reduce": {
+                                                      "input": {
+                                                        "Filter": {
+                                                          "input": {
+                                                            "Join": {
+                                                              "inputs": [
+                                                                {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Local": 2
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
                                                                         }
-                                                                      },
-                                                                      "typ": {
-                                                                        "column_types": [
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": false
-                                                                          },
-                                                                          {
-                                                                            "scalar_type": "Int32",
-                                                                            "nullable": true
-                                                                          }
-                                                                        ],
-                                                                        "keys": []
-                                                                      }
+                                                                      ],
+                                                                      "keys": [
+                                                                        [
+                                                                          0
+                                                                        ]
+                                                                      ]
                                                                     }
                                                                   }
-                                                                ],
-                                                                "equivalences": [],
-                                                                "implementation": "Unimplemented"
-                                                              }
-                                                            },
-                                                            "predicates": [
-                                                              {
-                                                                "CallBinary": {
-                                                                  "func": "Lt",
-                                                                  "expr1": {
-                                                                    "Column": 0
-                                                                  },
-                                                                  "expr2": {
-                                                                    "Column": 1
+                                                                },
+                                                                {
+                                                                  "Get": {
+                                                                    "id": {
+                                                                      "Global": {
+                                                                        "User": 5
+                                                                      }
+                                                                    },
+                                                                    "typ": {
+                                                                      "column_types": [
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": false
+                                                                        },
+                                                                        {
+                                                                          "scalar_type": "Int32",
+                                                                          "nullable": true
+                                                                        }
+                                                                      ],
+                                                                      "keys": []
+                                                                    }
                                                                   }
                                                                 }
-                                                              }
-                                                            ]
-                                                          }
-                                                        },
-                                                        "group_key": [
-                                                          {
-                                                            "Column": 0
-                                                          }
-                                                        ],
-                                                        "aggregates": [],
-                                                        "monotonic": false,
-                                                        "expected_group_size": null
-                                                      }
-                                                    },
-                                                    {
-                                                      "Constant": {
-                                                        "rows": {
-                                                          "Ok": [
-                                                            [
-                                                              {
-                                                                "data": [
-                                                                  2
-                                                                ]
-                                                              },
-                                                              1
-                                                            ]
-                                                          ]
-                                                        },
-                                                        "typ": {
-                                                          "column_types": [
-                                                            {
-                                                              "scalar_type": "Bool",
-                                                              "nullable": false
+                                                              ],
+                                                              "equivalences": [],
+                                                              "implementation": "Unimplemented"
                                                             }
-                                                          ],
-                                                          "keys": []
+                                                          },
+                                                          "predicates": [
+                                                            {
+                                                              "CallBinary": {
+                                                                "func": "Lt",
+                                                                "expr1": {
+                                                                  "Column": 0
+                                                                },
+                                                                "expr2": {
+                                                                  "Column": 1
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
                                                         }
-                                                      }
+                                                      },
+                                                      "group_key": [
+                                                        {
+                                                          "Column": 0
+                                                        }
+                                                      ],
+                                                      "aggregates": [],
+                                                      "monotonic": false,
+                                                      "expected_group_size": null
                                                     }
-                                                  ],
-                                                  "equivalences": [],
-                                                  "implementation": "Unimplemented"
+                                                  },
+                                                  "scalars": [
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              2
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "Bool",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
                                                 }
                                               },
                                               "body": {
@@ -2704,115 +2358,103 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
                                 "Let": {
                                   "id": 6,
                                   "value": {
-                                    "Join": {
-                                      "inputs": [
-                                        {
-                                          "Reduce": {
-                                            "input": {
-                                              "Filter": {
-                                                "input": {
-                                                  "Join": {
-                                                    "inputs": [
-                                                      {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Local": 5
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": [
-                                                              [
-                                                                0
-                                                              ]
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "Get": {
-                                                          "id": {
-                                                            "Global": {
-                                                              "User": 5
+                                    "Map": {
+                                      "input": {
+                                        "Reduce": {
+                                          "input": {
+                                            "Filter": {
+                                              "input": {
+                                                "Join": {
+                                                  "inputs": [
+                                                    {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Local": 5
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
                                                             }
-                                                          },
-                                                          "typ": {
-                                                            "column_types": [
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": false
-                                                              },
-                                                              {
-                                                                "scalar_type": "Int32",
-                                                                "nullable": true
-                                                              }
-                                                            ],
-                                                            "keys": []
-                                                          }
+                                                          ],
+                                                          "keys": [
+                                                            [
+                                                              0
+                                                            ]
+                                                          ]
                                                         }
                                                       }
-                                                    ],
-                                                    "equivalences": [],
-                                                    "implementation": "Unimplemented"
-                                                  }
-                                                },
-                                                "predicates": [
-                                                  {
-                                                    "CallBinary": {
-                                                      "func": "Gt",
-                                                      "expr1": {
-                                                        "Column": 0
-                                                      },
-                                                      "expr2": {
-                                                        "Column": 2
+                                                    },
+                                                    {
+                                                      "Get": {
+                                                        "id": {
+                                                          "Global": {
+                                                            "User": 5
+                                                          }
+                                                        },
+                                                        "typ": {
+                                                          "column_types": [
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": false
+                                                            },
+                                                            {
+                                                              "scalar_type": "Int32",
+                                                              "nullable": true
+                                                            }
+                                                          ],
+                                                          "keys": []
+                                                        }
                                                       }
                                                     }
-                                                  }
-                                                ]
-                                              }
-                                            },
-                                            "group_key": [
-                                              {
-                                                "Column": 0
-                                              }
-                                            ],
-                                            "aggregates": [],
-                                            "monotonic": false,
-                                            "expected_group_size": null
-                                          }
-                                        },
-                                        {
-                                          "Constant": {
-                                            "rows": {
-                                              "Ok": [
-                                                [
-                                                  {
-                                                    "data": [
-                                                      2
-                                                    ]
-                                                  },
-                                                  1
-                                                ]
-                                              ]
-                                            },
-                                            "typ": {
-                                              "column_types": [
-                                                {
-                                                  "scalar_type": "Bool",
-                                                  "nullable": false
+                                                  ],
+                                                  "equivalences": [],
+                                                  "implementation": "Unimplemented"
                                                 }
-                                              ],
-                                              "keys": []
+                                              },
+                                              "predicates": [
+                                                {
+                                                  "CallBinary": {
+                                                    "func": "Gt",
+                                                    "expr1": {
+                                                      "Column": 0
+                                                    },
+                                                    "expr2": {
+                                                      "Column": 2
+                                                    }
+                                                  }
+                                                }
+                                              ]
                                             }
-                                          }
+                                          },
+                                          "group_key": [
+                                            {
+                                              "Column": 0
+                                            }
+                                          ],
+                                          "aggregates": [],
+                                          "monotonic": false,
+                                          "expected_group_size": null
                                         }
-                                      ],
-                                      "equivalences": [],
-                                      "implementation": "Unimplemented"
+                                      },
+                                      "scalars": [
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  2
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "Bool",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   },
                                   "body": {

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -47,27 +47,19 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
 Union
-  Project (#2, #3)
-    Map (#0, #1)
-      Union
-        Project (#2, #3)
-          Map (#0, #1)
-            Project (#0, #1)
-              Map (1, 2)
-                Constant
-                  - ()
-        Project (#2, #3)
-          Map (#0, #1)
-            Project (#0, #1)
-              Map (1, 2)
-                Constant
-                  - ()
-  Project (#2, #3)
-    Map (#0, #1)
-      Project (#0, #1)
-        Map (3, 4)
-          Constant
-            - ()
+  Union
+    Project (#0, #1)
+      Map (1, 2)
+        Constant
+          - ()
+    Project (#0, #1)
+      Map (1, 2)
+        Constant
+          - ()
+  Project (#0, #1)
+    Map (3, 4)
+      Constant
+        - ()
 
 EOF
 
@@ -109,22 +101,18 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
 Threshold
   Union
     Distinct group_by=[#0]
-      Project (#1)
-        Map (#0)
-          Project (#0)
-            CrossJoin
-              Constant
-                - ()
-              Get materialize.public.t
+      Project (#0)
+        CrossJoin
+          Constant
+            - ()
+          Get materialize.public.t
     Negate
       Distinct group_by=[#0]
         Project (#1)
-          Map (#0)
-            Project (#1)
-              CrossJoin
-                Constant
-                  - ()
-                Get materialize.public.mv
+          CrossJoin
+            Constant
+              - ()
+            Get materialize.public.mv
 
 EOF
 
@@ -135,21 +123,17 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 Threshold
   Union
-    Project (#1)
-      Map (#0)
-        Project (#0)
-          CrossJoin
-            Constant
-              - ()
-            Get materialize.public.t
+    Project (#0)
+      CrossJoin
+        Constant
+          - ()
+        Get materialize.public.t
     Negate
       Project (#1)
-        Map (#0)
-          Project (#1)
-            CrossJoin
-              Constant
-                - ()
-              Get materialize.public.mv
+        CrossJoin
+          Constant
+            - ()
+          Get materialize.public.mv
 
 EOF
 
@@ -258,14 +242,12 @@ Return
                 - (false)
 With
   cte l5 =
-    CrossJoin
+    Map (true)
       Distinct group_by=[#0]
         Filter (#0 > #2)
           CrossJoin
             Get l4
             Get materialize.public.mv
-      Constant
-        - (true)
   cte l4 =
     Distinct group_by=[#1]
       Get l3
@@ -290,14 +272,12 @@ With
                 Constant
                   - (false)
   cte l2 =
-    CrossJoin
+    Map (true)
       Distinct group_by=[#0]
         Filter (#0 < #1)
           CrossJoin
             Get l1
             Get materialize.public.mv
-      Constant
-        - (true)
   cte l1 =
     Distinct group_by=[#0]
       Get l0

--- a/test/sqllogictest/explain/raw_plan_as_json.slt
+++ b/test/sqllogictest/explain/raw_plan_as_json.slt
@@ -234,48 +234,29 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
             "input": {
               "Project": {
                 "input": {
-                  "Map": {
-                    "input": {
-                      "Project": {
-                        "input": {
-                          "Get": {
-                            "id": {
-                              "Global": {
-                                "User": 1
-                              }
-                            },
-                            "typ": {
-                              "column_types": [
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                },
-                                {
-                                  "scalar_type": "Int32",
-                                  "nullable": true
-                                }
-                              ],
-                              "keys": []
-                            }
-                          }
-                        },
-                        "outputs": [
-                          0
-                        ]
+                  "Get": {
+                    "id": {
+                      "Global": {
+                        "User": 1
                       }
                     },
-                    "scalars": [
-                      {
-                        "Column": {
-                          "level": 0,
-                          "column": 0
+                    "typ": {
+                      "column_types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        },
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
                         }
-                      }
-                    ]
+                      ],
+                      "keys": []
+                    }
                   }
                 },
                 "outputs": [
-                  1
+                  0
                 ]
               }
             }
@@ -289,44 +270,25 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
                   "input": {
                     "Project": {
                       "input": {
-                        "Map": {
-                          "input": {
-                            "Project": {
-                              "input": {
-                                "Get": {
-                                  "id": {
-                                    "Global": {
-                                      "User": 5
-                                    }
-                                  },
-                                  "typ": {
-                                    "column_types": [
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": false
-                                      },
-                                      {
-                                        "scalar_type": "Int32",
-                                        "nullable": true
-                                      }
-                                    ],
-                                    "keys": []
-                                  }
-                                }
-                              },
-                              "outputs": [
-                                1
-                              ]
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 5
                             }
                           },
-                          "scalars": [
-                            {
-                              "Column": {
-                                "level": 0,
-                                "column": 0
+                          "typ": {
+                            "column_types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": false
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
                               }
-                            }
-                          ]
+                            ],
+                            "keys": []
+                          }
                         }
                       },
                       "outputs": [

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -58,16 +58,12 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
 Threshold
   Union
     Distinct
-      Project (#1)
-        Map (#0)
-          Project (#0)
-            Get materialize.public.t
+      Project (#0)
+        Get materialize.public.t
     Negate
       Distinct
         Project (#1)
-          Map (#0)
-            Project (#1)
-              Get materialize.public.mv
+          Get materialize.public.mv
 
 EOF
 
@@ -77,14 +73,10 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
 Except
+  Project (#0)
+    Get materialize.public.t
   Project (#1)
-    Map (#0)
-      Project (#0)
-        Get materialize.public.t
-  Project (#1)
-    Map (#0)
-      Project (#1)
-        Get materialize.public.mv
+    Get materialize.public.mv
 
 EOF
 
@@ -94,14 +86,10 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 ExceptAll
+  Project (#0)
+    Get materialize.public.t
   Project (#1)
-    Map (#0)
-      Project (#0)
-        Get materialize.public.t
-  Project (#1)
-    Map (#0)
-      Project (#1)
-        Get materialize.public.mv
+    Get materialize.public.mv
 
 EOF
 

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -734,22 +734,26 @@ EXPLAIN WITH(types, no_fast_path) SELECT 1 IN (SELECT col_not_null FROM int_tabl
 ----
 Explained Query:
   Return // { types: "(boolean, boolean)" }
-    Map (NOT(#0)) // { types: "(boolean, boolean)" }
-      CrossJoin type=differential // { types: "(boolean)" }
-        ArrangeBy keys=[[]] // { types: "()" }
-          Project () // { types: "()" }
-            Get materialize.public.int_table // { types: "(integer?, integer)" }
-        ArrangeBy keys=[[]] // { types: "(boolean)" }
-          Union // { types: "(boolean)" }
-            Map (true) // { types: "(boolean)" }
-              Get l0 // { types: "()" }
-            Map (false) // { types: "(boolean)" }
-              Union // { types: "()" }
-                Negate // { types: "()" }
-                  Get l0 // { types: "()" }
-                Constant // { types: "()" }
-                  - ()
+    Project (#0, #2) // { types: "(boolean, boolean)" }
+      Map (NOT(#1)) // { types: "(boolean, boolean, boolean)" }
+        CrossJoin type=delta // { types: "(boolean, boolean)" }
+          ArrangeBy keys=[[]] // { types: "()" }
+            Project () // { types: "()" }
+              Get materialize.public.int_table // { types: "(integer?, integer)" }
+          Get l1 // { types: "(boolean)" }
+          Get l1 // { types: "(boolean)" }
   With
+    cte l1 =
+      ArrangeBy keys=[[]] // { types: "(boolean)" }
+        Union // { types: "(boolean)" }
+          Map (true) // { types: "(boolean)" }
+            Get l0 // { types: "()" }
+          Map (false) // { types: "(boolean)" }
+            Union // { types: "()" }
+              Negate // { types: "()" }
+                Get l0 // { types: "()" }
+              Constant // { types: "()" }
+                - ()
     cte l0 =
       Distinct // { types: "()" }
         Project () // { types: "()" }

--- a/test/sqllogictest/qgm/qgm-type-inference.slt
+++ b/test/sqllogictest/qgm/qgm-type-inference.slt
@@ -1166,7 +1166,7 @@ digraph G {
     }
     subgraph cluster3 {
         label = "Box3:Select"
-        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: ((1 = Q2.C0) AND true) (boolean) }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: (1 = Q2.C0) (boolean) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -1202,7 +1202,7 @@ digraph G {
     }
     subgraph cluster7 {
         label = "Box7:Select"
-        boxhead7 [ shape = record, label = "{ Distinct: Preserve| 0: NOT(((1 = Q7.C0) AND true)) (boolean) }" ]
+        boxhead7 [ shape = record, label = "{ Distinct: Preserve| 0: NOT((1 = Q7.C0)) (boolean) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -1355,7 +1355,7 @@ digraph G {
     }
     subgraph cluster3 {
         label = "Box3:Select"
-        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: ((1 = Q2.C0) AND true) (boolean) }" ]
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: (1 = Q2.C0) (boolean) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -1391,7 +1391,7 @@ digraph G {
     }
     subgraph cluster8 {
         label = "Box8:Select"
-        boxhead8 [ shape = record, label = "{ Distinct: Preserve| 0: ((Q0.C1 = Q7.C0) AND true) (boolean) }" ]
+        boxhead8 [ shape = record, label = "{ Distinct: Preserve| 0: (Q0.C1 = Q7.C0) (boolean) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -1434,7 +1434,7 @@ digraph G {
     }
     subgraph cluster12 {
         label = "Box12:Select"
-        boxhead12 [ shape = record, label = "{ Distinct: Preserve| 0: ((Q0.C0 = Q12.C0) AND true) (boolean?) }" ]
+        boxhead12 [ shape = record, label = "{ Distinct: Preserve| 0: (Q0.C0 = Q12.C0) (boolean?) }" ]
         {
             rank = same
             node [ shape = circle ]

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1834,14 +1834,14 @@ Finish order_by=[#0 asc nulls_last] output=[#0, #1]
           Get materialize.public.nation
     Where
       cte l3 =
-        Reduce aggregates=[any(((#^0 = #0) AND true))]
+        Reduce aggregates=[any((#^0 = #0))]
           Project (#1)
             Return
               Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
                 Get materialize.public.partsupp
             Where
               cte l1 =
-                Reduce aggregates=[any(((#^0 = #0) AND true))]
+                Reduce aggregates=[any((#^0 = #0))]
                   Project (#0)
                     Filter (varchar_to_text(#1) like "forest%")
                       Get materialize.public.part

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -100,20 +100,16 @@ SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 ----
 Filter (#0 = 3) // { arity: 1 }
   Union // { arity: 1 }
-    Project (#1) // { arity: 1 }
-      Map (#0) // { arity: 2 }
-        Distinct group_by=[#0] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            CrossJoin // { arity: 3 }
-              Constant // { arity: 0 }
-                - ()
-              Get materialize.public.x // { arity: 3 }
-    Project (#1) // { arity: 1 }
-      Map (#0) // { arity: 2 }
-        CrossJoin // { arity: 1 }
+    Distinct group_by=[#0] // { arity: 1 }
+      Project (#0) // { arity: 1 }
+        CrossJoin // { arity: 3 }
           Constant // { arity: 0 }
             - ()
-          Get materialize.public.y // { arity: 1 }
+          Get materialize.public.x // { arity: 3 }
+    CrossJoin // { arity: 1 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.public.y // { arity: 1 }
 
 EOF
 

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -194,9 +194,9 @@ Return // { arity: 1 }
                 - (false)
 With
   cte l2 =
-    CrossJoin // { arity: 2 }
+    Map (true) // { arity: 2 }
       Distinct group_by=[#0] // { arity: 1 }
-        Filter ((integer_to_bigint(#0) = #1) AND true) // { arity: 2 }
+        Filter (integer_to_bigint(#0) = #1) // { arity: 2 }
           Project (#0, #4) // { arity: 2 }
             Map (#3) // { arity: 5 }
               Project (#3..=#6) // { arity: 4 }
@@ -206,8 +206,6 @@ With
                       CrossJoin // { arity: 3 }
                         Get l1 // { arity: 1 }
                         Get materialize.public.t2 // { arity: 2 }
-      Constant // { arity: 1 }
-        - (true)
   cte l1 =
     Distinct group_by=[#0] // { arity: 1 }
       Get l0 // { arity: 2 }

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -216,16 +216,11 @@ Explained Query:
       Project (#0)
         Distinct group_by=[#0, #1]
           Union
-            Project (#2, #3)
-              Map (#0, #1)
-                Map (1, 2)
-                  Constant
-                    - ()
-            Project (#1, #2)
-              Map (#0)
-                Project (#1, #2)
-                  Map (7, #0)
-                    Get l0
+            Map (1, 2)
+              Constant
+                - ()
+            Map (7)
+              Get l0
 
 EOF
 
@@ -249,22 +244,14 @@ Explained Query:
       Return
         Threshold
           Union
-            Project (#1)
-              Map (#0)
-                Get l1
+            Get l1
             Negate
-              Project (#1)
-                Map (#0)
-                  Get l0
+              Get l0
       With Mutually Recursive
         cte l0 =
           Union
-            Project (#1)
-              Map (#0)
-                Get l1
-            Project (#1)
-              Map (#0)
-                Get l0
+            Get l1
+            Get l0
 
 EOF
 
@@ -287,13 +274,9 @@ Explained Query:
     cte l0 =
       Threshold
         Union
-          Project (#1)
-            Map (#0)
-              Get l0
+          Get l0
           Negate
-            Project (#1)
-              Map (#0)
-                Get l0
+            Get l0
 
 EOF
 
@@ -314,12 +297,8 @@ SELECT * FROM (
 Explained Query:
   Return
     Union
-      Project (#1)
-        Map (#0)
-          Get l0
-      Project (#1)
-        Map (#0)
-          Get l1
+      Get l0
+      Get l1
   With Mutually Recursive
     cte l1 =
       Distinct group_by=[#0]


### PR DESCRIPTION
The SQL planner produces HIR and MIR with various nits that we expect subsequent optimization to clean up. However, we present HIR and unoptimized MIR at users, and as someone who's had to read this recently it has seemed that there are various low hanging fruit to clean up such that we don't emit grotty moments in the first place.

The examples here are:
1. For a `Union`, only produce casting `Map` and `Project` nodes if non-trivial casts occur.
2. For existential subqueries, `Map(true)` rather than cross join a singleton collection containing the literal `true`.
3. For row comparison desugaring, remove the `AND true` as we are certain to have elements to compare.

There is unknown SLT fallout that I'll let CI discover rather than wait the half a day for my laptop to do it.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

    * The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
