### PR TITLE
Replace some uses of HashMap with BTreeMap

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
@@ -64,7 +64,7 @@ pub struct PeekDataflowPlan<T = mz_repr::Timestamp> {
     desc: DataflowDescription<mz_compute_client::plan::Plan<T>, (), T>,
     id: GlobalId,
     key: Vec<MirScalarExpr>,
-    permutation: HashMap<usize, usize>,
+    permutation: BTreeMap<usize, usize>,
     thinned_arity: usize,
 }
 
@@ -164,8 +164,7 @@ fn permute_oneshot_mfp_around_index(
         .map_err(|_e| {
             AdapterError::Unstructured(::anyhow::anyhow!("OneShot plan has temporal constraints"))
         })?;
-    let (permute, thinning) =
-        mz_expr::permutation_for_arrangement::<HashMap<_, _>>(key, mfp.input_arity);
+    let (permute, thinning) = mz_expr::permutation_for_arrangement(key, mfp.input_arity);
     safe_mfp.permute(permute, key.len() + thinning.len());
     Ok(safe_mfp)
 }
@@ -255,7 +254,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         compute_instance: ComputeInstanceId,
         index_id: GlobalId,
         key: Vec<MirScalarExpr>,
-        permutation: HashMap<usize, usize>,
+        permutation: BTreeMap<usize, usize>,
         thinned_arity: usize,
     ) -> Result<PeekPlan, AdapterError> {
         // try to produce a `FastPathPlan`

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -20,11 +20,7 @@
 //!    pairs on the same line or as lowercase `$key` fields on indented lines.
 //! 5. A single non-recursive parameter can be written just as `$val`.
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-    ops::Deref,
-};
+use std::{collections::BTreeMap, fmt, ops::Deref};
 
 use mz_compute_client::plan::{
     join::{
@@ -715,9 +711,9 @@ struct Arrangement<'a> {
     thinning: &'a Vec<usize>,
 }
 
-impl<'a> From<&'a (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>)> for Arrangement<'a> {
+impl<'a> From<&'a (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)> for Arrangement<'a> {
     fn from(
-        (key, permutation, thinning): &'a (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>),
+        (key, permutation, thinning): &'a (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
     ) -> Self {
         Arrangement {
             key,
@@ -746,14 +742,12 @@ impl<'a> fmt::Display for Arrangement<'a> {
 }
 
 /// Helper struct for rendering a permutation.
-struct Permutation<'a>(&'a HashMap<usize, usize>);
+struct Permutation<'a>(&'a BTreeMap<usize, usize>);
 
 impl<'a> fmt::Display for Permutation<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut pairs = vec![];
-        // convert the wrapped `HashMap` to a `BTreeMap` first and then iterate
-        // over the individual pairs for deterministic output
-        for (x, y) in BTreeMap::from_iter(self.0.iter().filter(|(x, y)| x != y)) {
+        for (x, y) in self.0.iter().filter(|(x, y)| x != y) {
             pairs.push(format!("#{}: #{}", x, y));
         }
 

--- a/src/compute-client/src/controller/orchestrator.rs
+++ b/src/compute-client/src/controller/orchestrator.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -140,7 +140,7 @@ impl ComputeOrchestrator {
                     cpu_limit: allocation.cpu_limit,
                     memory_limit: allocation.memory_limit,
                     scale: allocation.scale,
-                    labels: HashMap::from([
+                    labels: BTreeMap::from([
                         ("replica-id".into(), replica_id.to_string()),
                         ("cluster-id".into(), instance_id.to_string()),
                         ("type".into(), "cluster".into()),

--- a/src/compute-client/src/plan/join/delta_join.rs
+++ b/src/compute-client/src/plan/join/delta_join.rs
@@ -17,8 +17,6 @@
 //! This implementation strategy allows us to re-use existing arrangements, and
 //! not create any new stateful operators.
 
-use std::collections::HashMap;
-
 use crate::plan::join::JoinBuildState;
 use crate::plan::join::JoinClosure;
 use crate::plan::AvailableCollections;
@@ -294,7 +292,7 @@ impl DeltaJoinPlan {
                         }
                     })
                     .unwrap_or_else(|| {
-                        let (permutation, thinning) = permutation_for_arrangement::<HashMap<_, _>>(
+                        let (permutation, thinning) = permutation_for_arrangement(
                             lookup_key,
                             input_mapper.input_arity(*lookup_relation),
                         );
@@ -327,11 +325,8 @@ impl DeltaJoinPlan {
                         bound_expr
                     })
                     .collect::<Vec<_>>();
-                let (stream_permutation, stream_thinning) = permutation_for_arrangement::<
-                    HashMap<_, _>,
-                >(
-                    &stream_key, unthinned_stream_arity
-                );
+                let (stream_permutation, stream_thinning) =
+                    permutation_for_arrangement(&stream_key, unthinned_stream_arity);
                 let key_arity = stream_key.len();
                 let permutation = join_permutations(
                     key_arity,

--- a/src/compute-client/src/plan/join/linear_join.rs
+++ b/src/compute-client/src/plan/join/linear_join.rs
@@ -9,7 +9,7 @@
 
 //! Planning of linear joins.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::plan::join::JoinBuildState;
 use crate::plan::join::JoinClosure;
@@ -163,7 +163,7 @@ impl LinearJoinPlan {
     pub fn create_from(
         source_relation: usize,
         // When specified, a key and its corresponding permutation and thinning.
-        source_arrangement: Option<&(Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>)>,
+        source_arrangement: Option<&(Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>)>,
         equivalences: &[Vec<MirScalarExpr>],
         join_order: &[(usize, Vec<MirScalarExpr>, Option<JoinInputCharacteristics>)],
         input_mapper: mz_expr::JoinInputMapper,
@@ -220,7 +220,7 @@ impl LinearJoinPlan {
                     }
                 })
                 .unwrap_or_else(|| {
-                    let (permutation, thinning) = permutation_for_arrangement::<HashMap<_, _>>(
+                    let (permutation, thinning) = permutation_for_arrangement(
                         lookup_key,
                         input_mapper.input_arity(*lookup_relation),
                     );
@@ -261,10 +261,7 @@ impl LinearJoinPlan {
                         })
                         .collect::<Vec<_>>();
                     let (stream_permutation, stream_thinning) =
-                        permutation_for_arrangement::<HashMap<_, _>>(
-                            &stream_key,
-                            unthinned_stream_arity,
-                        );
+                        permutation_for_arrangement(&stream_key, unthinned_stream_arity);
 
                     (stream_key, stream_permutation, stream_thinning)
                 });

--- a/src/compute-client/src/plan/join/mod.rs
+++ b/src/compute-client/src/plan/join/mod.rs
@@ -30,7 +30,7 @@
 pub mod delta_join;
 pub mod linear_join;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -156,10 +156,10 @@ impl JoinClosure {
     /// and `mfp` is left as an identity transform (which can then
     /// be ignored).
     fn build(
-        columns: &mut HashMap<usize, usize>,
+        columns: &mut BTreeMap<usize, usize>,
         equivalences: &mut Vec<Vec<MirScalarExpr>>,
         mfp: &mut MapFilterProject,
-        permutation: HashMap<usize, usize>,
+        permutation: BTreeMap<usize, usize>,
         thinned_arity_with_key: usize,
     ) -> Self {
         // First, determine which columns should be compared due to `equivalences`.
@@ -298,7 +298,7 @@ impl JoinClosure {
 #[derive(Debug)]
 pub struct JoinBuildState {
     /// Map from expected locations in extended output column reckoning to physical locations.
-    column_map: HashMap<usize, usize>,
+    column_map: BTreeMap<usize, usize>,
     /// A list of equivalence classes of expressions.
     ///
     /// Within each equivalence class, expressions must evaluate to the same result to pass
@@ -323,7 +323,7 @@ impl JoinBuildState {
         equivalences: &[Vec<MirScalarExpr>],
         mfp: &MapFilterProject,
     ) -> Self {
-        let mut column_map = HashMap::new();
+        let mut column_map = BTreeMap::new();
         for column in columns {
             column_map.insert(column, column_map.len());
         }
@@ -343,7 +343,7 @@ impl JoinBuildState {
         bound_expressions: &[MirScalarExpr],
         thinned_arity_with_key: usize,
         // The permutation to run on the join of the thinned collections
-        permutation: HashMap<usize, usize>,
+        permutation: BTreeMap<usize, usize>,
     ) -> JoinClosure {
         // Remove each element of `bound_expressions` from `equivalences`, so that we
         // avoid redundant predicate work. This removal also paves the way for
@@ -399,7 +399,7 @@ impl JoinBuildState {
     /// consider using the `.is_identity()` method to determine non-triviality.
     fn extract_closure(
         &mut self,
-        permutation: HashMap<usize, usize>,
+        permutation: BTreeMap<usize, usize>,
         thinned_arity_with_key: usize,
     ) -> JoinClosure {
         JoinClosure::build(

--- a/src/compute-client/src/plan/reduce.rs
+++ b/src/compute-client/src/plan/reduce.rs
@@ -60,18 +60,19 @@
 //! type, we can specialize and render the dataflow to compute those aggregations in the correct order, and
 //! return the output arrangement directly and avoid the extra collation arrangement.
 
+use std::collections::BTreeMap;
+
+use proptest::prelude::{any, Arbitrary, BoxedStrategy};
+use proptest::strategy::Strategy;
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
 use mz_expr::permutation_for_arrangement;
 use mz_expr::AggregateExpr;
 use mz_expr::AggregateFunc;
 use mz_expr::MirScalarExpr;
 use mz_ore::soft_assert_or_log;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
-use proptest::prelude::{any, Arbitrary, BoxedStrategy};
-use proptest::strategy::Strategy;
-use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::collections::HashMap;
 
 use super::AvailableCollections;
 
@@ -762,7 +763,7 @@ impl KeyValPlan {
         input_arity: usize,
         group_key: &[MirScalarExpr],
         aggregates: &[AggregateExpr],
-        input_permutation_and_new_arity: Option<(HashMap<usize, usize>, usize)>,
+        input_permutation_and_new_arity: Option<(BTreeMap<usize, usize>, usize)>,
     ) -> Self {
         // Form an operator for evaluating key expressions.
         let mut key_mfp = mz_expr::MapFilterProject::new(input_arity)

--- a/src/compute-client/src/plan/threshold.rs
+++ b/src/compute-client/src/plan/threshold.rs
@@ -23,7 +23,7 @@
 //!     is beneficial to use this operator if the number of retractions is expected to be small, and
 //!     if a potential downstream operator does not expect its input to be arranged.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::plan::any_arranged_thin;
 use proptest_derive::Arbitrary;
@@ -75,7 +75,7 @@ impl RustType<ProtoThresholdPlan> for ThresholdPlan {
     }
 }
 
-impl RustType<ProtoArrangement> for (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>) {
+impl RustType<ProtoArrangement> for (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>) {
     fn into_proto(&self) -> ProtoArrangement {
         use proto_arrangement::ProtoArrangementPermutation;
         ProtoArrangement {
@@ -93,7 +93,7 @@ impl RustType<ProtoArrangement> for (Vec<MirScalarExpr>, HashMap<usize, usize>, 
     }
 
     fn from_proto(proto: ProtoArrangement) -> Result<Self, TryFromProtoError> {
-        let perm: Result<HashMap<usize, usize>, TryFromProtoError> = proto
+        let perm: Result<BTreeMap<usize, usize>, TryFromProtoError> = proto
             .permutation
             .iter()
             .map(|x| {
@@ -131,7 +131,7 @@ impl ThresholdPlan {
 pub struct BasicThresholdPlan {
     /// Description of how the input has been arranged, and how to arrange the output
     #[proptest(strategy = "any_arranged_thin()")]
-    pub ensure_arrangement: (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>),
+    pub ensure_arrangement: (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
 }
 
 /// A plan to maintain all inputs with negative counts, which are subtracted from the output
@@ -140,7 +140,7 @@ pub struct BasicThresholdPlan {
 pub struct RetractionsThresholdPlan {
     /// Description of how the input has been arranged
     #[proptest(strategy = "any_arranged_thin()")]
-    pub ensure_arrangement: (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>),
+    pub ensure_arrangement: (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
 }
 
 impl ThresholdPlan {
@@ -154,7 +154,7 @@ impl ThresholdPlan {
         maintain_retractions: bool,
     ) -> (
         Self,
-        (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>),
+        (Vec<MirScalarExpr>, BTreeMap<usize, usize>, Vec<usize>),
     ) {
         // Arrange the input by all columns in order.
         let mut all_columns = Vec::new();

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -416,7 +416,7 @@ pub fn construct<A: Allocate>(
         for (variant, collection) in logs {
             if config.index_logs.contains_key(&variant) {
                 let key = variant.index_by();
-                let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
+                let (_, value) = permutation_for_arrangement(
                     &key.iter()
                         .cloned()
                         .map(MirScalarExpr::Column)

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -181,7 +181,7 @@ pub fn construct<A: Allocate>(
         for (variant, collection) in logs {
             if config.index_logs.contains_key(&variant) {
                 let key = variant.index_by();
-                let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
+                let (_, value) = permutation_for_arrangement(
                     &key.iter()
                         .cloned()
                         .map(MirScalarExpr::Column)

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -177,7 +177,7 @@ pub fn construct<A: Allocate>(
             for variant in logs_active {
                 if config.index_logs.contains_key(&variant) {
                     let key = variant.index_by();
-                    let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
+                    let (_, value) = permutation_for_arrangement(
                         &key.iter()
                             .cloned()
                             .map(MirScalarExpr::Column)

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -464,7 +464,7 @@ pub fn construct<A: Allocate>(
         for (variant, collection) in logs {
             if config.index_logs.contains_key(&variant) {
                 let key = variant.index_by();
-                let (_, value) = permutation_for_arrangement::<HashMap<_, _>>(
+                let (_, value) = permutation_for_arrangement(
                     &key.iter()
                         .cloned()
                         .map(MirScalarExpr::Column)

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -11,6 +11,8 @@
 //!
 //! Consult [ReducePlan] documentation for details.
 
+use std::collections::BTreeMap;
+
 use dec::OrderedDecimal;
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::difference::Multiply;
@@ -215,7 +217,7 @@ where
             demand.sort();
             demand.dedup();
             // remap column references to the subset we use.
-            let mut demand_map = std::collections::HashMap::new();
+            let mut demand_map = BTreeMap::new();
             for column in demand.iter() {
                 demand_map.insert(*column, demand_map.len());
             }

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -88,7 +88,7 @@
 //! Consult the `StorageController` and `ComputeController` documentation for more information
 //! about each of these interfaces.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::mem;
 use std::num::NonZeroI64;
 use std::sync::Arc;
@@ -163,7 +163,7 @@ pub enum ControllerResponse<T = mz_repr::Timestamp> {
     /// Notification that new resource usage metrics are available for a given replica.
     ComputeReplicaMetrics(ReplicaId, Vec<ServiceProcessMetrics>),
     /// Notification that the write frontiers of the replicas have changed.
-    ComputeReplicaWriteFrontiers(HashMap<ReplicaId, Vec<(GlobalId, T)>>),
+    ComputeReplicaWriteFrontiers(BTreeMap<ReplicaId, Vec<(GlobalId, T)>>),
 }
 
 impl<T> From<ComputeControllerResponse<T>> for ControllerResponse<T> {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -10,6 +10,7 @@
 use itertools::Itertools;
 use mz_repr::adt::date::DateError;
 use mz_repr::adt::timestamp::TimestampError;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::mem;
@@ -561,7 +562,7 @@ impl MirScalarExpr {
     /// This method is applicable even when `permutation` is not a
     /// strict permutation, and it only needs to have entries for
     /// each column referenced in `self`.
-    pub fn permute_map(&mut self, permutation: &std::collections::HashMap<usize, usize>) {
+    pub fn permute_map(&mut self, permutation: &BTreeMap<usize, usize>) {
         #[allow(deprecated)]
         self.visit_mut_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(old_i) = e {

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -74,7 +74,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -123,9 +123,9 @@ pub struct KubernetesOrchestratorConfig {
     /// is loaded from the local kubeconfig.
     pub context: String,
     /// Labels to install on every service created by the orchestrator.
-    pub service_labels: HashMap<String, String>,
+    pub service_labels: BTreeMap<String, String>,
     /// Node selector to install on every service created by the orchestrator.
-    pub service_node_selector: HashMap<String, String>,
+    pub service_node_selector: BTreeMap<String, String>,
     /// The service account that each service should run as, if any.
     pub service_account: Option<String>,
     /// The image pull policy to set for services created by the orchestrator.
@@ -163,7 +163,7 @@ pub struct KubernetesOrchestrator {
     config: KubernetesOrchestratorConfig,
     secret_api: Api<Secret>,
     vpc_endpoint_api: Api<VpcEndpoint>,
-    namespaces: Mutex<HashMap<String, Arc<dyn NamespacedOrchestrator>>>,
+    namespaces: Mutex<BTreeMap<String, Arc<dyn NamespacedOrchestrator>>>,
 }
 
 impl fmt::Debug for KubernetesOrchestrator {
@@ -184,7 +184,7 @@ impl KubernetesOrchestrator {
             config,
             secret_api: Api::default_namespaced(client.clone()),
             vpc_endpoint_api: Api::default_namespaced(client),
-            namespaces: Mutex::new(HashMap::new()),
+            namespaces: Mutex::new(BTreeMap::new()),
         })
     }
 }
@@ -201,7 +201,7 @@ impl Orchestrator for KubernetesOrchestrator {
                 kubernetes_namespace: self.kubernetes_namespace.clone(),
                 namespace: namespace.into(),
                 config: self.config.clone(),
-                service_scales: std::sync::Mutex::new(HashMap::new()),
+                service_scales: std::sync::Mutex::new(BTreeMap::new()),
             })
         }))
     }
@@ -215,7 +215,7 @@ struct NamespacedKubernetesOrchestrator {
     kubernetes_namespace: String,
     namespace: String,
     config: KubernetesOrchestratorConfig,
-    service_scales: std::sync::Mutex<HashMap<String, NonZeroUsize>>,
+    service_scales: std::sync::Mutex<BTreeMap<String, NonZeroUsize>>,
 }
 
 impl fmt::Debug for NamespacedKubernetesOrchestrator {
@@ -573,11 +573,11 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         let ports = ports_in
             .iter()
             .map(|p| (p.name.clone(), p.port_hint))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         let listen_addrs = ports_in
             .iter()
             .map(|p| (p.name.clone(), format!("0.0.0.0:{}", p.port_hint)))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         let mut args = args(&listen_addrs);
         args.push("--secrets-reader=kubernetes".into());
         args.push(format!(
@@ -900,7 +900,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
 #[derive(Debug, Clone)]
 struct KubernetesService {
     hosts: Vec<String>,
-    ports: HashMap<String, u16>,
+    ports: BTreeMap<String, u16>,
 }
 
 impl Service for KubernetesService {

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -74,7 +74,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::env;
 use std::fmt::Debug;
 use std::fs::Permissions;
@@ -183,7 +183,7 @@ pub struct ProcessOrchestratorTcpProxyConfig {
 pub struct ProcessOrchestrator {
     image_dir: PathBuf,
     suppress_output: bool,
-    namespaces: Mutex<HashMap<String, Arc<dyn NamespacedOrchestrator>>>,
+    namespaces: Mutex<BTreeMap<String, Arc<dyn NamespacedOrchestrator>>>,
     metadata_dir: PathBuf,
     secrets_dir: PathBuf,
     command_wrapper: Vec<String>,
@@ -226,7 +226,7 @@ impl ProcessOrchestrator {
         Ok(ProcessOrchestrator {
             image_dir: fs::canonicalize(image_dir).await?,
             suppress_output,
-            namespaces: Mutex::new(HashMap::new()),
+            namespaces: Mutex::new(BTreeMap::new()),
             metadata_dir: fs::canonicalize(metadata_dir).await?,
             secrets_dir: fs::canonicalize(secrets_dir).await?,
             command_wrapper,
@@ -623,7 +623,7 @@ struct ServiceProcessConfig<'a> {
     run_dir: PathBuf,
     i: usize,
     image: String,
-    args: &'a (dyn Fn(&HashMap<String, String>) -> Vec<String> + Send + Sync),
+    args: &'a (dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync),
     ports: Vec<ServiceProcessPort>,
 }
 
@@ -678,7 +678,7 @@ async fn supervise_existing_process(state_updater: &ProcessStateUpdater, pid_fil
 fn interpolate_command(
     command_part: &str,
     full_id: &str,
-    ports: &HashMap<String, String>,
+    ports: &BTreeMap<String, String>,
 ) -> String {
     let mut command_part = command_part.replace("%N", full_id);
     for (endpoint, port) in ports {

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -76,7 +76,7 @@
 
 //! Service orchestration for tracing-aware services.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fmt;
 use std::str::FromStr;
@@ -399,7 +399,7 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
         id: &str,
         mut service_config: ServiceConfig<'_>,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
-        let args_fn = |listen_addrs: &HashMap<String, String>| {
+        let args_fn = |listen_addrs: &BTreeMap<String, String>| {
             #[cfg(feature = "tokio-console")]
             let tokio_console_listen_addr = listen_addrs.get("tokio-console");
             let mut args = (service_config.args)(listen_addrs);

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -74,7 +74,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
@@ -240,7 +240,7 @@ pub struct ServiceConfig<'a> {
     /// A function that generates the arguments for each process of the service
     /// given the assigned listen addresses for each named port.
     #[derivative(Debug = "ignore")]
-    pub args: &'a (dyn Fn(&HashMap<String, String>) -> Vec<String> + Send + Sync),
+    pub args: &'a (dyn Fn(&BTreeMap<String, String>) -> Vec<String> + Send + Sync),
     /// Ports to expose.
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.
@@ -253,7 +253,7 @@ pub struct ServiceConfig<'a> {
     /// backend.
     ///
     /// The orchestrator backend may apply a prefix to the key if appropriate.
-    pub labels: HashMap<String, String>,
+    pub labels: BTreeMap<String, String>,
     /// The availability zone the service should be run in. If no availability
     /// zone is specified, the orchestrator is free to choose one.
     pub availability_zone: Option<String>,

--- a/src/storage-client/src/controller/hosts.rs
+++ b/src/storage-client/src/controller/hosts.rs
@@ -20,7 +20,7 @@
 //! host. This policy is subject to change in the future.
 
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -286,7 +286,7 @@ where
                     cpu_limit: allocation.cpu_limit,
                     memory_limit: allocation.memory_limit,
                     scale: NonZeroUsize::new(1).unwrap(),
-                    labels: HashMap::from_iter([(
+                    labels: BTreeMap::from_iter([(
                         "size".to_string(),
                         allocation.workers.to_string(),
                     )]),

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -16,7 +16,7 @@
 //! determining the orders of collections, lifting predicates if useful arrangements exist,
 //! and identifying opportunities to use indexes to replace filters.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use mz_expr::visit::{Visit, VisitChildren};
 use mz_expr::JoinImplementation::IndexedFilter;
@@ -264,7 +264,7 @@ impl JoinImplementation {
                         .into_iter()
                         .enumerate()
                         .map(|(i, c)| (c, i))
-                        .collect::<HashMap<_, _>>();
+                        .collect::<BTreeMap<_, _>>();
                     // Eliminate arrangements referring to columns that have been
                     // projected away by surrounding MFPs.
                     available_arrangements[index].retain(|key| {

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -30,7 +30,7 @@
 //! and thus currently exists outside of both the physical and logical
 //! optimizers.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use mz_expr::visit::Visit;
 use mz_expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
@@ -404,7 +404,7 @@ where
     let reverse_col_map = permutation
         .enumerate()
         .map(|(idx, c)| (*c, idx))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
     for expr in exprs {
         expr.permute_map(&reverse_col_map);
     }

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -47,7 +47,7 @@
 //! work around condition 1 by pushing down an inner reduce through the join
 //! while retaining the original outer reduce.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::FromIterator;
 
 use crate::TransformArgs;
@@ -394,7 +394,7 @@ struct ReduceBuilder {
     group_key: Vec<MirScalarExpr>,
     aggregates: Vec<AggregateExpr>,
     /// Maps (global column relative to old join) -> (local column relative to `input`)
-    localize_map: HashMap<usize, usize>,
+    localize_map: BTreeMap<usize, usize>,
 }
 
 impl ReduceBuilder {
@@ -409,7 +409,7 @@ impl ReduceBuilder {
             .flat_map(|i| old_join_mapper.global_columns(*i))
             .enumerate()
             .map(|(local, global)| (global, local))
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
         // Convert the subjoin from the `Component` representation to a
         // `MirRelationExpr` representation.
         let mut inputs = component

--- a/src/transform/src/semijoin_idempotence.rs
+++ b/src/transform/src/semijoin_idempotence.rs
@@ -25,7 +25,7 @@
 //! Should we find such, allowing arbitrary filters of `Get{id}` on the equated columns,
 //! which we will transfer to the columns of `D` thereby forming `C`.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::TransformArgs;
 
@@ -187,7 +187,7 @@ fn attempt_join_simplification(
 ///
 /// Returns a projection to apply to `candidate.replacement` if everything checks out.
 fn validate_replacement(
-    map: &HashMap<usize, usize>,
+    map: &BTreeMap<usize, usize>,
     candidate: &mut Replacement,
 ) -> Option<Vec<usize>> {
     if candidate.columns.len() == map.len()
@@ -389,7 +389,7 @@ fn list_replacements_join(
 }
 
 /// True iff some unique key of `input` is contained in the keys of `map`.
-fn distinct_on_keys_of(expr: &MirRelationExpr, map: &HashMap<usize, usize>) -> bool {
+fn distinct_on_keys_of(expr: &MirRelationExpr, map: &BTreeMap<usize, usize>) -> bool {
     expr.typ()
         .keys
         .iter()
@@ -431,7 +431,7 @@ fn as_filtered_get(
 fn semijoin_bijection(
     inputs: &[MirRelationExpr],
     equivalences: &Vec<Vec<MirScalarExpr>>,
-) -> Option<(HashMap<usize, usize>, HashMap<usize, usize>)> {
+) -> Option<(BTreeMap<usize, usize>, BTreeMap<usize, usize>)> {
     // Useful join manipulation helper.
     let input_mapper = JoinInputMapper::new(inputs);
 
@@ -471,9 +471,8 @@ fn semijoin_bijection(
     }
 
     if inputs.len() == 2 && equiv_pairs.len() == equivalences.len() {
-        let ltr: std::collections::HashMap<_, _> = equiv_pairs.iter().cloned().collect();
-        let rtl: std::collections::HashMap<_, _> =
-            equiv_pairs.iter().map(|(c0, c1)| (*c1, *c0)).collect();
+        let ltr = equiv_pairs.iter().cloned().collect();
+        let rtl = equiv_pairs.iter().map(|(c0, c1)| (*c1, *c0)).collect();
 
         Some((ltr, rtl))
     } else {


### PR DESCRIPTION
This PR replaces some existing uses of `HashMap`s with `BTreeMap`s, in an effort to remove sources of non-determinism from our code.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
