### PR TITLE
dbt-materialize: release v1.3.3

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.3.3 - 2023-01-05
 
 * Remove the 63-character limitation on relation names. Materialize does not
   have this limitation, unlike PostgreSQL (see [dbt-core #2727](https://github.com/dbt-labs/dbt-core/pull/2727)).

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -73,10 +73,6 @@ Component                            | Value     | Description
 
 ### Additional macros
 
-Macro | Purpose
-------|----------
-`mz_generate_name(identifier)` | (Deprecated) Generates a fully-qualified name given an object name. Use the native Jinja function [`{{ this }}`](https://docs.getdbt.com/reference/dbt-jinja-functions/this) to reference relations instead.
-
 We provide a `materialize-dbt-utils` package with Materialize-specific implementations of dispatched macros from `dbt-utils`. To use this package in your dbt project, check the latest installation instructions in [dbt Hub](https://hub.getdbt.com/materializeinc/materialize_dbt_utils/latest/).
 
 ### Seeds

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.3.2"
+version = "1.3.3"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,13 +24,13 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.3.2",
+    version="1.3.3",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
     author="Materialize, Inc.",
     author_email="support@materialize.com",
-    url="https://github.com/MaterializeInc/dbt-materialize",
+    url="https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize",
     packages=find_packages(),
     package_data={
         "dbt": [


### PR DESCRIPTION
Cut a new release of `dbt-materialize` with stashed improvements ahead of the release of dbt v1.4.0 (see the [beta release](https://github.com/dbt-labs/dbt-core/releases/tag/v1.4.0b1) for a preview; the tentative release date is Jan. 11).