### PR TITLE
environmentd: add a readiness probe

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -58,6 +58,7 @@ pub use sql::{SqlResponse, WebSocketAuth, WebSocketResponse};
 
 mod catalog;
 mod memory;
+mod probe;
 mod root;
 mod sql;
 
@@ -205,6 +206,7 @@ impl InternalHttpServer {
                 "/api/livez",
                 routing::get(mz_http_util::handle_liveness_check),
             )
+            .route("/api/readyz", routing::get(probe::handle_ready))
             .route(
                 "/api/opentelemetry/config",
                 routing::put({

--- a/src/environmentd/src/http/probe.rs
+++ b/src/environmentd/src/http/probe.rs
@@ -1,0 +1,46 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apach
+
+//! Health check HTTP endpoints.
+
+use axum::extract::Query;
+use axum::response::IntoResponse;
+use axum::Extension;
+use futures::FutureExt;
+use http::StatusCode;
+use serde::Deserialize;
+
+use crate::http::Delayed;
+
+/// Query parameters for [`handle_ready`].
+#[derive(Deserialize)]
+pub struct ReadyParams {
+    /// Whether to wait for readiness or to return immediately if unready.
+    #[serde(default)]
+    wait: bool,
+}
+
+/// Handles a readiness probe.
+pub async fn handle_ready(
+    Extension(client): Extension<Delayed<mz_adapter::Client>>,
+    query: Query<ReadyParams>,
+) -> impl IntoResponse {
+    // `environmentd` is ready to serve queries when the adapter client is
+    // available.
+    let is_ready = if query.wait {
+        let _ = client.await;
+        true
+    } else {
+        client.now_or_never().is_some()
+    };
+    match is_ready {
+        false => (StatusCode::SERVICE_UNAVAILABLE, "not ready"),
+        true => (StatusCode::OK, "ready"),
+    }
+}


### PR DESCRIPTION
Add an readiness probe on the internal HTTP server at /api/readyz that reports whether Materialize is ready to respond to requests. It reports a 503 status while the server is booting, and a 200 status thereafter. The `?wait=true` query parameter can be used to request that the response block until the server becomes ready.

This probe will be immediately useful as a Kubernetes readiness probe and a Docker Compose healthcheck.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a (this API endpoint is on the internal HTTP server)
