### PR TITLE
cloudtest: Call the Postgres server 'postgres' rather than 'postgres-…

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -24,7 +24,7 @@ from materialize.cloudtest.k8s.environmentd import (
     EnvironmentdStatefulSet,
 )
 from materialize.cloudtest.k8s.minio import Minio
-from materialize.cloudtest.k8s.postgres_source import POSTGRES_SOURCE_RESOURCES
+from materialize.cloudtest.k8s.postgres import POSTGRES_RESOURCES
 from materialize.cloudtest.k8s.redpanda import REDPANDA_RESOURCES
 from materialize.cloudtest.k8s.role_binding import AdminRoleBinding
 from materialize.cloudtest.k8s.ssh import SSH_RESOURCES
@@ -116,7 +116,7 @@ class MaterializeApplication(Application):
 
         self.resources = [
             *COCKROACH_RESOURCES,
-            *POSTGRES_SOURCE_RESOURCES,
+            *POSTGRES_RESOURCES,
             *REDPANDA_RESOURCES,
             *DEBEZIUM_RESOURCES,
             *SSH_RESOURCES,

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -104,7 +104,7 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
             dedent(
                 """\
             CREATE CONNECTION pg TO POSTGRES (
-                HOST 'postgres-source',
+                HOST 'postgres',
                 DATABASE postgres,
                 USER postgres,
                 AWS PRIVATELINK privatelinkconn,

--- a/test/cloudtest/test_ssh_tunnels.py
+++ b/test/cloudtest/test_ssh_tunnels.py
@@ -51,7 +51,7 @@ def test_ssh_tunnels(mz: MaterializeApplication) -> None:
             """
         > CREATE SECRET pgpass AS 'postgres'
         > CREATE CONNECTION pg TO POSTGRES (
-            HOST 'postgres-source',
+            HOST 'postgres',
             DATABASE postgres,
             USER postgres,
             PASSWORD SECRET pgpass,
@@ -59,7 +59,7 @@ def test_ssh_tunnels(mz: MaterializeApplication) -> None:
             SSH TUNNEL ssh_conn
           );
 
-        $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
         ALTER USER postgres WITH replication;
         DROP SCHEMA IF EXISTS public CASCADE;
         DROP PUBLICATION IF EXISTS mz_source;
@@ -82,7 +82,7 @@ def test_ssh_tunnels(mz: MaterializeApplication) -> None:
         > SELECT f1 FROM t1;
         1
 
-        $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
         INSERT INTO t1 VALUES (1), (2);
 
         > SELECT f1 FROM t1 ORDER BY f1 ASC;
@@ -114,7 +114,7 @@ def test_ssh_tunnels(mz: MaterializeApplication) -> None:
         1
         2
 
-        $ postgres-execute connection=postgres://postgres:postgres@postgres-source
+        $ postgres-execute connection=postgres://postgres:postgres@postgres
         INSERT INTO t1 VALUES (3), (4);
 
         > SELECT f1 FROM t1 ORDER BY f1 ASC;


### PR DESCRIPTION
…source'

cloudtest and mzcompose share Testdrive test content, so the name of the Postgres server must be consistent across the two frameworks.

### Motivation


  * This PR fixes a previously unreported bug.
Nightly cloudtest-upgrade was failing.