### PR TITLE
adapter: delay creating a temp user schema

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -167,14 +167,6 @@ impl<S: Append + 'static> Coordinator<S> {
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
     ) {
-        if let Err(e) = self.catalog.create_temporary_schema(session.conn_id()) {
-            let _ = tx.send(Response {
-                result: Err(e.into()),
-                session,
-            });
-            return;
-        }
-
         if self
             .catalog
             .for_session(&session)
@@ -198,6 +190,14 @@ impl<S: Append + 'static> Coordinator<S> {
                 });
                 return;
             }
+        }
+
+        if let Err(e) = self.catalog.create_temporary_schema(session.conn_id()) {
+            let _ = tx.send(Response {
+                result: Err(e.into()),
+                session,
+            });
+            return;
         }
 
         let mut messages = vec![];


### PR DESCRIPTION
We were previously creating temp user schemas before validating the user existed, which would those behind because bad connections don't go through handle_terminate.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a