### PR TITLE
Support using AZ-specific services when consuming a privatelink connection in kafka

### DIFF
--- a/src/cloud-resources/src/lib.rs
+++ b/src/cloud-resources/src/lib.rs
@@ -158,7 +158,7 @@ pub fn vpc_endpoint_name(id: GlobalId) -> String {
 
 /// Returns the host to use for the VPC endpoint with the given ID and
 /// optionally in the given availability zone.
-pub fn vpc_endpoint_host(id: GlobalId, availability_zone: Option<String>) -> String {
+pub fn vpc_endpoint_host(id: GlobalId, availability_zone: Option<&str>) -> String {
     let name = vpc_endpoint_name(id);
     // This naming scheme is part of the contract with the VpcEndpointController
     // in the cloud infrastructure layer.

--- a/src/cloud-resources/src/lib.rs
+++ b/src/cloud-resources/src/lib.rs
@@ -155,3 +155,15 @@ pub fn vpc_endpoint_name(id: GlobalId) -> String {
     // cloud infrastructure layer.
     format!("connection-{id}")
 }
+
+/// Returns the host to use for the VPC endpoint with the given ID and
+/// optionally in the given availability zone.
+pub fn vpc_endpoint_host(id: GlobalId, availability_zone: Option<String>) -> String {
+    let name = vpc_endpoint_name(id);
+    // This naming scheme is part of the contract with the VpcEndpointController
+    // in the cloud infrastructure layer.
+    match availability_zone {
+        Some(az) => format!("{name}-{az}"),
+        None => name,
+    }
+}

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -475,12 +475,14 @@ impl_display_t!(KafkaBrokerTunnel);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum KafkaBrokerAwsPrivatelinkOptionName {
+    AvailabilityZone,
     Port,
 }
 
 impl AstDisplay for KafkaBrokerAwsPrivatelinkOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
+            Self::AvailabilityZone => f.write_str("AVAILABILITY ZONE"),
             Self::Port => f.write_str("PORT"),
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2124,7 +2124,11 @@ impl<'a> Parser<'a> {
     fn parse_kafka_broker_aws_private_link_option(
         &mut self,
     ) -> Result<KafkaBrokerAwsPrivatelinkOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[PORT])? {
+        let name = match self.expect_one_of_keywords(&[AVAILABILITY, PORT])? {
+            AVAILABILITY => {
+                self.expect_keywords(&[ZONE])?;
+                KafkaBrokerAwsPrivatelinkOptionName::AvailabilityZone
+            }
             PORT => KafkaBrokerAwsPrivatelinkOptionName::Port,
             _ => unreachable!(),
         };

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -698,6 +698,8 @@ impl<'a> StatementContext<'a> {
                 match entry.connection()? {
                     Connection::AwsPrivatelink(_) => Ok(Tunnel::AwsPrivatelink(AwsPrivatelink {
                         connection_id: id,
+                        // By default we do not specify an availability zone for the tunnel.
+                        availability_zone: None,
                         // We always use the port as specified by the top-level connection.
                         port: None,
                     })),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2670,10 +2670,13 @@ Instead, specify BROKERS using multiple strings, e.g. BROKERS ('kafka:9092', 'ka
             let tunnel = match &broker.tunnel {
                 KafkaBrokerTunnel::Direct => Tunnel::Direct,
                 KafkaBrokerTunnel::AwsPrivatelink(aws_privatelink) => {
-                    let KafkaBrokerAwsPrivatelinkOptionExtracted { port, seen: _ } =
-                        KafkaBrokerAwsPrivatelinkOptionExtracted::try_from(
-                            aws_privatelink.options.clone(),
-                        )?;
+                    let KafkaBrokerAwsPrivatelinkOptionExtracted {
+                        availability_zone,
+                        port,
+                        seen: _,
+                    } = KafkaBrokerAwsPrivatelinkOptionExtracted::try_from(
+                        aws_privatelink.options.clone(),
+                    )?;
 
                     let id = match &aws_privatelink.connection {
                         ResolvedObjectName::Object { id, .. } => id,
@@ -2683,10 +2686,21 @@ Instead, specify BROKERS using multiple strings, e.g. BROKERS ('kafka:9092', 'ka
                     };
                     let entry = scx.catalog.get_item(id);
                     match entry.connection()? {
-                        Connection::AwsPrivatelink(_) => Tunnel::AwsPrivatelink(AwsPrivatelink {
-                            connection_id: *id,
-                            port,
-                        }),
+                        Connection::AwsPrivatelink(connection) => {
+                            if let Some(az) = &availability_zone {
+                                if !connection.availability_zones.contains(az) {
+                                    sql_bail!("AWS PrivateLink availability zone {} does not match any of the \
+                                      availability zones on the AWS PrivateLink connection {}",
+                                      az.quoted(),
+                                      entry.name().to_string().quoted())
+                                }
+                            }
+                            Tunnel::AwsPrivatelink(AwsPrivatelink {
+                                connection_id: *id,
+                                availability_zone,
+                                port,
+                            })
+                        }
                         _ => {
                             sql_bail!("{} is not an AWS PRIVATELINK connection", entry.name().item)
                         }
@@ -2817,7 +2831,11 @@ impl KafkaConnectionOptionExtracted {
     }
 }
 
-generate_extracted_config!(KafkaBrokerAwsPrivatelinkOption, (Port, u16));
+generate_extracted_config!(
+    KafkaBrokerAwsPrivatelinkOption,
+    (AvailabilityZone, String),
+    (Port, u16)
+);
 
 generate_extracted_config!(
     CsrConnectionOption,

--- a/src/storage-client/src/types/connections.proto
+++ b/src/storage-client/src/types/connections.proto
@@ -116,4 +116,5 @@ message ProtoSshConnection {
 message ProtoAwsPrivatelink {
     mz_repr.global_id.ProtoGlobalId connection_id = 1;
     optional uint32 port = 2;
+    optional string availability_zone = 3;
 }

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -332,7 +332,7 @@ impl KafkaConnection {
                         &broker.address,
                         &mz_cloud_resources::vpc_endpoint_host(
                             aws_privatelink.connection_id,
-                            aws_privatelink.availability_zone.clone(),
+                            aws_privatelink.availability_zone.as_deref(),
                         ),
                         aws_privatelink.port,
                     );
@@ -570,7 +570,7 @@ impl CsrConnection {
                     .ok_or_else(|| anyhow!("url missing host"))?;
                 let privatelink_host = mz_cloud_resources::vpc_endpoint_host(
                     connection.connection_id,
-                    connection.availability_zone.clone(),
+                    connection.availability_zone.as_deref(),
                 );
                 let addrs: Vec<_> = net::lookup_host((privatelink_host, DUMMY_PORT))
                     .await
@@ -931,7 +931,7 @@ impl RustType<ProtoSshConnection> for SshConnection {
 pub struct AwsPrivatelink {
     /// The ID of the connection to the AWS PrivateLink service.
     pub connection_id: GlobalId,
-    // THe availability zone to use when connecting to the AWS PrivateLink service.
+    // The availability zone to use when connecting to the AWS PrivateLink service.
     pub availability_zone: Option<String>,
     /// The port to use when connecting to the AWS PrivateLink service, if
     /// different from the port in [`KafkaBroker::address`].

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -330,7 +330,10 @@ impl KafkaConnection {
                 Tunnel::AwsPrivatelink(aws_privatelink) => {
                     context.add_broker_rewrite(
                         &broker.address,
-                        &mz_cloud_resources::vpc_endpoint_name(aws_privatelink.connection_id),
+                        &mz_cloud_resources::vpc_endpoint_host(
+                            aws_privatelink.connection_id,
+                            aws_privatelink.availability_zone.clone(),
+                        ),
                         aws_privatelink.port,
                     );
                 }
@@ -565,8 +568,10 @@ impl CsrConnection {
                     .url
                     .host_str()
                     .ok_or_else(|| anyhow!("url missing host"))?;
-                let privatelink_host =
-                    mz_cloud_resources::vpc_endpoint_name(connection.connection_id);
+                let privatelink_host = mz_cloud_resources::vpc_endpoint_host(
+                    connection.connection_id,
+                    connection.availability_zone.clone(),
+                );
                 let addrs: Vec<_> = net::lookup_host((privatelink_host, DUMMY_PORT))
                     .await
                     .context("resolving PrivateLink host")?
@@ -926,6 +931,8 @@ impl RustType<ProtoSshConnection> for SshConnection {
 pub struct AwsPrivatelink {
     /// The ID of the connection to the AWS PrivateLink service.
     pub connection_id: GlobalId,
+    // THe availability zone to use when connecting to the AWS PrivateLink service.
+    pub availability_zone: Option<String>,
     /// The port to use when connecting to the AWS PrivateLink service, if
     /// different from the port in [`KafkaBroker::address`].
     pub port: Option<u16>,
@@ -935,6 +942,7 @@ impl RustType<ProtoAwsPrivatelink> for AwsPrivatelink {
     fn into_proto(&self) -> ProtoAwsPrivatelink {
         ProtoAwsPrivatelink {
             connection_id: Some(self.connection_id.into_proto()),
+            availability_zone: self.availability_zone.into_proto(),
             port: self.port.into_proto(),
         }
     }
@@ -944,6 +952,7 @@ impl RustType<ProtoAwsPrivatelink> for AwsPrivatelink {
             connection_id: proto
                 .connection_id
                 .into_rust_if_some("ProtoAwsPrivatelink::connection_id")?,
+            availability_zone: proto.availability_zone.into_rust()?,
             port: proto.port.into_rust()?,
         })
     }


### PR DESCRIPTION
Add `AVAILABILITY ZONE` option to AWS PrivateLink Kafka brokers and pass thru to the vpc hostname.
Supports the `AVAILABILITY ZONE` option in this syntax
```
CREATE CONNECTION kafka_connection TO KAFKA (
    BROKERS (
        'broker1:9092' USING AWS PRIVATELINK privatelink_svc (AVAILABILITY ZONE 'use1-az1'),
        'broker2:9092' USING AWS PRIVATELINK privatelink_svc (AVAILABILITY ZONE 'use1-az4', PORT 9093)
    )
);
```
Also validates that the az is one of the ones configured for the PrivateLink connection object, as configured like
```
CREATE CONNECTION privatelink_svc TO AWS PRIVATELINK (
    SERVICE NAME 'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc',
    AVAILABILITY ZONES ('use1-az1', 'use1-az4')
);
```

### Motivation


  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/16145

### Tips for reviewer

* Please confirm comments make sense, since I'm not 100% familiar with the underlying mechanics of privatelink
* How can I effectively e2e test this to ensure the correct k8s services are being used?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add the `AVAILABILITY ZONE` option to Kafka brokers using AWS PrivateLink, when creating a connection to Kafka.