### PR TITLE
Specialize Top1Monoid for thread-local aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#c2e8fefce9ddad0aef5afcac0238b4dc6ae0ddcb"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8a04699df22600a332a5fafadbe7eebb84ea16d5"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1764,7 +1764,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#c2e8fefce9ddad0aef5afcac0238b4dc6ae0ddcb"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8a04699df22600a332a5fafadbe7eebb84ea16d5"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -136,6 +136,10 @@ impl Clone for Row {
             data: SmallVec::from_slice(self.data.as_slice()),
         }
     }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.data.clone_from(&source.data);
+    }
 }
 
 impl Row {


### PR DESCRIPTION
Similarly to #17056, use a non-allocating monoid for all top-k aggregations.

This currently depends on a change to Differential (https://github.com/TimelyDataflow/differential-dataflow/pull/375) before it can land (it has landed.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
