### PR TITLE
adapter: don't record storage usage for dropped shards

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -92,23 +92,6 @@ use crate::util::{PostgresErrorExt, KAFKA_ADDRS};
 
 pub mod util;
 
-#[derive(Debug)]
-struct UInt8(u64);
-
-impl<'a> FromSql<'a> for UInt8 {
-    fn from_sql(_: &Type, mut raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
-        let v = raw.get_u64();
-        if !raw.is_empty() {
-            return Err("invalid buffer size".into());
-        }
-        Ok(Self(v))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        ty.oid() == mz_pgrepr::oid::TYPE_UINT8_OID
-    }
-}
-
 #[test]
 fn test_persistence() {
     let data_dir = tempfile::tempdir().unwrap();

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -100,4 +100,5 @@ pub use value::interval::Interval;
 pub use value::jsonb::Jsonb;
 pub use value::numeric::Numeric;
 pub use value::record::Record;
+pub use value::unsigned::{UInt2, UInt4, UInt8};
 pub use value::{values_from_row, Value};

--- a/src/pgrepr/src/value/unsigned.rs
+++ b/src/pgrepr/src/value/unsigned.rs
@@ -1,0 +1,111 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+
+use bytes::{BufMut, BytesMut};
+use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
+
+use crate::oid;
+
+/// A wrapper for 16-bit unsigned integers that can be serialized to and
+/// deserialized from the PostgreSQL binary format.
+#[derive(Debug, Clone, Copy)]
+pub struct UInt2(pub u16);
+
+impl<'a> FromSql<'a> for UInt2 {
+    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<UInt2, Box<dyn Error + Sync + Send>> {
+        Ok(UInt2(u16::from_be_bytes(raw.try_into()?)))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == oid::TYPE_UINT2_OID
+    }
+}
+
+impl ToSql for UInt2 {
+    fn to_sql(
+        &self,
+        _: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + 'static + Send + Sync>> {
+        out.put_u16(self.0);
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == oid::TYPE_UINT2_OID
+    }
+
+    to_sql_checked!();
+}
+
+/// A wrapper for 32-bit unsigned integers that can be serialized to and
+/// deserialized from the PostgreSQL binary format.
+#[derive(Debug, Clone, Copy)]
+pub struct UInt4(pub u32);
+
+impl<'a> FromSql<'a> for UInt4 {
+    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<UInt4, Box<dyn Error + Sync + Send>> {
+        Ok(UInt4(u32::from_be_bytes(raw.try_into()?)))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == oid::TYPE_UINT4_OID
+    }
+}
+
+impl ToSql for UInt4 {
+    fn to_sql(
+        &self,
+        _: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + 'static + Send + Sync>> {
+        out.put_u32(self.0);
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == oid::TYPE_UINT4_OID
+    }
+
+    to_sql_checked!();
+}
+
+/// A wrapper for 64-bit unsigned integers that can be serialized to and
+/// deserialized from the PostgreSQL binary format.
+#[derive(Debug, Clone, Copy)]
+pub struct UInt8(pub u64);
+
+impl<'a> FromSql<'a> for UInt8 {
+    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<UInt8, Box<dyn Error + Sync + Send>> {
+        Ok(UInt8(u64::from_be_bytes(raw.try_into()?)))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == oid::TYPE_UINT8_OID
+    }
+}
+
+impl ToSql for UInt8 {
+    fn to_sql(
+        &self,
+        _: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + 'static + Send + Sync>> {
+        out.put_u64(self.0);
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == oid::TYPE_UINT8_OID
+    }
+
+    to_sql_checked!();
+}

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -191,6 +191,11 @@ pub trait StorageController: Debug + Send {
         id: GlobalId,
     ) -> Result<&mut CollectionState<Self::Timestamp>, StorageError>;
 
+    /// Acquire an iterator over all collection states.
+    fn collections(
+        &self,
+    ) -> Box<dyn Iterator<Item = (&GlobalId, &CollectionState<Self::Timestamp>)> + '_>;
+
     /// Create the sources described in the individual CreateSourceCommand commands.
     ///
     /// Each command carries the source id, the source description, and any associated metadata
@@ -795,6 +800,12 @@ where
             .collections
             .get_mut(&id)
             .ok_or(StorageError::IdentifierMissing(id))
+    }
+
+    fn collections(
+        &self,
+    ) -> Box<dyn Iterator<Item = (&GlobalId, &CollectionState<Self::Timestamp>)> + '_> {
+        Box::new(self.state.collections.iter())
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -25,7 +25,7 @@ use tokio_postgres::types::{FromSql, Type};
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
 use mz_ore::str::StrExt;
-use mz_pgrepr::{Interval, Jsonb, Numeric};
+use mz_pgrepr::{Interval, Jsonb, Numeric, UInt2, UInt4, UInt8};
 use mz_sql_parser::ast::Statement;
 
 use crate::action::{ControlFlow, State};
@@ -625,13 +625,13 @@ pub fn decode_row(state: &State, row: Row) -> Result<Vec<String>, anyhow::Error>
                 .map(|v| v.to_string()),
             _ => match ty.oid() {
                 mz_pgrepr::oid::TYPE_UINT2_OID => {
-                    row.get::<_, Option<Uint2>>(i).map(|x| x.0.to_string())
+                    row.get::<_, Option<UInt2>>(i).map(|x| x.0.to_string())
                 }
                 mz_pgrepr::oid::TYPE_UINT4_OID => {
-                    row.get::<_, Option<Uint4>>(i).map(|x| x.0.to_string())
+                    row.get::<_, Option<UInt4>>(i).map(|x| x.0.to_string())
                 }
                 mz_pgrepr::oid::TYPE_UINT8_OID => {
-                    row.get::<_, Option<Uint8>>(i).map(|x| x.0.to_string())
+                    row.get::<_, Option<UInt8>>(i).map(|x| x.0.to_string())
                 }
                 mz_pgrepr::oid::TYPE_MZ_TIMESTAMP_OID => {
                     row.get::<_, Option<MzTimestamp>>(i).map(|x| x.0)
@@ -650,42 +650,6 @@ pub fn decode_row(state: &State, row: Row) -> Result<Vec<String>, anyhow::Error>
         out.push(value);
     }
     Ok(out)
-}
-
-struct Uint2(u16);
-
-impl<'a> FromSql<'a> for Uint2 {
-    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Uint2, Box<dyn Error + Sync + Send>> {
-        Ok(Uint2(u16::from_be_bytes(raw.try_into()?)))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        ty.oid() == mz_pgrepr::oid::TYPE_UINT2_OID
-    }
-}
-
-struct Uint4(u32);
-
-impl<'a> FromSql<'a> for Uint4 {
-    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Uint4, Box<dyn Error + Sync + Send>> {
-        Ok(Uint4(u32::from_be_bytes(raw.try_into()?)))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        ty.oid() == mz_pgrepr::oid::TYPE_UINT4_OID
-    }
-}
-
-struct Uint8(u64);
-
-impl<'a> FromSql<'a> for Uint8 {
-    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Uint8, Box<dyn Error + Sync + Send>> {
-        Ok(Uint8(u64::from_be_bytes(raw.try_into()?)))
-    }
-
-    fn accepts(ty: &Type) -> bool {
-        ty.oid() == mz_pgrepr::oid::TYPE_UINT8_OID
-    }
 }
 
 struct MzTimestamp(String);


### PR DESCRIPTION
Materialize does not currently reclaim storage for dropped persist
shards (see https://github.com/MaterializeInc/materialize/issues/8185), and so it continues to record usage for these shards
in mz_internal.mz_storage_usage_by_shard even after they're dropped.

This commit omits reporting the usage from those dropped shards in
mz_storage_usage_by_shard. The storage is still in use, of course, but
this way we won't bill customers for it. (The billing metering will be
based on the values in mz_storage_usage_by_shard).

Touches https://github.com/MaterializeInc/cloud/issues/4998.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
