### PR TITLE
cluster-unification: test linked cluster sizes against the storage host map

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -887,7 +887,7 @@ impl<S: Append + 'static> Coordinator<S> {
             );
 
             let config = ComputeReplicaConfig {
-                location: self.catalog.concretize_replica_location(location)?,
+                location: self.catalog.concretize_replica_location(location, None)?,
                 logging,
                 idle_arrangement_merge_effort,
             };
@@ -1052,7 +1052,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .collect();
 
         let config = ComputeReplicaConfig {
-            location: self.catalog.concretize_replica_location(location)?,
+            location: self.catalog.concretize_replica_location(location, None)?,
             logging,
             idle_arrangement_merge_effort,
         };
@@ -3793,7 +3793,7 @@ impl<S: Append + 'static> Coordinator<S> {
             linked_object_id: Some(linked_object_id),
             arranged_introspection_sources,
         }];
-        ops.extend(self.create_linked_cluster_op(name, config)?);
+        ops.extend(self.create_linked_cluster_op(linked_object_id, name, config)?);
         Ok(ops)
     }
 
@@ -3801,6 +3801,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// cluster for the given storage host configuration.
     fn create_linked_cluster_op(
         &mut self,
+        linked_object_id: GlobalId,
         on_cluster_name: String,
         config: &StorageHostConfig,
     ) -> Result<Option<catalog::Op>, AdapterError> {
@@ -3823,6 +3824,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 availability_zone: Self::choose_az(&n_replicas_per_az),
                 az_user_specified: false,
             },
+            Some(linked_object_id),
         )?;
         let logging = {
             ComputeReplicaLogging {
@@ -3861,7 +3863,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .drop_compute_instance_replica_ops(&[(cluster_name.clone(), name.into())]);
                 ops.extend(drop_ops);
             }
-            ops.extend(self.create_linked_cluster_op(cluster_name, config)?)
+            ops.extend(self.create_linked_cluster_op(linked_object_id, cluster_name, config)?)
         }
         Ok(ops)
     }


### PR DESCRIPTION
This is a patch fix for v0.39.0.
We erroneously compare storage-linked cluster replica sizes to the compute replica size map, as opposed to the STORAGE host size map. This pr fixes it.

It likely need careful review. I tested it locally, but will attempt to add a testdrive (which may land after the patch is created)



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

