### PR TITLE
Coord: Use ts oracle to schedule storage usage

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -141,9 +141,9 @@ impl<S: Append + 'static> Coordinator<S> {
         // Instead of using an `tokio::timer::Interval`, we calculate the time since the last
         // collection and wait for however much time is left. This is so we can keep the intervals
         // consistent even across restarts.
-        let time_since_previous_collection = self
-            .now()
-            .saturating_sub(self.catalog.most_recent_storage_usage_collection());
+        let now: EpochMillis = self.peek_local_write_ts().into();
+        let time_since_previous_collection =
+            now.saturating_sub(self.catalog.most_recent_storage_usage_collection());
         let next_collection_interval = self
             .storage_usage_collection_interval
             .saturating_sub(Duration::from_millis(time_since_previous_collection));

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -368,7 +368,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
     /// Peek the current timestamp used for operations on local inputs. Used to determine how much
     /// to block group commits by.
-    pub(crate) fn peek_local_write_ts(&mut self) -> Timestamp {
+    pub(crate) fn peek_local_write_ts(&self) -> Timestamp {
         self.get_local_timestamp_oracle().peek_write_ts()
     }
 


### PR DESCRIPTION
Previously we were looking at the system clock to determine when to schedule the next storage usage collection. This commit converts the logic to look at the timestamp oracle instead. This is consistent with the timestamps we actually use in the storage usage events.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
