### PR TITLE
adapter: expose Materialize version in mz_version parameter

### DIFF
--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -11,7 +11,7 @@ use mz_repr::Row;
 use mz_sql::ast::{Ident, Raw, ShowStatement, ShowVariableStatement, Statement};
 
 use crate::catalog::SYSTEM_USER;
-use crate::session::{EndTransactionAction, Session};
+use crate::session::EndTransactionAction;
 use crate::{AdapterError, Client, ExecuteResponse, PeekResponseUnary, SessionClient};
 
 use super::SynchronizedParameters;
@@ -27,7 +27,7 @@ pub struct SystemParameterBackend {
 impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
         let conn_client = client.new_conn()?;
-        let session = Session::new(conn_client.conn_id(), SYSTEM_USER.clone());
+        let session = conn_client.new_session(SYSTEM_USER.clone());
         let (session_client, _) = conn_client.startup(session, true).await?;
         Ok(Self { session_client })
     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1251,7 +1251,7 @@ pub async fn serve<S: Append + 'static>(
                 start_instant,
                 _thread: thread.join_on_drop(),
             };
-            let client = Client::new(cmd_tx.clone(), metrics_clone);
+            let client = Client::new(build_info, cmd_tx.clone(), metrics_clone);
             Ok((handle, client))
         }
         Err(e) => Err(e),

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -44,7 +44,7 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::{error, warn};
 
 use mz_adapter::catalog::{HTTP_DEFAULT_USER, SYSTEM_USER};
-use mz_adapter::session::{ExternalUserMetadata, Session, User};
+use mz_adapter::session::{ExternalUserMetadata, User};
 use mz_adapter::{AdapterError, Client, SessionClient};
 use mz_frontegg_auth::{FronteggAuthentication, FronteggError};
 use mz_ore::metrics::MetricsRegistry;
@@ -282,7 +282,7 @@ impl AuthedClient {
             create_if_not_exists,
         } = user;
         let adapter_client = adapter_client.new_conn()?;
-        let session = Session::new(adapter_client.conn_id(), user);
+        let session = adapter_client.new_session(user);
         let (adapter_client, _) = adapter_client
             .startup(session, create_if_not_exists)
             .await?;

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -81,11 +81,6 @@ where
         }
     }
 
-    /// Returns the ID of this connection.
-    pub fn id(&self) -> u32 {
-        self.conn_id
-    }
-
     /// Reads and decodes one frontend message from the client.
     ///
     /// Blocks until the client sends a complete message. If the client

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -29,7 +29,7 @@ use mz_adapter::catalog::INTERNAL_USER_NAMES;
 use mz_adapter::session::User;
 use mz_adapter::session::{
     EndTransactionAction, ExternalUserMetadata, InProgressRows, Portal, PortalState,
-    RowBatchStream, Session, TransactionStatus,
+    RowBatchStream, TransactionStatus,
 };
 use mz_adapter::{ExecuteResponse, PeekResponseUnary, RowsFuture};
 use mz_frontegg_auth::FronteggAuthentication;
@@ -224,13 +224,10 @@ where
     };
 
     // Construct session.
-    let mut session = Session::new(
-        conn.id(),
-        User {
-            name: user,
-            external_metadata,
-        },
-    );
+    let mut session = adapter_client.new_session(User {
+        name: user,
+        external_metadata,
+    });
     for (name, value) in params {
         let local = false;
         let _ = session.vars_mut().set(&name, &value, local);

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -7,14 +7,14 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
+$ set-regex match="cluster1|default|v\d+\.\d+\.\d+(-[a-z0-9]+)? \([a-f0-9]{9}\)" replacement=<VARIES>
 
 > SHOW ALL
 allowed_cluster_replica_sizes           ""                     "The allowed sizes when creating a new cluster replica (Materialize)."
 application_name                        ""                     "Sets the application name to be reported in statistics and logs (PostgreSQL)."
 client_encoding                         UTF8                   "Sets the client's character set encoding (PostgreSQL)."
 client_min_messages                     notice                 "Sets the message levels that are sent to the client (PostgreSQL)."
-cluster                                 <CLUSTER_NAME>         "Sets the current cluster (Materialize)."
+cluster                                 <VARIES>               "Sets the current cluster (Materialize)."
 cluster_replica                         ""                     "Sets a target cluster replica for SELECT queries (Materialize)."
 database                                materialize            "Sets the current database (CockroachDB)."
 DateStyle                               "ISO, MDY"             "Sets the display format for date and time values (PostgreSQL)."
@@ -38,6 +38,7 @@ max_secrets                             100                    "The maximum numb
 max_sinks                               25                     "The maximum number of sinks in the region, across all schemas (Materialize)."
 max_sources                             25                     "The maximum number of sources in the region, across all schemas (Materialize)."
 max_tables                              25                     "The maximum number of tables in the region, across all schemas (Materialize)."
+mz_version                              <VARIES>               "Shows the Materialize server version (Materialize)."
 search_path                             "public"               "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
 server_version                          9.5.0                  "Shows the server version (PostgreSQL)."
 server_version_num                      90500                  "Shows the server version as an integer (PostgreSQL)."


### PR DESCRIPTION
This commit exposes the Materialize-specific information in a new `mz_version` parameter, as in:

    materialize=> show mz_version;
           mz_version
    -------------------------
     v0.39.0-dev (73f6bed0e)
    (1 row)

The `mz_version` parameter is additionally added to the parameter set that is automatically sent to the client during part of startup. This approach comes from CockroachDB, and allows clients to easily detect whether they're talking to Materialize or PostgreSQL without incurring an additional roundtrip.

I already have a PR out to sqlx [0] that uses this feature to automatically disable PostgreSQL-specific features that Materialize does not support.

The version string matches the output of the `mz_version()` function.

The implementation is somewhat irritating, as it requires plumbing the `BuildInfo` from the adapter into each session. Doesn't turn out too complicated, though, now that it's all written out.

[0]: https://github.com/launchbadge/sqlx/pull/2282

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified: sqlx support.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add an `mz_version` system configuration parameter, which reports the Materialize version information. The value of this parameter is the same as the value returned by the existing `mz_version()` function. The parameter form can be more convenient for downstream applications.
