### PR TITLE
cloudtest,mzcompose: generalize external service configuration

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -378,7 +378,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
+          args: [--scenario=RestartCockroach, --execution-mode=oneatatime]
 
   - id: checks-oneatatime-restart-redpanda-debezium
     label: "Checks oneatatime + restart Redpanda & Debezium"
@@ -448,7 +448,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartPostgresBackend, --execution-mode=parallel]
+          args: [--scenario=RestartCockroach, --execution-mode=parallel]
 
   - id: checks-parallel-restart-redpanda
     label: "Checks parallel + restart Redpanda & Debezium"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -508,8 +508,8 @@ steps:
           composition: platform-checks
           args: [--scenario=KillClusterdStorage]
 
-  - id: checks-restart-postgres-backend
-    label: "Checks + restart Postgres backend"
+  - id: checks-restart-cockroach
+    label: "Checks + restart Cockroach"
     depends_on: build-x86_64
     inputs: [misc/python/materialize/checks]
     timeout_in_minutes: 30
@@ -518,7 +518,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartPostgresBackend]
+          args: [--scenario=RestartCockroach]
 
   - id: checks-restart-source-postgres
     label: "Checks + restart source Postgres"

--- a/misc/cockroach/setup_materialize.sql
+++ b/misc/cockroach/setup_materialize.sql
@@ -1,0 +1,20 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- Sets up a CockroachDB cluster for use by Materialize.
+
+-- See: https://github.com/cockroachdb/cockroach/issues/93892
+-- See: https://github.com/MaterializeInc/materialize/issues/16726
+-- TODO: remove this workaround before upgrading to CockroachDB 22.2 in
+-- production.
+SET CLUSTER SETTING sql.stats.forecasts.enabled = false;
+
+CREATE SCHEMA consensus;
+CREATE SCHEMA adapter;
+CREATE SCHEMA storage;

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -11,17 +11,15 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services import Materialized, Redpanda, Service, TestCerts
+from materialize.mzcompose.services import Materialized, Redpanda, Service
 
 SERVICES = [
-    TestCerts(),
     Materialized(),
     Redpanda(),
     Service(
         "dbt-test",
         {
             "mzbuild": "dbt-materialize",
-            "depends_on": ["test-certs"],
             "environment": [
                 "TMPDIR=/share/tmp",
             ],
@@ -63,7 +61,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             materialized = Materialized(
                 options=test_case.materialized_options,
                 image=test_case.materialized_image,
-                depends_on=["test-certs"],
                 volumes_extra=["secrets:/secrets"],
             )
 

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -19,7 +19,7 @@ class DebeziumPostgres(Check):
         return Testdrive(
             dedent(
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 CREATE TABLE debezium_table (f1 TEXT, f2 INTEGER, f3 INTEGER, f4 TEXT, PRIMARY KEY (f1, f2));
                 ALTER TABLE debezium_table REPLICA IDENTITY FULL;
                 INSERT INTO debezium_table SELECT 'A', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
@@ -29,7 +29,7 @@ class DebeziumPostgres(Check):
                     "name": "psql-connector",
                   "config": {
                     "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
-                    "database.hostname": "postgres-source",
+                    "database.hostname": "postgres",
                     "database.port": "5432",
                     "database.user": "postgres",
                     "database.password": "postgres",
@@ -59,7 +59,7 @@ class DebeziumPostgres(Check):
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM;
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO debezium_table SELECT 'B', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
 
                 > CREATE MATERIALIZED VIEW debezium_view1 AS SELECT f1, f3, SUM(LENGTH(f4)) FROM debezium_source1 GROUP BY f1, f3;
@@ -76,7 +76,7 @@ class DebeziumPostgres(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 BEGIN;
                 INSERT INTO debezium_table SELECT 'C', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
                 UPDATE debezium_table SET f3 = f3 + 1;
@@ -87,7 +87,7 @@ class DebeziumPostgres(Check):
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM;
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 BEGIN;
                 INSERT INTO debezium_table SELECT 'D', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
                 UPDATE debezium_table SET f3 = f3 + 1;
@@ -96,7 +96,7 @@ class DebeziumPostgres(Check):
                 > CREATE MATERIALIZED VIEW debezium_view2 AS SELECT f1, f3, SUM(LENGTH(f4)) FROM debezium_source2 GROUP BY f1, f3;
                 """,
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 BEGIN;
                 INSERT INTO debezium_table SELECT 'E', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
                 UPDATE debezium_table SET f3 = f3 + 1;
@@ -107,7 +107,7 @@ class DebeziumPostgres(Check):
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM;
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 BEGIN;
                 INSERT INTO debezium_table SELECT 'F', generate_series, 1, REPEAT('X', 16) FROM generate_series(1,1000);
                 UPDATE debezium_table SET f3 = f3 + 1;

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -27,12 +27,6 @@ class MzcomposeAction(Action):
 
 
 class StartMz(MzcomposeAction):
-    DEFAULT_MZ_OPTIONS = [
-        "--persist-consensus-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=consensus",
-        "--storage-stash-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=storage",
-        "--adapter-stash-url=postgresql://postgres:postgres@postgres-backend:5432?options=--search_path=adapter",
-    ]
-
     def __init__(
         self, tag: Optional[str] = None, environment_extra: List[str] = []
     ) -> None:
@@ -46,7 +40,7 @@ class StartMz(MzcomposeAction):
         print(f"Starting Mz using image {image}")
         mz = Materialized(
             image=image,
-            options=StartMz.DEFAULT_MZ_OPTIONS,
+            external_cockroach=True,
             environment_extra=self.environment_extra,
         )
 
@@ -134,22 +128,21 @@ class RestartRedpandaDebezium(MzcomposeAction):
             c.start_and_wait_for_tcp(services=[service])
 
 
-class RestartPostgresBackend(MzcomposeAction):
+class RestartCockroach(MzcomposeAction):
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
 
-        c.kill("postgres-backend")
-        c.up("postgres-backend")
-        c.wait_for_postgres(service="postgres-backend")
+        c.kill("cockroach")
+        c.up("cockroach")
 
 
 class RestartSourcePostgres(MzcomposeAction):
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
 
-        c.kill("postgres-source")
-        c.up("postgres-source")
-        c.wait_for_postgres(service="postgres-source")
+        c.kill("postgres")
+        c.up("postgres")
+        c.wait_for_postgres(service="postgres")
 
 
 class KillClusterdStorage(MzcomposeAction):

--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -22,12 +22,12 @@ class PgCdc(Check):
                 > CREATE SECRET pgpass1 AS 'postgres';
 
                 > CREATE CONNECTION pg1 FOR POSTGRES
-                  HOST 'postgres-source',
+                  HOST 'postgres',
                   DATABASE postgres,
                   USER postgres1,
                   PASSWORD SECRET pgpass1
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 CREATE USER postgres1 WITH SUPERUSER PASSWORD 'postgres';
                 ALTER USER postgres1 WITH replication;
                 DROP PUBLICATION IF EXISTS postgres_source;
@@ -54,25 +54,25 @@ class PgCdc(Check):
                   (PUBLICATION 'postgres_source')
                   FOR TABLES (postgres_source_table AS postgres_source_tableA);
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'B', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
 
                 > CREATE SECRET pgpass2 AS 'postgres';
 
                 > CREATE CONNECTION pg2 FOR POSTGRES
-                  HOST 'postgres-source',
+                  HOST 'postgres',
                   DATABASE postgres,
                   USER postgres1,
                   PASSWORD SECRET pgpass1
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'C', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
                 """,
                 """
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'D', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
 
@@ -81,18 +81,18 @@ class PgCdc(Check):
                   (PUBLICATION 'postgres_source')
                   FOR TABLES (postgres_source_table AS postgres_source_tableB);
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'E', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'F', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
 
                 > CREATE SECRET pgpass3 AS 'postgres';
 
                 > CREATE CONNECTION pg3 FOR POSTGRES
-                  HOST 'postgres-source',
+                  HOST 'postgres',
                   DATABASE postgres,
                   USER postgres1,
                   PASSWORD SECRET pgpass3
@@ -102,12 +102,12 @@ class PgCdc(Check):
                   (PUBLICATION 'postgres_source')
                   FOR TABLES (postgres_source_table AS postgres_source_tableC);
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'G', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
 
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_source_table SELECT 'H', 1, REPEAT('X', 1024) FROM generate_series(1,100);
                 UPDATE postgres_source_table SET f2 = f2 + 1;
                 """,
@@ -160,12 +160,12 @@ class PgCdcMzNow(Check):
                 > CREATE SECRET postgres_mz_now_pass AS 'postgres';
 
                 > CREATE CONNECTION postgres_mz_now_conn FOR POSTGRES
-                  HOST 'postgres-source',
+                  HOST 'postgres',
                   DATABASE postgres,
                   USER postgres2,
                   PASSWORD SECRET postgres_mz_now_pass
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 CREATE USER postgres2 WITH SUPERUSER PASSWORD 'postgres';
                 ALTER USER postgres2 WITH replication;
                 DROP PUBLICATION IF EXISTS postgres_mz_now_publication;
@@ -201,7 +201,7 @@ class PgCdcMzNow(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'A2');
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'B2');
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'C2');
@@ -211,7 +211,7 @@ class PgCdcMzNow(Check):
                 UPDATE postgres_mz_now_table SET f1 = NOW() WHERE f2 = 'C1';
                 """,
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'A3');
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'B3');
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'C3');
@@ -230,7 +230,7 @@ class PgCdcMzNow(Check):
                 > SELECT COUNT(*) FROM postgres_mz_now_table;
                 13
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'A4');
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'B4');
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'C4');
@@ -250,7 +250,7 @@ class PgCdcMzNow(Check):
                 0
 
                 # Rollback the last INSERTs so that validate() can be called multiple times
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO postgres_mz_now_table VALUES (NOW(), 'B3');
                 DELETE FROM postgres_mz_now_table WHERE f2 LIKE '%4%';
                 """

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -29,7 +29,7 @@ from materialize.checks.mzcompose_actions import (
 )
 from materialize.checks.mzcompose_actions import KillMz
 from materialize.checks.mzcompose_actions import (
-    RestartPostgresBackend as RestartPostgresBackendAction,
+    RestartCockroach as RestartCockroachAction,
 )
 from materialize.checks.mzcompose_actions import (
     RestartRedpandaDebezium as RestartRedpandaDebeziumAction,
@@ -155,16 +155,16 @@ class KillClusterdStorage(Scenario):
         ]
 
 
-class RestartPostgresBackend(Scenario):
+class RestartCockroach(Scenario):
     def actions(self) -> List[Action]:
         return [
             StartMz(),
             Initialize(self.checks),
-            RestartPostgresBackendAction(),
+            RestartCockroachAction(),
             Manipulate(self.checks, phase=1),
-            RestartPostgresBackendAction(),
+            RestartCockroachAction(),
             Manipulate(self.checks, phase=2),
-            RestartPostgresBackendAction(),
+            RestartCockroachAction(),
             Validate(self.checks),
         ]
 

--- a/misc/python/materialize/checks/source_errors.py
+++ b/misc/python/materialize/checks/source_errors.py
@@ -22,12 +22,12 @@ class SourceErrors(Check):
                 > CREATE SECRET source_errors_secret AS 'postgres';
 
                 > CREATE CONNECTION source_errors_connection FOR POSTGRES
-                  HOST 'postgres-source',
+                  HOST 'postgres',
                   DATABASE postgres,
                   USER source_errors_user1,
                   PASSWORD SECRET source_errors_secret
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 # In order to avoid conflicts, user must be unique
                 CREATE USER source_errors_user1 WITH SUPERUSER PASSWORD 'postgres';
                 ALTER USER source_errors_user1 WITH replication;
@@ -54,7 +54,7 @@ class SourceErrors(Check):
                   (PUBLICATION 'source_errors_publicationb') /* all lowercase */
                   FOR TABLES (source_errors_table AS source_errors_tableB)
 
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 INSERT INTO source_errors_table VALUES (2);
 
                 > SELECT COUNT(*) FROM source_errors_tableA;
@@ -72,12 +72,12 @@ class SourceErrors(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 DROP PUBLICATION source_errors_publicationA;
                 INSERT INTO source_errors_table VALUES (3);
                 """,
                 """
-                $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
                 DROP PUBLICATION source_errors_publicationB;
                 INSERT INTO source_errors_table VALUES (4);
                 """,

--- a/misc/python/materialize/cloudtest/k8s/cockroach.py
+++ b/misc/python/materialize/cloudtest/k8s/cockroach.py
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from textwrap import dedent
-
 from kubernetes.client import (
     V1ConfigMap,
     V1ConfigMapVolumeSource,
@@ -30,6 +28,7 @@ from kubernetes.client import (
     V1VolumeMount,
 )
 
+from materialize import ROOT
 from materialize.cloudtest.k8s import K8sConfigMap, K8sService, K8sStatefulSet
 
 
@@ -40,13 +39,9 @@ class CockroachConfigMap(K8sConfigMap):
                 name="cockroach-init",
             ),
             data={
-                "schemas.sql": dedent(
-                    """
-                CREATE SCHEMA consensus;
-                CREATE SCHEMA catalog;
-                CREATE SCHEMA storage;
-                """
-                ),
+                "setup_materialize.sql": (
+                    ROOT / "misc" / "cockroach" / "setup_materialize.sql"
+                ).read_text(),
             },
         )
 

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -109,7 +109,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             "--orchestrator=kubernetes",
             "--orchestrator-kubernetes-image-pull-policy=if-not-present",
             "--persist-consensus-url=postgres://root@cockroach.default:26257?options=--search_path=consensus",
-            "--adapter-stash-url=postgres://root@cockroach.default:26257?options=--search_path=catalog",
+            "--adapter-stash-url=postgres://root@cockroach.default:26257?options=--search_path=adapter",
             "--storage-stash-url=postgres://root@cockroach.default:26257?options=--search_path=storage",
             "--internal-sql-listen-addr=0.0.0.0:6877",
             "--unsafe-mode",

--- a/misc/python/materialize/mzcompose/loader.py
+++ b/misc/python/materialize/mzcompose/loader.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+from typing import Optional
+
+# The path of the composition that is currently being loaded.
+composition_path: Optional[Path] = None

--- a/misc/python/materialize/zippy/crdb_actions.py
+++ b/misc/python/materialize/zippy/crdb_actions.py
@@ -19,21 +19,7 @@ class CockroachStart(Action):
     """Starts a CockroachDB instance."""
 
     def run(self, c: Composition) -> None:
-        c.start_and_wait_for_tcp(services=["cockroach"])
-        c.wait_for_cockroach()
-
-        for schema in ["adapter", "storage", "consensus"]:
-            c.sql(
-                f"CREATE SCHEMA IF NOT EXISTS {schema}",
-                service="cockroach",
-                user="root",
-            )
-
-        c.sql(
-            "SET CLUSTER SETTING sql.stats.forecasts.enabled = false",
-            service="cockroach",
-            user="root",
-        )
+        c.up("cockroach")
 
     def provides(self) -> List[Capability]:
         return [CockroachIsRunning()]

--- a/misc/python/materialize/zippy/minio_actions.py
+++ b/misc/python/materialize/zippy/minio_actions.py
@@ -19,26 +19,7 @@ class MinioStart(Action):
     """Starts a Minio instance."""
 
     def run(self, c: Composition) -> None:
-        c.start_and_wait_for_tcp(services=["minio"])
-
-        # Minio is managed using a dedicated container
-        c.up("minio_mc", persistent=True)
-
-        # Create user
-        c.exec(
-            "minio_mc",
-            "mc",
-            "config",
-            "host",
-            "add",
-            "myminio",
-            "http://minio:9000",
-            "minioadmin",
-            "minioadmin",
-        )
-
-        # Create bucket
-        c.exec("minio_mc", "mc", "mb", "myminio/persist"),
+        c.up("minio")
 
     def provides(self) -> List[Capability]:
         return [MinioIsRunning()]

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -547,10 +547,8 @@ def workflow_test_remote_storage(c: Composition) -> None:
         # Use a separate CockroachDB service for persist rather than the one in
         # the `Materialized` service, so that crashing `environmentd` does not
         # also take down CockroachDB.
-        Cockroach(),
-        Materialized(
-            options=["--persist-consensus-url=postgres://root@cockroach:26257"]
-        ),
+        Cockroach(setup_materialize=True),
+        Materialized(external_cockroach=True),
     ):
         dependencies = [
             "materialized",

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -26,7 +26,7 @@ SERVICES = [
     Materialized(),
     Testdrive(),
     testdrive_no_reset,
-    Cockroach(),
+    Cockroach(setup_materialize=True),
 ]
 
 
@@ -96,22 +96,8 @@ def workflow_stash(c: Composition) -> None:
     )
     c.rm_volumes("mzdata", "pgdata", force=True)
 
-    materialized = Materialized(
-        options=[
-            "--adapter-stash-url=postgres://root@cockroach:26257?options=--search_path=adapter",
-            "--storage-stash-url=postgres://root@cockroach:26257?options=--search_path=storage",
-            "--persist-consensus-url=postgres://root@cockroach:26257?options=--search_path=consensus",
-        ],
-    )
-    cockroach = Cockroach()
-
-    with c.override(materialized, cockroach):
+    with c.override(Materialized(external_cockroach=True)):
         c.up("cockroach")
-        c.wait_for_cockroach()
-
-        c.sql("CREATE SCHEMA adapter", service="cockroach", user="root")
-        c.sql("CREATE SCHEMA storage", service="cockroach", user="root")
-        c.sql("CREATE SCHEMA consensus", service="cockroach", user="root")
 
         c.start_and_wait_for_tcp(services=["materialized"])
         c.wait_for_materialized("materialized")
@@ -120,13 +106,11 @@ def workflow_stash(c: Composition) -> None:
 
         c.stop("cockroach")
         c.up("cockroach")
-        c.wait_for_cockroach()
 
         c.sql("CREATE TABLE b (i INT)")
 
         c.rm("cockroach")
         c.up("cockroach")
-        c.wait_for_cockroach()
 
         # CockroachDB cleared its database, so this should fail.
         try:


### PR DESCRIPTION
This commit avoids duplicating the configuration of CockroachDB and MinIO across our various test harnesses. The mzcompose `Cockroach`, `MinioSetup`, and `Materialized` services learn convenience options that configure them all appropriately for one another. Additionally, the CockroachDB initialization is shared between cloudtest and mzcompose. This yields a natural spot to install the workaround for the CockroachDB bug discovered in #16726.

Fix #16726.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.
   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
