### PR TITLE
Avoid clones in subscribe sinks

### DIFF
--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -86,22 +86,24 @@ fn subscribe<G>(
 {
     let mut results = Vec::new();
     let mut finished = false;
+    let mut rows = Default::default();
     sinked_collection
         .inner
         .sink(Pipeline, &format!("subscribe-{}", sink_id), move |input| {
             if finished {
                 return;
             }
-            input.for_each(|_, rows| {
-                for (row, time, diff) in rows.iter() {
+            input.for_each(|_, data| {
+                data.swap(&mut rows);
+                for (row, time, diff) in rows.drain(..) {
                     let should_emit_as_of = if as_of.strict {
-                        as_of.frontier.less_than(time)
+                        as_of.frontier.less_than(&time)
                     } else {
-                        as_of.frontier.less_equal(time)
+                        as_of.frontier.less_equal(&time)
                     };
-                    let should_emit = should_emit_as_of && !up_to.less_equal(time);
+                    let should_emit = should_emit_as_of && !up_to.less_equal(&time);
                     if should_emit {
-                        results.push((*time, row.clone(), *diff));
+                        results.push((time, row, diff));
                     }
                 }
             });


### PR DESCRIPTION
Changes the sink implementation to take ownership if its input data instead of working on references. This avoids the need to clone rows, which should yield a performance improvement in situations where large results are retrieved where individual rows spill to the heap.

### Checklist

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
