### PR TITLE
environmentd: support bearer auth over websocket

### DIFF
--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -55,10 +55,22 @@ The WebSocket API provides two modes with slightly different transactional seman
 wss://<MZ host address>/api/experimental/sql
 ```
 
-To authenticate, send an initial text or binary message containing a JSON object with keys:
+To authenticate using a username and password, send an initial text or binary message containing a JSON object:
 
-- `user`: Your email to access Materialize.
-- `password`: Your app password.
+```
+{
+			"user": "<Your email to access Materialize>"
+	"password": "<Your app password>",
+}
+```
+
+To authenticate using a token, send an initial text or binary message containing a JSON object:
+
+```
+{
+	"token": "<Your access token>",
+}
+```
 
 Successful authentication will result in an initial `ReadyForQuery` response from the server.
 Otherwise an error is indicated by a websocket Close message.
@@ -166,10 +178,15 @@ The payload is an array of JSON values corresponding to the columns from the `Ro
 You can model these with the following TypeScript definitions:
 
 ```typescript
-interface Auth {
+interface BasicAuth {
     user: string;
     password: string;
 }
+
+type Auth =
+    | { type: "Basic"; payload: BasicAuth }
+    | { type: "Token"; payload: string }
+    ;
 
 interface Simple {
     query: string;

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -178,11 +178,6 @@ The payload is an array of JSON values corresponding to the columns from the `Ro
 You can model these with the following TypeScript definitions:
 
 ```typescript
-interface BasicAuth {
-    user: string;
-    password: string;
-}
-
 type Auth =
     | { user: string; password: string }
     | { token: string }

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -59,7 +59,7 @@ To authenticate using a username and password, send an initial text or binary me
 
 ```
 {
-			"user": "<Your email to access Materialize>"
+    "user": "<Your email to access Materialize>"
 	"password": "<Your app password>",
 }
 ```

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -184,8 +184,8 @@ interface BasicAuth {
 }
 
 type Auth =
-    | { type: "Basic"; payload: BasicAuth }
-    | { type: "Token"; payload: string }
+    | { user: string, password: string }
+    | { token: string }
     ;
 
 interface Simple {

--- a/doc/user/content/integrations/websocket-api.md
+++ b/doc/user/content/integrations/websocket-api.md
@@ -59,7 +59,7 @@ To authenticate using a username and password, send an initial text or binary me
 
 ```
 {
-    "user": "<Your email to access Materialize>"
+  "user": "<Your email to access Materialize>"
 	"password": "<Your app password>",
 }
 ```
@@ -184,7 +184,7 @@ interface BasicAuth {
 }
 
 type Auth =
-    | { user: string, password: string }
+    | { user: string; password: string }
     | { token: string }
     ;
 

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -65,9 +65,10 @@ pub async fn handle_sql_ws(
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct WebSocketAuth {
-    pub user: String,
-    pub password: String,
+#[serde(untagged)]
+pub enum WebSocketAuth {
+    Basic { user: String, password: String },
+    Bearer { token: String },
 }
 
 async fn run_ws(state: &WsState, mut ws: WebSocket) {

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -271,7 +271,7 @@ fn test_http_sql() {
         let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
 
         ws.write_message(Message::Text(
-            serde_json::to_string(&WebSocketAuth {
+            serde_json::to_string(&WebSocketAuth::Basic {
                 user: "materialize".into(),
                 password: "".into(),
             })


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a