### PR TITLE
Break complex `Reduce` operators into simpler ones

### DIFF
--- a/src/repr/src/optimize.rs
+++ b/src/repr/src/optimize.rs
@@ -122,6 +122,8 @@ optimizer_feature_flags!({
     enable_reduce_unnest_list_fusion: bool,
     // See the feature flag of the same name.
     enable_window_aggregation_fusion: bool,
+    // See the feature flag of the same name.
+    enable_reduce_reduction: bool,
 });
 
 /// A trait used to implement layered config construction.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4661,6 +4661,7 @@ pub fn unplan_create_cluster(
                 enable_value_window_function_fusion,
                 enable_reduce_unnest_list_fusion,
                 enable_window_aggregation_fusion,
+                enable_reduce_reduction: _,
             } = optimizer_feature_overrides;
             let features_extracted = ClusterFeatureExtracted {
                 // Seen is ignored when unplanning.

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -425,6 +425,7 @@ impl TryFrom<ExplainPlanOptionExtracted> for ExplainConfig {
                 enable_value_window_function_fusion: v.enable_value_window_function_fusion,
                 enable_reduce_unnest_list_fusion: v.enable_reduce_unnest_list_fusion,
                 enable_window_aggregation_fusion: v.enable_window_aggregation_fusion,
+                enable_reduce_reduction: Default::default(),
             },
         })
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1281,6 +1281,7 @@ impl SystemVars {
             &ENABLE_STORAGE_SHARD_FINALIZATION,
             &ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE,
             &ENABLE_DEFAULT_CONNECTION_VALIDATION,
+            &ENABLE_REDUCE_REDUCTION,
             &MIN_TIMESTAMP_INTERVAL,
             &MAX_TIMESTAMP_INTERVAL,
             &LOGGING_FILTER,
@@ -2106,6 +2107,10 @@ impl SystemVars {
 
     pub fn enable_consolidate_after_union_negate(&self) -> bool {
         *self.expect_value(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
+    }
+
+    pub fn enable_reduce_reduction(&self) -> bool {
+        *self.expect_value(&ENABLE_REDUCE_REDUCTION)
     }
 
     /// Returns the `enable_default_connection_validation` configuration parameter.

--- a/src/sql/src/session/vars/definitions.rs
+++ b/src/sql/src/session/vars/definitions.rs
@@ -1474,6 +1474,13 @@ pub static ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: VarDefinition = VarDefinition:
     true,
 );
 
+pub static ENABLE_REDUCE_REDUCTION: VarDefinition = VarDefinition::new(
+    "enable_reduce_reduction",
+    value!(bool; true),
+    "split complex reductions in to simpler ones and a join (Materialize).",
+    true,
+);
+
 pub static MIN_TIMESTAMP_INTERVAL: VarDefinition = VarDefinition::new(
     "min_timestamp_interval",
     value!(Duration; Duration::from_millis(1000)),
@@ -2219,6 +2226,7 @@ impl From<&super::SystemVars> for OptimizerFeatures {
             enable_value_window_function_fusion: vars.enable_value_window_function_fusion(),
             enable_reduce_unnest_list_fusion: vars.enable_reduce_unnest_list_fusion(),
             enable_window_aggregation_fusion: vars.enable_window_aggregation_fusion(),
+            enable_reduce_reduction: vars.enable_reduce_reduction(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             reoptimize_imported_views: false,
         }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -56,6 +56,7 @@ pub mod notice;
 pub mod ordering;
 pub mod predicate_pushdown;
 pub mod reduce_elision;
+pub mod reduce_reduction;
 pub mod reduction_pushdown;
 pub mod redundant_join;
 pub mod semijoin_idempotence;
@@ -610,6 +611,8 @@ impl Optimizer {
                     // Replaces reduces with maps when the group keys are
                     // unique with maps
                     Box::new(reduce_elision::ReduceElision),
+                    // Rips complex reduces apart.
+                    Box::new(reduce_reduction::ReduceReduction),
                     // Converts `Cross Join {Constant(Literal) + Input}` to
                     // `Map {Cross Join (Input, Constant()), Literal}`.
                     // Join fusion will clean this up to `Map{Input, Literal}`

--- a/src/transform/src/reduce_reduction.rs
+++ b/src/transform/src/reduce_reduction.rs
@@ -23,10 +23,10 @@ use mz_expr::MirRelationExpr;
 pub struct ReduceReduction;
 
 impl crate::Transform for ReduceReduction {
-    #[tracing::instrument(
-        target = "optimizer"
-        level = "trace",
-        skip_all,
+    /// Transforms an expression through accumulated knowledge.
+    #[mz_ore::instrument(
+        target = "optimizer",
+        level = "debug",
         fields(path.segment = "reduce_reduction")
     )]
     fn transform(

--- a/src/transform/src/reduce_reduction.rs
+++ b/src/transform/src/reduce_reduction.rs
@@ -32,10 +32,12 @@ impl crate::Transform for ReduceReduction {
     fn transform(
         &self,
         relation: &mut MirRelationExpr,
-        _: &mut TransformCtx,
+        ctx: &mut TransformCtx,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_pre_mut(&mut Self::action);
-        mz_repr::explain::trace_plan(&*relation);
+        if ctx.features.enable_reduce_reduction {
+            relation.visit_pre_mut(&mut Self::action);
+            mz_repr::explain::trace_plan(&*relation);
+        }
         Ok(())
     }
 }

--- a/src/transform/src/reduce_reduction.rs
+++ b/src/transform/src/reduce_reduction.rs
@@ -1,0 +1,117 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Breaks complex `Reduce` variants into a join of simpler variants.
+
+use crate::TransformCtx;
+use mz_compute_types::plan::reduce::{reduction_type, ReductionType};
+use mz_expr::MirRelationExpr;
+
+/// Fuses multiple `Filter` operators into one and deduplicates predicates.
+#[derive(Debug)]
+pub struct ReduceReduction;
+
+impl crate::Transform for ReduceReduction {
+    #[tracing::instrument(
+        target = "optimizer"
+        level = "trace",
+        skip_all,
+        fields(path.segment = "reduce_reduction")
+    )]
+    fn transform(
+        &self,
+        relation: &mut MirRelationExpr,
+        _: &mut TransformCtx,
+    ) -> Result<(), crate::TransformError> {
+        relation.visit_pre_mut(&mut Self::action);
+        mz_repr::explain::trace_plan(&*relation);
+        Ok(())
+    }
+}
+
+impl ReduceReduction {
+    /// Breaks complex `Reduce` variants into a join of simpler variants.
+    pub fn action(relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::Reduce {
+            input,
+            group_key,
+            aggregates,
+            monotonic,
+            expected_group_size,
+        } = relation
+        {
+            // Do nothing if `aggregates` contains 1. nothing, 2. a single aggregate, or 3. only accumulable aggregates.
+            // Otherwise, rip apart `aggregates` into accumulable aggregates and each other aggregate.
+            let mut accumulable = Vec::new();
+            let mut all_others = Vec::new();
+            for (index, aggregate) in aggregates.iter().enumerate() {
+                if reduction_type(&aggregate.func) == ReductionType::Accumulable {
+                    accumulable.push((index, aggregate));
+                } else {
+                    all_others.push((index, aggregate));
+                }
+            }
+
+            // We only leap in to action if there are things to break apart.
+            if all_others.len() > 1 || (!accumulable.is_empty() && !all_others.is_empty()) {
+                let mut reduces = Vec::new();
+                for (_index, aggr) in all_others.iter() {
+                    reduces.push(MirRelationExpr::Reduce {
+                        input: input.clone(),
+                        group_key: group_key.clone(),
+                        aggregates: vec![(*aggr).clone()],
+                        monotonic: *monotonic,
+                        expected_group_size: *expected_group_size,
+                    });
+                }
+                if !accumulable.is_empty() {
+                    reduces.push(MirRelationExpr::Reduce {
+                        input: input.clone(),
+                        group_key: group_key.clone(),
+                        aggregates: accumulable
+                            .iter()
+                            .map(|(_index, aggr)| (*aggr).clone())
+                            .collect(),
+                        monotonic: *monotonic,
+                        expected_group_size: *expected_group_size,
+                    });
+                }
+                // Now build a `Join` of the reduces, on their keys, followed by a permutation of their aggregates.
+                // Equate all `group_key` columns in all inputs.
+                let mut equivalences = vec![Vec::with_capacity(reduces.len()); group_key.len()];
+                for column in 0..group_key.len() {
+                    for input in 0..reduces.len() {
+                        equivalences[column].push((input, column));
+                    }
+                }
+                // Project the group key and then each of the aggregates in order.
+                let mut projection =
+                    Vec::with_capacity(group_key.len() + all_others.len() + accumulable.len());
+                projection.extend(0..group_key.len());
+                let mut accumulable_count = 0;
+                let mut all_others_count = 0;
+                for aggr in aggregates.iter() {
+                    if reduction_type(&aggr.func) == ReductionType::Accumulable {
+                        projection.push(
+                            (group_key.len() + 1) * all_others.len()
+                                + group_key.len()
+                                + accumulable_count,
+                        );
+                        accumulable_count += 1;
+                    } else {
+                        projection.push((group_key.len() + 1) * all_others_count + group_key.len());
+                        all_others_count += 1;
+                    }
+                }
+                // Now make the join.
+                *relation = MirRelationExpr::join(reduces, equivalences).project(projection);
+            }
+        }
+    }
+}

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -96,13 +96,13 @@ EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
 SELECT sum(e * f), max(f) FROM v GROUP BY mod(e, 5)
 ----
 Explained Query:
-  Project (#1, #3) // { arity: 2 }
+  Project (#3, #1) // { arity: 2 }
     Join on=(#0 = #2) type=differential // { arity: 4 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
-        Reduce group_by=[(#0 % 5)] aggregates=[sum((#0 * #1))] // { arity: 2 }
+        Reduce group_by=[(#0 % 5)] aggregates=[max(#1)] // { arity: 2 }
           ReadStorage materialize.public.v // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
-        Reduce group_by=[(#0 % 5)] aggregates=[max(#1)] // { arity: 2 }
+        Reduce group_by=[(#0 % 5)] aggregates=[sum((#0 * #1))] // { arity: 2 }
           ReadStorage materialize.public.v // { arity: 2 }
 
 Source materialize.public.v

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -96,9 +96,14 @@ EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
 SELECT sum(e * f), max(f) FROM v GROUP BY mod(e, 5)
 ----
 Explained Query:
-  Project (#1, #2) // { arity: 2 }
-    Reduce group_by=[(#0 % 5)] aggregates=[sum((#0 * #1)), max(#1)] // { arity: 3 }
-      ReadStorage materialize.public.v // { arity: 2 }
+  Project (#1, #3) // { arity: 2 }
+    Join on=(#0 = #2) type=differential // { arity: 4 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Reduce group_by=[(#0 % 5)] aggregates=[sum((#0 * #1))] // { arity: 2 }
+          ReadStorage materialize.public.v // { arity: 2 }
+      ArrangeBy keys=[[#0]] // { arity: 2 }
+        Reduce group_by=[(#0 % 5)] aggregates=[max(#1)] // { arity: 2 }
+          ReadStorage materialize.public.v // { arity: 2 }
 
 Source materialize.public.v
 

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -73,15 +73,15 @@ Explained Query:
   Threshold // { types: "(bigint?, text?, date?)" }
     Union // { types: "(bigint?, text?, date?)" }
       Negate // { types: "(bigint?, text?, date?)" }
-        Project (#1, #3, #0) // { types: "(bigint?, text?, date?)" }
-          Join on=(#0 = #2) type=differential // { types: "(date?, bigint?, date?, text?)" }
-            ArrangeBy keys=[[#0]] // { types: "(date?, bigint?)" }
-              Reduce group_by=[#1] aggregates=[sum(#0)] // { types: "(date?, bigint?)" }
-                Project (#0, #2) // { types: "(integer?, date?)" }
-                  ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+        Project (#3, #1, #0) // { types: "(bigint?, text?, date?)" }
+          Join on=(#0 = #2) type=differential // { types: "(date?, text?, date?, bigint?)" }
             ArrangeBy keys=[[#0]] // { types: "(date?, text?)" }
               Reduce group_by=[#1] aggregates=[max(#0)] // { types: "(date?, text?)" }
                 Project (#1, #2) // { types: "(text?, date?)" }
+                  ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+            ArrangeBy keys=[[#0]] // { types: "(date?, bigint?)" }
+              Reduce group_by=[#1] aggregates=[sum(#0)] // { types: "(date?, bigint?)" }
+                Project (#0, #2) // { types: "(integer?, date?)" }
                   ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
       Constant // { types: "(bigint, text, date?)" }
         - (1, "hello", null)
@@ -145,15 +145,15 @@ Explained Query:
       Union // { types: "(boolean?, bigint)" }
         Negate // { types: "(boolean?, bigint)" }
           TopK limit=1 // { types: "(boolean?, bigint)" }
-            Project (#3, #1) // { types: "(boolean?, bigint)" }
-              Join on=(#0 = #2) type=differential // { types: "(double precision, bigint, double precision, boolean?)" }
+            Project (#1, #3) // { types: "(boolean?, bigint)" }
+              Join on=(#0 = #2) type=differential // { types: "(double precision, boolean?, double precision, bigint)" }
+                ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
+                  Reduce group_by=[#0] aggregates=[min(#1)] // { types: "(double precision, boolean?)" }
+                    Get l0 // { types: "(double precision, boolean?)" }
                 ArrangeBy keys=[[#0]] // { types: "(double precision, bigint)" }
                   Reduce group_by=[#0] aggregates=[count(*)] // { types: "(double precision, bigint)" }
                     Project (#0) // { types: "(double precision)" }
                       Get l0 // { types: "(double precision, boolean?)" }
-                ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
-                  Reduce group_by=[#0] aggregates=[min(#1)] // { types: "(double precision, boolean?)" }
-                    Get l0 // { types: "(double precision, boolean?)" }
         Constant // { types: "(boolean?, bigint)" }
           - (null, 10)
   With

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -73,9 +73,16 @@ Explained Query:
   Threshold // { types: "(bigint?, text?, date?)" }
     Union // { types: "(bigint?, text?, date?)" }
       Negate // { types: "(bigint?, text?, date?)" }
-        Project (#1, #2, #0) // { types: "(bigint?, text?, date?)" }
-          Reduce group_by=[#2] aggregates=[sum(#0), max(#1)] // { types: "(date?, bigint?, text?)" }
-            ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+        Project (#1, #3, #0) // { types: "(bigint?, text?, date?)" }
+          Join on=(#0 = #2) type=differential // { types: "(date?, bigint?, date?, text?)" }
+            ArrangeBy keys=[[#0]] // { types: "(date?, bigint?)" }
+              Reduce group_by=[#1] aggregates=[sum(#0)] // { types: "(date?, bigint?)" }
+                Project (#0, #2) // { types: "(integer?, date?)" }
+                  ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
+            ArrangeBy keys=[[#0]] // { types: "(date?, text?)" }
+              Reduce group_by=[#1] aggregates=[max(#0)] // { types: "(date?, text?)" }
+                Project (#1, #2) // { types: "(text?, date?)" }
+                  ReadStorage materialize.public.t // { types: "(integer?, text?, date?)" }
       Constant // { types: "(bigint, text, date?)" }
         - (1, "hello", null)
 
@@ -133,31 +140,41 @@ EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR
 (SELECT null::boolean as f1, 10 as f2) EXCEPT (SELECT min(f), count(*) FROM v WHERE (select d::double FROM u) = v.e GROUP BY e LIMIT 1)
 ----
 Explained Query:
-  Threshold // { types: "(boolean?, bigint)" }
-    Union // { types: "(boolean?, bigint)" }
-      Negate // { types: "(boolean?, bigint)" }
-        TopK limit=1 // { types: "(boolean?, bigint)" }
-          Project (#1, #2) // { types: "(boolean?, bigint)" }
-            Reduce group_by=[#0] aggregates=[min(#1), count(*)] // { types: "(double precision, boolean?, bigint)" }
-              Project (#0, #1) // { types: "(double precision, boolean?)" }
-                Join on=(#0 = #2) type=differential // { types: "(double precision, boolean?, double precision)" }
-                  ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
-                    Filter (#0) IS NOT NULL // { types: "(double precision, boolean?)" }
-                      ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
-                  ArrangeBy keys=[[#0]] // { types: "(double precision?)" }
-                    Union // { types: "(double precision?)" }
-                      Project (#1) // { types: "(double precision?)" }
-                        Filter (#0) IS NOT NULL // { types: "(integer, double precision?)" }
-                          Map (integer_to_double(#0)) // { types: "(integer?, double precision?)" }
-                            ReadStorage materialize.public.u // { types: "(integer?)" }
-                      Map (error("more than one record produced in subquery")) // { types: "(double precision)" }
-                        Project () // { types: "()" }
-                          Filter (#0 > 1) // { types: "(bigint)" }
-                            Reduce aggregates=[count(*)] // { types: "(bigint)" }
-                              Project () // { types: "()" }
-                                ReadStorage materialize.public.u // { types: "(integer?)" }
-      Constant // { types: "(boolean?, bigint)" }
-        - (null, 10)
+  Return // { types: "(boolean?, bigint)" }
+    Threshold // { types: "(boolean?, bigint)" }
+      Union // { types: "(boolean?, bigint)" }
+        Negate // { types: "(boolean?, bigint)" }
+          TopK limit=1 // { types: "(boolean?, bigint)" }
+            Project (#3, #1) // { types: "(boolean?, bigint)" }
+              Join on=(#0 = #2) type=differential // { types: "(double precision, bigint, double precision, boolean?)" }
+                ArrangeBy keys=[[#0]] // { types: "(double precision, bigint)" }
+                  Reduce group_by=[#0] aggregates=[count(*)] // { types: "(double precision, bigint)" }
+                    Project (#0) // { types: "(double precision)" }
+                      Get l0 // { types: "(double precision, boolean?)" }
+                ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
+                  Reduce group_by=[#0] aggregates=[min(#1)] // { types: "(double precision, boolean?)" }
+                    Get l0 // { types: "(double precision, boolean?)" }
+        Constant // { types: "(boolean?, bigint)" }
+          - (null, 10)
+  With
+    cte l0 =
+      Project (#0, #1) // { types: "(double precision, boolean?)" }
+        Join on=(#0 = #2) type=differential // { types: "(double precision, boolean?, double precision)" }
+          ArrangeBy keys=[[#0]] // { types: "(double precision, boolean?)" }
+            Filter (#0) IS NOT NULL // { types: "(double precision, boolean?)" }
+              ReadStorage materialize.public.v // { types: "(double precision?, boolean?)" }
+          ArrangeBy keys=[[#0]] // { types: "(double precision?)" }
+            Union // { types: "(double precision?)" }
+              Project (#1) // { types: "(double precision?)" }
+                Filter (#0) IS NOT NULL // { types: "(integer, double precision?)" }
+                  Map (integer_to_double(#0)) // { types: "(integer?, double precision?)" }
+                    ReadStorage materialize.public.u // { types: "(integer?)" }
+              Map (error("more than one record produced in subquery")) // { types: "(double precision)" }
+                Project () // { types: "()" }
+                  Filter (#0 > 1) // { types: "(bigint)" }
+                    Reduce aggregates=[count(*)] // { types: "(bigint)" }
+                      Project () // { types: "()" }
+                        ReadStorage materialize.public.u // { types: "(integer?)" }
 
 Source materialize.public.u
 Source materialize.public.v

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -306,8 +306,20 @@ GROUP BY 1,
          2
 ----
 Explained Query:
-  Project (#0..=#4, #3) // { arity: 6 }
-    Reduce group_by=[#1, #2] aggregates=[count(*), min(#2), min(#0)] // { arity: 5 }
+  Return // { arity: 6 }
+    Project (#0..=#2, #5, #6, #5) // { arity: 6 }
+      Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 7 }
+        implementation
+          %0[#0, #1]UKKA » %1[#0, #1]UKKA
+        ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+          Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+            Project (#1, #2) // { arity: 2 }
+              Get l0 // { arity: 3 }
+        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+          Reduce group_by=[#1, #2] aggregates=[min(#2), min(#0)] // { arity: 4 }
+            Get l0 // { arity: 3 }
+  With
+    cte l0 =
       Project (#0, #1, #28) // { arity: 3 }
         Filter (#10 <= 1995-11-14) AND (#30 <= 12907776) AND (#10 >= 1995-04-19) AND (#30 >= #5) // { arity: 33 }
           Join on=(#0 = #16 AND #17 = #25) type=delta // { arity: 33 }
@@ -608,8 +620,20 @@ GROUP BY 1,
          2
 ----
 Explained Query:
-  Project (#0, #0..=#2) // { arity: 4 }
-    Reduce group_by=[#1] aggregates=[min(#0), count(*)] // { arity: 3 }
+  Return // { arity: 4 }
+    Project (#0, #0, #3, #1) // { arity: 4 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            Project (#1) // { arity: 1 }
+              Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#1] aggregates=[min(#0)] // { arity: 2 }
+            Get l0 // { arity: 2 }
+  With
+    cte l0 =
       Project (#2, #3) // { arity: 2 }
         Filter (#1 < #5) AND (#11 > #4) AND (#11 >= #0) // { arity: 14 }
           Join on=(#3 = #6) type=delta // { arity: 14 }

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -307,17 +307,17 @@ GROUP BY 1,
 ----
 Explained Query:
   Return // { arity: 6 }
-    Project (#0..=#2, #5, #6, #5) // { arity: 6 }
-      Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 7 }
+    Project (#0, #1, #6, #2, #3, #2) // { arity: 6 }
+      Join on=(#0 = #4 AND #1 = #5) type=differential // { arity: 7 }
         implementation
           %0[#0, #1]UKKA » %1[#0, #1]UKKA
+        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
+          Reduce group_by=[#1, #2] aggregates=[min(#2), min(#0)] // { arity: 4 }
+            Get l0 // { arity: 3 }
         ArrangeBy keys=[[#0, #1]] // { arity: 3 }
           Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
             Project (#1, #2) // { arity: 2 }
               Get l0 // { arity: 3 }
-        ArrangeBy keys=[[#0, #1]] // { arity: 4 }
-          Reduce group_by=[#1, #2] aggregates=[min(#2), min(#0)] // { arity: 4 }
-            Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #1, #28) // { arity: 3 }
@@ -621,17 +621,17 @@ GROUP BY 1,
 ----
 Explained Query:
   Return // { arity: 4 }
-    Project (#0, #0, #3, #1) // { arity: 4 }
+    Project (#0, #0, #1, #3) // { arity: 4 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
           %0[#0]UKA » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#1] aggregates=[min(#0)] // { arity: 2 }
+            Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
           Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
             Project (#1) // { arity: 1 }
               Get l0 // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#1] aggregates=[min(#0)] // { arity: 2 }
-            Get l0 // { arity: 2 }
   With
     cte l0 =
       Project (#2, #3) // { arity: 2 }

--- a/test/sqllogictest/explain/aggregates.slt
+++ b/test/sqllogictest/explain/aggregates.slt
@@ -37,8 +37,16 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), array_agg(c) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), array_agg[order_by=[]](row(array[#2]))]
-    ReadStorage materialize.public.t
+  Project (#0, #1, #3)
+    Join on=(#0 = #2) type=differential
+      ArrangeBy keys=[[#0]]
+        Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+          Project (#0, #1)
+            ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0]]
+        Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+          Project (#0, #2)
+            ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -50,8 +58,16 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), string_agg(c, ',') FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), string_agg[order_by=[]](row(row(#2, ",")))]
-    ReadStorage materialize.public.t
+  Project (#0, #1, #3)
+    Join on=(#0 = #2) type=differential
+      ArrangeBy keys=[[#0]]
+        Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+          Project (#0, #1)
+            ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0]]
+        Reduce group_by=[#0] aggregates=[string_agg[order_by=[]](row(row(#1, ",")))]
+          Project (#0, #2)
+            ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -63,8 +79,15 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), string_agg(c, ',' ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), string_agg[order_by=[#0 desc nulls_first]](row(row(#2, ","), #1))]
-    ReadStorage materialize.public.t
+  Project (#0, #1, #3)
+    Join on=(#0 = #2) type=differential
+      ArrangeBy keys=[[#0]]
+        Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+          Project (#0, #1)
+            ReadStorage materialize.public.t
+      ArrangeBy keys=[[#0]]
+        Reduce group_by=[#0] aggregates=[string_agg[order_by=[#0 desc nulls_first]](row(row(#2, ","), #1))]
+          ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -76,9 +99,21 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), max(c) FROM t WHERE c <> 'x' GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), max(#2)]
-    Filter (#2 != "x")
-      ReadStorage materialize.public.t
+  Return
+    Project (#0, #3, #1)
+      Join on=(#0 = #2) type=differential
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[max(#1)]
+            Project (#0, #2)
+              Get l0
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+            Project (#0, #1)
+              Get l0
+  With
+    cte l0 =
+      Filter (#2 != "x")
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
   filter=((#2 != "x"))
@@ -91,11 +126,24 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), max(b) FROM t GROUP BY a HAVING count(a) > 1;
 ----
 Explained Query:
-  Project (#0..=#2)
-    Filter (#3 > 1)
-      Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), max(#1), count(*)]
-        Project (#0, #1)
-          ReadStorage materialize.public.t
+  Return
+    Project (#0, #5, #1)
+      Filter (#3 > 1)
+        Join on=(#0 = #2 = #4) type=delta
+          ArrangeBy keys=[[#0]]
+            Reduce group_by=[#0] aggregates=[max(#1)]
+              Get l0
+          ArrangeBy keys=[[#0]]
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Project (#0)
+                ReadStorage materialize.public.t
+          ArrangeBy keys=[[#0]]
+            Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+              Get l0
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -121,9 +169,19 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1)), array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1))]
-    Project (#0, #1)
-      ReadStorage materialize.public.t
+  Return
+    Project (#0, #1, #3)
+      Join on=(#0 = #2) type=differential
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1))]
+            Get l0
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1))]
+            Get l0
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -139,19 +197,31 @@ Explained Query:
     Project (#0, #1, #3)
       Map ((#2 > 0))
         Union
-          Get l0
+          Project (#1, #2, #0)
+            Get l1
           Map (null, null, null)
             Union
               Negate
                 Project ()
-                  Get l0
+                  Get l1
               Constant
                 - ()
   With
+    cte l1 =
+      CrossJoin type=delta
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(1)]
+            Project ()
+              ReadStorage materialize.public.t
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#0], #0))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#0], #0))]
+            Get l0
     cte l0 =
-      Reduce aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#0], #0)), array_agg[order_by=[#0 desc nulls_first]](row(array[#0], #0)), sum(1)]
-        Project (#1)
-          ReadStorage materialize.public.t
+      Project (#1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -193,19 +263,30 @@ Explained Query:
   Return
     Project (#0..=#2, #2)
       Union
-        Get l0
+        Get l1
         Map (null, null, null)
           Union
             Negate
               Project ()
-                Get l0
+                Get l1
             Constant
               - ()
   With
+    cte l1 =
+      CrossJoin type=delta
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[sum(#0)]
+            Project (#0)
+              ReadStorage materialize.public.t
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#0)))]
+            Get l0
+        ArrangeBy keys=[[]]
+          Reduce aggregates=[array_agg[order_by=[]](row(array[#0]))]
+            Get l0
     cte l0 =
-      Reduce aggregates=[sum(#0), jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#1))), array_agg[order_by=[]](row(array[#1]))]
-        Project (#0, #1)
-          ReadStorage materialize.public.t
+      Project (#1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -217,11 +298,19 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY a HAVING array_agg(b ORDER BY b) = array_agg(b ORDER BY b DESC);
 ----
 Explained Query:
-  Project (#0, #1)
-    Filter (#1 = #2)
-      Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1)), array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1))]
-        Project (#0, #1)
-          ReadStorage materialize.public.t
+  Return
+    Project (#0, #1)
+      Join on=(#0 = #2 AND #1 = #3) type=differential
+        ArrangeBy keys=[[#0, #1]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1))]
+            Get l0
+        ArrangeBy keys=[[#0, #1]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1))]
+            Get l0
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -234,9 +323,19 @@ EXPLAIN SELECT a, array_agg(b), array_agg(sha256(b::BYTEA)) FROM t GROUP BY a;
 
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), array_agg[order_by=[]](row(array[digest(text_to_bytea(#1), "sha256")]))]
-    Project (#0, #1)
-      ReadStorage materialize.public.t
+  Return
+    Project (#0, #3, #1)
+      Join on=(#0 = #2) type=differential
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[digest(text_to_bytea(#1), "sha256")]))]
+            Get l0
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+            Get l0
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 
@@ -249,9 +348,19 @@ query T multiline
 EXPLAIN SELECT a, array_agg(b), array_agg(CASE WHEN a = 1 THEN 'ooo' ELSE b END) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1])), array_agg[order_by=[]](row(array[case when (#0 = 1) then "ooo" else #1 end]))]
-    Project (#0, #1)
-      ReadStorage materialize.public.t
+  Return
+    Project (#0, #1, #3)
+      Join on=(#0 = #2) type=differential
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[#1]))]
+            Get l0
+        ArrangeBy keys=[[#0]]
+          Reduce group_by=[#0] aggregates=[array_agg[order_by=[]](row(array[case when (#0 = 1) then "ooo" else #1 end]))]
+            Get l0
+  With
+    cte l0 =
+      Project (#0, #1)
+        ReadStorage materialize.public.t
 
 Source materialize.public.t
 

--- a/test/sqllogictest/explain/physical_plan_aggregates.slt
+++ b/test/sqllogictest/explain/physical_plan_aggregates.slt
@@ -44,18 +44,31 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), array_agg(c) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1])))
-    aggrs[1]=(1, array_agg[order_by=[]](row(array[#2])))
-    val_plan
-      project=(#3, #4)
-      map=(row(array[#1]), row(array[#2]))
-    key_plan
-      project=(#0)
-    Get::PassArrangements materialize.public.t
-      raw=true
-
-Source materialize.public.t
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1])))
+      val_plan
+        project=(#2)
+        map=(row(array[#1]))
+      key_plan
+        project=(#0)
+      Get::Collection materialize.public.t
+        project=(#0, #1)
+        raw=true
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1])))
+      val_plan
+        project=(#2)
+        map=(row(array[#1]))
+      key_plan
+        project=(#0)
+      Get::Collection materialize.public.t
+        project=(#0, #2)
+        raw=true
 
 Target cluster: quickstart
 
@@ -65,18 +78,31 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), string_agg(c, ',') FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1])))
-    aggrs[1]=(1, string_agg[order_by=[]](row(row(#2, ","))))
-    val_plan
-      project=(#3, #4)
-      map=(row(array[#1]), row(row(#2, ",")))
-    key_plan
-      project=(#0)
-    Get::PassArrangements materialize.public.t
-      raw=true
-
-Source materialize.public.t
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1])))
+      val_plan
+        project=(#2)
+        map=(row(array[#1]))
+      key_plan
+        project=(#0)
+      Get::Collection materialize.public.t
+        project=(#0, #1)
+        raw=true
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row(#1, ","))))
+      val_plan
+        project=(#2)
+        map=(row(row(#1, ",")))
+      key_plan
+        project=(#0)
+      Get::Collection materialize.public.t
+        project=(#0, #2)
+        raw=true
 
 Target cluster: quickstart
 
@@ -86,16 +112,30 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), string_agg(c, ',' ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1])))
-    aggrs[1]=(1, string_agg[order_by=[#0 desc nulls_first]](row(row(#2, ","), #1)))
-    val_plan
-      project=(#3, #4)
-      map=(row(array[#1]), row(row(#2, ","), #1))
-    key_plan
-      project=(#0)
-    Get::PassArrangements materialize.public.t
-      raw=true
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, array_agg[order_by=[]](row(array[#1])))
+      val_plan
+        project=(#2)
+        map=(row(array[#1]))
+      key_plan
+        project=(#0)
+      Get::Collection materialize.public.t
+        project=(#0, #1)
+        raw=true
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[#0 desc nulls_first]](row(row(#2, ","), #1)))
+      val_plan
+        project=(#3)
+        map=(row(row(#2, ","), #1))
+      key_plan
+        project=(#0)
+      Get::PassArrangements materialize.public.t
+        raw=true
 
 Source materialize.public.t
 
@@ -107,22 +147,40 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), max(c) FROM t WHERE c <> 'x' GROUP BY a;
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[b, h]
-    hierarchical
-      aggr_funcs=[max]
-      skips=[1]
-      monotonic
-      must_consolidate
-    basic
-      aggr=(0, array_agg[order_by=[]](row(array[#1])))
-    val_plan
-      project=(#3, #2)
-      map=(row(array[#1]))
-    key_plan
-      project=(#0)
-    Get::Collection materialize.public.t
-      raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        closure
+          project=(#0, #2, #1)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Hierarchical
+        aggr_funcs=[max]
+        skips=[0]
+        monotonic
+        must_consolidate
+        val_plan
+          project=(#1)
+        key_plan
+          project=(#0)
+        Get::Collection l0
+          project=(#0, #2)
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1])))
+        val_plan
+          project=(#2)
+          map=(row(array[#1]))
+        key_plan
+          project=(#0)
+        Get::Collection l0
+          project=(#0, #1)
+          raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   filter=((#2 != "x"))
@@ -135,27 +193,80 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), max(b) FROM t GROUP BY a HAVING count(a) > 1;
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[b, h, a]
-    accumulable
-      simple_aggrs[0]=(0, 2, count(*))
-    hierarchical
-      aggr_funcs=[max]
-      skips=[1]
-      monotonic
-      must_consolidate
-    basic
-      aggr=(0, array_agg[order_by=[]](row(array[#1])))
-    val_plan
-      project=(#2, #1, #3)
-      map=(row(array[#1]), true)
-    key_plan
-      project=(#0)
-    mfp_after
-      project=(#0..=#2)
-      filter=((#3 > 1))
-    Get::Collection materialize.public.t
-      raw=true
+  Return
+    Join::Delta
+      plan_path[0]
+        delta_stage[1]
+          closure
+            project=(#0, #2, #1)
+          lookup={ relation=2, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        delta_stage[0]
+          closure
+            project=(#0, #1)
+            filter=((#2 > 1))
+          lookup={ relation=1, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        source={ relation=0, key=[#0] }
+      plan_path[1]
+        delta_stage[1]
+          closure
+            project=(#1, #3, #2)
+          lookup={ relation=2, key=[#0] }
+          stream={ key=[#2], thinning=(#0, #1) }
+        delta_stage[0]
+          closure
+            project=(#0, #1, #0)
+          lookup={ relation=0, key=[#0] }
+          stream={ key=[#0], thinning=() }
+        initial_closure
+          project=(#0)
+          filter=((#1 > 1))
+        source={ relation=1, key=[#0] }
+      plan_path[2]
+        delta_stage[1]
+          lookup={ relation=0, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        delta_stage[0]
+          closure
+            project=(#0, #1)
+            filter=((#2 > 1))
+          lookup={ relation=1, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        source={ relation=2, key=[#0] }
+      Reduce::Hierarchical
+        aggr_funcs=[max]
+        skips=[0]
+        monotonic
+        must_consolidate
+        val_plan
+          project=(#1)
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, count(*))
+        val_plan
+          project=(#1)
+          map=(true)
+        key_plan=id
+        Get::Collection materialize.public.t
+          project=(#0)
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1])))
+        val_plan
+          project=(#2)
+          map=(row(array[#1]))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -191,16 +302,34 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b ORDER BY b ASC), array_agg(b ORDER BY b DESC) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1)))
-    aggrs[1]=(1, array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1)))
-    val_plan
-      project=(#2, #2)
-      map=(row(array[#1], #1))
-    key_plan
-      project=(#0)
-    Get::Collection materialize.public.t
-      raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1)))
+        val_plan
+          project=(#2)
+          map=(row(array[#1], #1))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1)))
+        val_plan
+          project=(#2)
+          map=(row(array[#1], #1))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -218,40 +347,82 @@ Explained Query:
       project=(#0, #1, #3)
       map=((#2 > 0))
       Union
-        ArrangeBy
-          input_key=[]
+        Get::Collection l1
+          project=(#1, #2, #0)
           raw=true
-          Get::PassArrangements l0
-            raw=false
-            arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
         Mfp
           project=(#0..=#2)
           map=(null, null, null)
           Union consolidate_output=true
             Negate
-              Get::Arrangement l0
+              Get::Collection l1
                 project=()
-                key=
-                raw=false
-                arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
+                raw=true
             Constant
               - ()
   With
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #2, #1)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
+          simple_aggrs[0]=(0, 0, sum(1))
+          val_plan
+            project=(#0)
+            map=(1)
+          key_plan=id
+          Get::Collection materialize.public.t
+            project=()
+            raw=true
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#0], #0)))
+          val_plan
+            project=(#1)
+            map=(row(array[#0], #0))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 desc nulls_first]](row(array[#0], #0)))
+          val_plan
+            project=(#1)
+            map=(row(array[#0], #0))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
     cte l0 =
-      Reduce::Collation
-        aggregate_types=[b, b, a]
-        accumulable
-          simple_aggrs[0]=(0, 2, sum(1))
-        basic
-          aggrs[0]=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#0], #0)))
-          aggrs[1]=(1, array_agg[order_by=[#0 desc nulls_first]](row(array[#0], #0)))
-        val_plan
-          project=(#1, #1, #2)
-          map=(row(array[#0], #0), 1)
-        key_plan
-          project=()
-        Get::Collection materialize.public.t
-          raw=true
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   project=(#1)
@@ -316,40 +487,81 @@ Explained Query:
     Mfp
       project=(#0..=#2, #2)
       Union
-        ArrangeBy
-          input_key=[]
+        Get::PassArrangements l1
           raw=true
-          Get::PassArrangements l0
-            raw=false
-            arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
         Mfp
           project=(#0..=#2)
           map=(null, null, null)
           Union consolidate_output=true
             Negate
-              Get::Arrangement l0
+              Get::Collection l1
                 project=()
-                key=
-                raw=false
-                arrangements[0]={ key=[], permutation=id, thinning=(#0..=#2) }
+                raw=true
             Constant
               - ()
   With
-    cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, b]
-        accumulable
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #2, #1)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          delta_stage[0]
+            closure
+              project=(#1, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
           simple_aggrs[0]=(0, 0, sum(#0))
-        basic
-          aggrs[0]=(1, jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#1))))
-          aggrs[1]=(2, array_agg[order_by=[]](row(array[#1])))
-        val_plan
-          project=(#0, #2, #3)
-          map=(row(jsonbable_to_jsonb(#1)), row(array[#1]))
-        key_plan
-          project=()
-        Get::Collection materialize.public.t
-          raw=true
+          val_plan=id
+          key_plan
+            project=()
+          Get::Collection materialize.public.t
+            project=(#0)
+            raw=true
+        Reduce::Basic
+          aggr=(0, jsonb_agg[order_by=[]](row(jsonbable_to_jsonb(#0))))
+          val_plan
+            project=(#1)
+            map=(row(jsonbable_to_jsonb(#0)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[]](row(array[#0])))
+          val_plan
+            project=(#1)
+            map=(row(array[#0]))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+    cte l0 =
+      Get::Collection materialize.public.t
+        project=(#1)
+        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -362,19 +574,46 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b ORDER BY b) FROM t GROUP BY a HAVING array_agg(b ORDER BY b) = array_agg(b ORDER BY b DESC);
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1)))
-    aggrs[1]=(1, array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1)))
-    val_plan
-      project=(#2, #2)
-      map=(row(array[#1], #1))
-    key_plan
-      project=(#0)
-    mfp_after
-      project=(#0, #1)
-      filter=((#1 = #2))
-    Get::Collection materialize.public.t
-      raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#0, #1] }
+        stream={ key=[#0, #1], thinning=() }
+      source={ relation=0, key=[#0, #1] }
+      ArrangeBy
+        input_key=[#0]
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        arrangements[1]={ key=[#0, #1], permutation=id, thinning=() }
+        types=[integer, text[]]
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 asc nulls_last]](row(array[#1], #1)))
+          val_plan
+            project=(#2)
+            map=(row(array[#1], #1))
+          key_plan
+            project=(#0)
+          Get::PassArrangements l0
+            raw=true
+      ArrangeBy
+        input_key=[#0]
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        arrangements[1]={ key=[#0, #1], permutation=id, thinning=() }
+        types=[integer, text[]]
+        Reduce::Basic
+          aggr=(0, array_agg[order_by=[#0 desc nulls_first]](row(array[#1], #1)))
+          val_plan
+            project=(#2)
+            map=(row(array[#1], #1))
+          key_plan
+            project=(#0)
+          Get::PassArrangements l0
+            raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -388,16 +627,36 @@ EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), array_agg(sha256(b::BY
 
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1])))
-    aggrs[1]=(1, array_agg[order_by=[]](row(array[digest(text_to_bytea(#1), "sha256")])))
-    val_plan
-      project=(#2, #3)
-      map=(row(array[#1]), row(array[digest(text_to_bytea(#1), "sha256")]))
-    key_plan
-      project=(#0)
-    Get::Collection materialize.public.t
-      raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        closure
+          project=(#0, #2, #1)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[digest(text_to_bytea(#1), "sha256")])))
+        val_plan
+          project=(#2)
+          map=(row(array[digest(text_to_bytea(#1), "sha256")]))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1])))
+        val_plan
+          project=(#2)
+          map=(row(array[#1]))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   project=(#0, #1)
@@ -411,16 +670,34 @@ query T multiline
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT a, array_agg(b), array_agg(CASE WHEN a = 1 THEN 'ooo' ELSE b END) FROM t GROUP BY a;
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, array_agg[order_by=[]](row(array[#1])))
-    aggrs[1]=(1, array_agg[order_by=[]](row(array[case when (#0 = 1) then "ooo" else #1 end])))
-    val_plan
-      project=(#2, #3)
-      map=(row(array[#1]), row(array[case when (#0 = 1) then "ooo" else #1 end]))
-    key_plan
-      project=(#0)
-    Get::Collection materialize.public.t
-      raw=true
+  Return
+    Join::Linear
+      linear_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=0, key=[#0] }
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[#1])))
+        val_plan
+          project=(#2)
+          map=(row(array[#1]))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+      Reduce::Basic
+        aggr=(0, array_agg[order_by=[]](row(array[case when (#0 = 1) then "ooo" else #1 end])))
+        val_plan
+          project=(#2)
+          map=(row(array[case when (#0 = 1) then "ooo" else #1 end]))
+        key_plan
+          project=(#0)
+        Get::PassArrangements l0
+          raw=true
+  With
+    cte l0 =
+      Get::Collection materialize.public.t
+        raw=true
 
 Source materialize.public.t
   project=(#0, #1)

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -3098,683 +3098,160 @@ GROUP BY a
     {
       "id": "Explained Query",
       "plan": {
-        "lir_id": 2,
+        "lir_id": 5,
         "node": {
-          "Reduce": {
-            "input": {
-              "lir_id": 1,
-              "node": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
-                    }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
-                          {
-                            "Column": 0
-                          }
-                        ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      },
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
-                      }
-                    ]
-                  },
-                  "plan": "PassArrangements"
-                }
-              }
-            },
-            "key_val_plan": {
-              "key_plan": {
-                "mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 2
-                }
-              },
-              "val_plan": {
-                "mfp": {
-                  "expressions": [
-                    {
-                      "CallUnary": {
-                        "func": {
-                          "CastInt32ToString": null
-                        },
-                        "expr": {
-                          "Column": 1
-                        }
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": 2
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              49
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": 2
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              50
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "predicates": [],
-                  "projection": [
-                    3,
-                    4
-                  ],
-                  "input_arity": 2
-                }
-              }
-            },
-            "plan": {
-              "Basic": {
-                "Multiple": [
-                  [
-                    0,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": 1
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                49
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
-                  ],
-                  [
-                    1,
-                    {
-                      "func": {
-                        "StringAgg": {
-                          "order_by": []
-                        }
-                      },
-                      "expr": {
-                        "CallVariadic": {
-                          "func": {
-                            "RecordCreate": {
-                              "field_names": [
-                                ""
-                              ]
-                            }
-                          },
-                          "exprs": [
-                            {
-                              "CallVariadic": {
-                                "func": {
-                                  "RecordCreate": {
-                                    "field_names": [
-                                      "value",
-                                      "sep"
-                                    ]
-                                  }
-                                },
-                                "exprs": [
-                                  {
-                                    "CallBinary": {
-                                      "func": "TextConcat",
-                                      "expr1": {
-                                        "CallUnary": {
-                                          "func": {
-                                            "CastInt32ToString": null
-                                          },
-                                          "expr": {
-                                            "Column": 1
-                                          }
-                                        }
-                                      },
-                                      "expr2": {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                50
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "Literal": [
-                                      {
-                                        "Ok": {
-                                          "data": [
-                                            19,
-                                            1,
-                                            44
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "scalar_type": "String",
-                                        "nullable": false
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      "distinct": false
-                    }
-                  ]
-                ]
-              }
-            },
-            "input_key": [
+          "Join": {
+            "inputs": [
               {
-                "Column": 0
-              }
-            ],
-            "mfp_after": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1,
-                2
-              ],
-              "input_arity": 3
-            }
-          }
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Reduce::Basic (global aggregate).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-SELECT
-  STRING_AGG(b::text || '1',  ','),
-  STRING_AGG(b::text || '2',  ',')
-FROM t
-----
-{
-  "plans": [
-    {
-      "id": "Explained Query",
-      "plan": {
-        "lir_id": 11,
-        "node": {
-          "Let": {
-            "id": 0,
-            "value": {
-              "lir_id": 2,
-              "node": {
-                "Reduce": {
-                  "input": {
-                    "lir_id": 1,
-                    "node": {
-                      "Get": {
-                        "id": {
-                          "Global": {
-                            "User": 1
-                          }
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
+                "lir_id": 2,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
                               [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
                                 {
-                                  "Column": 0
-                                }
-                              ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
-                              [
-                                1
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
                               ]
-                            ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": 0
-                              }
                             ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                1
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
                         }
                       }
-                    }
-                  },
-                  "key_val_plan": {
-                    "key_plan": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [],
-                        "input_arity": 1
-                      }
                     },
-                    "val_plan": {
-                      "mfp": {
-                        "expressions": [
-                          {
-                            "CallUnary": {
-                              "func": {
-                                "CastInt32ToString": null
-                              },
-                              "expr": {
-                                "Column": 0
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
                               }
                             }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": 1
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    49
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": 1
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    50
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "predicates": [],
-                        "projection": [
-                          2,
-                          3
-                        ],
-                        "input_arity": 1
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
                       }
-                    }
-                  },
-                  "plan": {
-                    "Basic": {
-                      "Multiple": [
-                        [
-                          0,
-                          {
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
                             "func": {
                               "StringAgg": {
                                 "order_by": []
@@ -3810,7 +3287,7 @@ FROM t
                                                   "CastInt32ToString": null
                                                 },
                                                 "expr": {
-                                                  "Column": 0
+                                                  "Column": 1
                                                 }
                                               }
                                             },
@@ -3857,11 +3334,178 @@ FROM t
                               }
                             },
                             "distinct": false
-                          }
-                        ],
-                        [
-                          1,
-                          {
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
                             "func": {
                               "StringAgg": {
                                 "order_by": []
@@ -3897,7 +3541,7 @@ FROM t
                                                   "CastInt32ToString": null
                                                 },
                                                 "expr": {
-                                                  "Column": 0
+                                                  "Column": 1
                                                 }
                                               }
                                             },
@@ -3944,203 +3588,779 @@ FROM t
                               }
                             },
                             "distinct": false
-                          }
-                        ]
-                      ]
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
                     }
-                  },
-                  "input_key": null,
-                  "mfp_after": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
+                  }
+                }
+              }
+            ],
+            "plan": {
+              "Linear": {
+                "source_relation": 0,
+                "source_key": [
+                  {
+                    "Column": 0
+                  }
+                ],
+                "initial_closure": null,
+                "stage_plans": [
+                  {
+                    "lookup_relation": 1,
+                    "stream_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "stream_thinning": [
                       1
                     ],
-                    "input_arity": 2
+                    "lookup_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    }
+                  }
+                ],
+                "final_closure": null
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Basic (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+SELECT
+  STRING_AGG(b::text || '1',  ','),
+  STRING_AGG(b::text || '2',  ',')
+FROM t
+----
+{
+  "plans": [
+    {
+      "id": "Explained Query",
+      "plan": {
+        "lir_id": 15,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
+              "lir_id": 1,
+              "node": {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "plan": {
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": 0
+                        }
+                      ],
+                      null,
+                      {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1
+                        ],
+                        "input_arity": 2
+                      }
+                    ]
                   }
                 }
               }
             },
             "body": {
-              "lir_id": 10,
+              "lir_id": 14,
               "node": {
-                "Union": {
-                  "inputs": [
-                    {
-                      "lir_id": 9,
-                      "node": {
-                        "ArrangeBy": {
-                          "input": {
+                "Let": {
+                  "id": 1,
+                  "value": {
+                    "lir_id": 6,
+                    "node": {
+                      "Join": {
+                        "inputs": [
+                          {
                             "lir_id": 3,
+                            "node": {
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 5,
+                            "node": {
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 4,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "plan": {
+                          "Linear": {
+                            "source_relation": 0,
+                            "source_key": [],
+                            "initial_closure": null,
+                            "stage_plans": [
+                              {
+                                "lookup_relation": 1,
+                                "stream_key": [],
+                                "stream_thinning": [
+                                  0
+                                ],
+                                "lookup_key": [],
+                                "closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "final_closure": null
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "body": {
+                    "lir_id": 13,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 7,
                             "node": {
                               "Get": {
                                 "id": {
-                                  "Local": 0
+                                  "Local": 1
                                 },
                                 "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [],
-                                      {
-                                        "0": 0,
-                                        "1": 1
-                                      },
-                                      [
-                                        0,
-                                        1
-                                      ]
-                                    ]
-                                  ],
+                                  "raw": true,
+                                  "arranged": [],
                                   "types": null
                                 },
                                 "plan": "PassArrangements"
                               }
                             }
                           },
-                          "forms": {
-                            "raw": true,
-                            "arranged": [],
-                            "types": null
-                          },
-                          "input_key": [],
-                          "input_mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1
-                            ],
-                            "input_arity": 2
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lir_id": 8,
-                      "node": {
-                        "Mfp": {
-                          "input": {
-                            "lir_id": 7,
+                          {
+                            "lir_id": 12,
                             "node": {
-                              "Union": {
-                                "inputs": [
-                                  {
-                                    "lir_id": 5,
-                                    "node": {
-                                      "Negate": {
-                                        "input": {
-                                          "lir_id": 4,
+                              "Mfp": {
+                                "input": {
+                                  "lir_id": 11,
+                                  "node": {
+                                    "Union": {
+                                      "inputs": [
+                                        {
+                                          "lir_id": 9,
                                           "node": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 0
-                                              },
-                                              "keys": {
-                                                "raw": false,
-                                                "arranged": [
-                                                  [
-                                                    [],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1
+                                            "Negate": {
+                                              "input": {
+                                                "lir_id": 8,
+                                                "node": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 1
                                                     },
-                                                    [
-                                                      0,
-                                                      1
-                                                    ]
-                                                  ]
-                                                ],
-                                                "types": null
-                                              },
-                                              "plan": {
-                                                "Arrangement": [
-                                                  [],
-                                                  null,
-                                                  {
-                                                    "expressions": [],
-                                                    "predicates": [],
-                                                    "projection": [],
-                                                    "input_arity": 2
+                                                    "keys": {
+                                                      "raw": true,
+                                                      "arranged": [],
+                                                      "types": null
+                                                    },
+                                                    "plan": {
+                                                      "Collection": {
+                                                        "expressions": [],
+                                                        "predicates": [],
+                                                        "projection": [],
+                                                        "input_arity": 2
+                                                      }
+                                                    }
                                                   }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "lir_id": 10,
+                                          "node": {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": []
+                                                    },
+                                                    0,
+                                                    1
+                                                  ]
                                                 ]
                                               }
                                             }
                                           }
                                         }
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "lir_id": 6,
-                                    "node": {
-                                      "Constant": {
-                                        "rows": {
-                                          "Ok": [
-                                            [
-                                              {
-                                                "data": []
-                                              },
-                                              0,
-                                              1
-                                            ]
-                                          ]
-                                        }
-                                      }
+                                      ],
+                                      "consolidate_output": true
                                     }
                                   }
-                                ],
-                                "consolidate_output": true
+                                },
+                                "mfp": {
+                                  "expressions": [
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 0
+                                },
+                                "input_key_val": null
                               }
                             }
-                          },
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              }
-                            ],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1
-                            ],
-                            "input_arity": 0
-                          },
-                          "input_key_val": null
-                        }
+                          }
+                        ],
+                        "consolidate_output": false
                       }
                     }
-                  ],
-                  "consolidate_output": false
+                  }
                 }
               }
             }
@@ -4163,500 +4383,1315 @@ MATERIALIZED VIEW collated_group_by_mv
     {
       "id": "materialize.public.collated_group_by_mv",
       "plan": {
-        "lir_id": 2,
+        "lir_id": 9,
         "node": {
-          "Reduce": {
-            "input": {
-              "lir_id": 1,
-              "node": {
-                "Get": {
-                  "id": {
-                    "Global": {
-                      "User": 1
+          "Join": {
+            "inputs": [
+              {
+                "lir_id": 2,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Hierarchical": {
+                        "Bucketed": {
+                          "aggr_funcs": [
+                            "MinInt32",
+                            "MaxInt32"
+                          ],
+                          "skips": [
+                            0,
+                            0
+                          ],
+                          "buckets": [
+                            268435456,
+                            16777216,
+                            1048576,
+                            65536,
+                            4096,
+                            256,
+                            16
+                          ]
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
                     }
-                  },
-                  "keys": {
-                    "raw": false,
-                    "arranged": [
-                      [
-                        [
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Accumulable": {
+                        "full_aggrs": [
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": 1
+                            },
+                            "distinct": true
+                          },
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": 1
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        "simple_aggrs": [
+                          [
+                            1,
+                            1,
+                            {
+                              "func": "SumInt32",
+                              "expr": {
+                                "Column": 1
+                              },
+                              "distinct": false
+                            }
+                          ]
+                        ],
+                        "distinct_aggrs": [
+                          [
+                            0,
+                            0,
+                            {
+                              "func": "Count",
+                              "expr": {
+                                "Column": 1
+                              },
+                              "distinct": true
+                            }
+                          ]
+                        ]
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 6,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 5,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 8,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 7,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              }
+            ],
+            "plan": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
                           {
                             "Column": 0
                           }
                         ],
-                        {
-                          "0": 0,
-                          "1": 1
-                        },
-                        [
-                          1
-                        ]
-                      ]
-                    ],
-                    "types": [
-                      {
-                        "scalar_type": "Int32",
-                        "nullable": true
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
                       },
                       {
-                        "scalar_type": "Int32",
-                        "nullable": true
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5
+                              ],
+                              "input_arity": 6
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                5,
+                                1,
+                                2,
+                                4,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
                       }
-                    ]
+                    ],
+                    "final_closure": null
                   },
-                  "plan": "PassArrangements"
-                }
-              }
-            },
-            "key_val_plan": {
-              "key_plan": {
-                "mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 2
-                }
-              },
-              "val_plan": {
-                "mfp": {
-                  "expressions": [
-                    {
-                      "CallUnary": {
-                        "func": {
-                          "CastInt32ToString": null
-                        },
-                        "expr": {
-                          "Column": 1
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
                         }
                       }
                     },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
                           {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": 2
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              49
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                4,
+                                0,
+                                1,
+                                2
+                              ],
+                              "input_arity": 5
                             }
                           }
-                        ]
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
                           {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": 2
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              50
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                0,
+                                4,
+                                5,
+                                6
+                              ],
+                              "input_arity": 7
                             }
                           }
-                        ]
-                      }
-                    }
-                  ],
-                  "predicates": [],
-                  "projection": [
-                    1,
-                    3,
-                    1,
-                    1,
-                    1,
-                    4
-                  ],
-                  "input_arity": 2
-                }
-              }
-            },
-            "plan": {
-              "Collation": {
-                "accumulable": {
-                  "full_aggrs": [
-                    {
-                      "func": "Count",
-                      "expr": {
-                        "Column": 1
+                        }
                       },
-                      "distinct": true
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
                     },
-                    {
-                      "func": "SumInt32",
-                      "expr": {
-                        "Column": 1
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
                       },
-                      "distinct": false
-                    }
-                  ],
-                  "simple_aggrs": [
-                    [
-                      1,
-                      4,
                       {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": 1
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ],
-                  "distinct_aggrs": [
-                    [
-                      0,
-                      0,
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
                       {
-                        "func": "Count",
-                        "expr": {
-                          "Column": 1
-                        },
-                        "distinct": true
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": 5
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
                       }
-                    ]
-                  ]
-                },
-                "hierarchical": {
-                  "Bucketed": {
-                    "aggr_funcs": [
-                      "MinInt32",
-                      "MaxInt32"
                     ],
-                    "skips": [
-                      2,
-                      0
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 3,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
                     ],
-                    "buckets": [
-                      268435456,
-                      16777216,
-                      1048576,
-                      65536,
-                      4096,
-                      256,
-                      16
-                    ]
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 5
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                7,
+                                2,
+                                3,
+                                5,
+                                6
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
                   }
-                },
-                "basic": {
-                  "Multiple": [
-                    [
-                      1,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": 1
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  49
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    [
-                      5,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": 1
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  50
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ]
-                },
-                "aggregate_types": [
-                  "Accumulable",
-                  "Basic",
-                  "Hierarchical",
-                  "Hierarchical",
-                  "Accumulable",
-                  "Basic"
                 ]
               }
-            },
-            "input_key": [
-              {
-                "Column": 0
-              }
-            ],
-            "mfp_after": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6
-              ],
-              "input_arity": 7
             }
           }
         }
@@ -4677,10 +5712,1332 @@ SELECT * FROM collated_group_by
     {
       "id": "Explained Query",
       "plan": {
-        "lir_id": 2,
+        "lir_id": 9,
         "node": {
-          "Reduce": {
-            "input": {
+          "Join": {
+            "inputs": [
+              {
+                "lir_id": 2,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 1,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Hierarchical": {
+                        "Monotonic": {
+                          "aggr_funcs": [
+                            "MinInt32",
+                            "MaxInt32"
+                          ],
+                          "skips": [
+                            0,
+                            0
+                          ],
+                          "must_consolidate": true
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 4,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 3,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            1,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Accumulable": {
+                        "full_aggrs": [
+                          {
+                            "func": "Count",
+                            "expr": {
+                              "Column": 1
+                            },
+                            "distinct": true
+                          },
+                          {
+                            "func": "SumInt32",
+                            "expr": {
+                              "Column": 1
+                            },
+                            "distinct": false
+                          }
+                        ],
+                        "simple_aggrs": [
+                          [
+                            1,
+                            1,
+                            {
+                              "func": "SumInt32",
+                              "expr": {
+                                "Column": 1
+                              },
+                              "distinct": false
+                            }
+                          ]
+                        ],
+                        "distinct_aggrs": [
+                          [
+                            0,
+                            0,
+                            {
+                              "func": "Count",
+                              "expr": {
+                                "Column": 1
+                              },
+                              "distinct": true
+                            }
+                          ]
+                        ]
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "input_arity": 3
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 6,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 5,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      49
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              },
+              {
+                "lir_id": 8,
+                "node": {
+                  "Reduce": {
+                    "input": {
+                      "lir_id": 7,
+                      "node": {
+                        "Get": {
+                          "id": {
+                            "Global": {
+                              "User": 1
+                            }
+                          },
+                          "keys": {
+                            "raw": false,
+                            "arranged": [
+                              [
+                                [
+                                  {
+                                    "Column": 0
+                                  }
+                                ],
+                                {
+                                  "0": 0,
+                                  "1": 1
+                                },
+                                [
+                                  1
+                                ]
+                              ]
+                            ],
+                            "types": [
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              },
+                              {
+                                "scalar_type": "Int32",
+                                "nullable": true
+                              }
+                            ]
+                          },
+                          "plan": "PassArrangements"
+                        }
+                      }
+                    },
+                    "key_val_plan": {
+                      "key_plan": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0
+                          ],
+                          "input_arity": 2
+                        }
+                      },
+                      "val_plan": {
+                        "mfp": {
+                          "expressions": [
+                            {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "predicates": [],
+                          "projection": [
+                            2
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "plan": {
+                      "Basic": {
+                        "Single": {
+                          "index": 0,
+                          "expr": {
+                            "func": {
+                              "StringAgg": {
+                                "order_by": []
+                              }
+                            },
+                            "expr": {
+                              "CallVariadic": {
+                                "func": {
+                                  "RecordCreate": {
+                                    "field_names": [
+                                      ""
+                                    ]
+                                  }
+                                },
+                                "exprs": [
+                                  {
+                                    "CallVariadic": {
+                                      "func": {
+                                        "RecordCreate": {
+                                          "field_names": [
+                                            "value",
+                                            "sep"
+                                          ]
+                                        }
+                                      },
+                                      "exprs": [
+                                        {
+                                          "CallBinary": {
+                                            "func": "TextConcat",
+                                            "expr1": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "CastInt32ToString": null
+                                                },
+                                                "expr": {
+                                                  "Column": 1
+                                                }
+                                              }
+                                            },
+                                            "expr2": {
+                                              "Literal": [
+                                                {
+                                                  "Ok": {
+                                                    "data": [
+                                                      19,
+                                                      1,
+                                                      50
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "scalar_type": "String",
+                                                  "nullable": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "Literal": [
+                                            {
+                                              "Ok": {
+                                                "data": [
+                                                  19,
+                                                  1,
+                                                  44
+                                                ]
+                                              }
+                                            },
+                                            {
+                                              "scalar_type": "String",
+                                              "nullable": false
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "distinct": false
+                          },
+                          "fused_unnest_list": false
+                        }
+                      }
+                    },
+                    "input_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "mfp_after": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0,
+                        1
+                      ],
+                      "input_arity": 2
+                    }
+                  }
+                }
+              }
+            ],
+            "plan": {
+              "Delta": {
+                "path_plans": [
+                  {
+                    "source_relation": 0,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5
+                              ],
+                              "input_arity": 6
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2,
+                          3,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                5,
+                                1,
+                                2,
+                                4,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 1,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1,
+                            2
+                          ],
+                          "input_arity": 3
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1,
+                          2
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                3,
+                                4,
+                                0,
+                                1,
+                                2
+                              ],
+                              "input_arity": 5
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                0,
+                                4,
+                                5,
+                                6
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4,
+                          5,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 2,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 3,
+                        "stream_key": [
+                          {
+                            "Column": 5
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                6,
+                                2,
+                                3,
+                                5,
+                                7
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  },
+                  {
+                    "source_relation": 3,
+                    "source_key": [
+                      {
+                        "Column": 0
+                      }
+                    ],
+                    "initial_closure": {
+                      "ready_equivalences": [],
+                      "before": {
+                        "mfp": {
+                          "expressions": [],
+                          "predicates": [],
+                          "projection": [
+                            0,
+                            1
+                          ],
+                          "input_arity": 2
+                        }
+                      }
+                    },
+                    "stage_plans": [
+                      {
+                        "lookup_relation": 0,
+                        "stream_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "stream_thinning": [
+                          1
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                0,
+                                2,
+                                3,
+                                0,
+                                1
+                              ],
+                              "input_arity": 4
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 1,
+                        "stream_key": [
+                          {
+                            "Column": 3
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          4
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                2,
+                                3,
+                                5,
+                                6,
+                                0,
+                                4
+                              ],
+                              "input_arity": 7
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "lookup_relation": 2,
+                        "stream_key": [
+                          {
+                            "Column": 5
+                          }
+                        ],
+                        "stream_thinning": [
+                          0,
+                          1,
+                          2,
+                          3,
+                          4,
+                          6
+                        ],
+                        "lookup_key": [
+                          {
+                            "Column": 0
+                          }
+                        ],
+                        "closure": {
+                          "ready_equivalences": [],
+                          "before": {
+                            "mfp": {
+                              "expressions": [],
+                              "predicates": [],
+                              "projection": [
+                                1,
+                                4,
+                                7,
+                                2,
+                                3,
+                                5,
+                                6
+                              ],
+                              "input_arity": 8
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "final_closure": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "sources": []
+}
+EOF
+
+# Test Reduce::Collated (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS JSON FOR
+MATERIALIZED VIEW collated_global_mv
+----
+{
+  "plans": [
+    {
+      "id": "materialize.public.collated_global_mv",
+      "plan": {
+        "lir_id": 19,
+        "node": {
+          "Let": {
+            "id": 0,
+            "value": {
               "lir_id": 1,
               "node": {
                 "Get": {
@@ -4718,1247 +7075,1284 @@ SELECT * FROM collated_group_by
                       }
                     ]
                   },
-                  "plan": "PassArrangements"
-                }
-              }
-            },
-            "key_val_plan": {
-              "key_plan": {
-                "mfp": {
-                  "expressions": [],
-                  "predicates": [],
-                  "projection": [
-                    0
-                  ],
-                  "input_arity": 2
-                }
-              },
-              "val_plan": {
-                "mfp": {
-                  "expressions": [
-                    {
-                      "CallUnary": {
-                        "func": {
-                          "CastInt32ToString": null
-                        },
-                        "expr": {
-                          "Column": 1
+                  "plan": {
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": 0
                         }
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": 2
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              49
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "CallVariadic": {
-                        "func": {
-                          "RecordCreate": {
-                            "field_names": [
-                              ""
-                            ]
-                          }
-                        },
-                        "exprs": [
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    "value",
-                                    "sep"
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallBinary": {
-                                    "func": "TextConcat",
-                                    "expr1": {
-                                      "Column": 2
-                                    },
-                                    "expr2": {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              50
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "Literal": [
-                                    {
-                                      "Ok": {
-                                        "data": [
-                                          19,
-                                          1,
-                                          44
-                                        ]
-                                      }
-                                    },
-                                    {
-                                      "scalar_type": "String",
-                                      "nullable": false
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "predicates": [],
-                  "projection": [
-                    1,
-                    3,
-                    1,
-                    1,
-                    1,
-                    4
-                  ],
-                  "input_arity": 2
-                }
-              }
-            },
-            "plan": {
-              "Collation": {
-                "accumulable": {
-                  "full_aggrs": [
-                    {
-                      "func": "Count",
-                      "expr": {
-                        "Column": 1
-                      },
-                      "distinct": true
-                    },
-                    {
-                      "func": "SumInt32",
-                      "expr": {
-                        "Column": 1
-                      },
-                      "distinct": false
-                    }
-                  ],
-                  "simple_aggrs": [
-                    [
-                      1,
-                      4,
+                      ],
+                      null,
                       {
-                        "func": "SumInt32",
-                        "expr": {
-                          "Column": 1
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ],
-                  "distinct_aggrs": [
-                    [
-                      0,
-                      0,
-                      {
-                        "func": "Count",
-                        "expr": {
-                          "Column": 1
-                        },
-                        "distinct": true
-                      }
-                    ]
-                  ]
-                },
-                "hierarchical": {
-                  "Monotonic": {
-                    "aggr_funcs": [
-                      "MinInt32",
-                      "MaxInt32"
-                    ],
-                    "skips": [
-                      2,
-                      0
-                    ],
-                    "must_consolidate": true
-                  }
-                },
-                "basic": {
-                  "Multiple": [
-                    [
-                      1,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": 1
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  49
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ],
-                    [
-                      5,
-                      {
-                        "func": {
-                          "StringAgg": {
-                            "order_by": []
-                          }
-                        },
-                        "expr": {
-                          "CallVariadic": {
-                            "func": {
-                              "RecordCreate": {
-                                "field_names": [
-                                  ""
-                                ]
-                              }
-                            },
-                            "exprs": [
-                              {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        "value",
-                                        "sep"
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallBinary": {
-                                        "func": "TextConcat",
-                                        "expr1": {
-                                          "CallUnary": {
-                                            "func": {
-                                              "CastInt32ToString": null
-                                            },
-                                            "expr": {
-                                              "Column": 1
-                                            }
-                                          }
-                                        },
-                                        "expr2": {
-                                          "Literal": [
-                                            {
-                                              "Ok": {
-                                                "data": [
-                                                  19,
-                                                  1,
-                                                  50
-                                                ]
-                                              }
-                                            },
-                                            {
-                                              "scalar_type": "String",
-                                              "nullable": false
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "Literal": [
-                                        {
-                                          "Ok": {
-                                            "data": [
-                                              19,
-                                              1,
-                                              44
-                                            ]
-                                          }
-                                        },
-                                        {
-                                          "scalar_type": "String",
-                                          "nullable": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "distinct": false
-                      }
-                    ]
-                  ]
-                },
-                "aggregate_types": [
-                  "Accumulable",
-                  "Basic",
-                  "Hierarchical",
-                  "Hierarchical",
-                  "Accumulable",
-                  "Basic"
-                ]
-              }
-            },
-            "input_key": [
-              {
-                "Column": 0
-              }
-            ],
-            "mfp_after": {
-              "expressions": [],
-              "predicates": [],
-              "projection": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6
-              ],
-              "input_arity": 7
-            }
-          }
-        }
-      }
-    }
-  ],
-  "sources": []
-}
-EOF
-
-# Test Reduce::Collated (global aggregate).
-query T multiline
-EXPLAIN PHYSICAL PLAN AS JSON FOR
-MATERIALIZED VIEW collated_global_mv
-----
-{
-  "plans": [
-    {
-      "id": "materialize.public.collated_global_mv",
-      "plan": {
-        "lir_id": 11,
-        "node": {
-          "Let": {
-            "id": 0,
-            "value": {
-              "lir_id": 2,
-              "node": {
-                "Reduce": {
-                  "input": {
-                    "lir_id": 1,
-                    "node": {
-                      "Get": {
-                        "id": {
-                          "Global": {
-                            "User": 1
-                          }
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [
-                                {
-                                  "Column": 0
-                                }
-                              ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
-                              [
-                                1
-                              ]
-                            ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": 0
-                              }
-                            ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                1
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "key_val_plan": {
-                    "key_plan": {
-                      "mfp": {
                         "expressions": [],
                         "predicates": [],
-                        "projection": [],
-                        "input_arity": 1
-                      }
-                    },
-                    "val_plan": {
-                      "mfp": {
-                        "expressions": [
-                          {
-                            "CallUnary": {
-                              "func": {
-                                "CastInt32ToString": null
-                              },
-                              "expr": {
-                                "Column": 0
-                              }
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": 1
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    49
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": 1
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    50
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        "predicates": [],
                         "projection": [
-                          0,
-                          2,
-                          0,
-                          0,
-                          0,
-                          3
+                          1
                         ],
-                        "input_arity": 1
+                        "input_arity": 2
                       }
-                    }
-                  },
-                  "plan": {
-                    "Collation": {
-                      "accumulable": {
-                        "full_aggrs": [
-                          {
-                            "func": "Count",
-                            "expr": {
-                              "Column": 0
-                            },
-                            "distinct": true
-                          },
-                          {
-                            "func": "SumInt32",
-                            "expr": {
-                              "Column": 0
-                            },
-                            "distinct": false
-                          }
-                        ],
-                        "simple_aggrs": [
-                          [
-                            1,
-                            4,
-                            {
-                              "func": "SumInt32",
-                              "expr": {
-                                "Column": 0
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ],
-                        "distinct_aggrs": [
-                          [
-                            0,
-                            0,
-                            {
-                              "func": "Count",
-                              "expr": {
-                                "Column": 0
-                              },
-                              "distinct": true
-                            }
-                          ]
-                        ]
-                      },
-                      "hierarchical": {
-                        "Bucketed": {
-                          "aggr_funcs": [
-                            "MinInt32",
-                            "MaxInt32"
-                          ],
-                          "skips": [
-                            2,
-                            0
-                          ],
-                          "buckets": [
-                            268435456,
-                            16777216,
-                            1048576,
-                            65536,
-                            4096,
-                            256,
-                            16
-                          ]
-                        }
-                      },
-                      "basic": {
-                        "Multiple": [
-                          [
-                            1,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": 0
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        49
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ],
-                          [
-                            5,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": 0
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        50
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ]
-                      },
-                      "aggregate_types": [
-                        "Accumulable",
-                        "Basic",
-                        "Hierarchical",
-                        "Hierarchical",
-                        "Accumulable",
-                        "Basic"
-                      ]
-                    }
-                  },
-                  "input_key": null,
-                  "mfp_after": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      1,
-                      2,
-                      3,
-                      4,
-                      5
-                    ],
-                    "input_arity": 6
+                    ]
                   }
                 }
               }
             },
             "body": {
-              "lir_id": 10,
+              "lir_id": 18,
               "node": {
-                "Union": {
-                  "inputs": [
-                    {
-                      "lir_id": 9,
-                      "node": {
-                        "ArrangeBy": {
-                          "input": {
+                "Let": {
+                  "id": 1,
+                  "value": {
+                    "lir_id": 10,
+                    "node": {
+                      "Join": {
+                        "inputs": [
+                          {
                             "lir_id": 3,
                             "node": {
-                              "Get": {
-                                "id": {
-                                  "Local": 0
-                                },
-                                "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [],
-                                      {
-                                        "0": 0,
-                                        "1": 1,
-                                        "2": 2,
-                                        "3": 3,
-                                        "4": 4,
-                                        "5": 5
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
                                       },
-                                      [
-                                        0,
-                                        1,
-                                        2,
-                                        3,
-                                        4,
-                                        5
-                                      ]
-                                    ]
-                                  ],
-                                  "types": null
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
                                 },
-                                "plan": "PassArrangements"
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Hierarchical": {
+                                    "Bucketed": {
+                                      "aggr_funcs": [
+                                        "MinInt32",
+                                        "MaxInt32"
+                                      ],
+                                      "skips": [
+                                        0,
+                                        0
+                                      ],
+                                      "buckets": [
+                                        268435456,
+                                        16777216,
+                                        1048576,
+                                        65536,
+                                        4096,
+                                        256,
+                                        16
+                                      ]
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
                               }
                             }
                           },
-                          "forms": {
-                            "raw": true,
-                            "arranged": [],
-                            "types": null
+                          {
+                            "lir_id": 5,
+                            "node": {
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 4,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Accumulable": {
+                                    "full_aggrs": [
+                                      {
+                                        "func": "Count",
+                                        "expr": {
+                                          "Column": 0
+                                        },
+                                        "distinct": true
+                                      },
+                                      {
+                                        "func": "SumInt32",
+                                        "expr": {
+                                          "Column": 0
+                                        },
+                                        "distinct": false
+                                      }
+                                    ],
+                                    "simple_aggrs": [
+                                      [
+                                        1,
+                                        1,
+                                        {
+                                          "func": "SumInt32",
+                                          "expr": {
+                                            "Column": 0
+                                          },
+                                          "distinct": false
+                                        }
+                                      ]
+                                    ],
+                                    "distinct_aggrs": [
+                                      [
+                                        0,
+                                        0,
+                                        {
+                                          "func": "Count",
+                                          "expr": {
+                                            "Column": 0
+                                          },
+                                          "distinct": true
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
+                              }
+                            }
                           },
-                          "input_key": [],
-                          "input_mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 6
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lir_id": 8,
-                      "node": {
-                        "Mfp": {
-                          "input": {
+                          {
                             "lir_id": 7,
                             "node": {
-                              "Union": {
-                                "inputs": [
-                                  {
-                                    "lir_id": 5,
-                                    "node": {
-                                      "Negate": {
-                                        "input": {
-                                          "lir_id": 4,
-                                          "node": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 0
-                                              },
-                                              "keys": {
-                                                "raw": false,
-                                                "arranged": [
-                                                  [
-                                                    [],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1,
-                                                      "2": 2,
-                                                      "3": 3,
-                                                      "4": 4,
-                                                      "5": 5
-                                                    },
-                                                    [
-                                                      0,
-                                                      1,
-                                                      2,
-                                                      3,
-                                                      4,
-                                                      5
-                                                    ]
-                                                  ]
-                                                ],
-                                                "types": null
-                                              },
-                                              "plan": {
-                                                "Arrangement": [
-                                                  [],
-                                                  null,
-                                                  {
-                                                    "expressions": [],
-                                                    "predicates": [],
-                                                    "projection": [],
-                                                    "input_arity": 6
-                                                  }
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 6,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
                                                 ]
                                               }
-                                            }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
                                           }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 9,
+                            "node": {
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 8,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "plan": {
+                          "Delta": {
+                            "path_plans": [
+                              {
+                                "source_relation": 0,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3
+                                          ],
+                                          "input_arity": 4
                                         }
                                       }
                                     }
                                   },
                                   {
-                                    "lir_id": 6,
-                                    "node": {
-                                      "Constant": {
-                                        "rows": {
-                                          "Ok": [
-                                            [
-                                              {
-                                                "data": []
-                                              },
-                                              0,
-                                              1
-                                            ]
-                                          ]
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
                                         }
                                       }
                                     }
                                   }
                                 ],
-                                "consolidate_output": true
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 1,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            2,
+                                            3,
+                                            0,
+                                            1
+                                          ],
+                                          "input_arity": 4
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 2,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 3,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            5,
+                                            4
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
                               }
-                            }
-                          },
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        49
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": false
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              }
-                            ],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 0
-                          },
-                          "input_key_val": null
+                            ]
+                          }
                         }
                       }
                     }
-                  ],
-                  "consolidate_output": false
+                  },
+                  "body": {
+                    "lir_id": 17,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 11,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "keys": {
+                                  "raw": true,
+                                  "arranged": [],
+                                  "types": null
+                                },
+                                "plan": {
+                                  "Collection": {
+                                    "expressions": [],
+                                    "predicates": [],
+                                    "projection": [
+                                      2,
+                                      4,
+                                      0,
+                                      1,
+                                      3,
+                                      5
+                                    ],
+                                    "input_arity": 6
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 16,
+                            "node": {
+                              "Mfp": {
+                                "input": {
+                                  "lir_id": 15,
+                                  "node": {
+                                    "Union": {
+                                      "inputs": [
+                                        {
+                                          "lir_id": 13,
+                                          "node": {
+                                            "Negate": {
+                                              "input": {
+                                                "lir_id": 12,
+                                                "node": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 1
+                                                    },
+                                                    "keys": {
+                                                      "raw": true,
+                                                      "arranged": [],
+                                                      "types": null
+                                                    },
+                                                    "plan": {
+                                                      "Collection": {
+                                                        "expressions": [],
+                                                        "predicates": [],
+                                                        "projection": [],
+                                                        "input_arity": 6
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "lir_id": 14,
+                                          "node": {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": []
+                                                    },
+                                                    0,
+                                                    1
+                                                  ]
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "consolidate_output": true
+                                    }
+                                  }
+                                },
+                                "mfp": {
+                                  "expressions": [
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              49
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5
+                                  ],
+                                  "input_arity": 0
+                                },
+                                "input_key_val": null
+                              }
+                            }
+                          }
+                        ],
+                        "consolidate_output": false
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5981,774 +8375,1318 @@ SELECT * FROM collated_global
     {
       "id": "Explained Query",
       "plan": {
-        "lir_id": 11,
+        "lir_id": 19,
         "node": {
           "Let": {
             "id": 0,
             "value": {
-              "lir_id": 2,
+              "lir_id": 1,
               "node": {
-                "Reduce": {
-                  "input": {
-                    "lir_id": 1,
-                    "node": {
-                      "Get": {
-                        "id": {
-                          "Global": {
-                            "User": 1
-                          }
-                        },
-                        "keys": {
-                          "raw": false,
-                          "arranged": [
-                            [
-                              [
-                                {
-                                  "Column": 0
-                                }
-                              ],
-                              {
-                                "0": 0,
-                                "1": 1
-                              },
-                              [
-                                1
-                              ]
-                            ]
-                          ],
-                          "types": [
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            },
-                            {
-                              "scalar_type": "Int32",
-                              "nullable": true
-                            }
-                          ]
-                        },
-                        "plan": {
-                          "Arrangement": [
-                            [
-                              {
-                                "Column": 0
-                              }
-                            ],
-                            null,
-                            {
-                              "expressions": [],
-                              "predicates": [],
-                              "projection": [
-                                1
-                              ],
-                              "input_arity": 2
-                            }
-                          ]
-                        }
-                      }
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
                     }
                   },
-                  "key_val_plan": {
-                    "key_plan": {
-                      "mfp": {
-                        "expressions": [],
-                        "predicates": [],
-                        "projection": [],
-                        "input_arity": 1
-                      }
-                    },
-                    "val_plan": {
-                      "mfp": {
-                        "expressions": [
+                  "keys": {
+                    "raw": false,
+                    "arranged": [
+                      [
+                        [
                           {
-                            "CallUnary": {
-                              "func": {
-                                "CastInt32ToString": null
-                              },
-                              "expr": {
-                                "Column": 0
-                              }
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": 1
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    49
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "CallVariadic": {
-                              "func": {
-                                "RecordCreate": {
-                                  "field_names": [
-                                    ""
-                                  ]
-                                }
-                              },
-                              "exprs": [
-                                {
-                                  "CallVariadic": {
-                                    "func": {
-                                      "RecordCreate": {
-                                        "field_names": [
-                                          "value",
-                                          "sep"
-                                        ]
-                                      }
-                                    },
-                                    "exprs": [
-                                      {
-                                        "CallBinary": {
-                                          "func": "TextConcat",
-                                          "expr1": {
-                                            "Column": 1
-                                          },
-                                          "expr2": {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    50
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "Literal": [
-                                          {
-                                            "Ok": {
-                                              "data": [
-                                                19,
-                                                1,
-                                                44
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "scalar_type": "String",
-                                            "nullable": false
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
+                            "Column": 0
                           }
                         ],
-                        "predicates": [],
-                        "projection": [
-                          0,
-                          2,
-                          0,
-                          0,
-                          0,
-                          3
-                        ],
-                        "input_arity": 1
+                        {
+                          "0": 0,
+                          "1": 1
+                        },
+                        [
+                          1
+                        ]
+                      ]
+                    ],
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
                       }
-                    }
+                    ]
                   },
                   "plan": {
-                    "Collation": {
-                      "accumulable": {
-                        "full_aggrs": [
-                          {
-                            "func": "Count",
-                            "expr": {
-                              "Column": 0
-                            },
-                            "distinct": true
-                          },
-                          {
-                            "func": "SumInt32",
-                            "expr": {
-                              "Column": 0
-                            },
-                            "distinct": false
-                          }
-                        ],
-                        "simple_aggrs": [
-                          [
-                            1,
-                            4,
-                            {
-                              "func": "SumInt32",
-                              "expr": {
-                                "Column": 0
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ],
-                        "distinct_aggrs": [
-                          [
-                            0,
-                            0,
-                            {
-                              "func": "Count",
-                              "expr": {
-                                "Column": 0
-                              },
-                              "distinct": true
-                            }
-                          ]
-                        ]
-                      },
-                      "hierarchical": {
-                        "Monotonic": {
-                          "aggr_funcs": [
-                            "MinInt32",
-                            "MaxInt32"
-                          ],
-                          "skips": [
-                            2,
-                            0
-                          ],
-                          "must_consolidate": true
+                    "Arrangement": [
+                      [
+                        {
+                          "Column": 0
                         }
-                      },
-                      "basic": {
-                        "Multiple": [
-                          [
-                            1,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": 0
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        49
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ],
-                          [
-                            5,
-                            {
-                              "func": {
-                                "StringAgg": {
-                                  "order_by": []
-                                }
-                              },
-                              "expr": {
-                                "CallVariadic": {
-                                  "func": {
-                                    "RecordCreate": {
-                                      "field_names": [
-                                        ""
-                                      ]
-                                    }
-                                  },
-                                  "exprs": [
-                                    {
-                                      "CallVariadic": {
-                                        "func": {
-                                          "RecordCreate": {
-                                            "field_names": [
-                                              "value",
-                                              "sep"
-                                            ]
-                                          }
-                                        },
-                                        "exprs": [
-                                          {
-                                            "CallBinary": {
-                                              "func": "TextConcat",
-                                              "expr1": {
-                                                "CallUnary": {
-                                                  "func": {
-                                                    "CastInt32ToString": null
-                                                  },
-                                                  "expr": {
-                                                    "Column": 0
-                                                  }
-                                                }
-                                              },
-                                              "expr2": {
-                                                "Literal": [
-                                                  {
-                                                    "Ok": {
-                                                      "data": [
-                                                        19,
-                                                        1,
-                                                        50
-                                                      ]
-                                                    }
-                                                  },
-                                                  {
-                                                    "scalar_type": "String",
-                                                    "nullable": false
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "Literal": [
-                                              {
-                                                "Ok": {
-                                                  "data": [
-                                                    19,
-                                                    1,
-                                                    44
-                                                  ]
-                                                }
-                                              },
-                                              {
-                                                "scalar_type": "String",
-                                                "nullable": false
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "distinct": false
-                            }
-                          ]
-                        ]
-                      },
-                      "aggregate_types": [
-                        "Accumulable",
-                        "Basic",
-                        "Hierarchical",
-                        "Hierarchical",
-                        "Accumulable",
-                        "Basic"
-                      ]
-                    }
-                  },
-                  "input_key": null,
-                  "mfp_after": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0,
-                      1,
-                      2,
-                      3,
-                      4,
-                      5
-                    ],
-                    "input_arity": 6
+                      ],
+                      null,
+                      {
+                        "expressions": [],
+                        "predicates": [],
+                        "projection": [
+                          1
+                        ],
+                        "input_arity": 2
+                      }
+                    ]
                   }
                 }
               }
             },
             "body": {
-              "lir_id": 10,
+              "lir_id": 18,
               "node": {
-                "Union": {
-                  "inputs": [
-                    {
-                      "lir_id": 9,
-                      "node": {
-                        "ArrangeBy": {
-                          "input": {
+                "Let": {
+                  "id": 1,
+                  "value": {
+                    "lir_id": 10,
+                    "node": {
+                      "Join": {
+                        "inputs": [
+                          {
                             "lir_id": 3,
                             "node": {
-                              "Get": {
-                                "id": {
-                                  "Local": 0
-                                },
-                                "keys": {
-                                  "raw": false,
-                                  "arranged": [
-                                    [
-                                      [],
-                                      {
-                                        "0": 0,
-                                        "1": 1,
-                                        "2": 2,
-                                        "3": 3,
-                                        "4": 4,
-                                        "5": 5
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 2,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
                                       },
-                                      [
-                                        0,
-                                        1,
-                                        2,
-                                        3,
-                                        4,
-                                        5
-                                      ]
-                                    ]
-                                  ],
-                                  "types": null
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
                                 },
-                                "plan": "PassArrangements"
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Hierarchical": {
+                                    "Monotonic": {
+                                      "aggr_funcs": [
+                                        "MinInt32",
+                                        "MaxInt32"
+                                      ],
+                                      "skips": [
+                                        0,
+                                        0
+                                      ],
+                                      "must_consolidate": true
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
                               }
                             }
                           },
-                          "forms": {
-                            "raw": true,
-                            "arranged": [],
-                            "types": null
+                          {
+                            "lir_id": 5,
+                            "node": {
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 4,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Accumulable": {
+                                    "full_aggrs": [
+                                      {
+                                        "func": "Count",
+                                        "expr": {
+                                          "Column": 0
+                                        },
+                                        "distinct": true
+                                      },
+                                      {
+                                        "func": "SumInt32",
+                                        "expr": {
+                                          "Column": 0
+                                        },
+                                        "distinct": false
+                                      }
+                                    ],
+                                    "simple_aggrs": [
+                                      [
+                                        1,
+                                        1,
+                                        {
+                                          "func": "SumInt32",
+                                          "expr": {
+                                            "Column": 0
+                                          },
+                                          "distinct": false
+                                        }
+                                      ]
+                                    ],
+                                    "distinct_aggrs": [
+                                      [
+                                        0,
+                                        0,
+                                        {
+                                          "func": "Count",
+                                          "expr": {
+                                            "Column": 0
+                                          },
+                                          "distinct": true
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1
+                                  ],
+                                  "input_arity": 2
+                                }
+                              }
+                            }
                           },
-                          "input_key": [],
-                          "input_mfp": {
-                            "expressions": [],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 6
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "lir_id": 8,
-                      "node": {
-                        "Mfp": {
-                          "input": {
+                          {
                             "lir_id": 7,
                             "node": {
-                              "Union": {
-                                "inputs": [
-                                  {
-                                    "lir_id": 5,
-                                    "node": {
-                                      "Negate": {
-                                        "input": {
-                                          "lir_id": 4,
-                                          "node": {
-                                            "Get": {
-                                              "id": {
-                                                "Local": 0
-                                              },
-                                              "keys": {
-                                                "raw": false,
-                                                "arranged": [
-                                                  [
-                                                    [],
-                                                    {
-                                                      "0": 0,
-                                                      "1": 1,
-                                                      "2": 2,
-                                                      "3": 3,
-                                                      "4": 4,
-                                                      "5": 5
-                                                    },
-                                                    [
-                                                      0,
-                                                      1,
-                                                      2,
-                                                      3,
-                                                      4,
-                                                      5
-                                                    ]
-                                                  ]
-                                                ],
-                                                "types": null
-                                              },
-                                              "plan": {
-                                                "Arrangement": [
-                                                  [],
-                                                  null,
-                                                  {
-                                                    "expressions": [],
-                                                    "predicates": [],
-                                                    "projection": [],
-                                                    "input_arity": 6
-                                                  }
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 6,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
                                                 ]
                                               }
-                                            }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
                                           }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  49
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 9,
+                            "node": {
+                              "Reduce": {
+                                "input": {
+                                  "lir_id": 8,
+                                  "node": {
+                                    "Get": {
+                                      "id": {
+                                        "Local": 0
+                                      },
+                                      "keys": {
+                                        "raw": true,
+                                        "arranged": [],
+                                        "types": null
+                                      },
+                                      "plan": "PassArrangements"
+                                    }
+                                  }
+                                },
+                                "key_val_plan": {
+                                  "key_plan": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [],
+                                      "input_arity": 1
+                                    }
+                                  },
+                                  "val_plan": {
+                                    "mfp": {
+                                      "expressions": [
+                                        {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "predicates": [],
+                                      "projection": [
+                                        1
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "plan": {
+                                  "Basic": {
+                                    "Single": {
+                                      "index": 0,
+                                      "expr": {
+                                        "func": {
+                                          "StringAgg": {
+                                            "order_by": []
+                                          }
+                                        },
+                                        "expr": {
+                                          "CallVariadic": {
+                                            "func": {
+                                              "RecordCreate": {
+                                                "field_names": [
+                                                  ""
+                                                ]
+                                              }
+                                            },
+                                            "exprs": [
+                                              {
+                                                "CallVariadic": {
+                                                  "func": {
+                                                    "RecordCreate": {
+                                                      "field_names": [
+                                                        "value",
+                                                        "sep"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "exprs": [
+                                                    {
+                                                      "CallBinary": {
+                                                        "func": "TextConcat",
+                                                        "expr1": {
+                                                          "CallUnary": {
+                                                            "func": {
+                                                              "CastInt32ToString": null
+                                                            },
+                                                            "expr": {
+                                                              "Column": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "expr2": {
+                                                          "Literal": [
+                                                            {
+                                                              "Ok": {
+                                                                "data": [
+                                                                  19,
+                                                                  1,
+                                                                  50
+                                                                ]
+                                                              }
+                                                            },
+                                                            {
+                                                              "scalar_type": "String",
+                                                              "nullable": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "Literal": [
+                                                        {
+                                                          "Ok": {
+                                                            "data": [
+                                                              19,
+                                                              1,
+                                                              44
+                                                            ]
+                                                          }
+                                                        },
+                                                        {
+                                                          "scalar_type": "String",
+                                                          "nullable": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "distinct": false
+                                      },
+                                      "fused_unnest_list": false
+                                    }
+                                  }
+                                },
+                                "input_key": null,
+                                "mfp_after": {
+                                  "expressions": [],
+                                  "predicates": [],
+                                  "projection": [
+                                    0
+                                  ],
+                                  "input_arity": 1
+                                }
+                              }
+                            }
+                          }
+                        ],
+                        "plan": {
+                          "Delta": {
+                            "path_plans": [
+                              {
+                                "source_relation": 0,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3
+                                          ],
+                                          "input_arity": 4
                                         }
                                       }
                                     }
                                   },
                                   {
-                                    "lir_id": 6,
-                                    "node": {
-                                      "Constant": {
-                                        "rows": {
-                                          "Ok": [
-                                            [
-                                              {
-                                                "data": []
-                                              },
-                                              0,
-                                              1
-                                            ]
-                                          ]
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
                                         }
                                       }
                                     }
                                   }
                                 ],
-                                "consolidate_output": true
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 1,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0,
+                                        1
+                                      ],
+                                      "input_arity": 2
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            2,
+                                            3,
+                                            0,
+                                            1
+                                          ],
+                                          "input_arity": 4
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 2,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 3,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            4,
+                                            5
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
+                              },
+                              {
+                                "source_relation": 3,
+                                "source_key": [],
+                                "initial_closure": {
+                                  "ready_equivalences": [],
+                                  "before": {
+                                    "mfp": {
+                                      "expressions": [],
+                                      "predicates": [],
+                                      "projection": [
+                                        0
+                                      ],
+                                      "input_arity": 1
+                                    }
+                                  }
+                                },
+                                "stage_plans": [
+                                  {
+                                    "lookup_relation": 0,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            1,
+                                            2,
+                                            0
+                                          ],
+                                          "input_arity": 3
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 1,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            3,
+                                            4,
+                                            2
+                                          ],
+                                          "input_arity": 5
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "lookup_relation": 2,
+                                    "stream_key": [],
+                                    "stream_thinning": [
+                                      0,
+                                      1,
+                                      2,
+                                      3,
+                                      4
+                                    ],
+                                    "lookup_key": [],
+                                    "closure": {
+                                      "ready_equivalences": [],
+                                      "before": {
+                                        "mfp": {
+                                          "expressions": [],
+                                          "predicates": [],
+                                          "projection": [
+                                            0,
+                                            1,
+                                            2,
+                                            3,
+                                            5,
+                                            4
+                                          ],
+                                          "input_arity": 6
+                                        }
+                                      }
+                                    }
+                                  }
+                                ],
+                                "final_closure": null
                               }
-                            }
-                          },
-                          "mfp": {
-                            "expressions": [
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        49
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": false
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int32",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "Int64",
-                                    "nullable": true
-                                  }
-                                ]
-                              },
-                              {
-                                "Literal": [
-                                  {
-                                    "Ok": {
-                                      "data": [
-                                        0
-                                      ]
-                                    }
-                                  },
-                                  {
-                                    "scalar_type": "String",
-                                    "nullable": true
-                                  }
-                                ]
-                              }
-                            ],
-                            "predicates": [],
-                            "projection": [
-                              0,
-                              1,
-                              2,
-                              3,
-                              4,
-                              5
-                            ],
-                            "input_arity": 0
-                          },
-                          "input_key_val": null
+                            ]
+                          }
                         }
                       }
                     }
-                  ],
-                  "consolidate_output": false
+                  },
+                  "body": {
+                    "lir_id": 17,
+                    "node": {
+                      "Union": {
+                        "inputs": [
+                          {
+                            "lir_id": 11,
+                            "node": {
+                              "Get": {
+                                "id": {
+                                  "Local": 1
+                                },
+                                "keys": {
+                                  "raw": true,
+                                  "arranged": [],
+                                  "types": null
+                                },
+                                "plan": {
+                                  "Collection": {
+                                    "expressions": [],
+                                    "predicates": [],
+                                    "projection": [
+                                      2,
+                                      4,
+                                      0,
+                                      1,
+                                      3,
+                                      5
+                                    ],
+                                    "input_arity": 6
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "lir_id": 16,
+                            "node": {
+                              "Mfp": {
+                                "input": {
+                                  "lir_id": 15,
+                                  "node": {
+                                    "Union": {
+                                      "inputs": [
+                                        {
+                                          "lir_id": 13,
+                                          "node": {
+                                            "Negate": {
+                                              "input": {
+                                                "lir_id": 12,
+                                                "node": {
+                                                  "Get": {
+                                                    "id": {
+                                                      "Local": 1
+                                                    },
+                                                    "keys": {
+                                                      "raw": true,
+                                                      "arranged": [],
+                                                      "types": null
+                                                    },
+                                                    "plan": {
+                                                      "Collection": {
+                                                        "expressions": [],
+                                                        "predicates": [],
+                                                        "projection": [],
+                                                        "input_arity": 6
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "lir_id": 14,
+                                          "node": {
+                                            "Constant": {
+                                              "rows": {
+                                                "Ok": [
+                                                  [
+                                                    {
+                                                      "data": []
+                                                    },
+                                                    0,
+                                                    1
+                                                  ]
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "consolidate_output": true
+                                    }
+                                  }
+                                },
+                                "mfp": {
+                                  "expressions": [
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              49
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int32",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "Int64",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Literal": [
+                                        {
+                                          "Ok": {
+                                            "data": [
+                                              0
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "scalar_type": "String",
+                                          "nullable": true
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "predicates": [],
+                                  "projection": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5
+                                  ],
+                                  "input_arity": 0
+                                },
+                                "input_key_val": null
+                              }
+                            }
+                          }
+                        ],
+                        "consolidate_output": false
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -776,28 +776,79 @@ EXPLAIN PHYSICAL PLAN AS TEXT FOR
 MATERIALIZED VIEW collated_group_by_mv
 ----
 materialize.public.collated_group_by_mv:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1))
+  Join::Delta
+    plan_path[0]
+      delta_stage[1]
+        closure
+          project=(#0, #1, #5, #3, #4, #2, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #6, #4, #5, #3, #7)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #4, #6, #7, #3, #5)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=2, key=[#0] }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
       distinct_aggrs[0]=(0, 0, count(distinct #1))
-    hierarchical
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
-    key_plan
-      project=(#0)
-    input_key=#0
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+      val_plan
+        project=(#3, #4)
+        map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -812,29 +863,80 @@ EXPLAIN PHYSICAL PLAN AS TEXT FOR
 SELECT * FROM collated_group_by
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1))
+  Join::Delta
+    plan_path[0]
+      delta_stage[1]
+        closure
+          project=(#0, #1, #5, #3, #4, #2, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #6, #4, #5, #3, #7)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #4, #6, #7, #3, #5)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=2, key=[#0] }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
       distinct_aggrs[0]=(0, 0, count(distinct #1))
-    hierarchical
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       monotonic
       must_consolidate
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
-    key_plan
-      project=(#0)
-    input_key=#0
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+      val_plan
+        project=(#3, #4)
+        map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -851,49 +953,88 @@ MATERIALIZED VIEW collated_global_mv
 materialize.public.collated_global_mv:
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#0, #4, #2, #3, #1, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(0, null, null, null, null, null)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
   With
-    cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0))
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #1, #4, #5, #2, #3)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
           distinct_aggrs[0]=(0, 0, count(distinct #0))
-        hierarchical
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+          val_plan
+            project=(#2, #3)
+            map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -910,50 +1051,89 @@ SELECT * FROM collated_global
 Explained Query:
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#0, #4, #2, #3, #1, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(0, null, null, null, null, null)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
   With
-    cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0))
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #1, #4, #5, #2, #3)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
           distinct_aggrs[0]=(0, 0, count(distinct #0))
-        hierarchical
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           monotonic
           must_consolidate
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+          val_plan
+            project=(#2, #3)
+            map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1822,3 +1822,66 @@ Used Indexes:
 Target cluster: quickstart
 
 EOF
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_reduce_reduction = false;
+----
+COMPLETE 0
+
+# Test Reduce::Basic (global aggregate).
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT
+  STRING_AGG(b::text || '1',  ','),
+  STRING_AGG(b::text || '2',  ',')
+FROM t
+----
+Explained Query:
+  Return
+    Union
+      ArrangeBy
+        input_key=[]
+        raw=true
+        Get::PassArrangements l0
+          raw=false
+          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+      Mfp
+        project=(#0, #1)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Get::Arrangement l0
+              project=()
+              key=
+              raw=false
+              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+          Constant
+            - ()
+  With
+    cte l0 =
+      Reduce::Basic
+        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+        val_plan
+          project=(#2, #3)
+          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+        key_plan
+          project=()
+        Get::Arrangement materialize.public.t
+          project=(#1)
+          key=#0
+          raw=false
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          types=[integer?, integer?]
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+Target cluster: quickstart
+
+EOF
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_reduce_reduction = true;
+----
+COMPLETE 0

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -696,19 +696,35 @@ FROM t
 GROUP BY a
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
-    aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
-    val_plan
-      project=(#3, #4)
-      map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
-    key_plan
-      project=(#0)
-    input_key=#0
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || "1"), ",")))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || "2"), ",")))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -728,40 +744,50 @@ FROM t
 Explained Query:
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::PassArrangements l1
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
       Mfp
         project=(#0, #1)
         map=(null, null)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+              raw=true
           Constant
             - ()
   With
+    cte l1 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[] }
+          stream={ key=[], thinning=(#0) }
+        source={ relation=0, key=[] }
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || "1"), ",")))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || "2"), ",")))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
     cte l0 =
-      Reduce::Basic
-        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
-        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
-        val_plan
-          project=(#2, #3)
-          map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -778,9 +804,12 @@ MATERIALIZED VIEW collated_group_by_mv
 materialize.public.collated_group_by_mv:
   Join::Delta
     plan_path[0]
-      delta_stage[1]
+      delta_stage[2]
         closure
-          project=(#0, #1, #5, #3, #4, #2, #6)
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
         lookup={ relation=2, key=[#0] }
         stream={ key=[#0], thinning=(#1..=#4) }
       delta_stage[0]
@@ -788,9 +817,14 @@ materialize.public.collated_group_by_mv:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=0, key=[#0] }
     plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #6, #4, #5, #3, #7)
+          project=(#1..=#3, #0, #4..=#6)
         lookup={ relation=2, key=[#0] }
         stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
       delta_stage[0]
@@ -800,29 +834,39 @@ materialize.public.collated_group_by_mv:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=1, key=[#0] }
     plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #4, #6, #7, #3, #5)
+          project=(#1..=#3, #5, #6, #0, #4)
         lookup={ relation=1, key=[#0] }
-        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
       delta_stage[0]
         closure
-          project=(#0, #3, #4, #0..=#2)
+          project=(#0, #2, #3, #0, #1)
         lookup={ relation=0, key=[#0] }
-        stream={ key=[#0], thinning=(#1, #2) }
+        stream={ key=[#0], thinning=(#1) }
       source={ relation=2, key=[#0] }
-    Reduce::Accumulable
-      simple_aggrs[0]=(1, 1, sum(#1))
-      distinct_aggrs[0]=(0, 0, count(distinct #1))
-      val_plan
-        project=(#1, #1)
-      key_plan
-        project=(#0)
-      input_key=#0
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
     Reduce::Hierarchical
       aggr_funcs=[min, max]
       skips=[0, 0]
@@ -836,12 +880,35 @@ materialize.public.collated_group_by_mv:
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
         types=[integer?, integer?]
-    Reduce::Basic
-      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
-      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
       val_plan
-        project=(#3, #4)
-        map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || "1"), ",")))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || "2"), ",")))
       key_plan
         project=(#0)
       input_key=#0
@@ -865,9 +932,12 @@ SELECT * FROM collated_group_by
 Explained Query:
   Join::Delta
     plan_path[0]
-      delta_stage[1]
+      delta_stage[2]
         closure
-          project=(#0, #1, #5, #3, #4, #2, #6)
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
         lookup={ relation=2, key=[#0] }
         stream={ key=[#0], thinning=(#1..=#4) }
       delta_stage[0]
@@ -875,9 +945,14 @@ Explained Query:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=0, key=[#0] }
     plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #6, #4, #5, #3, #7)
+          project=(#1..=#3, #0, #4..=#6)
         lookup={ relation=2, key=[#0] }
         stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
       delta_stage[0]
@@ -887,29 +962,39 @@ Explained Query:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=1, key=[#0] }
     plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #4, #6, #7, #3, #5)
+          project=(#1..=#3, #5, #6, #0, #4)
         lookup={ relation=1, key=[#0] }
-        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
       delta_stage[0]
         closure
-          project=(#0, #3, #4, #0..=#2)
+          project=(#0, #2, #3, #0, #1)
         lookup={ relation=0, key=[#0] }
-        stream={ key=[#0], thinning=(#1, #2) }
+        stream={ key=[#0], thinning=(#1) }
       source={ relation=2, key=[#0] }
-    Reduce::Accumulable
-      simple_aggrs[0]=(1, 1, sum(#1))
-      distinct_aggrs[0]=(0, 0, count(distinct #1))
-      val_plan
-        project=(#1, #1)
-      key_plan
-        project=(#0)
-      input_key=#0
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
     Reduce::Hierarchical
       aggr_funcs=[min, max]
       skips=[0, 0]
@@ -924,12 +1009,35 @@ Explained Query:
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
         types=[integer?, integer?]
-    Reduce::Basic
-      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
-      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
       val_plan
-        project=(#3, #4)
-        map=(integer_to_text(#1), row(row((#2 || "1"), ",")), row(row((#2 || "2"), ",")))
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "1"), ","))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || "1"), ",")))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || "2"), ","))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || "2"), ",")))
       key_plan
         project=(#0)
       input_key=#0
@@ -954,7 +1062,7 @@ materialize.public.collated_global_mv:
   Return
     Union
       Get::Collection l1
-        project=(#0, #4, #2, #3, #1, #5)
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
       Mfp
         project=(#0..=#5)
@@ -970,6 +1078,9 @@ materialize.public.collated_global_mv:
     cte l1 =
       Join::Delta
         plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -978,6 +1089,9 @@ materialize.public.collated_global_mv:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=0, key=[] }
         plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -988,26 +1102,37 @@ materialize.public.collated_global_mv:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=1, key=[] }
         plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             closure
-              project=(#0, #1, #4, #5, #2, #3)
+              project=(#0, #1, #3, #4, #2)
             lookup={ relation=1, key=[] }
-            stream={ key=[], thinning=(#0..=#3) }
+            stream={ key=[], thinning=(#0..=#2) }
           delta_stage[0]
             closure
-              project=(#2, #3, #0, #1)
+              project=(#1, #2, #0)
             lookup={ relation=0, key=[] }
-            stream={ key=[], thinning=(#0, #1) }
+            stream={ key=[], thinning=(#0) }
           source={ relation=2, key=[] }
-        Reduce::Accumulable
-          simple_aggrs[0]=(1, 1, sum(#0))
-          distinct_aggrs[0]=(0, 0, count(distinct #0))
-          val_plan
-            project=(#0, #0)
-          key_plan
-            project=()
-          Get::PassArrangements l0
-            raw=true
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
         Reduce::Hierarchical
           aggr_funcs=[min, max]
           skips=[0, 0]
@@ -1018,12 +1143,29 @@ materialize.public.collated_global_mv:
             project=()
           Get::PassArrangements l0
             raw=true
-        Reduce::Basic
-          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
-          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
           val_plan
-            project=(#2, #3)
-            map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || "1"), ",")))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || "2"), ",")))
           key_plan
             project=()
           Get::PassArrangements l0
@@ -1052,7 +1194,7 @@ Explained Query:
   Return
     Union
       Get::Collection l1
-        project=(#0, #4, #2, #3, #1, #5)
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
       Mfp
         project=(#0..=#5)
@@ -1068,6 +1210,9 @@ Explained Query:
     cte l1 =
       Join::Delta
         plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -1076,6 +1221,9 @@ Explained Query:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=0, key=[] }
         plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -1086,26 +1234,37 @@ Explained Query:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=1, key=[] }
         plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             closure
-              project=(#0, #1, #4, #5, #2, #3)
+              project=(#0, #1, #3, #4, #2)
             lookup={ relation=1, key=[] }
-            stream={ key=[], thinning=(#0..=#3) }
+            stream={ key=[], thinning=(#0..=#2) }
           delta_stage[0]
             closure
-              project=(#2, #3, #0, #1)
+              project=(#1, #2, #0)
             lookup={ relation=0, key=[] }
-            stream={ key=[], thinning=(#0, #1) }
+            stream={ key=[], thinning=(#0) }
           source={ relation=2, key=[] }
-        Reduce::Accumulable
-          simple_aggrs[0]=(1, 1, sum(#0))
-          distinct_aggrs[0]=(0, 0, count(distinct #0))
-          val_plan
-            project=(#0, #0)
-          key_plan
-            project=()
-          Get::PassArrangements l0
-            raw=true
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
         Reduce::Hierarchical
           aggr_funcs=[min, max]
           skips=[0, 0]
@@ -1117,12 +1276,29 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-        Reduce::Basic
-          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
-          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
           val_plan
-            project=(#2, #3)
-            map=(integer_to_text(#0), row(row((#1 || "1"), ",")), row(row((#1 || "2"), ",")))
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "1"), ","))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || "1"), ",")))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || "2"), ","))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || "2"), ",")))
           key_plan
             project=()
           Get::PassArrangements l0

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -761,28 +761,79 @@ EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
 MATERIALIZED VIEW collated_group_by_mv
 ----
 materialize.public.collated_group_by_mv:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1))
+  Join::Delta
+    plan_path[0]
+      delta_stage[1]
+        closure
+          project=(#0, #1, #5, #3, #4, #2, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #6, #4, #5, #3, #7)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #4, #6, #7, #3, #5)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=2, key=[#0] }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
       distinct_aggrs[0]=(0, 0, count(distinct #1))
-    hierarchical
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
-    key_plan
-      project=(#0)
-    input_key=#0
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#3, #4)
+        map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -797,29 +848,80 @@ EXPLAIN PHYSICAL PLAN WITH(redacted) AS TEXT FOR
 SELECT * FROM collated_group_by
 ----
 Explained Query:
-  Reduce::Collation
-    aggregate_types=[a, b, h, h, a, b]
-    accumulable
-      simple_aggrs[0]=(1, 4, sum(#1))
+  Join::Delta
+    plan_path[0]
+      delta_stage[1]
+        closure
+          project=(#0, #1, #5, #3, #4, #2, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#4) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #6, #4, #5, #3, #7)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      delta_stage[1]
+        closure
+          project=(#1, #2, #4, #6, #7, #3, #5)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+      delta_stage[0]
+        closure
+          project=(#0, #3, #4, #0..=#2)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      source={ relation=2, key=[#0] }
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
       distinct_aggrs[0]=(0, 0, count(distinct #1))
-    hierarchical
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Hierarchical
       aggr_funcs=[min, max]
-      skips=[2, 0]
+      skips=[0, 0]
       monotonic
       must_consolidate
-    basic
-      aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-      aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-    val_plan
-      project=(#1, #3, #1, #1, #1, #4)
-      map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
-    key_plan
-      project=(#0)
-    input_key=#0
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#3, #4)
+        map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -836,49 +938,88 @@ MATERIALIZED VIEW collated_global_mv
 materialize.public.collated_global_mv:
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#0, #4, #2, #3, #1, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(█, █, █, █, █, █)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
   With
-    cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0))
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #1, #4, #5, #2, #3)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
           distinct_aggrs[0]=(0, 0, count(distinct #0))
-        hierarchical
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           buckets=[268435456, 16777216, 1048576, 65536, 4096, 256, 16]
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#2, #3)
+            map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -895,50 +1036,89 @@ SELECT * FROM collated_global
 Explained Query:
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::Collection l1
+        project=(#0, #4, #2, #3, #1, #5)
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
       Mfp
         project=(#0..=#5)
         map=(█, █, █, █, █, █)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
+              raw=true
           Constant
             - ()
   With
-    cte l0 =
-      Reduce::Collation
-        aggregate_types=[a, b, h, h, a, b]
-        accumulable
-          simple_aggrs[0]=(1, 4, sum(#0))
+    cte l1 =
+      Join::Delta
+        plan_path[0]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=0, key=[] }
+        plan_path[1]
+          delta_stage[1]
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=1, key=[] }
+        plan_path[2]
+          delta_stage[1]
+            closure
+              project=(#0, #1, #4, #5, #2, #3)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#3) }
+          delta_stage[0]
+            closure
+              project=(#2, #3, #0, #1)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0, #1) }
+          source={ relation=2, key=[] }
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
           distinct_aggrs[0]=(0, 0, count(distinct #0))
-        hierarchical
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Hierarchical
           aggr_funcs=[min, max]
-          skips=[2, 0]
+          skips=[0, 0]
           monotonic
           must_consolidate
-        basic
-          aggrs[0]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-          aggrs[1]=(5, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-        val_plan
-          project=(#0, #2, #0, #0, #0, #3)
-          map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+          val_plan
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#2, #3)
+            map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+    cte l0 =
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)

--- a/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text_redacted.slt
@@ -681,19 +681,35 @@ FROM t
 GROUP BY a
 ----
 Explained Query:
-  Reduce::Basic
-    aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-    aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-    val_plan
-      project=(#3, #4)
-      map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
-    key_plan
-      project=(#0)
-    input_key=#0
-    Get::PassArrangements materialize.public.t
-      raw=false
-      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-      types=[integer?, integer?]
+  Join::Linear
+    linear_stage[0]
+      lookup={ relation=1, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    source={ relation=0, key=[#0] }
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || █), █)))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || █), █)))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -713,40 +729,50 @@ FROM t
 Explained Query:
   Return
     Union
-      ArrangeBy
-        input_key=[]
+      Get::PassArrangements l1
         raw=true
-        Get::PassArrangements l0
-          raw=false
-          arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
       Mfp
         project=(#0, #1)
         map=(█, █)
         Union consolidate_output=true
           Negate
-            Get::Arrangement l0
+            Get::Collection l1
               project=()
-              key=
-              raw=false
-              arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
+              raw=true
           Constant
             - ()
   With
+    cte l1 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[] }
+          stream={ key=[], thinning=(#0) }
+        source={ relation=0, key=[] }
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || █), █)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || █), █)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
     cte l0 =
-      Reduce::Basic
-        aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-        aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-        val_plan
-          project=(#2, #3)
-          map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
-        key_plan
-          project=()
-        Get::Arrangement materialize.public.t
-          project=(#1)
-          key=#0
-          raw=false
-          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          types=[integer?, integer?]
+      Get::Arrangement materialize.public.t
+        project=(#1)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
@@ -763,9 +789,12 @@ MATERIALIZED VIEW collated_group_by_mv
 materialize.public.collated_group_by_mv:
   Join::Delta
     plan_path[0]
-      delta_stage[1]
+      delta_stage[2]
         closure
-          project=(#0, #1, #5, #3, #4, #2, #6)
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
         lookup={ relation=2, key=[#0] }
         stream={ key=[#0], thinning=(#1..=#4) }
       delta_stage[0]
@@ -773,9 +802,14 @@ materialize.public.collated_group_by_mv:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=0, key=[#0] }
     plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #6, #4, #5, #3, #7)
+          project=(#1..=#3, #0, #4..=#6)
         lookup={ relation=2, key=[#0] }
         stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
       delta_stage[0]
@@ -785,29 +819,39 @@ materialize.public.collated_group_by_mv:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=1, key=[#0] }
     plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #4, #6, #7, #3, #5)
+          project=(#1..=#3, #5, #6, #0, #4)
         lookup={ relation=1, key=[#0] }
-        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
       delta_stage[0]
         closure
-          project=(#0, #3, #4, #0..=#2)
+          project=(#0, #2, #3, #0, #1)
         lookup={ relation=0, key=[#0] }
-        stream={ key=[#0], thinning=(#1, #2) }
+        stream={ key=[#0], thinning=(#1) }
       source={ relation=2, key=[#0] }
-    Reduce::Accumulable
-      simple_aggrs[0]=(1, 1, sum(#1))
-      distinct_aggrs[0]=(0, 0, count(distinct #1))
-      val_plan
-        project=(#1, #1)
-      key_plan
-        project=(#0)
-      input_key=#0
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
     Reduce::Hierarchical
       aggr_funcs=[min, max]
       skips=[0, 0]
@@ -821,12 +865,35 @@ materialize.public.collated_group_by_mv:
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
         types=[integer?, integer?]
-    Reduce::Basic
-      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
       val_plan
-        project=(#3, #4)
-        map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || █), █)))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || █), █)))
       key_plan
         project=(#0)
       input_key=#0
@@ -850,9 +917,12 @@ SELECT * FROM collated_group_by
 Explained Query:
   Join::Delta
     plan_path[0]
-      delta_stage[1]
+      delta_stage[2]
         closure
-          project=(#0, #1, #5, #3, #4, #2, #6)
+          project=(#0, #3, #5, #1, #2, #4, #6)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#5) }
+      delta_stage[1]
         lookup={ relation=2, key=[#0] }
         stream={ key=[#0], thinning=(#1..=#4) }
       delta_stage[0]
@@ -860,9 +930,14 @@ Explained Query:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=0, key=[#0] }
     plan_path[1]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4..=#6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #6, #4, #5, #3, #7)
+          project=(#1..=#3, #0, #4..=#6)
         lookup={ relation=2, key=[#0] }
         stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
       delta_stage[0]
@@ -872,29 +947,39 @@ Explained Query:
         stream={ key=[#0], thinning=(#1, #2) }
       source={ relation=1, key=[#0] }
     plan_path[2]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #6, #2, #3, #5, #7)
+        lookup={ relation=3, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
       delta_stage[1]
         closure
-          project=(#1, #2, #4, #6, #7, #3, #5)
+          project=(#1..=#3, #5, #6, #0, #4)
         lookup={ relation=1, key=[#0] }
-        stream={ key=[#3], thinning=(#0..=#2, #4, #5) }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
       delta_stage[0]
         closure
-          project=(#0, #3, #4, #0..=#2)
+          project=(#0, #2, #3, #0, #1)
         lookup={ relation=0, key=[#0] }
-        stream={ key=[#0], thinning=(#1, #2) }
+        stream={ key=[#0], thinning=(#1) }
       source={ relation=2, key=[#0] }
-    Reduce::Accumulable
-      simple_aggrs[0]=(1, 1, sum(#1))
-      distinct_aggrs[0]=(0, 0, count(distinct #1))
-      val_plan
-        project=(#1, #1)
-      key_plan
-        project=(#0)
-      input_key=#0
-      Get::PassArrangements materialize.public.t
-        raw=false
-        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-        types=[integer?, integer?]
+    plan_path[3]
+      delta_stage[2]
+        closure
+          project=(#1, #4, #7, #2, #3, #5, #6)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#5], thinning=(#0..=#4, #6) }
+      delta_stage[1]
+        closure
+          project=(#1..=#3, #5, #6, #0, #4)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#3], thinning=(#0..=#2, #4) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #3, #0, #1)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=3, key=[#0] }
     Reduce::Hierarchical
       aggr_funcs=[min, max]
       skips=[0, 0]
@@ -909,12 +994,35 @@ Explained Query:
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
         types=[integer?, integer?]
-    Reduce::Basic
-      aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
-      aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+    Reduce::Accumulable
+      simple_aggrs[0]=(1, 1, sum(#1))
+      distinct_aggrs[0]=(0, 0, count(distinct #1))
       val_plan
-        project=(#3, #4)
-        map=(integer_to_text(#1), row(row((#2 || █), █)), row(row((#2 || █), █)))
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || █), █)))
+      key_plan
+        project=(#0)
+      input_key=#0
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+        types=[integer?, integer?]
+    Reduce::Basic
+      aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#1) || █), █))))
+      val_plan
+        project=(#2)
+        map=(row(row((integer_to_text(#1) || █), █)))
       key_plan
         project=(#0)
       input_key=#0
@@ -939,7 +1047,7 @@ materialize.public.collated_global_mv:
   Return
     Union
       Get::Collection l1
-        project=(#0, #4, #2, #3, #1, #5)
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
       Mfp
         project=(#0..=#5)
@@ -955,6 +1063,9 @@ materialize.public.collated_global_mv:
     cte l1 =
       Join::Delta
         plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -963,6 +1074,9 @@ materialize.public.collated_global_mv:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=0, key=[] }
         plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -973,26 +1087,37 @@ materialize.public.collated_global_mv:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=1, key=[] }
         plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             closure
-              project=(#0, #1, #4, #5, #2, #3)
+              project=(#0, #1, #3, #4, #2)
             lookup={ relation=1, key=[] }
-            stream={ key=[], thinning=(#0..=#3) }
+            stream={ key=[], thinning=(#0..=#2) }
           delta_stage[0]
             closure
-              project=(#2, #3, #0, #1)
+              project=(#1, #2, #0)
             lookup={ relation=0, key=[] }
-            stream={ key=[], thinning=(#0, #1) }
+            stream={ key=[], thinning=(#0) }
           source={ relation=2, key=[] }
-        Reduce::Accumulable
-          simple_aggrs[0]=(1, 1, sum(#0))
-          distinct_aggrs[0]=(0, 0, count(distinct #0))
-          val_plan
-            project=(#0, #0)
-          key_plan
-            project=()
-          Get::PassArrangements l0
-            raw=true
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
         Reduce::Hierarchical
           aggr_funcs=[min, max]
           skips=[0, 0]
@@ -1003,12 +1128,29 @@ materialize.public.collated_global_mv:
             project=()
           Get::PassArrangements l0
             raw=true
-        Reduce::Basic
-          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
           val_plan
-            project=(#2, #3)
-            map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || █), █)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || █), █)))
           key_plan
             project=()
           Get::PassArrangements l0
@@ -1037,7 +1179,7 @@ Explained Query:
   Return
     Union
       Get::Collection l1
-        project=(#0, #4, #2, #3, #1, #5)
+        project=(#2, #4, #0, #1, #3, #5)
         raw=true
       Mfp
         project=(#0..=#5)
@@ -1053,6 +1195,9 @@ Explained Query:
     cte l1 =
       Join::Delta
         plan_path[0]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -1061,6 +1206,9 @@ Explained Query:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=0, key=[] }
         plan_path[1]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             lookup={ relation=2, key=[] }
             stream={ key=[], thinning=(#0..=#3) }
@@ -1071,26 +1219,37 @@ Explained Query:
             stream={ key=[], thinning=(#0, #1) }
           source={ relation=1, key=[] }
         plan_path[2]
+          delta_stage[2]
+            lookup={ relation=3, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
           delta_stage[1]
             closure
-              project=(#0, #1, #4, #5, #2, #3)
+              project=(#0, #1, #3, #4, #2)
             lookup={ relation=1, key=[] }
-            stream={ key=[], thinning=(#0..=#3) }
+            stream={ key=[], thinning=(#0..=#2) }
           delta_stage[0]
             closure
-              project=(#2, #3, #0, #1)
+              project=(#1, #2, #0)
             lookup={ relation=0, key=[] }
-            stream={ key=[], thinning=(#0, #1) }
+            stream={ key=[], thinning=(#0) }
           source={ relation=2, key=[] }
-        Reduce::Accumulable
-          simple_aggrs[0]=(1, 1, sum(#0))
-          distinct_aggrs[0]=(0, 0, count(distinct #0))
-          val_plan
-            project=(#0, #0)
-          key_plan
-            project=()
-          Get::PassArrangements l0
-            raw=true
+        plan_path[3]
+          delta_stage[2]
+            closure
+              project=(#0..=#3, #5, #4)
+            lookup={ relation=2, key=[] }
+            stream={ key=[], thinning=(#0..=#4) }
+          delta_stage[1]
+            closure
+              project=(#0, #1, #3, #4, #2)
+            lookup={ relation=1, key=[] }
+            stream={ key=[], thinning=(#0..=#2) }
+          delta_stage[0]
+            closure
+              project=(#1, #2, #0)
+            lookup={ relation=0, key=[] }
+            stream={ key=[], thinning=(#0) }
+          source={ relation=3, key=[] }
         Reduce::Hierarchical
           aggr_funcs=[min, max]
           skips=[0, 0]
@@ -1102,12 +1261,29 @@ Explained Query:
             project=()
           Get::PassArrangements l0
             raw=true
-        Reduce::Basic
-          aggrs[0]=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
-          aggrs[1]=(1, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+        Reduce::Accumulable
+          simple_aggrs[0]=(1, 1, sum(#0))
+          distinct_aggrs[0]=(0, 0, count(distinct #0))
           val_plan
-            project=(#2, #3)
-            map=(integer_to_text(#0), row(row((#1 || █), █)), row(row((#1 || █), █)))
+            project=(#0, #0)
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || █), █)))
+          key_plan
+            project=()
+          Get::PassArrangements l0
+            raw=true
+        Reduce::Basic
+          aggr=(0, string_agg[order_by=[]](row(row((integer_to_text(#0) || █), █))))
+          val_plan
+            project=(#1)
+            map=(row(row((integer_to_text(#0) || █), █)))
           key_plan
             project=()
           Get::PassArrangements l0

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -321,19 +321,30 @@ Explained Query:
     Project (#0, #1, #8, #9, #7) // { types: "(integer?, integer?, numeric?, numeric?, integer list?)" }
       Map ((bigint_to_numeric(#2) / bigint_to_numeric(case when (#3 = 0) then null else #3 end)), sqrtnumeric(case when ((#4) IS NULL OR (#5) IS NULL OR (case when (#6 = 0) then null else #6 end) IS NULL OR (case when (0 = (#6 - 1)) then null else (#6 - 1) end) IS NULL) then null else greatest(((#4 - ((#5 * #5) / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) / bigint_to_numeric(case when (0 = (#6 - 1)) then null else (#6 - 1) end)), 0) end)) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?, numeric?, numeric?)" }
         Union // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)" }
-          Get l0 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+          Project (#5, #6, #0..=#4, #7) // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+            Get l1 // { types: "(bigint, bigint, numeric, numeric, bigint, integer, integer, integer list)" }
           Map (null, null, null, 0, null, null, 0, null) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)" }
             Union // { types: "()" }
               Negate // { types: "()" }
                 Project () // { types: "()" }
-                  Get l0 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
+                  Get l1 // { types: "(bigint, bigint, numeric, numeric, bigint, integer, integer, integer list)" }
               Constant // { types: "()" }
                 - ()
   With
+    cte l1 =
+      CrossJoin type=delta // { types: "(bigint, bigint, numeric, numeric, bigint, integer, integer, integer list)" }
+        ArrangeBy keys=[[]] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+          Reduce aggregates=[sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0))] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(integer, integer)" }
+          Reduce aggregates=[min(#0), max(#0)] // { types: "(integer, integer)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(integer list)" }
+          Reduce aggregates=[list_agg[order_by=[]](row(list[#0]))] // { types: "(integer list)" }
+            Get l0 // { types: "(integer)" }
     cte l0 =
-      Reduce aggregates=[min(#0), max(#0), sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0)), list_agg[order_by=[]](row(list[#0]))] // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
-        Project (#1) // { types: "(integer)" }
-          ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
+      Project (#1) // { types: "(integer)" }
+        ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 Source materialize.public.int_table
 

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -321,23 +321,22 @@ Explained Query:
     Project (#0, #1, #8, #9, #7) // { types: "(integer?, integer?, numeric?, numeric?, integer list?)" }
       Map ((bigint_to_numeric(#2) / bigint_to_numeric(case when (#3 = 0) then null else #3 end)), sqrtnumeric(case when ((#4) IS NULL OR (#5) IS NULL OR (case when (#6 = 0) then null else #6 end) IS NULL OR (case when (0 = (#6 - 1)) then null else (#6 - 1) end) IS NULL) then null else greatest(((#4 - ((#5 * #5) / bigint_to_numeric(case when (#6 = 0) then null else #6 end))) / bigint_to_numeric(case when (0 = (#6 - 1)) then null else (#6 - 1) end)), 0) end)) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?, numeric?, numeric?)" }
         Union // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)" }
-          Project (#5, #6, #0..=#4, #7) // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
-            Get l1 // { types: "(bigint, bigint, numeric, numeric, bigint, integer, integer, integer list)" }
+          Get l1 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
           Map (null, null, null, 0, null, null, 0, null) // { types: "(integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)" }
             Union // { types: "()" }
               Negate // { types: "()" }
                 Project () // { types: "()" }
-                  Get l1 // { types: "(bigint, bigint, numeric, numeric, bigint, integer, integer, integer list)" }
+                  Get l1 // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
               Constant // { types: "()" }
                 - ()
   With
     cte l1 =
-      CrossJoin type=delta // { types: "(bigint, bigint, numeric, numeric, bigint, integer, integer, integer list)" }
-        ArrangeBy keys=[[]] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
-          Reduce aggregates=[sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0))] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
-            Get l0 // { types: "(integer)" }
+      CrossJoin type=delta // { types: "(integer, integer, bigint, bigint, numeric, numeric, bigint, integer list)" }
         ArrangeBy keys=[[]] // { types: "(integer, integer)" }
           Reduce aggregates=[min(#0), max(#0)] // { types: "(integer, integer)" }
+            Get l0 // { types: "(integer)" }
+        ArrangeBy keys=[[]] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
+          Reduce aggregates=[sum(#0), count(*), sum((integer_to_numeric(#0) * integer_to_numeric(#0))), sum(integer_to_numeric(#0)), count(integer_to_numeric(#0))] // { types: "(bigint, bigint, numeric, numeric, bigint)" }
             Get l0 // { types: "(integer)" }
         ArrangeBy keys=[[]] // { types: "(integer list)" }
           Reduce aggregates=[list_agg[order_by=[]](row(list[#0]))] // { types: "(integer list)" }

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1791,7 +1791,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1805,7 +1804,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1974,7 +1972,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1988,7 +1985,6 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1
 

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1791,6 +1791,7 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1804,6 +1805,7 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1972,6 +1974,7 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 
@@ -1985,6 +1988,7 @@ Source materialize.public.t
 
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1
 

--- a/test/sqllogictest/simple_multiline.slt
+++ b/test/sqllogictest/simple_multiline.slt
@@ -21,5 +21,6 @@ materialize.public.mv:
 
 Target cluster: quickstart
 
+COMPLETE 1
 EOF
 COMPLETE 1

--- a/test/sqllogictest/simple_multiline.slt
+++ b/test/sqllogictest/simple_multiline.slt
@@ -21,6 +21,5 @@ materialize.public.mv:
 
 Target cluster: quickstart
 
-COMPLETE 1
 EOF
 COMPLETE 1

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -494,12 +494,22 @@ LIMIT 10;
 ----
 Explained Query:
   Finish order_by=[#0 desc nulls_first] limit=10 output=[#0..=#2]
-    Project (#1, #0, #2)
-      Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000)), count(*)]
-        Project (#0, #3)
-          Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
-            Map (timestamp_tz_to_mz_timestamp(#0))
-              ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
+    Return
+      Project (#3, #0, #1)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Project (#3)
+                Get l0
+          ArrangeBy keys=[[#0]]
+            Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000))]
+              Project (#0, #3)
+                Get l0
+    With
+      cte l0 =
+        Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
+          Map (timestamp_tz_to_mz_timestamp(#0))
+            ReadIndex on=mz_internal.mz_source_status_history mz_source_status_history_ind=[lookup value=("u6")]
 
 Used Indexes:
   - mz_internal.mz_source_status_history_ind (lookup)

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -495,15 +495,15 @@ LIMIT 10;
 Explained Query:
   Finish order_by=[#0 desc nulls_first] limit=10 output=[#0..=#2]
     Return
-      Project (#3, #0, #1)
+      Project (#1, #0, #3)
         Join on=(#0 = #2) type=differential
-          ArrangeBy keys=[[#0]]
-            Reduce group_by=[#0] aggregates=[count(*)]
-              Project (#3)
-                Get l0
           ArrangeBy keys=[[#0]]
             Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000))]
               Project (#0, #3)
+                Get l0
+          ArrangeBy keys=[[#0]]
+            Reduce group_by=[#0] aggregates=[count(*)]
+              Project (#3)
                 Get l0
     With
       cte l0 =

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -310,19 +310,31 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[sum(#0), max(#0)] // { arity: 3 }
-    Project (#0) // { arity: 1 }
-      Join on=(#0 = #1) type=differential // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %0:t1[#0]Kif » %1:t2[#0]Kiif
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
+            Get l0 // { arity: 1 }
+  With
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:t1[#0]Kif » %1:t2[#0]Kiif
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0 >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0 >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))
@@ -338,8 +350,20 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0 and sum(t2.f1) >= 0;
 ----
 Explained Query:
-  Filter (#1 >= 0) // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[sum(#0), max(#0)] // { arity: 3 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#3 >= 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+              Get l0 // { arity: 1 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
+              Get l0 // { arity: 1 }
+  With
+    cte l0 =
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
           implementation
@@ -428,18 +452,31 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f1 + t2.f2), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[sum((#0 + #1)), max(#0)] // { arity: 3 }
-    Project (#0, #2) // { arity: 2 }
-      Join on=(#0 = #1) type=differential // { arity: 3 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %0:t1[#0]Kif » %1:t2[#0]Kiif
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
+          %0[#0]UKA » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 2 }
-          Filter (#0 >= 0) // { arity: 2 }
-            ReadStorage materialize.public.t2 // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              Get l0 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum((#0 + #1))] // { arity: 2 }
+            Get l0 // { arity: 2 }
+  With
+    cte l0 =
+      Project (#0, #2) // { arity: 2 }
+        Join on=(#0 = #1) type=differential // { arity: 3 }
+          implementation
+            %0:t1[#0]Kif » %1:t2[#0]Kiif
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0 >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Filter (#0 >= 0) // { arity: 2 }
+              ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))
@@ -455,19 +492,31 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t1.f1 + t2.f1), max(t2.f1) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f1) >= 0;
 ----
 Explained Query:
-  Reduce group_by=[#0] aggregates=[sum((#0 + #0)), max(#0)] // { arity: 3 }
-    Project (#0) // { arity: 1 }
-      Join on=(#0 = #1) type=differential // { arity: 2 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
-          %0:t1[#0]Kif » %1:t2[#0]Kiif
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Project (#0) // { arity: 1 }
-            Filter (#0 >= 0) // { arity: 2 }
-              ReadStorage materialize.public.t2 // { arity: 2 }
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
+            Get l0 // { arity: 1 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[sum((#0 + #0))] // { arity: 2 }
+            Get l0 // { arity: 1 }
+  With
+    cte l0 =
+      Project (#0) // { arity: 1 }
+        Join on=(#0 = #1) type=differential // { arity: 2 }
+          implementation
+            %0:t1[#0]Kif » %1:t2[#0]Kiif
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0 >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t1 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (#0 >= 0) // { arity: 2 }
+                ReadStorage materialize.public.t2 // { arity: 2 }
 
 Source materialize.public.t1
   filter=((#0 >= 0))

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -112,15 +112,15 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1)
 ----
 Explained Query:
   Return // { arity: 9 }
-    Project (#0..=#2, #6, #7, #3, #4, #8, #9) // { arity: 9 }
+    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
       Join on=(#0 = #5) type=differential // { arity: 10 }
         implementation
           %0[#0]UKA » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 5 }
-          Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
             Get l2 // { arity: 3 }
         ArrangeBy keys=[[#0]] // { arity: 5 }
-          Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
             Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -168,16 +168,16 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1)
 ----
 Explained Query:
   Return // { arity: 9 }
-    Project (#0..=#2, #6, #7, #3, #4, #8, #9) // { arity: 9 }
-      Filter (#4 >= 0) // { arity: 10 }
+    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
+      Filter (#9 >= 0) // { arity: 10 }
         Join on=(#0 = #5) type=differential // { arity: 10 }
           implementation
-            %0[#0]UKAif » %1[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 5 }
-            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
-              Get l2 // { arity: 3 }
+            %1[#0]UKAif » %0[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 5 }
             Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
               Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -225,16 +225,16 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1)
 ----
 Explained Query:
   Return // { arity: 9 }
-    Project (#0..=#2, #6, #7, #3, #4, #8, #9) // { arity: 9 }
-      Filter (#2 >= 0) // { arity: 10 }
+    Project (#0, #6, #7, #1, #2, #8, #9, #3, #4) // { arity: 9 }
+      Filter (#7 >= 0) // { arity: 10 }
         Join on=(#0 = #5) type=differential // { arity: 10 }
           implementation
-            %0[#0]UKAif » %1[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 5 }
-            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
-              Get l2 // { arity: 3 }
+            %1[#0]UKAif » %0[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 5 }
             Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
               Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -368,18 +368,18 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f2), max(t2.f1) f
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #1, #3) // { arity: 3 }
-      Filter (#3 >= 0) // { arity: 4 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 >= 0) // { arity: 4 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
-              Project (#0, #2) // { arity: 2 }
-                Get l2 // { arity: 3 }
+            %0[#0]UKAif » %1[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
                 Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -484,18 +484,18 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t1.f1), max(t2.f1) f
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #1, #3) // { arity: 3 }
-      Filter (#3 >= 0) // { arity: 4 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 >= 0) // { arity: 4 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKAif » %0[#0]UKAif
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Get l2 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
               Project (#0) // { arity: 1 }
                 Get l2 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
-              Get l2 // { arity: 2 }
   With
     cte l2 =
       Union // { arity: 2 }
@@ -591,15 +591,15 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #1, #3) // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
           %0[#0]UKA » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
             Get l2 // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
             Get l2 // { arity: 2 }
   With
     cte l2 =
@@ -648,16 +648,16 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #1, #3) // { arity: 3 }
-      Filter (#3 > 0) // { arity: 4 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 > 0) // { arity: 4 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
-              Get l0 // { arity: 2 }
+            %0[#0]UKAif » %1[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
               Get l0 // { arity: 2 }
   With
     cte l0 =
@@ -688,18 +688,18 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, max(t1.f1 + t2.f2), sum(
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #3, #1) // { arity: 3 }
-      Filter (#3 > 0) // { arity: 4 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Filter (#1 > 0) // { arity: 4 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[sum((#1 + #2))] // { arity: 2 }
-              Get l0 // { arity: 3 }
+            %0[#0]UKAif » %1[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[max((#0 + #1))] // { arity: 2 }
               Project (#0, #2) // { arity: 2 }
                 Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum((#1 + #2))] // { arity: 2 }
+              Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #1, #3) // { arity: 3 }
@@ -756,17 +756,17 @@ explain with(arity, join implementations) select t1.f1, count(t1.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #1, #3) // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
       Join on=(#0 = #2) type=differential // { arity: 4 }
         implementation
           %0[#0]UKA » %1[#0]UKA
         ArrangeBy keys=[[#0]] // { arity: 2 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
-            Project (#0, #1) // { arity: 2 }
-              Get l2 // { arity: 3 }
-        ArrangeBy keys=[[#0]] // { arity: 2 }
           Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
             Project (#0, #2) // { arity: 2 }
+              Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
               Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -812,18 +812,18 @@ explain with(arity, join implementations) select t1.f1, count(t1.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Project (#0, #1, #3) // { arity: 3 }
-      Filter (#3 > 0) // { arity: 4 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#1 > 0) // { arity: 4 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
-            %1[#0]UKAif » %0[#0]UKAif
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
-              Project (#0, #1) // { arity: 2 }
-                Get l2 // { arity: 3 }
+            %0[#0]UKAif » %1[#0]UKAif
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
               Project (#0, #2) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
                 Get l2 // { arity: 3 }
   With
     cte l2 =
@@ -972,22 +972,22 @@ WHERE t1.f2 = derived.agg2;
 ----
 Explained Query:
   Return // { arity: 1 }
-    Project (#1) // { arity: 1 }
-      Join on=(#0 = #2) type=delta // { arity: 3 }
+    Project (#2) // { arity: 1 }
+      Join on=(#0 = #1) type=delta // { arity: 3 }
         implementation
-          %0:t1 » %2[#0]UK » %1[×]UA
+          %0:t1 » %1[#0]UK » %2[×]UA
           %1 » %2[×]UA » %0:t1[#0]K
           %2 » %1[×]UA » %0:t1[#0]K
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[]] // { arity: 1 }
-          Reduce aggregates=[count(*)] // { arity: 1 }
-            Project () // { arity: 0 }
-              Get l1 // { arity: 1 }
         ArrangeBy keys=[[], [#0]] // { arity: 1 }
           Filter (#0) IS NOT NULL // { arity: 1 }
             Reduce aggregates=[max(#0)] // { arity: 1 }
+              Get l1 // { arity: 1 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
               Get l1 // { arity: 1 }
   With
     cte l1 =

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -112,7 +112,18 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1)
 ----
 Explained Query:
   Return // { arity: 9 }
-    Reduce group_by=[#0] aggregates=[count(#2), sum(#2), max(#2), min(#2), count(#1), sum(#1), min(#1), max(#1)] // { arity: 9 }
+    Project (#0..=#2, #6, #7, #3, #4, #8, #9) // { arity: 9 }
+      Join on=(#0 = #5) type=differential // { arity: 10 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+            Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0]] // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+            Get l2 // { arity: 3 }
+  With
+    cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
           Union // { arity: 2 }
@@ -129,7 +140,6 @@ Explained Query:
             ReadStorage materialize.public.t1 // { arity: 2 }
         Project (#0, #1, #0) // { arity: 3 }
           Get l1 // { arity: 2 }
-  With
     cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -158,25 +168,35 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1)
 ----
 Explained Query:
   Return // { arity: 9 }
-    Filter (#6 >= 0) // { arity: 9 }
-      Reduce group_by=[#0] aggregates=[count(#2), sum(#2), max(#2), min(#2), count(#1), sum(#1), min(#1), max(#1)] // { arity: 9 }
-        Union // { arity: 3 }
-          Map (null) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Join on=(#0 = #2) type=differential // { arity: 3 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0]K
-                    Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
-                          Get l1 // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0, #1, #0) // { arity: 3 }
-            Get l1 // { arity: 2 }
+    Project (#0..=#2, #6, #7, #3, #4, #8, #9) // { arity: 9 }
+      Filter (#4 >= 0) // { arity: 10 }
+        Join on=(#0 = #5) type=differential // { arity: 10 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
   With
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Join on=(#0 = #2) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l1 // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0, #1, #0) // { arity: 3 }
+          Get l1 // { arity: 2 }
     cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -205,25 +225,35 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f1), sum(t2.f1)
 ----
 Explained Query:
   Return // { arity: 9 }
-    Filter (#2 >= 0) // { arity: 9 }
-      Reduce group_by=[#0] aggregates=[count(#2), sum(#2), max(#2), min(#2), count(#1), sum(#1), min(#1), max(#1)] // { arity: 9 }
-        Union // { arity: 3 }
-          Map (null) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Join on=(#0 = #2) type=differential // { arity: 3 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0]K
-                    Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
-                          Get l1 // { arity: 2 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0, #1, #0) // { arity: 3 }
-            Get l1 // { arity: 2 }
+    Project (#0..=#2, #6, #7, #3, #4, #8, #9) // { arity: 9 }
+      Filter (#2 >= 0) // { arity: 10 }
+        Join on=(#0 = #5) type=differential // { arity: 10 }
+          implementation
+            %0[#0]UKAif » %1[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[count(#2), sum(#2), count(#1), sum(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 5 }
+            Reduce group_by=[#0] aggregates=[max(#2), min(#2), min(#1), max(#1)] // { arity: 5 }
+              Get l2 // { arity: 3 }
   With
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Join on=(#0 = #2) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l1 // { arity: 2 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0, #1, #0) // { arity: 3 }
+          Get l1 // { arity: 2 }
     cte l1 =
       Project (#0, #1) // { arity: 2 }
         Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -338,26 +368,38 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t2.f2), max(t2.f1) f
 ----
 Explained Query:
   Return // { arity: 3 }
-    Filter (#2 >= 0) // { arity: 3 }
-      Reduce group_by=[#0] aggregates=[sum(#2), max(#1)] // { arity: 3 }
-        Union // { arity: 3 }
-          Map (null, null) // { arity: 3 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Join on=(#0 = #1) type=differential // { arity: 2 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0]K
-                    Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
-                          Get l1 // { arity: 2 }
-              Project (#0) // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0, #0, #1) // { arity: 3 }
-            Get l1 // { arity: 2 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Filter (#3 >= 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Get l2 // { arity: 3 }
   With
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null, null) // { arity: 3 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Join on=(#0 = #1) type=differential // { arity: 2 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 1 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l1 // { arity: 2 }
+            Project (#0) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0, #0, #1) // { arity: 3 }
+          Get l1 // { arity: 2 }
     cte l1 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -442,25 +484,36 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, sum(t1.f1), max(t2.f1) f
 ----
 Explained Query:
   Return // { arity: 3 }
-    Filter (#2 >= 0) // { arity: 3 }
-      Reduce group_by=[#0] aggregates=[sum(#0), max(#1)] // { arity: 3 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Join on=(#0 = #1) type=differential // { arity: 2 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#0]K
-                    Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
-                        Get l1 // { arity: 1 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Filter (#3 >= 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum(#0)] // { arity: 2 }
               Project (#0) // { arity: 1 }
-                ReadStorage materialize.public.t1 // { arity: 2 }
-          Project (#0, #0) // { arity: 2 }
-            Get l1 // { arity: 1 }
+                Get l2 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Get l2 // { arity: 2 }
   With
+    cte l2 =
+      Union // { arity: 2 }
+        Map (null) // { arity: 2 }
+          Union // { arity: 1 }
+            Negate // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Join on=(#0 = #1) type=differential // { arity: 2 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#0]K
+                  Get l0 // { arity: 1 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Get l1 // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              ReadStorage materialize.public.t1 // { arity: 2 }
+        Project (#0, #0) // { arity: 2 }
+          Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
         Join on=(#0 = #1) type=differential // { arity: 2 }
@@ -538,7 +591,18 @@ EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[count(#1), max(#1)] // { arity: 3 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+            Get l2 // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+            Get l2 // { arity: 2 }
+  With
+    cte l2 =
       Union // { arity: 2 }
         Map (null) // { arity: 2 }
           Union // { arity: 1 }
@@ -555,7 +619,6 @@ Explained Query:
             Project (#0) // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 2 }
-  With
     cte l1 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
@@ -584,8 +647,20 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, count(t2.f2), max(t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t2.f2) > 0;
 ----
 Explained Query:
-  Filter (#2 > 0) // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[count(#1), max(#1)] // { arity: 3 }
+  Return // { arity: 3 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Filter (#3 > 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+              Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Get l0 // { arity: 2 }
+  With
+    cte l0 =
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           implementation
@@ -612,8 +687,21 @@ query T multiline
 EXPLAIN WITH(arity, join implementations) select t1.f1, max(t1.f1 + t2.f2), sum(t1.f2 + t2.f2) from t1 LEFT JOIN t2 ON t1.f1 = t2.f1 group by t1.f1 having max(t1.f1 + t2.f2) > 0;
 ----
 Explained Query:
-  Filter (#1 > 0) // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[max((#0 + #2)), sum((#1 + #2))] // { arity: 3 }
+  Return // { arity: 3 }
+    Project (#0, #3, #1) // { arity: 3 }
+      Filter (#3 > 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[sum((#1 + #2))] // { arity: 2 }
+              Get l0 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max((#0 + #1))] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Get l0 // { arity: 3 }
+  With
+    cte l0 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#0 = #2) type=differential // { arity: 4 }
           implementation
@@ -668,7 +756,20 @@ explain with(arity, join implementations) select t1.f1, count(t1.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Reduce group_by=[#0] aggregates=[count(#1), max(#2)] // { arity: 3 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Join on=(#0 = #2) type=differential // { arity: 4 }
+        implementation
+          %0[#0]UKA » %1[#0]UKA
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+            Project (#0, #1) // { arity: 2 }
+              Get l2 // { arity: 3 }
+        ArrangeBy keys=[[#0]] // { arity: 2 }
+          Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+            Project (#0, #2) // { arity: 2 }
+              Get l2 // { arity: 3 }
+  With
+    cte l2 =
       Union // { arity: 3 }
         Map (null) // { arity: 3 }
           Union // { arity: 2 }
@@ -684,7 +785,6 @@ Explained Query:
                         Get l1 // { arity: 3 }
             ReadStorage materialize.public.t1 // { arity: 2 }
         Get l1 // { arity: 3 }
-  With
     cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
@@ -712,24 +812,36 @@ explain with(arity, join implementations) select t1.f1, count(t1.f2), max(t2.f2)
 ----
 Explained Query:
   Return // { arity: 3 }
-    Filter (#2 > 0) // { arity: 3 }
-      Reduce group_by=[#0] aggregates=[count(#1), max(#2)] // { arity: 3 }
-        Union // { arity: 3 }
-          Map (null) // { arity: 3 }
-            Union // { arity: 2 }
-              Negate // { arity: 2 }
-                Project (#0, #1) // { arity: 2 }
-                  Join on=(#1 = #2) type=differential // { arity: 3 }
-                    implementation
-                      %1[#0]UKA » %0:l0[#1]K
-                    Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct project=[#0] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Get l1 // { arity: 3 }
-              ReadStorage materialize.public.t1 // { arity: 2 }
-          Get l1 // { arity: 3 }
+    Project (#0, #1, #3) // { arity: 3 }
+      Filter (#3 > 0) // { arity: 4 }
+        Join on=(#0 = #2) type=differential // { arity: 4 }
+          implementation
+            %1[#0]UKAif » %0[#0]UKAif
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Get l2 // { arity: 3 }
+          ArrangeBy keys=[[#0]] // { arity: 2 }
+            Reduce group_by=[#0] aggregates=[max(#1)] // { arity: 2 }
+              Project (#0, #2) // { arity: 2 }
+                Get l2 // { arity: 3 }
   With
+    cte l2 =
+      Union // { arity: 3 }
+        Map (null) // { arity: 3 }
+          Union // { arity: 2 }
+            Negate // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Join on=(#1 = #2) type=differential // { arity: 3 }
+                  implementation
+                    %1[#0]UKA » %0:l0[#1]K
+                  Get l0 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
+                      Project (#1) // { arity: 1 }
+                        Get l1 // { arity: 3 }
+            ReadStorage materialize.public.t1 // { arity: 2 }
+        Get l1 // { arity: 3 }
     cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Join on=(#1 = #2) type=differential // { arity: 4 }
@@ -861,35 +973,43 @@ WHERE t1.f2 = derived.agg2;
 Explained Query:
   Return // { arity: 1 }
     Project (#1) // { arity: 1 }
-      Join on=(#0 = #2) type=differential // { arity: 3 }
+      Join on=(#0 = #2) type=delta // { arity: 3 }
         implementation
-          %1[#1]UK » %0:t1[#0]K
+          %0:t1 » %2[#0]UK » %1[×]UA
+          %1 » %2[×]UA » %0:t1[#0]K
+          %2 » %1[×]UA » %0:t1[#0]K
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }
-        ArrangeBy keys=[[#1]] // { arity: 2 }
-          Filter (#1) IS NOT NULL // { arity: 2 }
-            Reduce aggregates=[count(*), max(#0)] // { arity: 2 }
-              Union // { arity: 1 }
-                Project (#0) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-                Project (#4) // { arity: 1 }
-                  Map (null) // { arity: 5 }
-                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                      implementation
-                        %0[#0, #1]KK » %1:t3[#0, #1]KK
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Union // { arity: 2 }
-                          Negate // { arity: 2 }
-                            Map (6) // { arity: 2 }
-                              Distinct project=[#0] // { arity: 1 }
-                                Project (#1) // { arity: 1 }
-                                  Get l0 // { arity: 2 }
-                          Distinct project=[#0, #1] // { arity: 2 }
-                            ReadStorage materialize.public.t3 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        ReadStorage materialize.public.t3 // { arity: 2 }
+        ArrangeBy keys=[[]] // { arity: 1 }
+          Reduce aggregates=[count(*)] // { arity: 1 }
+            Project () // { arity: 0 }
+              Get l1 // { arity: 1 }
+        ArrangeBy keys=[[], [#0]] // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 1 }
+            Reduce aggregates=[max(#0)] // { arity: 1 }
+              Get l1 // { arity: 1 }
   With
+    cte l1 =
+      Union // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 2 }
+        Project (#4) // { arity: 1 }
+          Map (null) // { arity: 5 }
+            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+              implementation
+                %0[#0, #1]KK » %1:t3[#0, #1]KK
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Map (6) // { arity: 2 }
+                      Distinct project=[#0] // { arity: 1 }
+                        Project (#1) // { arity: 1 }
+                          Get l0 // { arity: 2 }
+                  Distinct project=[#0, #1] // { arity: 2 }
+                    ReadStorage materialize.public.t3 // { arity: 2 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                ReadStorage materialize.public.t3 // { arity: 2 }
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
         implementation

--- a/test/testdrive/distinct-arrangements.td
+++ b/test/testdrive/distinct-arrangements.td
@@ -19,8 +19,8 @@ ALTER SYSTEM SET enable_introspection_subscribes = false
 
 # Run the majority of this test on its own cluster to ensure it doesn't
 # interfere with any other tests.
-> CREATE CLUSTER distinct_arrangements REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
-> SET cluster TO distinct_arrangements
+> CREATE CLUSTER arrangement_sharing REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
+> SET cluster TO arrangement_sharing
 > SET cluster_replica = r1
 
 # from attributes/mir_unique_keys.slt
@@ -304,7 +304,6 @@ DistinctByErrorCheck
 
 > SELECT mdo.name FROM mz_introspection.mz_arrangement_sharing mash JOIN mz_introspection.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
 AccumulableErrorCheck
-"Arrange ReduceCollation"
 "Arrange ReduceMinsMaxes"
 "Arrange ReduceMinsMaxes"
 "Arrange ReduceMinsMaxes"
@@ -342,8 +341,6 @@ ArrangeBy[[Column(2)]]
 "DistinctBy"
 DistinctByErrorCheck
 ReduceAccumulable
-ReduceCollation
-"ReduceCollation Errors"
 ReduceMinsMaxes
 ReduceMinsMaxes
 ReduceMinsMaxes
@@ -575,7 +572,7 @@ ArrangeBy[[]]
 ReduceAccumulable
 
 > DROP TABLE t1 CASCADE
-> SET cluster=distinct_arrangements
+> SET cluster=arrangement_sharing
 > DROP CLUSTER linear_join CASCADE
 
 # from negative-multiplicities.td
@@ -611,10 +608,8 @@ ALTER SYSTEM SET enable_repeat_row  = true
 AccumulableErrorCheck
 AccumulableErrorCheck
 AccumulableErrorCheck
-"Arrange ReduceCollation"
 "Arrange ReduceMinsMaxes"
 "Arrange ReduceMinsMaxes"
-"Arrange bundle err"
 "ArrangeAccumulable [val: empty]"
 "ArrangeAccumulable [val: empty]"
 "ArrangeAccumulable [val: empty]"
@@ -622,7 +617,9 @@ AccumulableErrorCheck
 "ArrangeBy[[CallUnary { func: CastInt32ToInt64(CastInt32ToInt64), expr: Column(0) }]]"
 ArrangeBy[[Column(0)]]
 ArrangeBy[[Column(0)]]
+ArrangeBy[[Column(0)]]
 "ArrangeBy[[Column(0)]]"
+ArrangeBy[[Column(0)]]-errors
 ArrangeBy[[Column(0)]]-errors
 ArrangeBy[[Column(0)]]-errors
 "Arranged Accumulable Distinct [val: empty]"
@@ -640,7 +637,6 @@ ArrangeBy[[Column(0)]]-errors
 "Arranged MinsMaxesHierarchical input"
 "Arranged MinsMaxesHierarchical input"
 "Arranged MinsMaxesHierarchical input"
-"Arranged ReduceFuseBasic input"
 "Arranged ReduceInaccumulable"
 "Arranged ReduceInaccumulable"
 "Arranged TopK input"
@@ -654,11 +650,9 @@ ArrangeBy[[Column(0)]]-errors
 ReduceAccumulable
 ReduceAccumulable
 ReduceAccumulable
-ReduceCollation
-"ReduceCollation Errors"
-ReduceFuseBasic
 ReduceInaccumulable
 ReduceInaccumulable
+"ReduceInaccumulable Error Check"
 "ReduceInaccumulable Error Check"
 ReduceMinsMaxes
 ReduceMinsMaxes
@@ -776,11 +770,11 @@ ReduceMinsMaxes
 "Reduced TopK input" 52
 "Threshold local" 10
 
-> SET cluster TO distinct_arrangements
+> SET cluster TO arrangement_sharing
 
 # Check dataflows of our logging infrastructure with log_logging
-> ALTER CLUSTER distinct_arrangements SET (MANAGED = false);
-> CREATE CLUSTER REPLICA distinct_arrangements.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
+> ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
+> CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
 
 > SET cluster_replica = replica;
 
@@ -821,10 +815,10 @@ ALTER SYSTEM SET enable_introspection_subscribes = true
 
 # Flipping `enable_introspection_subscribes` affects new replicas, so force a
 # restart.
-> DROP CLUSTER REPLICA distinct_arrangements.replica
-> ALTER CLUSTER distinct_arrangements SET (MANAGED = true)
-> ALTER CLUSTER distinct_arrangements SET (REPLICATION FACTOR = 0)
-> ALTER CLUSTER distinct_arrangements SET (REPLICATION FACTOR = 1)
+> DROP CLUSTER REPLICA arrangement_sharing.replica
+> ALTER CLUSTER arrangement_sharing SET (MANAGED = true)
+> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 0)
+> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 1)
 > RESET cluster_replica
 
 > SELECT mdod.name, count(*)
@@ -833,11 +827,8 @@ ALTER SYSTEM SET enable_introspection_subscribes = true
   GROUP BY mdod.name
   ORDER BY mdod.name
 AccumulableErrorCheck 2
-"Arrange ReduceCollation" 1
 "Arrange ReduceMinsMaxes" 1
 "ArrangeAccumulable [val: empty]" 2
 ReduceAccumulable 2
-ReduceCollation 1
-"ReduceCollation Errors" 1
 ReduceMinsMaxes 1
 "ReduceMinsMaxes Error Check" 1

--- a/test/testdrive/distinct-arrangements.td
+++ b/test/testdrive/distinct-arrangements.td
@@ -19,8 +19,8 @@ ALTER SYSTEM SET enable_introspection_subscribes = false
 
 # Run the majority of this test on its own cluster to ensure it doesn't
 # interfere with any other tests.
-> CREATE CLUSTER arrangement_sharing REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
-> SET cluster TO arrangement_sharing
+> CREATE CLUSTER distinct_arrangements REPLICAS (r1 (SIZE '${arg.default-replica-size}'))
+> SET cluster TO distinct_arrangements
 > SET cluster_replica = r1
 
 # from attributes/mir_unique_keys.slt
@@ -572,7 +572,7 @@ ArrangeBy[[]]
 ReduceAccumulable
 
 > DROP TABLE t1 CASCADE
-> SET cluster=arrangement_sharing
+> SET cluster=distinct_arrangements
 > DROP CLUSTER linear_join CASCADE
 
 # from negative-multiplicities.td
@@ -705,7 +705,6 @@ ReduceMinsMaxes
   GROUP BY mdod.name
   ORDER BY mdod.name;
 "AccumulableErrorCheck" 9
-"Arrange ReduceCollation" 1
 "Arrange ReduceMinsMaxes" 3
 "Arrange export iterative" 1
 "Arrange export iterative err" 1
@@ -760,8 +759,6 @@ ReduceMinsMaxes
 "DistinctBy" 46
 "DistinctByErrorCheck" 46
 "ReduceAccumulable" 9
-"ReduceCollation" 1
-"ReduceCollation Errors" 1
 "ReduceInaccumulable" 3
 "ReduceInaccumulable Error Check" 3
 "ReduceMinsMaxes" 3
@@ -770,11 +767,11 @@ ReduceMinsMaxes
 "Reduced TopK input" 52
 "Threshold local" 10
 
-> SET cluster TO arrangement_sharing
+> SET cluster TO distinct_arrangements
 
 # Check dataflows of our logging infrastructure with log_logging
-> ALTER CLUSTER arrangement_sharing SET (MANAGED = false);
-> CREATE CLUSTER REPLICA arrangement_sharing.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
+> ALTER CLUSTER distinct_arrangements SET (MANAGED = false);
+> CREATE CLUSTER REPLICA distinct_arrangements.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
 
 > SET cluster_replica = replica;
 
@@ -815,10 +812,10 @@ ALTER SYSTEM SET enable_introspection_subscribes = true
 
 # Flipping `enable_introspection_subscribes` affects new replicas, so force a
 # restart.
-> DROP CLUSTER REPLICA arrangement_sharing.replica
-> ALTER CLUSTER arrangement_sharing SET (MANAGED = true)
-> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 0)
-> ALTER CLUSTER arrangement_sharing SET (REPLICATION FACTOR = 1)
+> DROP CLUSTER REPLICA distinct_arrangements.replica
+> ALTER CLUSTER distinct_arrangements SET (MANAGED = true)
+> ALTER CLUSTER distinct_arrangements SET (REPLICATION FACTOR = 0)
+> ALTER CLUSTER distinct_arrangements SET (REPLICATION FACTOR = 1)
 > RESET cluster_replica
 
 > SELECT mdod.name, count(*)

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -31,6 +31,7 @@ emit_plan_insights_notice           off                     "Boolean flag indica
 emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
+enable_reduce_reduction             on                      "split complex reductions in to simpler ones and a join (Materialize)."
 enable_session_rbac_checks          off                     "User facing session boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 extra_float_digits                  3                       "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                          <omitted>               "Allows failpoints to be dynamically activated."


### PR DESCRIPTION
This is an experimental PR where we break apart `Reduce` operators that would be rendered with the `Collation` plan into atomic `Reduce` operators that are joined together instead. This has the potential to be (much) better than the collation plan, or .. to be worse. If we put an `ArrangeBy` at the end it wouldn't be worse, but it could be much better.

This PR is mostly to look at some plans and see what changes and how.

Edit: More explanation here: https://materializeinc.slack.com/archives/C02PPB50ZHS/p1673028168703109

Edit2: Slack message copy/pasted for visibility:

> Other Reduce thought: We have various flavors of reduce plans, roughly three (accumulable, hierarchical, and "generic"). We collate these together with another reduce though .. we should just use a delta join. All of the constituents present arrangements of their outputs, and a delta join would use no additional memory (unlike the collation operator). Moreover, we could then push down predicates and projection and mapping and such.
> Downside: delta joins don't produce an output arrangement, so it wouldn't always be the case that Reduce has an arrangement of its output. We could always make one at not much additional cost (and I think strictly less than the collation operator).

Edit 3: scope has changed to only breaking apart enough aggregates to prevent collation. Fixes https://github.com/MaterializeInc/database-issues/issues/2273

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
