### PR TITLE
Drain input in subscribe that is past its `UP TO`

### DIFF
--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -90,6 +90,9 @@ fn subscribe<G>(
         .inner
         .sink(Pipeline, &format!("subscribe-{}", sink_id), move |input| {
             if finished {
+                // Drain the input, to avoid the
+                // operator being constantly rescheduled
+                input.for_each(|_, _| {});
                 return;
             }
             input.for_each(|_, rows| {


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

    Reported by @antiguru [here](https://github.com/MaterializeInc/materialize/pull/16768/files/9f5bf8b4244658cf5827f824de1ea3876424dd99#r1063597453)


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
