### PR TITLE
stash: add logging for unexpected lower

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1206,7 +1206,10 @@ impl Append for Postgres {
                                 let current_upper =
                                     Self::upper_tx(stmts, tx, collection_id).await?;
                                 if current_upper != lower1 {
-                                    return Err(StashError::from("unexpected lower"));
+                                    return Err(StashError::from(format!(
+                                        "unexpected lower, got {:?}, expected {:?}",
+                                        current_upper, lower1
+                                    )));
                                 }
                                 Self::compact_batch_tx(
                                     stmts,


### PR DESCRIPTION
To help debug #16927

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a