### PR TITLE
[persist] Track live/current diff/blob metrics during GC

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -976,9 +976,8 @@ pub struct ShardsMetrics {
     encoded_batch_size: mz_ore::metrics::UIntGaugeVec,
     largest_batch_size: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
-    current_blobs: mz_ore::metrics::UIntGaugeVec,
-    live_blobs: mz_ore::metrics::UIntGaugeVec,
-    live_diffs: mz_ore::metrics::UIntGaugeVec,
+    gc_seqno_held_parts: mz_ore::metrics::UIntGaugeVec,
+    gc_live_diffs: mz_ore::metrics::UIntGaugeVec,
     gc_finished: mz_ore::metrics::IntCounterVec,
     compaction_applied: mz_ore::metrics::IntCounterVec,
     cmd_succeeded: mz_ore::metrics::IntCounterVec,
@@ -1049,19 +1048,14 @@ impl ShardsMetrics {
                 help: "maximum count of gc-ineligible states by shard",
                 var_labels: ["shard"],
             )),
-            current_blobs: registry.register(metric!(
-                name: "mz_persist_shard_current_blobs",
-                help: "the total number of batch blobs that constitute the current state",
+            gc_seqno_held_parts: registry.register(metric!(
+                name: "mz_persist_shard_gc_seqno_held_parts",
+                help: "count of parts referenced by some live state but not the current state (ie. parts kept only to satisfy seqno holds) at GC time",
                 var_labels: ["shard"],
             )),
-            live_blobs: registry.register(metric!(
-                name: "mz_persist_shard_live_blobs",
-                help: "the current number of batch blobs that are referenced by any live diff",
-                var_labels: ["shard"],
-            )),
-            live_diffs: registry.register(metric!(
-                name: "mz_persist_shard_live_diffs",
-                help: "the number of diffs (or, alternatively, the number of seqnos) present in consensus state",
+            gc_live_diffs: registry.register(metric!(
+                name: "mz_persist_shard_gc_live_diffs",
+                help: "the number of diffs (or, alternatively, the number of seqnos) present in consensus state at GC time",
                 var_labels: ["shard"],
             )),
             gc_finished: registry.register(metric!(
@@ -1130,9 +1124,8 @@ pub struct ShardMetrics {
     encoded_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     largest_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub(crate) current_blobs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub(crate) live_blobs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub(crate) live_diffs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) gc_seqno_held_parts: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub(crate) gc_live_diffs: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     // These are already counted elsewhere in aggregate, so delete them if we
     // remove per-shard labels.
     pub gc_finished: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
@@ -1172,14 +1165,11 @@ impl ShardMetrics {
             seqnos_held: shards_metrics
                 .seqnos_held
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
-            current_blobs: shards_metrics
-                .current_blobs
+            gc_seqno_held_parts: shards_metrics
+                .gc_seqno_held_parts
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
-            live_blobs: shards_metrics
-                .live_blobs
-                .get_delete_on_drop_gauge(vec![shard.clone()]),
-            live_diffs: shards_metrics
-                .live_diffs
+            gc_live_diffs: shards_metrics
+                .gc_live_diffs
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             gc_finished: shards_metrics
                 .gc_finished
@@ -1213,6 +1203,10 @@ impl ShardMetrics {
 
     pub fn set_batch_part_count(&self, batch_count: usize) {
         self.batch_part_count.set(u64::cast_from(batch_count))
+    }
+
+    pub fn set_gc_seqno_held_parts(&self, parts: usize) {
+        self.gc_seqno_held_parts.set(u64::cast_from(parts))
     }
 
     pub fn set_update_count(&self, update_count: usize) {

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -780,7 +780,7 @@ impl<K, V, T: Timestamp + Lattice + Codec64, D> StateVersionsIter<K, V, T, D> {
         Some(&self.state)
     }
 
-    pub fn into_inner(self) -> State<K, V, T, D> {
-        self.state
+    pub fn state(&self) -> &State<K, V, T, D> {
+        &self.state
     }
 }


### PR DESCRIPTION
This adds three new metrics: a count of blobs accessible from all live states, a count of blobs accessible from the current state, and the count of live diffs.

### Motivation

Known-desirable metrics: see https://github.com/MaterializeInc/materialize/issues/16557.

### Tips for reviewer

In general this code calculates metrics assuming that the `new_seqno_since` is indeed the actual since. This is a little racy but probably harmless?

The M3 issue only requests two metrics where this PR introduces three: instead of adding "blobs that are only sticking around because of seqno hold", i've added "blobs that are reachable from live states" and "blobs that are reachable from the current state". This is because I found those metrics easier to name and explain, and we can subtract the latter from the former to get the number we're interested in... but happy to revert to the specced metrics if that's preferred.

Assuming the right test for metrics is "run in staging and see if it looks right" -- will check the box below when that's done.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
