### PR TITLE
adapter: fix storage collection timestamp semantics

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2201,7 +2201,7 @@ impl<S: Append> Catalog<S> {
             Catalog<S>,
             BuiltinMigrationMetadata,
             Vec<BuiltinTableUpdate>,
-            Option<String>,
+            String,
         ),
         AdapterError,
     > {
@@ -2595,14 +2595,13 @@ impl<S: Append> Catalog<S> {
             .storage()
             .await
             .get_catalog_content_version()
-            .await?;
+            .await?
+            .unwrap_or_else(|| "new".to_string());
 
         if !config.skip_migrations {
             migrate::migrate(&mut catalog).await.map_err(|e| {
                 Error::new(ErrorKind::FailedMigration {
-                    last_seen_version: last_seen_version
-                        .clone()
-                        .unwrap_or_else(|| "new".to_string()),
+                    last_seen_version: last_seen_version.clone(),
                     this_version: catalog.config().build_info.version,
                     cause: e.to_string(),
                 })

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -91,7 +91,7 @@ use mz_compute_client::controller::{ComputeInstanceEvent, ComputeInstanceId, Rep
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::{EpochMillis, NowFn};
+use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
 use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -198,7 +198,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     },
     LinearizeReads(Vec<PendingReadTxn>),
     StorageUsageFetch,
-    StorageUsageUpdate(HashMap<Option<ShardId>, u64>, EpochMillis),
+    StorageUsageUpdate(HashMap<Option<ShardId>, u64>),
     Consolidate(Vec<mz_stash::Id>),
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -483,7 +483,6 @@ impl<S: Append + 'static> Coordinator<S> {
         &mut self,
         builtin_migration_metadata: BuiltinMigrationMetadata,
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
-        last_catalog_version: Option<String>,
     ) -> Result<(), AdapterError> {
         info!("coordinator init: beginning bootstrap");
 
@@ -1032,10 +1031,6 @@ impl<S: Append + 'static> Coordinator<S> {
         self.catalog_transact(Some(&Session::dummy()), linked_cluster_ops)
             .await?;
 
-        if last_catalog_version.is_none() {
-            self.storage_usage_fetch().await;
-        }
-
         info!("coordinator init: bootstrap complete");
         Ok(())
     }
@@ -1219,7 +1214,7 @@ pub async fn serve<S: Append + 'static>(
         .map(|azs_vec| HashSet::from_iter(azs_vec.iter().cloned()));
 
     info!("coordinator init: opening catalog");
-    let (mut catalog, builtin_migration_metadata, builtin_table_updates, last_catalog_version) =
+    let (mut catalog, builtin_migration_metadata, builtin_table_updates, _last_catalog_version) =
         Catalog::open(catalog::Config {
             storage,
             unsafe_mode,
@@ -1301,11 +1296,7 @@ pub async fn serve<S: Append + 'static>(
             };
             let bootstrap = handle.block_on(async {
                 coord
-                    .bootstrap(
-                        builtin_migration_metadata,
-                        builtin_table_updates,
-                        last_catalog_version,
-                    )
+                    .bootstrap(builtin_migration_metadata, builtin_table_updates)
                     .await?;
                 coord
                     .controller

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -190,12 +190,18 @@ impl<S: Append + 'static> Coordinator<S> {
         // thundering herds across environments.
         const SEED_LEN: usize = 32;
         let mut seed = [0; SEED_LEN];
-        for (i, byte) in format!("{}", self.catalog.state().config().environment_id)
-            .bytes()
+        for (i, byte) in self
+            .catalog
+            .state()
+            .config()
+            .environment_id
+            .organization_id()
+            .as_bytes()
+            .into_iter()
             .take(SEED_LEN)
             .enumerate()
         {
-            seed[i] = byte;
+            seed[i] = *byte;
         }
         let storage_usage_collection_interval_ms: EpochMillis =
             EpochMillis::try_from(self.storage_usage_collection_interval.as_millis())

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -23,6 +23,7 @@ pub struct Metrics {
     pub queue_busy_seconds: HistogramVec,
     pub determine_timestamp: IntCounterVec,
     pub commands: IntCounterVec,
+    pub storage_usage_collection_time_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -57,6 +58,10 @@ impl Metrics {
                 help: "The total number of adapter commands issued of the given type since process start.",
                 var_labels: ["command_type", "status"],
             )),
+            storage_usage_collection_time_seconds: registry.register(metric!(
+                name: "mz_storage_usage_collection_time_seconds",
+                help: "The number of seconds the coord spends collecting usage metrics from storage.",
+            ))
         }
     }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -663,7 +663,7 @@ fn test_storage_usage_doesnt_update_between_restarts() {
 #[test]
 fn test_storage_usage_collection_interval_timestamps() {
     let config =
-        util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(30));
+        util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(5));
     let server = util::start_server(config).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -511,7 +511,7 @@ fn test_storage_usage_collection_interval() {
         row.get::<_, UInt8>("size").0
     }
 
-    // mz_ore::test::init_logging();
+    mz_ore::test::init_logging();
 
     let config =
         util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(1));

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -451,7 +451,7 @@ fn test_cancel_dataflow_removal() {
 #[test]
 fn test_storage_usage_collection_interval() {
     /// Waits for the next storage collection to occur, then returns the
-    /// timestamp at which the collection occured. The timestamp of the last
+    /// timestamp at which the collection occurred. The timestamp of the last
     /// collection must be provided
     fn wait_for_next_collection(
         client: &mut postgres::Client,
@@ -511,7 +511,7 @@ fn test_storage_usage_collection_interval() {
         row.get::<_, UInt8>("size").0
     }
 
-    mz_ore::test::init_logging();
+    // mz_ore::test::init_logging();
 
     let config =
         util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(1));

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -415,7 +415,7 @@ impl Usage {
 
         Ok(format!(
             "catalog upgrade from {} to {} would succeed",
-            last_catalog_version.unwrap_or_else(|| "new".to_string()),
+            last_catalog_version,
             BUILD_INFO.human_version(),
         ))
     }

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -415,7 +415,7 @@ impl Usage {
 
         Ok(format!(
             "catalog upgrade from {} to {} would succeed",
-            last_catalog_version,
+            last_catalog_version.unwrap_or_else(|| "new".to_string()),
             BUILD_INFO.human_version(),
         ))
     }


### PR DESCRIPTION
So that we don't write data in the past. See comments within.

Candidate fix for https://github.com/MaterializeInc/cloud/issues/4942.