### PR TITLE
adapter: use timestamp oracle in bootstrapping

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3282,8 +3282,8 @@ impl<S: Append> Catalog<S> {
         std::mem::forget(consolidations_rx);
         let storage = storage::Connection::open(
             stash,
+            now.clone(),
             &BootstrapArgs {
-                now: (now)(),
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
@@ -3442,14 +3442,6 @@ impl<S: Append> Catalog<S> {
         &mut self,
     ) -> Result<BTreeMap<Timeline, mz_repr::Timestamp>, Error> {
         self.storage().await.get_all_persisted_timestamps().await
-    }
-
-    /// Get a global timestamp for a timeline that has been persisted to disk.
-    pub async fn get_persisted_timestamp(
-        &mut self,
-        timeline: &Timeline,
-    ) -> Result<mz_repr::Timestamp, Error> {
-        self.storage().await.get_persisted_timestamp(timeline).await
     }
 
     /// Get the next user id without allocating it.

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -9,8 +9,10 @@
 
 //! A mechanism to ensure that a sequence of writes and reads proceed correctly through timestamps.
 
+use std::cmp;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
+use std::thread;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -182,10 +184,47 @@ pub const TIMESTAMP_INTERVAL_UPPER_BOUND: u64 = 2;
 
 /// Convenience function for calculating the current upper bound that we want to
 /// prevent the global timestamp from exceeding.
-pub fn upper_bound(now: &Timestamp) -> Timestamp {
+fn upper_bound(now: &Timestamp) -> Timestamp {
     now.saturating_add(
         TIMESTAMP_PERSIST_INTERVAL.saturating_mul(Timestamp::from(TIMESTAMP_INTERVAL_UPPER_BOUND)),
     )
+}
+
+/// Returns the current system time while protecting against backwards time
+/// jumps.
+///
+/// The caller is responsible for providing the previously recorded system time
+/// via the `previous_now` parameter.
+///
+/// If `previous_now` is more than `TIMESTAMP_INTERVAL_UPPER_BOUND *
+/// TIMESTAMP_PERSIST_INTERVAL` milliseconds ahead of the current system time
+/// (i.e., due to a backwards time jump), this function will block until the
+/// system time advances.
+///
+/// The returned time is guaranteed to be greater than or equal to
+/// `previous_now`.
+pub fn monotonic_now(now: NowFn, previous_now: Timestamp) -> Timestamp {
+    let mut now_ts = now();
+    let monotonic_now = cmp::max(previous_now, now_ts.into());
+    let mut upper_bound = timeline::upper_bound(&mz_repr::Timestamp::from(now_ts));
+    while monotonic_now > upper_bound {
+        // Cap retry time to 1s. In cases where the system clock has retreated
+        // by some large amount of time, this prevents against then waiting for
+        // that large amount of time in case the system clock then advances back
+        // to near what it was.
+        let remaining_ms = cmp::min(monotonic_now.saturating_sub(upper_bound), 1_000.into());
+        error!(
+            "Coordinator tried to start with initial timestamp of \
+            {monotonic_now}, which is more than \
+            {TIMESTAMP_INTERVAL_UPPER_BOUND} intervals of size {} larger than \
+            now, {now_ts}. Sleeping for {remaining_ms} ms.",
+            *TIMESTAMP_PERSIST_INTERVAL
+        );
+        thread::sleep(Duration::from_millis(remaining_ms.into()));
+        now_ts = now();
+        upper_bound = timeline::upper_bound(&mz_repr::Timestamp::from(now_ts));
+    }
+    monotonic_now
 }
 
 /// A type that wraps a [`TimestampOracle`] and provides durable timestamps. This allows us to

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -344,8 +344,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         .expect("a real environmentd should always have an epoch number");
     let adapter_storage = mz_adapter::catalog::storage::Connection::open(
         stash,
+        config.now.clone(),
         &BootstrapArgs {
-            now: (config.now)(),
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size,
             builtin_cluster_replica_size: config.bootstrap_builtin_cluster_replica_size,
             // TODO(benesch, brennan): remove this after v0.27.0-alpha.4 has

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -381,8 +381,8 @@ impl Usage {
         std::mem::forget(consolidations_rx);
         let storage = mz_adapter::catalog::storage::Connection::open(
             stash,
+            now.clone(),
             &BootstrapArgs {
-                now: (now)(),
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),

--- a/src/stash/src/cache.rs
+++ b/src/stash/src/cache.rs
@@ -316,6 +316,10 @@ impl<S: Stash> Stash for Cache<S> {
     fn epoch(&self) -> Option<NonZeroI64> {
         self.stash.epoch()
     }
+
+    fn is_readonly(&self) -> bool {
+        self.stash.is_readonly()
+    }
 }
 
 #[async_trait]

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -464,6 +464,11 @@ pub trait Stash: std::fmt::Debug + Send {
     /// Returns the stash's epoch number. If `Some`, it is a positive number that
     /// increases with each start of a stash.
     fn epoch(&self) -> Option<NonZeroI64>;
+
+    /// Reports whether the stash is in readonly mode.
+    ///
+    /// In readonly mode, any attempt to mutate the stash will fail.
+    fn is_readonly(&self) -> bool;
 }
 
 /// `StashCollection` is like a differential dataflow [`Collection`], but the

--- a/src/stash/src/memory.rs
+++ b/src/stash/src/memory.rs
@@ -398,6 +398,10 @@ impl Stash for Memory {
     fn epoch(&self) -> Option<NonZeroI64> {
         None
     }
+
+    fn is_readonly(&self) -> bool {
+        false
+    }
 }
 
 #[async_trait]

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1159,6 +1159,10 @@ impl Stash for Postgres {
         self.transact(|_, _| Box::pin(async { Ok(()) })).await
     }
 
+    fn is_readonly(&self) -> bool {
+        matches!(self.txn_mode, TransactionMode::Readonly)
+    }
+
     fn epoch(&self) -> Option<NonZeroI64> {
         self.epoch
     }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -29,7 +29,7 @@ use mz_adapter::catalog::{Catalog, ConnCatalog};
 use mz_adapter::session::Session;
 use mz_kafka_util::client::{create_new_client_config_simple, MzClientContext};
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::NOW_ZERO;
+use mz_ore::now::SYSTEM_TIME;
 use mz_stash::PostgresFactory;
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -355,7 +355,7 @@ impl State {
                 .postgres_factory
                 .open_readonly(url.clone(), None, tls)
                 .await?;
-            let catalog = Catalog::open_debug(stash, NOW_ZERO.clone()).await?;
+            let catalog = Catalog::open_debug(stash, SYSTEM_TIME.clone()).await?;
             let res = f(catalog.for_session(&Session::dummy()));
             Ok(Some(res))
         } else {


### PR DESCRIPTION
@jkosh44 please take a _very_ close look at this. I'm quite unfamiliar with all this code.

----

Adapter bootstrap was previously using the system clock directly when writing timestamps to the stash. In the case of a (admittedly unlikely) backwards time jump after bootstrapping but before timestamp oracle initialization, this could result in an invariant violation, where data written during bootstrapping used a timestamp *later* than data written by subsequent commands.

This commit is mostly code movement. The logic for initializing the EpochMilliseconds timeline is hoisted from coordinator initialization to catalog storage initialization.

Related to #16938.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
