### PR TITLE
adapter: use peek write ts for shard collection

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -99,7 +99,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let internal_cmd_tx = self.internal_cmd_tx.clone();
         let client = self.storage_usage_client.clone();
         // Similar to audit events, use the oracle ts so this is guaranteed to increase.
-        let collection_timestamp: EpochMillis = self.get_local_write_ts().await.timestamp.into();
+        let collection_timestamp: EpochMillis = self.peek_local_write_ts().into();
         task::spawn(|| "storage_usage_fetch", async move {
             let shard_sizes = client.shard_sizes().await;
             // It is not an error for shard sizes to become ready after `internal_cmd_rx`


### PR DESCRIPTION
This matches the usage in #17000.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a