### PR TITLE
mz: make URL in docstring a markdown link

### DIFF
--- a/src/mz/src/vault.rs
+++ b/src/mz/src/vault.rs
@@ -117,7 +117,7 @@ mod keychain {
     }
 
     /// The MacOS error codes used here are from:
-    /// https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-78/lib/SecBase.h.auto.html
+    /// <https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-78/lib/SecBase.h.auto.html>
     fn error_handler(error: Error) -> anyhow::Error {
         if error.code() == -25300 {
             anyhow!("no credentials found in local keychain. reauthenticate with mz login.")


### PR DESCRIPTION
This commit converts a URL in a docstring into a proper markdown link, to conform to [the `rustdoc::bare_urls` lint](https://doc.rust-lang.org/beta/rustdoc/lints.html#bare_urls).

### Motivation

  * This PR fixes a previously unreported bug.

Running `cargo doc` on the Materialize repo outputs the following warning for the `mz` crate:

```
warning: this URL is not a hyperlink
   --> src/mz/src/vault.rs:120:9
    |
120 |     /// https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-78/lib/SecBase.h.auto.html
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://opensource.apple.com/source/libsecurity_keychain/libsecurity_keychain-78/lib/SecBase.h.auto.html>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: `mz` (bin "mz" doc) generated 1 warning
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
