### PR TITLE
Enable new-style Rust debug symbols

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,4 +5,4 @@
 #
 # See: https://github.com/rust-lang/rust/issues/56068
 # See: https://reviews.llvm.org/D74169#1990180
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]
+rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-C", "symbol-mangling-version=v0"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -5,4 +5,4 @@
 #
 # See: https://github.com/rust-lang/rust/issues/56068
 # See: https://reviews.llvm.org/D74169#1990180
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-C", "symbol-mangling-version=v0"]
+rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi", "-Csymbol-mangling-version=v0"]

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -231,7 +231,7 @@ ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
 ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
-ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -C symbol-mangling-version=v0"
+ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -Csymbol-mangling-version=v0"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -231,7 +231,7 @@ ENV CC=$ARCH_GCC-unknown-linux-gnu-cc
 ENV CXX=$ARCH_GCC-unknown-linux-gnu-c++
 ENV CXXSTDLIB=static=stdc++
 ENV LDFLAGS="-fuse-ld=lld -static-libstdc++"
-ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/"
+ENV RUSTFLAGS="-Clink-arg=-Wl,--compress-debug-sections=zlib -Clink-arg=-fuse-ld=lld -L/opt/x-tools/$ARCH_GCC-unknown-linux-gnu/$ARCH_GCC-unknown-linux-gnu/sysroot/lib/ -C symbol-mangling-version=v0"
 ENV TARGET_AR=$AR
 ENV TARGET_CC=$CC
 ENV TARGET_CXX=$CXX

--- a/misc/nix/shell.nix
+++ b/misc/nix/shell.nix
@@ -32,5 +32,5 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "fortify" ];
 
-  RUSTFLAGS = "-C linker=clang -C link-arg=--ld-path=${pkgs.mold}/bin/mold -C link-arg=-Wl,--warn-unresolved-symbols -C debuginfo=1";
+  RUSTFLAGS = "-Clinker=clang -Clink-arg=--ld-path=${pkgs.mold}/bin/mold -Clink-arg=-Wl,--warn-unresolved-symbols -Cdebuginfo=1 -Csymbol-mangling-version=v0";
 }

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -73,7 +73,8 @@ def cargo(
     _target_env = _target.upper().replace("-", "_")
 
     rustflags += [
-        "-Clink-arg=-Wl,--compress-debug-sections=zlib,-Csymbol-mangling-version=v0"
+        "-Clink-arg=-Wl,--compress-debug-sections=zlib",
+        "-Csymbol-mangling-version=v0",
     ]
 
     if sys.platform == "darwin":

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -72,7 +72,9 @@ def cargo(
     _target = target(arch)
     _target_env = _target.upper().replace("-", "_")
 
-    rustflags += ["-Clink-arg=-Wl,--compress-debug-sections=zlib"]
+    rustflags += [
+        "-Clink-arg=-Wl,--compress-debug-sections=zlib,-Csymbol-mangling-version=v0"
+    ]
 
     if sys.platform == "darwin":
         _bootstrap_darwin(arch)


### PR DESCRIPTION
This is needed for PS integration.

We set rustflags in at least four different places. I will try them one-by-one until I find the one that actually causes them to be set in the CI-produced build.