### PR TITLE
test/upgrade: use standalone CockroachDB

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -112,7 +112,7 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && tar -xJf shellcheck.tar.xz -C /usr/local/bin --strip-components 1 shellcheck-v0.8.0/shellcheck \
     && rm shellcheck.tar.xz \
     && mkdir -p /usr/local/lib/docker/cli-plugins \
-    && curl -fsSL https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-$ARCH_GCC > /usr/local/lib/docker/cli-plugins/docker-compose \
+    && curl -fsSL https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-$ARCH_GCC > /usr/local/lib/docker/cli-plugins/docker-compose \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -617,12 +617,11 @@ class Testdrive(Service):
         default_timeout: str = "120s",
         seed: Optional[int] = None,
         consistent_seed: bool = False,
-        validate_postgres_stash: bool = False,
+        validate_postgres_stash: Optional[str] = None,
         entrypoint: Optional[List[str]] = None,
         entrypoint_extra: List[str] = [],
         environment: Optional[List[str]] = None,
-        volumes: Optional[List[str]] = None,
-        volumes_extra: Optional[List[str]] = None,
+        volumes_extra: List[str] = [],
         volume_workdir: str = ".:/workdir",
         propagate_uid_gid: bool = True,
         forward_buildkite_shard: bool = False,
@@ -645,11 +644,12 @@ class Testdrive(Service):
                 "AWS_SESSION_TOKEN",
             ]
 
-        if volumes is None:
-            volumes = [*DEFAULT_MZ_VOLUMES]
+        volumes = [
+            volume_workdir,
+            *(v for v in DEFAULT_MZ_VOLUMES if v.startswith("tmp:")),
+        ]
         if volumes_extra:
             volumes.extend(volumes_extra)
-        volumes.append(volume_workdir)
 
         if entrypoint is None:
             entrypoint = [
@@ -668,7 +668,7 @@ class Testdrive(Service):
 
         if validate_postgres_stash:
             entrypoint.append(
-                "--validate-postgres-stash=postgres://root@materialized:26257?options=--search_path=adapter"
+                f"--validate-postgres-stash=postgres://root@{validate_postgres_stash}:26257?options=--search_path=adapter"
             )
 
         if no_reset:

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -26,7 +26,7 @@ SERVICES = [
     SchemaRegistry(),
     # We use mz_panic() in some test scenarios, so environmentd must stay up.
     Materialized(propagate_crashes=False),
-    Testdrive(volumes=["mzdata:/mzdata"]),
+    Testdrive(),
 ]
 
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -42,12 +42,8 @@ SERVICES = [
     Materialized(propagate_crashes=False),
     Redpanda(),
     Testdrive(
-        volumes=[
-            "mzdata:/mzdata",
-            "tmp:/share/tmp",
-            ".:/workdir/smoke",
-            "../testdrive:/workdir/testdrive",
-        ],
+        volume_workdir="../testdrive:/workdir/testdrive",
+        volumes_extra=[".:/workdir/smoke"],
         materialize_params={"cluster": "cluster1"},
     ),
     Clusterd(name="storage"),

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -29,7 +29,7 @@ SERVICES = [
     SchemaRegistry(),
     Localstack(),
     Materialized(),
-    Testdrive(volumes=["mzdata:/mzdata"]),
+    Testdrive(),
 ]
 
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -79,7 +79,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
-        validate_postgres_stash=True,
+        validate_postgres_stash="materialized",
     )
 
     materialized = Materialized(default_size=args.default_size)

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -19,6 +19,7 @@ from semver import Version
 from materialize import util
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
+    Cockroach,
     Kafka,
     Materialized,
     Postgres,
@@ -49,9 +50,11 @@ SERVICES = [
         ],
     ),
     Postgres(),
+    Cockroach(setup_materialize=True),
     Materialized(
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
+        external_cockroach=True,
     ),
     # N.B.: we need to use `validate_postgres_stash=False` because testdrive uses
     # HEAD to load the catalog from disk but does *not* run migrations. There
@@ -65,7 +68,7 @@ SERVICES = [
     # because that would involve maintaining backwards compatibility for all
     # testdrive commands.
     Testdrive(
-        validate_postgres_stash=False,
+        validate_postgres_stash=None,
         volumes_extra=["secrets:/share/secrets"],
     ),
 ]
@@ -166,6 +169,7 @@ def test_upgrade_from_version(
                 if from_version[1:] >= start_version
             ],
             volumes_extra=["secrets:/share/secrets"],
+            external_cockroach=True,
         )
         with c.override(mz_from):
             c.up("materialized")
@@ -187,6 +191,12 @@ def test_upgrade_from_version(
 
     c.kill("materialized")
     c.rm("materialized", "testdrive")
+    # Remove the pgdata volume, which is where the CockroachDB embedded into
+    # the materialized image stores its state. We don't use the embedded
+    # CockroachDB in this test, and we might *downgrade* it, if the new version
+    # of Materialize reverts a version bump of CockroachDB, and that would
+    # result in the new container failing to start up.
+    c.rm_volumes("pgdata")
 
     c.up("materialized")
     c.wait_for_materialized("materialized")
@@ -199,7 +209,8 @@ def test_upgrade_from_version(
 
     with c.override(
         Testdrive(
-            validate_postgres_stash=True, volumes_extra=["secrets:/share/secrets"]
+            validate_postgres_stash="cockroach",
+            volumes_extra=["secrets:/share/secrets"],
         )
     ):
         c.run(
@@ -283,7 +294,7 @@ def ssl_services() -> Tuple[Kafka, SchemaRegistry, Testdrive]:
         volumes_extra=["secrets:/share/secrets"],
         # Required to install root certs above
         propagate_uid_gid=False,
-        validate_postgres_stash=False,
+        validate_postgres_stash=None,
     )
 
     return (kafka, schema_registry, testdrive)


### PR DESCRIPTION
This PR makes it possible to downgrade the version of CockroachDB in the `materialized` image without failing the upgrade tests (and similarly for several other compositions).