### PR TITLE
adapter: drop linked cluster if sink fails to create

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -465,9 +465,10 @@ impl<S: Append + 'static> Coordinator<S> {
             Err(e) => {
                 // Drop the placeholder sink if still present.
                 if self.catalog.try_get_entry(&id).is_some() {
+                    let ops = self.catalog.drop_items_ops(&[id]);
                     self.catalog_transact(
                         session_and_tx.as_ref().map(|(ref session, _tx)| session),
-                        vec![catalog::Op::DropItem(id)],
+                        ops,
                     )
                     .await
                     .expect("deleting placeholder sink cannot fail");

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -50,6 +50,11 @@ contains:REPLICATION FACTOR for sink topics must be a positive integer or -1 for
   ENVELOPE DEBEZIUM
 contains:Invalid value for configuration property "request.required.acks" acks foo
 
+# Ensure that a sink whose topic fails to create does not result in an
+# orphaned linked cluster. See #17061.
+> SELECT count(*) FROM mz_clusters WHERE name = 'materialize_public_invalid_acks'
+0
+
 ! CREATE SINK invalid_key FROM v1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   KEY(f2)


### PR DESCRIPTION
If a sink fails to create in the external system (e.g., because the Kafka broker rejects the topic configuration), we need to remove both the sink *and* the linked cluster associated with the sink. Teach the sink cleanup code path to handle this.

Fix #17061.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a (bug was never released)
