### PR TITLE
Update jemalloc to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7108,9 +7108,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb833c46ecbf8b6daeccb347cefcabf9c1beb5c9b0f853e1cec45632d9963e69"
+checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
 dependencies = [
  "libc",
  "paste",
@@ -7119,9 +7119,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.4.3+5.2.1-patched.2"
+version = "0.5.2+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
 dependencies = [
  "cc",
  "fs_extra",
@@ -7130,9 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -38,7 +38,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 # (Namely: if the application relies on new threads not being created for whatever reason)
 #
 # See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
-tikv-jemallocator = { version = "0.4.3", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"], optional = true }
+tikv-jemallocator = { version = "0.5.0", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"], optional = true }
 
 [features]
 default = ["jemalloc"]

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -89,7 +89,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 # (Namely: if the application relies on new threads not being created for whatever reason)
 #
 # See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
-tikv-jemallocator = { version = "0.4.3", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"], optional = true }
+tikv-jemallocator = { version = "0.5.0", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.5"

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.23.0", features = ["time"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-tikv-jemalloc-ctl = { version = "0.4.1", features = ["use_std"], optional = true }
+tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"], optional = true }
 
 [build-dependencies]
 anyhow = "1.0.66"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -218,14 +218,14 @@ byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
 libc = { version = "0.2.138", default-features = false, features = ["use_std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
-tikv-jemalloc-sys = { version = "0.4.3+5.2.1-patched.2", features = ["background_threads", "background_threads_runtime_support", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-sys = { version = "0.5.2+5.3.0-patched", features = ["background_threads", "background_threads_runtime_support", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 byteorder = { version = "1.4.3", default-features = false, features = ["i128"] }
 libc = { version = "0.2.138", default-features = false, features = ["use_std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std", "unstable"] }
-tikv-jemalloc-sys = { version = "0.4.3+5.2.1-patched.2", features = ["background_threads", "background_threads_runtime_support", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-sys = { version = "0.5.2+5.3.0-patched", features = ["background_threads", "background_threads_runtime_support", "profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [target.x86_64-apple-darwin.dependencies]
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }


### PR DESCRIPTION
Update the jemalloc dependencies to 0.5.0.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
