### PR TITLE
Panic using scope address

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -76,8 +76,6 @@ where
     pub(crate) scope: S,
     /// The debug name of the dataflow associated with this context.
     pub debug_name: String,
-    /// The Timely ID of the dataflow associated with this context.
-    pub dataflow_id: usize,
     /// Indicates a frontier that can be used to compact input timestamps
     /// without affecting the results. We *should* apply it, to sources and
     /// imported traces, both because it improves performance, and because
@@ -99,8 +97,6 @@ where
         dataflow: &DataflowDescription<Plan, CollectionMetadata>,
         scope: S,
     ) -> Self {
-        use mz_ore::collections::CollectionExt as IteratorExt;
-        let dataflow_id = scope.addr().into_first();
         let as_of_frontier = dataflow
             .as_of
             .clone()
@@ -109,7 +105,6 @@ where
         Self {
             scope,
             debug_name: dataflow.debug_name.clone(),
-            dataflow_id,
             as_of_frontier,
             until: dataflow.until.clone(),
             bindings: BTreeMap::new(),

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -446,8 +446,9 @@ where
             );
         } else {
             panic!(
-                "import of index {} failed while building dataflow {}",
-                idx_id, self.dataflow_id
+                "failed to import index {} into dataflow scope {:?}",
+                idx_id,
+                self.scope.addr()
             );
         }
     }


### PR DESCRIPTION
This PR demonstrates how to panic with the containing scope address, rather than the first digit of this address, at the same time avoiding arguments to the various rendering methods. The scope is available from all of these methods, and we just read its address out (providing potentially more information as the scope address can provide more detail).

I think this simplifies some logic, but I think actually moves us no closer to panic messages that are easy to interpret, and we should instead either 1. rely on better messages, or 2. not panic so much, or 3. not worry about identifying the scope when we panic (e.g. when we have invalid plans; probably more important to point out the invalid part of the plan than the scope in which its rendering was attempted).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
