### PR TITLE
compute-client: add protocol documentation

### DIFF
--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -25,12 +25,11 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.logging.rs"));
 /// Logging configuration.
 ///
 /// Setting `enable_logging` to `false` specifies that logging is disabled.
-///
-/// Ideally we'd want to instead signal disabled logging by leaving both `index_logs` and
-/// `sink_logs` empty. Unfortunately, we have to always provide `index_logs`, because we must
-/// install the logging dataflows even on replicas that have logging disabled. See
-/// <https://github.com/MaterializeInc/materialize/issues/15799>.
-/// TODO(teskje): Clean this up once we remove the arranged introspection sources.
+//
+// Ideally we'd want to instead signal disabled logging by leaving both `index_logs` and
+// `sink_logs` empty. Unfortunately, we have to always provide `index_logs`, because we must
+// install the logging dataflows even on replicas that have logging disabled. See #15799.
+// TODO(teskje): Clean this up once we remove the arranged introspection sources.
 #[derive(Arbitrary, Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggingConfig {
     /// The logging interval

--- a/src/compute-client/src/protocol.rs
+++ b/src/compute-client/src/protocol.rs
@@ -7,8 +7,116 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! The compute command protocol defines the communication between the compute controller and
-//! indiviual compute replicas.
+//! The compute protocol defines the communication between the compute controller and indiviual
+//! compute replicas.
+//!
+//! # Overview
+//!
+//! The compute protocol consists of [`ComputeCommand`]s and [`ComputeResponse`]s.
+//! [`ComputeCommand`]s are sent from the compute controller to the replicas and instruct the
+//! receivers to perform some action. [`ComputeResponse`]s are sent in the opposite direction and
+//! inform the receiver about status changes of their senders.
+//!
+//! The compute protocol is an asynchronous protocol. Both participants must expect and be able to
+//! gracefully handle messages that don’t reflect the state of the world described by the messages
+//! they have previously sent. In other words, messages sent take effect only eventually. For
+//! example, after the compute controller has instructed the replica to cancel a peek (by sending a
+//! [`CancelPeeks`] command, it must still be ready to accept non-[`Canceled`] responses to the
+//! peek. Similarly, if a replica receives a [`CancelPeeks`] command for a peek it has already
+//! answered, it must handle that command gracefully (e.g., by ignoring it).
+//!
+//! While the protocol does not provide any guarantees about the delay between sending a message
+//! and it being received and processed, it does guarantee that messages are delivered in the same
+//! order they are sent in. For example, if the compute controller sends a [`Peek`] command
+//! followed by a [`CancelPeeks`] command, it is guaranteed that [`CancelPeeks`] is only received
+//! by the replica after the [`Peek`] command.
+//!
+//! # Message Transport and Encoding
+//!
+//! To initiate communication, the replica starts listening on a known host and port, to which the
+//! compute controller then connects. We use the gRPC framework for transmitting Protobuf-encoded
+//! messages. The replica exposes a single gRPC service (`ProtoCompute`) which contains a single
+//! RPC (`CommandResponseStream`). The compute controller invokes this RPC to finalize the
+//! connection setup. After the streams have been established, compute commands and responses are
+//! transmitted over these streams.
+//!
+//! # Protocol Stages
+//!
+//! The compute protocol consists of three stages that must be transitioned in order:
+//!
+//!   1. Creation
+//!   2. Initialization
+//!   3. Computation
+//!
+//! ## Creation Stage
+//!
+//! The creation stage is the first stage of the compute protocol. It is initiated by the
+//! successful establishment of a gRPC connection between compute controller and replica. In this
+//! stage, the compute controller must send two creation commands in order:
+//!
+//!   1. A [`CreateTimely`] command, which instructs the replica to create the timely dataflow
+//!      runtime.
+//!   2. A [`CreateInstance`] command, which instructs the replica to initialize the rest of its
+//!      state.
+//!
+//! The replica must not send any responses.
+//!
+//! ## Initialization Stage
+//!
+//! The initialization stage begins as soon as the compute controller has sent the
+//! [`CreateInstance`] command. In this stage, the compute controller informs the replica about its
+//! expected dataflow state. It does so by sending any number of [computation
+//! commands](#computation-stage), followed by an [`InitializationComplete`] command, which marks
+//! the end of the initialization stage.
+//!
+//! Upon receiving computation commands during the initialization phase, the replica is obligated
+//! to ensure its state matches what is requested through the commands. It is up to the replica
+//! whether it ensures that by initializing new state or by reusing existing state (through a
+//! reconciliation process).
+//!
+//! The replica may send responses to computation commands it receives. It may also opt to defer
+//! sending responses to the computation stage instead.
+//!
+//! ## Computation Stage
+//!
+//! The computation stage begins as soon as the compute controller has sent the
+//! [`InitializationComplete`] command. In this stage, the compute controller instructs the replica
+//! to create and maintain dataflows, and to perform peeks on indexes exported by dataflows.
+//!
+//! The compute controller may send any number of computation commands:
+//!
+//!   - [`CreateDataflows`]
+//!   - [`AllowCompaction`]
+//!   - [`Peek`]
+//!   - [`CancelPeeks`]
+//!   - [`UpdateConfiguration`]
+//!
+//! The compute controller must respect dependencies between commands. For example, it must send a
+//! [`CreateDataflows`] command before it sends [`AllowCompaction`] or [`Peek`] commands that
+//! target the created dataflow.
+//!
+//! The replica must send the required responses to computation commands. This includes commands it
+//! has received in the initialization phase that have not already been responded to.
+//!
+//! The replica may also send [`FrontierUppers`] and [`SubscribeResponse::DroppedAt`] responses
+//! for compute collections that it wasn’t instructed to create through a [`CreateDataflows`]
+//! command. This accounts for replicas reporting the dropping of unneeded collections during
+//! reconciliation ([#16247]). The compute controller should ignore these responses.
+//!
+//! [`ComputeCommand`]: self::command::ComputeCommand
+//! [`CreateTimely`]: self::command::ComputeCommand::CreateTimely
+//! [`CreateInstance`]: self::command::ComputeCommand::CreateInstance
+//! [`InitializationComplete`]: self::command::ComputeCommand::InitializationComplete
+//! [`CreateDataflows`]: self::command::ComputeCommand::CreateDataflows
+//! [`AllowCompaction`]: self::command::ComputeCommand::AllowCompaction
+//! [`Peek`]: self::command::ComputeCommand::Peek
+//! [`CancelPeeks`]: self::command::ComputeCommand::CancelPeeks
+//! [`UpdateConfiguration`]: self::command::ComputeCommand::UpdateConfiguration
+//! [`ComputeResponse`]: self::response::ComputeResponse
+//! [`FrontierUppers`]: self::response::ComputeResponse::FrontierUppers
+//! [`Canceled`]: self::response::PeekResponse::Canceled
+//! [`SubscribeResponse::DroppedAt`]: self::response::SubscribeResponse::DroppedAt
+//! [#16247]: https://github.com/MaterializeInc/materialize/issues/16274
 
 pub mod command;
 pub mod history;

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -52,7 +52,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// distribution requires the timely dataflow runtime to be initialized, which is why the
     /// `CreateTimely` command exists.
     ///
-    /// The `epoch` value that imposes an ordering on iterations of the compute protocol. When the
+    /// The `epoch` value imposes an ordering on iterations of the compute protocol. When the
     /// compute controller connects to a replica, it must send an `epoch` that is greater than all
     /// epochs it sent to the same replica on previous connections. Multi-process replicas should
     /// use the `epoch` to ensure that their individual processes agree on which protocol iteration
@@ -89,7 +89,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Parameter updates transmitted through this command must be applied by the replica as soon
     /// as it receives the command, and they must be apply globally to all replica state, even
     /// dataflows and pending peeks that were created before the parameter update. This property
-    /// allows the replica to hoist `UpdateConiguration` commands during reconciliation.
+    /// allows the replica to hoist `UpdateConfiguration` commands during reconciliation.
     ///
     /// Configuration parameters that should not be applied globally, but only to specific
     /// dataflows or peeks, should be added to the [`DataflowDescription`] or [`Peek`] types,

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Compute layer responses.
+//! Compute protocol responses.
 
 use std::num::NonZeroUsize;
 
@@ -27,17 +27,100 @@ include!(concat!(
     "/mz_compute_client.protocol.response.rs"
 ));
 
-/// Responses that the compute nature of a worker/dataflow can provide back to the coordinator.
+/// Compute protocol responses, sent by replicas to the compute controller.
+///
+/// Replicas send `ComputeResponse`s in response to [`ComputeCommand`]s they previously received
+/// from the compute controller.
+///
+/// [`ComputeCommand`]: super::command::ComputeCommand
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
-    /// A list of identifiers of traces, with new upper frontiers.
+    /// `FrontierUppers` announces the advancement of the upper frontiers of the specified compute
+    /// collections. The response contains a mapping of collection IDs to their new upper
+    /// frontiers.
     ///
-    /// TODO(teskje): Consider also reporting the previous upper frontier and using that
-    /// information to assert the correct implementation of our protocols at various places.
+    /// Upon receiving a `FrontierUppers` response, the controller may assume that the replica has
+    /// finished computing the given collections up to at least the given frontiers. It may also
+    /// assume that the replica has finished reading from the collections’ inputs up to those
+    /// frontiers.
+    ///
+    /// Replicas must send `FrontierUppers` responses for compute collections that are indexes or
+    /// storage sinks. Replicas must not send `FrontierUppers` responses for subscribes.
+    ///
+    /// Replicas must send a `FrontierUppers` response reporting advancement to the empty frontier
+    /// for a collection in two cases:
+    ///
+    ///   * The collection has advanced to the empty frontier (e.g. because its inputs have advanced
+    ///     to the empty frontier).
+    ///   * The collection was dropped in response to an [`AllowCompaction` command] that advanced
+    ///     its read frontier to the empty frontier. ([#16275])
+    ///
+    /// Once a collection was reported to have been advanced to the empty upper frontier:
+    ///
+    ///   * It must no longer read from its inputs.
+    ///   * The replica must not send further `FrontierUppers` responses for that collection.
+    ///
+    /// The replica must not send send `FrontierUppers` responses for collections that have not
+    /// been created previously by a [`CreateDataflows` command]. An exception are `FrontierUppers`
+    /// responses that report the empty frontier. ([#16247])
+    ///
+    /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
+    /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
+    /// [#16247]: https://github.com/MaterializeInc/materialize/issues/16247
+    /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
-    /// The worker's response to a specified (by connection id) peek.
+
+    /// `PeekResponse` reports the result of a previous [`Peek` command]. The peek is identified by
+    /// a `Uuid` that matches the command's [`Peek::uuid`].
+    ///
+    /// The replica must send exactly one `PeekResponse` for every [`Peek` command] it received.
+    ///
+    /// If the replica did not receive a [`CancelPeeks` command] for a peek, it must not send a
+    /// [`Canceled`] response for that peek. If the replica did receive a [`CancelPeeks` command]
+    /// for a peek, it may send any of the three [`PeekResponse`] variants.
+    ///
+    /// The replica must not send `PeekResponse`s for peek IDs that were not previously specified
+    /// in a [`Peek` command].
+    ///
+    /// [`Peek` command]: super::command::ComputeCommand::Peek
+    /// [`CancelPeeks` command]: super::command::ComputeCommand::CancelPeeks
+    /// [`Peek::uuid`]: super::command::Peek::uuid
+    /// [`Canceled`]: PeekResponse::Canceled
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
-    /// The worker's next response to a specified subscribe.
+
+    /// `SubscribeResponse` reports the results emitted by an active subscribe over some time
+    /// interval.
+    ///
+    /// For each subscribe that was installed by a previous [`CreateDataflows` command], the
+    /// replica must emit [`Batch`] responses that cover the entire time interval from the
+    /// subscribe dataflow's `as_of` until the subscribe advances to the empty frontier or is
+    /// dropped. The time intervals of consecutive [`Batch`]es must be increasing, contiguous,
+    /// non-overlapping, and non-empty. All updates transmitted in a batch must have times within
+    /// that batch’s time interval.
+    ///
+    /// The replica must send [`DroppedAt`] responses if the subscribe was dropped in response to
+    /// an [`AllowCompaction` command] that advanced its read frontier to the empty frontier. The
+    /// [`DroppedAt`] frontier must be the upper frontier of the last emitted batch.
+    ///
+    /// The replica must not send a [`DroppedAt`] response if the subscribe’s upper frontier
+    /// (reported by [`Batch`] responses) has advanced to the empty frontier (e.g. because its
+    /// inputs advanced to the empty frontier).
+    ///
+    /// Once a subscribe was reported to have advanced to the empty frontier, or has been dropped:
+    ///
+    ///   * It must no longer read from its inputs.
+    ///   * The replica must not send further `SubscribeResponse`s for that subscribe.
+    ///
+    /// The replica must not send send [`Batch`] responses for subscribes that have not been
+    /// created previously by a [`CreateDataflows` command]. The replica may send [`DroppedAt`]
+    /// responses for subscribes that have not been created previously by a [`CreateDataflows`
+    /// command]. ([#16247])
+    ///
+    /// [`Batch`]: SubscribeResponse::Batch
+    /// [`DroppedAt`]: SubscribeResponse::DroppedAt
+    /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
+    /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
+    /// [#16247]: https://github.com/MaterializeInc/materialize/issues/16247
     SubscribeResponse(GlobalId, SubscribeResponse<T>),
 }
 
@@ -116,8 +199,11 @@ impl Arbitrary for ComputeResponse<mz_repr::Timestamp> {
 /// we expect a 1:1 contract between `Peek` and `PeekResponse`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum PeekResponse {
+    /// Returned rows of a successful peek.
     Rows(Vec<(Row, NonZeroUsize)>),
+    /// Error of an unsuccessful peek.
     Error(String),
+    /// The peek was canceled.
     Canceled,
 }
 

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -60,7 +60,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * It must no longer read from its inputs.
     ///   * The replica must not send further `FrontierUppers` responses for that collection.
     ///
-    /// The replica must not send send `FrontierUppers` responses for collections that have not
+    /// The replica must not send `FrontierUppers` responses for collections that have not
     /// been created previously by a [`CreateDataflows` command]. An exception are `FrontierUppers`
     /// responses that report the empty frontier. ([#16247])
     ///
@@ -111,7 +111,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * It must no longer read from its inputs.
     ///   * The replica must not send further `SubscribeResponse`s for that subscribe.
     ///
-    /// The replica must not send send [`Batch`] responses for subscribes that have not been
+    /// The replica must not send [`Batch`] responses for subscribes that have not been
     /// created previously by a [`CreateDataflows` command]. The replica may send [`DroppedAt`]
     /// responses for subscribes that have not been created previously by a [`CreateDataflows`
     /// command]. ([#16247])


### PR DESCRIPTION
This commit adds documentation for the compute protocol in the form of doc strings on the `protocol` module, as well as the `ComputeCommand` and `ComputeResponse` enums.

The text is copied from [Notion](https://www.notion.so/materialize/Compute-Command-Protocol-8e1a461025d24a829db001906b0205c1), with adjustments for the doc string markdown format and updates for the things that changed since the Notion version was written (mostly `UpdateConfiguration`).

### Motivation

* This PR adds documentation.

Closes #15192.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
