### PR TITLE
Form regions around nontrivial dataflows

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -25,7 +25,7 @@ use mz_compute_client::plan::AvailableCollections;
 use timely::communication::message::RefOrMut;
 use timely::container::columnation;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::{Scope, ScopeParent};
+use timely::dataflow::{scopes::Child, Scope, ScopeParent};
 use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
@@ -270,6 +270,52 @@ where
         }
     }
 }
+impl<S: Scope, V: Data + columnation::Columnation, T> ArrangementFlavor<S, V, T>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
+    /// The scope containing the collection bundle.
+    pub fn scope(&self) -> S {
+        match self {
+            ArrangementFlavor::Local(oks, _errs) => oks.stream.scope(),
+            ArrangementFlavor::Trace(_gid, oks, _errs) => oks.stream.scope(),
+        }
+    }
+
+    /// Brings the arrangement flavor into a region.
+    pub fn enter_region<'a>(
+        &self,
+        region: &Child<'a, S, S::Timestamp>,
+    ) -> ArrangementFlavor<Child<'a, S, S::Timestamp>, V, T> {
+        match self {
+            ArrangementFlavor::Local(oks, errs) => {
+                ArrangementFlavor::Local(oks.enter_region(region), errs.enter_region(region))
+            }
+            ArrangementFlavor::Trace(gid, oks, errs) => {
+                ArrangementFlavor::Trace(*gid, oks.enter_region(region), errs.enter_region(region))
+            }
+        }
+    }
+}
+impl<'a, S: Scope, V: Data + columnation::Columnation, T>
+    ArrangementFlavor<Child<'a, S, S::Timestamp>, V, T>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
+    /// Extracts the arrangement flavor from a region.
+    pub fn leave_region(&self) -> ArrangementFlavor<S, V, T> {
+        match self {
+            ArrangementFlavor::Local(oks, errs) => {
+                ArrangementFlavor::Local(oks.leave_region(), errs.leave_region())
+            }
+            ArrangementFlavor::Trace(gid, oks, errs) => {
+                ArrangementFlavor::Trace(*gid, oks.leave_region(), errs.leave_region())
+            }
+        }
+    }
+}
 
 /// A bundle of the various ways a collection can be represented.
 ///
@@ -324,6 +370,59 @@ where
             keys.push(MirScalarExpr::Column(column));
         }
         Self::from_expressions(keys, arrangements)
+    }
+
+    /// The scope containing the collection bundle.
+    pub fn scope(&self) -> S {
+        if let Some((oks, _errs)) = &self.collection {
+            oks.inner.scope()
+        } else {
+            self.arranged
+                .values()
+                .next()
+                .expect("Must contain a valid collection")
+                .scope()
+        }
+    }
+
+    /// Brings the collection bundle into a region.
+    pub fn enter_region<'a>(
+        &self,
+        region: &Child<'a, S, S::Timestamp>,
+    ) -> CollectionBundle<Child<'a, S, S::Timestamp>, V, T> {
+        CollectionBundle {
+            collection: self
+                .collection
+                .as_ref()
+                .map(|(oks, errs)| (oks.enter_region(region), errs.enter_region(region))),
+            arranged: self
+                .arranged
+                .iter()
+                .map(|(key, bundle)| (key.clone(), bundle.enter_region(region)))
+                .collect(),
+        }
+    }
+}
+
+impl<'a, S: Scope, V: Data + columnation::Columnation, T>
+    CollectionBundle<Child<'a, S, S::Timestamp>, V, T>
+where
+    T: Timestamp + Lattice,
+    S::Timestamp: Lattice + Refines<T>,
+{
+    /// Extracts the collection bundle from a region.
+    pub fn leave_region(&self) -> CollectionBundle<S, V, T> {
+        CollectionBundle {
+            collection: self
+                .collection
+                .as_ref()
+                .map(|(oks, errs)| (oks.leave_region(), errs.leave_region())),
+            arranged: self
+                .arranged
+                .iter()
+                .map(|(key, bundle)| (key.clone(), bundle.leave_region()))
+                .collect(),
+        }
     }
 }
 

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -40,14 +40,14 @@ where
         inputs: Vec<CollectionBundle<G, Row>>,
         join_plan: DeltaJoinPlan,
     ) -> CollectionBundle<G, Row> {
-        // Collects error streams for the ambient scope.
-        let mut scope_errs = Vec::new();
-
-        // Deduplicate the error streams of multiply used arrangements.
-        let mut err_dedup = HashSet::new();
-
         // We create a new region to contain the dataflow paths for the delta join.
-        let (oks, errs) = self.scope.clone().region_named("delta query", |inner| {
+        let (oks, errs) = self.scope.clone().region_named("Join(Delta)", |inner| {
+            // Collects error streams for the ambient scope.
+            let mut inner_errs = Vec::new();
+
+            // Deduplicate the error streams of multiply used arrangements.
+            let mut err_dedup = HashSet::new();
+
             // Our plan is to iterate through each input relation, and attempt
             // to find a plan that maximally uses existing keys (better: uses
             // existing arrangements, to which we have access).
@@ -75,23 +75,27 @@ where
                                 }) {
                                 ArrangementFlavor::Local(oks, errs) => {
                                     if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        scope_errs.push(errs.as_collection(|k, _v| k.clone()));
+                                        inner_errs.push(
+                                            errs.enter_region(inner)
+                                                .as_collection(|k, _v| k.clone()),
+                                        );
                                     }
-                                    Ok(oks.enter(inner))
+                                    Ok(oks.enter_region(inner))
                                 }
                                 ArrangementFlavor::Trace(_gid, oks, errs) => {
                                     if err_dedup.insert((lookup_idx, lookup_key)) {
-                                        scope_errs.push(errs.as_collection(|k, _v| k.clone()));
+                                        inner_errs.push(
+                                            errs.enter_region(inner)
+                                                .as_collection(|k, _v| k.clone()),
+                                        );
                                     }
-                                    Err(oks.enter(inner))
+                                    Err(oks.enter_region(inner))
                                 }
                             }
                         });
                 }
             }
 
-            // Collects error streams for the inner scope. Concats before leaving.
-            let mut inner_errs = Vec::with_capacity(inputs.len());
             for path_plan in join_plan.path_plans {
                 // Deconstruct the stages of the path plan.
                 let DeltaPathPlan {
@@ -133,7 +137,7 @@ where
                     let as_of = self.as_of_frontier.clone();
                     let update_stream = match val {
                         Ok(local) => {
-                            let arranged = local.enter(region);
+                            let arranged = local.enter_region(region);
                             let (update_stream, err_stream) = build_update_stream(
                                 arranged,
                                 as_of,
@@ -144,7 +148,7 @@ where
                             update_stream
                         }
                         Err(trace) => {
-                            let arranged = trace.enter(region);
+                            let arranged = trace.enter_region(region);
                             let (update_stream, err_stream) = build_update_stream(
                                 arranged,
                                 as_of,
@@ -268,21 +272,19 @@ where
                     }
 
                     inner_errs.push(
-                        differential_dataflow::collection::concatenate(region, region_errs).leave(),
+                        differential_dataflow::collection::concatenate(region, region_errs)
+                            .leave_region(),
                     );
-                    update_stream.leave()
+                    update_stream.leave_region()
                 });
 
                 join_results.push(path_results);
             }
 
-            scope_errs
-                .push(differential_dataflow::collection::concatenate(inner, inner_errs).leave());
-
             // Concatenate the results of each delta query as the accumulated results.
             (
-                differential_dataflow::collection::concatenate(inner, join_results).leave(),
-                differential_dataflow::collection::concatenate(&mut self.scope, scope_errs),
+                differential_dataflow::collection::concatenate(inner, join_results).leave_region(),
+                differential_dataflow::collection::concatenate(inner, inner_errs).leave_region(),
             )
         });
         CollectionBundle::from_collections(oks, errs)

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -57,41 +57,83 @@ where
         inputs: Vec<CollectionBundle<G, Row, T>>,
         linear_plan: LinearJoinPlan,
     ) -> CollectionBundle<G, Row, T> {
-        // Collect all error streams, and concatenate them at the end.
-        let mut errors = Vec::new();
+        self.scope.region_named("Join(Linear)", |inner| {
+            // Collect all error streams, and concatenate them at the end.
+            let mut errors = Vec::new();
 
-        // Determine which form our maintained spine of updates will initially take.
-        // First, just check out the availability of an appropriate arrangement.
-        // This will be `None` in the degenerate single-input join case, which ensures
-        // that we do not panic if we never go around the `stage_plans` loop.
-        let arrangement = linear_plan
-            .stage_plans
-            .get(0)
-            .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
-        // We can use an arrangement if it exists and an initial closure does not.
-        let mut joined = match (arrangement, linear_plan.initial_closure) {
-            (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                errors.push(errs.as_collection(|k, _v| k.clone()));
-                JoinedFlavor::Local(oks)
-            }
-            (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                errors.push(errs.as_collection(|k, _v| k.clone()));
-                JoinedFlavor::Trace(oks)
-            }
-            (_, initial_closure) => {
-                // TODO: extract closure from the first stage in the join plan, should it exist.
-                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                let (mut joined, errs) = inputs[linear_plan.source_relation]
-                    .as_specific_collection(linear_plan.source_key.as_deref());
-                errors.push(errs);
+            // Determine which form our maintained spine of updates will initially take.
+            // First, just check out the availability of an appropriate arrangement.
+            // This will be `None` in the degenerate single-input join case, which ensures
+            // that we do not panic if we never go around the `stage_plans` loop.
+            let arrangement = linear_plan.stage_plans.get(0).and_then(|stage| {
+                inputs[linear_plan.source_relation].arrangement(&stage.stream_key)
+            });
+            // We can use an arrangement if it exists and an initial closure does not.
+            let mut joined = match (arrangement, linear_plan.initial_closure) {
+                (Some(ArrangementFlavor::Local(oks, errs)), None) => {
+                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                    JoinedFlavor::Local(oks.enter_region(inner))
+                }
+                (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
+                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                    JoinedFlavor::Trace(oks.enter_region(inner))
+                }
+                (_, initial_closure) => {
+                    // TODO: extract closure from the first stage in the join plan, should it exist.
+                    // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+                    let (joined, errs) = inputs[linear_plan.source_relation]
+                        .as_specific_collection(linear_plan.source_key.as_deref());
+                    errors.push(errs.enter_region(inner));
+                    let mut joined = joined.enter_region(inner);
 
-                // In the current code this should always be `None`, but we have this here should
-                // we change that and want to know what we should be doing.
-                if let Some(closure) = initial_closure {
-                    // If there is no starting arrangement, then we can run filters
-                    // directly on the starting collection.
-                    // If there is only one input, we are done joining, so run filters
-                    let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
+                    // In the current code this should always be `None`, but we have this here should
+                    // we change that and want to know what we should be doing.
+                    if let Some(closure) = initial_closure {
+                        // If there is no starting arrangement, then we can run filters
+                        // directly on the starting collection.
+                        // If there is only one input, we are done joining, so run filters
+                        let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
+                            // Reuseable allocation for unpacking.
+                            let mut datums = DatumVec::new();
+                            let mut row_builder = Row::default();
+                            move |row| {
+                                let temp_storage = RowArena::new();
+                                let mut datums_local = datums.borrow_with(&row);
+                                // TODO(mcsherry): re-use `row` allocation.
+                                closure
+                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                    .map_err(DataflowError::from)
+                                    .transpose()
+                            }
+                        });
+                        joined = j;
+                        errors.push(errs);
+                    }
+
+                    JoinedFlavor::Collection(joined)
+                }
+            };
+
+            // progress through stages, updating partial results and errors.
+            for stage_plan in linear_plan.stage_plans.into_iter() {
+                // Different variants of `joined` implement this differently,
+                // and the logic is centralized there.
+                let stream = differential_join(
+                    joined,
+                    inputs[stage_plan.lookup_relation].enter_region(inner),
+                    stage_plan,
+                    &mut errors,
+                );
+                // Update joined results and capture any errors.
+                joined = JoinedFlavor::Collection(stream);
+            }
+
+            // We have completed the join building, but may have work remaining.
+            // For example, we may have expressions not pushed down (e.g. literals)
+            // and projections that could not be applied (e.g. column repetition).
+            if let JoinedFlavor::Collection(mut joined) = joined {
+                if let Some(closure) = linear_plan.final_closure {
+                    let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         let mut row_builder = Row::default();
@@ -105,203 +147,169 @@ where
                                 .transpose()
                         }
                     });
-                    joined = j;
+
+                    joined = updates;
                     errors.push(errs);
                 }
 
-                JoinedFlavor::Collection(joined)
+                // Return joined results and all produced errors collected together.
+                CollectionBundle::from_collections(
+                    joined,
+                    differential_dataflow::collection::concatenate(inner, errors),
+                )
+            } else {
+                panic!("Unexpectedly arranged join output");
             }
-        };
+            .leave_region()
+        })
+    }
+}
 
-        // progress through stages, updating partial results and errors.
-        for stage_plan in linear_plan.stage_plans.into_iter() {
-            // Different variants of `joined` implement this differently,
-            // and the logic is centralized there.
-            let stream = self.differential_join(
-                joined,
-                inputs[stage_plan.lookup_relation].clone(),
-                stage_plan,
-                &mut errors,
-            );
-            // Update joined results and capture any errors.
-            joined = JoinedFlavor::Collection(stream);
-        }
-
-        // We have completed the join building, but may have work remaining.
-        // For example, we may have expressions not pushed down (e.g. literals)
-        // and projections that could not be applied (e.g. column repetition).
-        if let JoinedFlavor::Collection(mut joined) = joined {
-            if let Some(closure) = linear_plan.final_closure {
-                let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
-                    // Reuseable allocation for unpacking.
-                    let mut datums = DatumVec::new();
-                    let mut row_builder = Row::default();
-                    move |row| {
-                        let temp_storage = RowArena::new();
-                        let mut datums_local = datums.borrow_with(&row);
-                        // TODO(mcsherry): re-use `row` allocation.
-                        closure
-                            .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                            .map_err(DataflowError::from)
-                            .transpose()
-                    }
-                });
-
-                joined = updates;
-                errors.push(errs);
+/// Looks up the arrangement for the next input and joins it to the arranged
+/// version of the join of previous inputs. This is split into its own method
+/// to enable reuse of code with different types of `prev_keyed`.
+fn differential_join<G, T>(
+    mut joined: JoinedFlavor<G, T>,
+    lookup_relation: CollectionBundle<G, Row, T>,
+    LinearStagePlan {
+        stream_key,
+        stream_thinning,
+        lookup_key,
+        closure,
+        lookup_relation: _,
+    }: LinearStagePlan,
+    errors: &mut Vec<Collection<G, DataflowError, Diff>>,
+) -> Collection<G, Row, Diff>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+{
+    // If we have only a streamed collection, we must first form an arrangement.
+    if let JoinedFlavor::Collection(stream) = joined {
+        let mut row_buf = Row::default();
+        let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
+            // Reuseable allocation for unpacking.
+            let mut datums = DatumVec::new();
+            move |row| {
+                let temp_storage = RowArena::new();
+                let datums_local = datums.borrow_with(&row);
+                row_buf.packer().try_extend(
+                    stream_key
+                        .iter()
+                        .map(|e| e.eval(&datums_local, &temp_storage)),
+                )?;
+                let key = row_buf.clone();
+                row_buf
+                    .packer()
+                    .extend(stream_thinning.iter().map(|e| datums_local[*e]));
+                let value = row_buf.clone();
+                Ok((key, value))
             }
+        });
 
-            // Return joined results and all produced errors collected together.
-            CollectionBundle::from_collections(
-                joined,
-                differential_dataflow::collection::concatenate(&mut self.scope, errors),
-            )
-        } else {
-            panic!("Unexpectedly arranged join output");
-        }
+        errors.push(errs);
+        let arranged = keyed.arrange_named::<RowSpine<_, _, _, _>>("JoinStage");
+        joined = JoinedFlavor::Local(arranged);
     }
 
-    /// Looks up the arrangement for the next input and joins it to the arranged
-    /// version of the join of previous inputs. This is split into its own method
-    /// to enable reuse of code with different types of `prev_keyed`.
-    fn differential_join(
-        &mut self,
-        mut joined: JoinedFlavor<G, T>,
-        lookup_relation: CollectionBundle<G, Row, T>,
-        LinearStagePlan {
-            stream_key,
-            stream_thinning,
-            lookup_key,
-            closure,
-            lookup_relation: _,
-        }: LinearStagePlan,
-        errors: &mut Vec<Collection<G, DataflowError, Diff>>,
-    ) -> Collection<G, Row, Diff> {
-        // If we have only a streamed collection, we must first form an arrangement.
-        if let JoinedFlavor::Collection(stream) = joined {
-            let mut row_buf = Row::default();
-            let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
-                // Reuseable allocation for unpacking.
-                let mut datums = DatumVec::new();
-                move |row| {
-                    let temp_storage = RowArena::new();
-                    let datums_local = datums.borrow_with(&row);
-                    row_buf.packer().try_extend(
-                        stream_key
-                            .iter()
-                            .map(|e| e.eval(&datums_local, &temp_storage)),
-                    )?;
-                    let key = row_buf.clone();
-                    row_buf
-                        .packer()
-                        .extend(stream_thinning.iter().map(|e| datums_local[*e]));
-                    let value = row_buf.clone();
-                    Ok((key, value))
-                }
-            });
-
-            errors.push(errs);
-            let arranged = keyed.arrange_named::<RowSpine<_, _, _, _>>("JoinStage");
-            joined = JoinedFlavor::Local(arranged);
+    // Demultiplex the four different cross products of arrangement types we might have.
+    let arrangement = lookup_relation
+        .arrangement(&lookup_key[..])
+        .expect("Arrangement absent despite explicit construction");
+    match joined {
+        JoinedFlavor::Collection(_) => {
+            unreachable!("JoinedFlavor::Collection variant avoided at top of method");
         }
-
-        // Demultiplex the four different cross products of arrangement types we might have.
-        let arrangement = lookup_relation
-            .arrangement(&lookup_key[..])
-            .expect("Arrangement absent despite explicit construction");
-        match joined {
-            JoinedFlavor::Collection(_) => {
-                unreachable!("JoinedFlavor::Collection variant avoided at top of method");
+        JoinedFlavor::Local(local) => match arrangement {
+            ArrangementFlavor::Local(oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(local, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
             }
-            JoinedFlavor::Local(local) => match arrangement {
-                ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(local, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-                ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(local, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-            },
-            JoinedFlavor::Trace(trace) => match arrangement {
-                ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-                ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-            },
-        }
+            ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(local, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+        },
+        JoinedFlavor::Trace(trace) => match arrangement {
+            ArrangementFlavor::Local(oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(trace, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+            ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(trace, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+        },
     }
+}
 
-    /// Joins the arrangement for `next_input` to the arranged version of the
-    /// join of previous inputs. This is split into its own method to enable
-    /// reuse of code with different types of `next_input`.
-    ///
-    /// The return type includes an optional error collection, which may be
-    /// `None` if we can determine that `closure` cannot error.
-    fn differential_join_inner<J, Tr2>(
-        &mut self,
-        prev_keyed: J,
-        next_input: Arranged<G, Tr2>,
-        closure: JoinClosure,
-    ) -> (
-        Collection<G, Row, Diff>,
-        Option<Collection<G, DataflowError, Diff>>,
-    )
-    where
-        J: JoinCore<G, Row, Row, mz_repr::Diff>,
-        Tr2: TraceReader<Key = Row, Val = Row, Time = G::Timestamp, R = mz_repr::Diff>
-            + Clone
-            + 'static,
-    {
-        use differential_dataflow::AsCollection;
-        use timely::dataflow::operators::OkErr;
+/// Joins the arrangement for `next_input` to the arranged version of the
+/// join of previous inputs. This is split into its own method to enable
+/// reuse of code with different types of `next_input`.
+///
+/// The return type includes an optional error collection, which may be
+/// `None` if we can determine that `closure` cannot error.
+fn differential_join_inner<G, T, J, Tr2>(
+    prev_keyed: J,
+    next_input: Arranged<G, Tr2>,
+    closure: JoinClosure,
+) -> (
+    Collection<G, Row, Diff>,
+    Option<Collection<G, DataflowError, Diff>>,
+)
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+    J: JoinCore<G, Row, Row, mz_repr::Diff>,
+    Tr2:
+        TraceReader<Key = Row, Val = Row, Time = G::Timestamp, R = mz_repr::Diff> + Clone + 'static,
+{
+    use differential_dataflow::AsCollection;
+    use timely::dataflow::operators::OkErr;
 
-        // Reuseable allocation for unpacking.
-        let mut datums = DatumVec::new();
-        let mut row_builder = Row::default();
+    // Reuseable allocation for unpacking.
+    let mut datums = DatumVec::new();
+    let mut row_builder = Row::default();
 
-        if closure.could_error() {
-            let (oks, err) = prev_keyed
-                .join_core(&next_input, move |key, old, new| {
-                    let temp_storage = RowArena::new();
-                    let mut datums_local = datums.borrow_with_many(&[key, old, new]);
-                    closure
-                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                        .map_err(DataflowError::from)
-                        .transpose()
-                })
-                .inner
-                .ok_err(|(x, t, d)| {
-                    // TODO(mcsherry): consider `ok_err()` for `Collection`.
-                    match x {
-                        Ok(x) => Ok((x, t, d)),
-                        Err(x) => Err((x, t, d)),
-                    }
-                });
-
-            (oks.as_collection(), Some(err.as_collection()))
-        } else {
-            let oks = prev_keyed.join_core(&next_input, move |key, old, new| {
+    if closure.could_error() {
+        let (oks, err) = prev_keyed
+            .join_core(&next_input, move |key, old, new| {
                 let temp_storage = RowArena::new();
                 let mut datums_local = datums.borrow_with_many(&[key, old, new]);
                 closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                    .expect("Closure claimed to never error")
+                    .map_err(DataflowError::from)
+                    .transpose()
+            })
+            .inner
+            .ok_err(|(x, t, d)| {
+                // TODO(mcsherry): consider `ok_err()` for `Collection`.
+                match x {
+                    Ok(x) => Ok((x, t, d)),
+                    Err(x) => Err((x, t, d)),
+                }
             });
 
-            (oks, None)
-        }
+        (oks.as_collection(), Some(err.as_collection()))
+    } else {
+        let oks = prev_keyed.join_core(&next_input, move |key, old, new| {
+            let temp_storage = RowArena::new();
+            let mut datums_local = datums.borrow_with_many(&[key, old, new]);
+            closure
+                .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                .expect("Closure claimed to never error")
+        });
+
+        (oks, None)
     }
 }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -197,80 +197,95 @@ where
         reduce_plan: ReducePlan,
         input_key: Option<Vec<MirScalarExpr>>,
     ) -> CollectionBundle<G, Row, T> {
-        let KeyValPlan {
-            mut key_plan,
-            mut val_plan,
-        } = key_val_plan;
-        let key_arity = key_plan.projection.len();
-        let mut row_buf = Row::default();
-        let mut row_mfp = Row::default();
-        let mut datums = DatumVec::new();
-        let mut row_datums = DatumVec::new();
-        let (key_val_input, err_input): (
-            timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
-            _,
-        ) = input.flat_map(input_key.map(|k| (k, None)), || {
-            // Determine the columns we'll need from the row.
-            let mut demand = Vec::new();
-            demand.extend(key_plan.demand());
-            demand.extend(val_plan.demand());
-            demand.sort();
-            demand.dedup();
-            // remap column references to the subset we use.
-            let mut demand_map = BTreeMap::new();
-            for column in demand.iter() {
-                demand_map.insert(*column, demand_map.len());
-            }
-            let demand_map_len = demand_map.len();
-            key_plan.permute(demand_map.clone(), demand_map_len);
-            val_plan.permute(demand_map, demand_map_len);
-            let skips = mz_compute_client::plan::reduce::convert_indexes_to_skips(demand);
-            move |row_parts, time, diff| {
-                let temp_storage = RowArena::new();
-
-                let mut row_datums = row_datums.borrow_with_many(row_parts);
-
-                let mut row_iter = row_datums.drain(..);
-                let mut datums_local = datums.borrow();
-                // Unpack only the demanded columns.
-                for skip in skips.iter() {
-                    datums_local.push(row_iter.nth(*skip).unwrap());
-                }
-
-                // Evaluate the key expressions.
-                let key =
-                    match key_plan.evaluate_into(&mut datums_local, &temp_storage, &mut row_mfp) {
-                        Err(e) => {
-                            return Some((Err(DataflowError::from(e)), time.clone(), diff.clone()))
-                        }
-                        Ok(key) => key.expect("Row expected as no predicate was used"),
-                    };
-                // Evaluate the value expressions.
-                // The prior evaluation may have left additional columns we should delete.
-                datums_local.truncate(skips.len());
-                let val = match val_plan.evaluate_iter(&mut datums_local, &temp_storage) {
-                    Err(e) => {
-                        return Some((Err(DataflowError::from(e)), time.clone(), diff.clone()))
+        input.scope().region_named("Reduce", |inner| {
+            let KeyValPlan {
+                mut key_plan,
+                mut val_plan,
+            } = key_val_plan;
+            let key_arity = key_plan.projection.len();
+            let mut row_buf = Row::default();
+            let mut row_mfp = Row::default();
+            let mut datums = DatumVec::new();
+            let mut row_datums = DatumVec::new();
+            let (key_val_input, err_input): (
+                timely::dataflow::Stream<_, (Result<(Row, Row), DataflowError>, _, _)>,
+                _,
+            ) = input
+                .enter_region(inner)
+                .flat_map(input_key.map(|k| (k, None)), || {
+                    // Determine the columns we'll need from the row.
+                    let mut demand = Vec::new();
+                    demand.extend(key_plan.demand());
+                    demand.extend(val_plan.demand());
+                    demand.sort();
+                    demand.dedup();
+                    // remap column references to the subset we use.
+                    let mut demand_map = BTreeMap::new();
+                    for column in demand.iter() {
+                        demand_map.insert(*column, demand_map.len());
                     }
-                    Ok(val) => val.expect("Row expected as no predicate was used"),
-                };
-                row_buf.packer().extend(val);
-                let row = row_buf.clone();
-                Some((Ok((key, row)), time.clone(), diff.clone()))
-            }
-        });
+                    let demand_map_len = demand_map.len();
+                    key_plan.permute(demand_map.clone(), demand_map_len);
+                    val_plan.permute(demand_map, demand_map_len);
+                    let skips = mz_compute_client::plan::reduce::convert_indexes_to_skips(demand);
+                    move |row_parts, time, diff| {
+                        let temp_storage = RowArena::new();
 
-        // Demux out the potential errors from key and value selector evaluation.
-        use differential_dataflow::operators::consolidate::ConsolidateStream;
-        let (ok, mut err) = key_val_input
-            .as_collection()
-            .consolidate_stream()
-            .flat_map_fallible("OkErrDemux", Some);
+                        let mut row_datums = row_datums.borrow_with_many(row_parts);
 
-        err = err.concat(&err_input);
+                        let mut row_iter = row_datums.drain(..);
+                        let mut datums_local = datums.borrow();
+                        // Unpack only the demanded columns.
+                        for skip in skips.iter() {
+                            datums_local.push(row_iter.nth(*skip).unwrap());
+                        }
 
-        // Render the reduce plan
-        render_reduce_plan(&self.debug_name, reduce_plan, ok, err, key_arity)
+                        // Evaluate the key expressions.
+                        let key = match key_plan.evaluate_into(
+                            &mut datums_local,
+                            &temp_storage,
+                            &mut row_mfp,
+                        ) {
+                            Err(e) => {
+                                return Some((
+                                    Err(DataflowError::from(e)),
+                                    time.clone(),
+                                    diff.clone(),
+                                ))
+                            }
+                            Ok(key) => key.expect("Row expected as no predicate was used"),
+                        };
+                        // Evaluate the value expressions.
+                        // The prior evaluation may have left additional columns we should delete.
+                        datums_local.truncate(skips.len());
+                        let val = match val_plan.evaluate_iter(&mut datums_local, &temp_storage) {
+                            Err(e) => {
+                                return Some((
+                                    Err(DataflowError::from(e)),
+                                    time.clone(),
+                                    diff.clone(),
+                                ))
+                            }
+                            Ok(val) => val.expect("Row expected as no predicate was used"),
+                        };
+                        row_buf.packer().extend(val);
+                        let row = row_buf.clone();
+                        Some((Ok((key, row)), time.clone(), diff.clone()))
+                    }
+                });
+
+            // Demux out the potential errors from key and value selector evaluation.
+            use differential_dataflow::operators::consolidate::ConsolidateStream;
+            let (ok, mut err) = key_val_input
+                .as_collection()
+                .consolidate_stream()
+                .flat_map_fallible("OkErrDemux", Some);
+
+            err = err.concat(&err_input);
+
+            // Render the reduce plan
+            render_reduce_plan(&self.debug_name, reduce_plan, ok, err, key_arity).leave_region()
+        })
     }
 }
 

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -48,7 +48,7 @@ where
 
         // We create a new region to compartmentalize the topk logic.
         let ok_result = ok_input.scope().region_named("TopK", |inner| {
-            let ok_input = ok_input.enter(inner);
+            let ok_input = ok_input.enter_region(inner);
             let ok_result = match top_k_plan {
                 TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                     group_key,


### PR DESCRIPTION
This is a revision of https://github.com/MaterializeInc/materialize/pull/14864 that only forms regions around non-trivial dataflows, increasing the interpretability of these dataflows.

In some cases `enter(region)` are converted to `enter_region(region)` which should be a strict performance improvement there. Adding regions elsewhere is a fairly low runtime cost (scheduling overhead) but I suspect it will be non-noticeable.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
