### PR TITLE
*: remove is_cockroach special casing

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -68,6 +68,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             COCKROACH_URL=cockroach_url,
             MZ_SOFT_ASSERTIONS="1",
             MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET="mtlz-test-persist-1d-lifecycle-delete",
-            MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL=postgres_url,
+            MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL=cockroach_url,
         ),
     )

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -120,10 +120,10 @@ async fn test_stash_postgres() {
             .contains("stash error: postgres: error connecting to server"));
     }
 
-    let connstr = match std::env::var("POSTGRES_URL") {
+    let connstr = match std::env::var("COCKROACH_URL") {
         Ok(s) => s,
         Err(_) => {
-            println!("skipping test_stash_postgres because POSTGRES_URL is not set");
+            println!("skipping test_stash_postgres because COCKROACH_URL is not set");
             return;
         }
     };


### PR DESCRIPTION
Now that we use cockroach in all testing we can remove the ability to work with postgres and assume cockroach.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a