### PR TITLE
doc/user: document `IDLE ARRANGEMENT MERGE EFFORT` replica option

### DIFF
--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -2,5 +2,6 @@ Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
 `SIZE`                              | `text`     | The size of the replica. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
 `AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
-`INTROSPECTION INTERVAL`         | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data. Defaults to `1s`.
+`INTROSPECTION INTERVAL`            | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data. Defaults to `1s`.
 `INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data. Defaults to false.
+`IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -2,6 +2,6 @@ Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
 `SIZE`                              | `text`     | The size of the replica. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
 `AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
-`INTROSPECTION INTERVAL`            | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data. Defaults to `1s`.
-`INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data. Defaults to false.
+`INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
+`INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Whether to introspect the gathering of the introspection data.
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*


### PR DESCRIPTION
This PR adds documentation for the new `IDLE ARRANGEMENT MERGE EFFORT` replica option, introduced in #16908.

### Motivation

  * This PR adds a known-desirable feature.

Closes #16794.

### Tips for reviewer

Since this option is mostly intended for Materialize engineers and we don't expect users to understand or make use it, I intentionally kept its documentation very short. If we wanted to explain more, we could mention that idle arrangement merge effort trades less memory usage for higher CPU usage and higher query latencies, and we could point to Differential's `idle_merge_effort` docs. In this case we should probably find more space outside of that one table cell.

I couldn't find precedence for marking unstable SQL options, so I invented my own way. I'm not entirely happy with it, but it gets the point across. LMK if you'd like to change this in any way.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add documentation for the `IDLE ARRANGEMENT MERGE EFFORT` replica option.
