### PR TITLE
adapter: use oracle ts for storage collection time

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -198,7 +198,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         conn_id: ConnectionId,
     },
     LinearizeReads(Vec<PendingReadTxn>),
-    StorageUsageFetch(EpochMillis),
+    StorageUsageFetch,
     StorageUsageUpdate(HashMap<Option<ShardId>, u64>, EpochMillis),
     Consolidate(Vec<mz_stash::Id>),
 }

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -308,10 +308,6 @@ impl<S: Append + 'static> Coordinator<S> {
         to_datetime(self.now())
     }
 
-    pub(crate) fn now_fn(&self) -> NowFn {
-        self.catalog.config().now.clone()
-    }
-
     pub(crate) fn get_timestamp_oracle_mut(
         &mut self,
         timeline: &Timeline,


### PR DESCRIPTION
See #16938
See https://github.com/MaterializeInc/cloud/issues/4907#issuecomment-1370474874

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a