### PR TITLE
Dynamic persist configuration (part 1)

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -20,6 +20,7 @@ use anyhow::bail;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use mz_compute_client::protocol::command::ComputeParameter;
+use mz_storage_client::client::StorageParameter;
 use mz_storage_client::controller::IntrospectionType;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -5757,6 +5758,18 @@ impl<S: Append> Catalog<S> {
         let config = self.system_config();
         [
             MaxResultSize(config.max_result_size()),
+            PersistBlobTargetSize(config.persist_blob_target_size()),
+            PersistCompactionMinimumTimeout(config.persist_compaction_minimum_timeout()),
+        ]
+        .into()
+    }
+
+    /// Return the current storage configuration, derived from the system configuration.
+    pub fn storage_config(&self) -> BTreeSet<StorageParameter> {
+        use StorageParameter::*;
+
+        let config = self.system_config();
+        [
             PersistBlobTargetSize(config.persist_blob_target_size()),
             PersistCompactionMinimumTimeout(config.persist_compaction_minimum_timeout()),
         ]

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -19,9 +19,9 @@ use std::time::{Duration, Instant};
 use anyhow::bail;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
-use mz_compute_client::protocol::command::ComputeParameter;
-use mz_storage_client::client::StorageParameter;
+use mz_compute_client::protocol::command::ComputeParameters;
 use mz_storage_client::controller::IntrospectionType;
+use mz_storage_client::types::parameters::{PersistParameters, StorageParameters};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -5752,28 +5752,27 @@ impl<S: Append> Catalog<S> {
     }
 
     /// Return the current compute configuration, derived from the system configuration.
-    pub fn compute_config(&self) -> BTreeSet<ComputeParameter> {
-        use ComputeParameter::*;
-
+    pub fn compute_config(&self) -> ComputeParameters {
         let config = self.system_config();
-        [
-            MaxResultSize(config.max_result_size()),
-            PersistBlobTargetSize(config.persist_blob_target_size()),
-            PersistCompactionMinimumTimeout(config.persist_compaction_minimum_timeout()),
-        ]
-        .into()
+        ComputeParameters {
+            max_result_size: Some(config.max_result_size()),
+            persist: self.persist_config(),
+        }
     }
 
     /// Return the current storage configuration, derived from the system configuration.
-    pub fn storage_config(&self) -> BTreeSet<StorageParameter> {
-        use StorageParameter::*;
+    pub fn storage_config(&self) -> StorageParameters {
+        StorageParameters {
+            persist: self.persist_config(),
+        }
+    }
 
+    fn persist_config(&self) -> PersistParameters {
         let config = self.system_config();
-        [
-            PersistBlobTargetSize(config.persist_blob_target_size()),
-            PersistCompactionMinimumTimeout(config.persist_compaction_minimum_timeout()),
-        ]
-        .into()
+        PersistParameters {
+            blob_target_size: Some(config.persist_blob_target_size()),
+            compaction_minimum_timeout: Some(config.persist_compaction_minimum_timeout()),
+        }
     }
 }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5757,7 +5757,8 @@ impl<S: Append> Catalog<S> {
         let config = self.system_config();
         [
             MaxResultSize(config.max_result_size()),
-            // TODO: add persist configuration parameters
+            PersistBlobTargetSize(config.persist_blob_target_size()),
+            PersistCompactionMinimumTimeout(config.persist_compaction_minimum_timeout()),
         ]
         .into()
     }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, Instant};
 use anyhow::bail;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
+use mz_compute_client::protocol::command::ComputeParameter;
 use mz_storage_client::controller::IntrospectionType;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -5747,6 +5748,18 @@ impl<S: Append> Catalog<S> {
         } else {
             Ok(())
         }
+    }
+
+    /// Return the current compute configuration, derived from the system configuration.
+    pub fn compute_config(&self) -> BTreeSet<ComputeParameter> {
+        use ComputeParameter::*;
+
+        let config = self.system_config();
+        [
+            MaxResultSize(config.max_result_size()),
+            // TODO: add persist configuration parameters
+        ]
+        .into()
     }
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -486,6 +486,9 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Result<(), AdapterError> {
         info!("coordinator init: beginning bootstrap");
 
+        let compute_config = self.catalog.compute_config();
+        self.controller.compute.update_configuration(compute_config);
+
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
         //
         // TODO[btv] -- This is of type `Timestamp` because that's what `initialize_read_policies`
@@ -509,11 +512,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 continue;
             }
 
-            self.controller.compute.create_instance(
-                instance.id,
-                instance.log_indexes.clone(),
-                self.catalog.system_config().max_result_size(),
-            )?;
+            self.controller
+                .compute
+                .create_instance(instance.id, instance.log_indexes.clone())?;
             for (replica_id, replica) in instance.replicas_by_id.clone() {
                 let introspection_collections = replica
                     .config

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -486,8 +486,11 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Result<(), AdapterError> {
         info!("coordinator init: beginning bootstrap");
 
+        // Inform the controllers about their initial configuration.
         let compute_config = self.catalog.compute_config();
         self.controller.compute.update_configuration(compute_config);
+        let storage_config = self.catalog.storage_config();
+        self.controller.storage.update_configuration(storage_config);
 
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
         //

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -922,11 +922,9 @@ impl<S: Append + 'static> Coordinator<S> {
             .into_iter()
             .map(|(log, id)| (log.variant.clone(), id))
             .collect();
-        self.controller.compute.create_instance(
-            instance_id,
-            arranged_logs,
-            self.catalog.system_config().max_result_size(),
-        )?;
+        self.controller
+            .compute
+            .create_instance(instance_id, arranged_logs)?;
         for (replica_id, replica) in instance.replicas_by_id.clone() {
             self.controller
                 .active_compute()
@@ -3532,7 +3530,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session)?;
         use mz_sql::ast::{SetVariableValue, Value};
-        let update_max_result_size = name == session::vars::MAX_RESULT_SIZE.name();
+        let update_compute_config = session::vars::is_compute_config_var(&name);
         let update_metrics_retention = name == session::vars::METRICS_RETENTION.name();
         let op = match value {
             SetVariableValue::Default => catalog::Op::ResetSystemConfiguration { name },
@@ -3549,8 +3547,8 @@ impl<S: Append + 'static> Coordinator<S> {
             },
         };
         self.catalog_transact(Some(session), vec![op]).await?;
-        if update_max_result_size {
-            self.update_max_result_size();
+        if update_compute_config {
+            self.update_compute_config();
         }
         if update_metrics_retention {
             self.update_metrics_retention();
@@ -3564,12 +3562,12 @@ impl<S: Append + 'static> Coordinator<S> {
         AlterSystemResetPlan { name }: AlterSystemResetPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session)?;
-        let update_max_result_size = name == session::vars::MAX_RESULT_SIZE.name();
+        let update_compute_config = session::vars::is_compute_config_var(&name);
         let update_metrics_retention = name == session::vars::METRICS_RETENTION.name();
         let op = catalog::Op::ResetSystemConfiguration { name };
         self.catalog_transact(Some(session), vec![op]).await?;
-        if update_max_result_size {
-            self.update_max_result_size();
+        if update_compute_config {
+            self.update_compute_config();
         }
         if update_metrics_retention {
             self.update_metrics_retention();
@@ -3585,7 +3583,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.is_user_allowed_to_alter_system(session)?;
         let op = catalog::Op::ResetAllSystemConfiguration {};
         self.catalog_transact(Some(session), vec![op]).await?;
-        self.update_max_result_size();
+        self.update_compute_config();
         self.update_metrics_retention();
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
@@ -3601,25 +3599,9 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
-    fn update_max_result_size(&mut self) {
-        let mut compute = self.controller.active_compute();
-        for compute_instance in self.catalog.compute_instances() {
-            // Linked clusters are presently a fiction maintained by the
-            // catalog. They do not yet result in the creation of actual
-            // compute instances.
-            //
-            // TODO(benesch): turn linked clusters into real clusters. See
-            // MaterializeInc/cloud#4929.
-            if compute_instance.linked_object_id.is_some() {
-                continue;
-            }
-            compute
-                .update_max_result_size(
-                    compute_instance.id,
-                    self.catalog.system_config().max_result_size(),
-                )
-                .unwrap();
-        }
+    fn update_compute_config(&mut self) {
+        let config_params = self.catalog.compute_config();
+        self.controller.compute.update_configuration(config_params);
     }
 
     fn update_metrics_retention(&mut self) {

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -2197,12 +2197,15 @@ impl From<TransactionIsolationLevel> for IsolationLevel {
 
 /// Returns whether the named variable is a compute configuration parameter.
 pub(crate) fn is_compute_config_var(name: &str) -> bool {
-    name == MAX_RESULT_SIZE.name()
-        || name == PERSIST_BLOB_TARGET_SIZE.name()
-        || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+    name == MAX_RESULT_SIZE.name() || is_persist_config_var(name)
 }
 
 /// Returns whether the named variable is a storage configuration parameter.
 pub(crate) fn is_storage_config_var(name: &str) -> bool {
+    is_persist_config_var(name)
+}
+
+/// Returns whether the named variable is a persist configuration parameter.
+fn is_persist_config_var(name: &str) -> bool {
     name == PERSIST_BLOB_TARGET_SIZE.name() || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -18,6 +18,7 @@ use uncased::UncasedStr;
 
 use mz_build_info::BuildInfo;
 use mz_ore::cast;
+use mz_persist_client::PersistConfig;
 use mz_sql::ast::{Ident, SetVariableValue, Value as AstValue};
 use mz_sql::DEFAULT_SCHEMA;
 use mz_sql_parser::ast::TransactionIsolationLevel;
@@ -335,6 +336,23 @@ static WINDOW_FUNCTIONS: ServerVar<bool> = ServerVar {
     value: &true,
     description: "Feature flag indicating whether window functions are enabled (Materialize).",
     internal: false,
+};
+
+/// Controls [`PersistConfig::blob_target_size`].
+const PERSIST_BLOB_TARGET_SIZE: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("persist_blob_target_size"),
+    value: &PersistConfig::DEFAULT_BLOB_TARGET_SIZE,
+    description: "A target maximum size of persist blob payloads in bytes (Materialize).",
+    internal: true,
+};
+
+/// Controls [`PersistConfig::compaction_minimum_timeout`].
+const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_compaction_minimum_timeout"),
+    value: &PersistConfig::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
+    description: "The minimum amount of time to allow a persist compaction request to run before \
+                  timing it out (Materialize).",
+    internal: true,
 };
 
 /// Boolean flag indicating that the remote configuration was synchronized at
@@ -980,6 +998,10 @@ impl SessionVars {
 /// See [`SessionVars`] for more details on the Materialize configuration model.
 #[derive(Debug, Clone)]
 pub struct SystemVars {
+    // internal bookkeeping
+    config_has_synced_once: SystemVar<bool>,
+
+    // limits
     max_aws_privatelink_connections: SystemVar<u32>,
     max_tables: SystemVar<u32>,
     max_sources: SystemVar<u32>,
@@ -994,14 +1016,22 @@ pub struct SystemVars {
     max_roles: SystemVar<u32>,
     max_result_size: SystemVar<u32>,
     allowed_cluster_replica_sizes: SystemVar<Vec<String>>, // TODO: BTreeSet<String> will be better
+
+    // features
     window_functions: SystemVar<bool>,
-    config_has_synced_once: SystemVar<bool>,
+
+    // persist configuration
+    persist_blob_target_size: SystemVar<usize>,
+    persist_compaction_minimum_timeout: SystemVar<Duration>,
+
+    // misc
     metrics_retention: SystemVar<Duration>,
 }
 
 impl Default for SystemVars {
     fn default() -> Self {
         SystemVars {
+            config_has_synced_once: SystemVar::new(&CONFIG_HAS_SYNCED_ONCE),
             max_aws_privatelink_connections: SystemVar::new(&MAX_AWS_PRIVATELINK_CONNECTIONS),
             max_tables: SystemVar::new(&MAX_TABLES),
             max_sources: SystemVar::new(&MAX_SOURCES),
@@ -1017,7 +1047,8 @@ impl Default for SystemVars {
             max_result_size: SystemVar::new(&MAX_RESULT_SIZE),
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             window_functions: SystemVar::new(&WINDOW_FUNCTIONS),
-            config_has_synced_once: SystemVar::new(&CONFIG_HAS_SYNCED_ONCE),
+            persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
+            persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
         }
     }
@@ -1027,7 +1058,8 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        let vars: [&dyn Var; 17] = [
+        let vars: [&dyn Var; 19] = [
+            &self.config_has_synced_once,
             &self.max_aws_privatelink_connections,
             &self.max_tables,
             &self.max_sources,
@@ -1043,7 +1075,8 @@ impl SystemVars {
             &self.max_result_size,
             &self.allowed_cluster_replica_sizes,
             &self.window_functions,
-            &self.config_has_synced_once,
+            &self.persist_blob_target_size,
+            &self.persist_compaction_minimum_timeout,
             &self.metrics_retention,
         ];
         vars.into_iter()
@@ -1072,7 +1105,9 @@ impl SystemVars {
     /// The call will return an error:
     /// 1. If `name` does not refer to a valid [`SystemVars`] field.
     pub fn get(&self, name: &str) -> Result<&dyn Var, AdapterError> {
-        if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
+        if name == CONFIG_HAS_SYNCED_ONCE.name {
+            Ok(&self.config_has_synced_once)
+        } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
             Ok(&self.max_aws_privatelink_connections)
         } else if name == MAX_TABLES.name {
             Ok(&self.max_tables)
@@ -1102,8 +1137,10 @@ impl SystemVars {
             Ok(&self.allowed_cluster_replica_sizes)
         } else if name == WINDOW_FUNCTIONS.name {
             Ok(&self.window_functions)
-        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
-            Ok(&self.config_has_synced_once)
+        } else if name == PERSIST_BLOB_TARGET_SIZE.name {
+            Ok(&self.persist_blob_target_size)
+        } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
+            Ok(&self.persist_compaction_minimum_timeout)
         } else if name == METRICS_RETENTION.name {
             Ok(&self.metrics_retention)
         } else {
@@ -1121,7 +1158,9 @@ impl SystemVars {
     /// 2. If `value` does not represent a valid [`SystemVars`] value for
     ///    `name`.
     pub fn is_default(&self, name: &str, value: &str) -> Result<bool, AdapterError> {
-        if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
+        if name == CONFIG_HAS_SYNCED_ONCE.name {
+            self.config_has_synced_once.is_default(value)
+        } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
             self.max_aws_privatelink_connections.is_default(value)
         } else if name == MAX_TABLES.name {
             self.max_tables.is_default(value)
@@ -1151,8 +1190,10 @@ impl SystemVars {
             self.allowed_cluster_replica_sizes.is_default(value)
         } else if name == WINDOW_FUNCTIONS.name {
             self.window_functions.is_default(value)
-        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
-            self.config_has_synced_once.is_default(value)
+        } else if name == PERSIST_BLOB_TARGET_SIZE.name {
+            self.persist_blob_target_size.is_default(value)
+        } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
+            self.persist_compaction_minimum_timeout.is_default(value)
         } else if name == METRICS_RETENTION.name {
             self.metrics_retention.is_default(value)
         } else {
@@ -1179,7 +1220,9 @@ impl SystemVars {
     /// 2. If `value` does not represent a valid [`SystemVars`] value for
     ///    `name`.
     pub fn set(&mut self, name: &str, value: &str) -> Result<bool, AdapterError> {
-        if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
+        if name == CONFIG_HAS_SYNCED_ONCE.name {
+            self.config_has_synced_once.set(value)
+        } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
             self.max_aws_privatelink_connections.set(value)
         } else if name == MAX_TABLES.name {
             self.max_tables.set(value)
@@ -1209,8 +1252,10 @@ impl SystemVars {
             self.allowed_cluster_replica_sizes.set(value)
         } else if name == WINDOW_FUNCTIONS.name {
             self.window_functions.set(value)
-        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
-            self.config_has_synced_once.set(value)
+        } else if name == PERSIST_BLOB_TARGET_SIZE.name {
+            self.persist_blob_target_size.set(value)
+        } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
+            self.persist_compaction_minimum_timeout.set(value)
         } else if name == METRICS_RETENTION.name {
             self.metrics_retention.set(value)
         } else {
@@ -1232,7 +1277,9 @@ impl SystemVars {
     /// The call will return an error:
     /// 1. If `name` does not refer to a valid [`SystemVars`] field.
     pub fn reset(&mut self, name: &str) -> Result<bool, AdapterError> {
-        if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
+        if name == CONFIG_HAS_SYNCED_ONCE.name {
+            Ok(self.config_has_synced_once.reset())
+        } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
             Ok(self.max_aws_privatelink_connections.reset())
         } else if name == MAX_TABLES.name {
             Ok(self.max_tables.reset())
@@ -1262,13 +1309,20 @@ impl SystemVars {
             Ok(self.allowed_cluster_replica_sizes.reset())
         } else if name == WINDOW_FUNCTIONS.name {
             Ok(self.window_functions.reset())
-        } else if name == CONFIG_HAS_SYNCED_ONCE.name {
-            Ok(self.config_has_synced_once.reset())
+        } else if name == PERSIST_BLOB_TARGET_SIZE.name {
+            Ok(self.persist_blob_target_size.reset())
+        } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
+            Ok(self.persist_compaction_minimum_timeout.reset())
         } else if name == METRICS_RETENTION.name {
             Ok(self.metrics_retention.reset())
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
+    }
+
+    /// Returns the `config_has_synced_once` configuration parameter.
+    pub fn config_has_synced_once(&self) -> bool {
+        *self.config_has_synced_once.value()
     }
 
     /// Returns the value of the `max_aws_privatelink_connections` configuration parameter.
@@ -1346,9 +1400,14 @@ impl SystemVars {
         *self.window_functions.value()
     }
 
-    /// Returns the `config_has_synced_once` configuration parameter.
-    pub fn config_has_synced_once(&self) -> bool {
-        *self.config_has_synced_once.value()
+    /// Returns the `persist_blob_target_size` configuration parameter.
+    pub fn persist_blob_target_size(&self) -> usize {
+        *self.persist_blob_target_size.value()
+    }
+
+    /// Returns the `persist_compaction_minimum_timeout` configuration parameter.
+    pub fn persist_compaction_minimum_timeout(&self) -> Duration {
+        *self.persist_compaction_minimum_timeout.value()
     }
 
     pub fn metrics_retention(&self) -> Duration {
@@ -1686,6 +1745,18 @@ impl Value for u32 {
     }
 }
 
+impl Value for usize {
+    const TYPE_NAME: &'static str = "unsigned integer";
+
+    fn parse(s: &str) -> Result<usize, ()> {
+        s.parse().map_err(|_| ())
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
 const SEC_TO_MIN: u64 = 60u64;
 const SEC_TO_HOUR: u64 = 60u64 * 60;
 const SEC_TO_DAY: u64 = 60u64 * 60 * 24;
@@ -1887,16 +1958,16 @@ impl Value for Vec<String> {
 impl Value for Option<String> {
     const TYPE_NAME: &'static str = "optional string";
 
-    fn parse(s: &str) -> Result<Self::Owned, ()> {
+    fn parse(s: &str) -> Result<Option<String>, ()> {
         match s {
             "" => Ok(None),
-            _ => Ok(Some(s.into())),
+            _ => <str as Value>::parse(s).map(Some),
         }
     }
 
     fn format(&self) -> String {
         match self {
-            Some(s) => s.clone(),
+            Some(s) => s.format(),
             None => "".into(),
         }
     }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -2194,3 +2194,9 @@ impl From<TransactionIsolationLevel> for IsolationLevel {
         }
     }
 }
+
+/// Returns whether the named variable is a compute configuration parameter.
+pub(crate) fn is_compute_config_var(name: &str) -> bool {
+    name == MAX_RESULT_SIZE.name()
+    // TODO: add persist configuration parameters
+}

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -2198,5 +2198,6 @@ impl From<TransactionIsolationLevel> for IsolationLevel {
 /// Returns whether the named variable is a compute configuration parameter.
 pub(crate) fn is_compute_config_var(name: &str) -> bool {
     name == MAX_RESULT_SIZE.name()
-    // TODO: add persist configuration parameters
+        || name == PERSIST_BLOB_TARGET_SIZE.name()
+        || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
 }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -2201,3 +2201,8 @@ pub(crate) fn is_compute_config_var(name: &str) -> bool {
         || name == PERSIST_BLOB_TARGET_SIZE.name()
         || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
 }
+
+/// Returns whether the named variable is a storage configuration parameter.
+pub(crate) fn is_storage_config_var(name: &str) -> bool {
+    name == PERSIST_BLOB_TARGET_SIZE.name() || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
+}

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -56,6 +56,7 @@ use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::{ReadPolicy, StorageController};
 
 use crate::logging::{LogVariant, LogView, LoggingConfig};
+use crate::protocol::command::ComputeParameter;
 use crate::protocol::response::{ComputeResponse, PeekResponse, SubscribeResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 use crate::types::dataflows::DataflowDescription;
@@ -280,6 +281,8 @@ pub struct ComputeController<T> {
     orchestrator: ComputeOrchestrator,
     /// Set to `true` once `initialization_complete` has been called.
     initialized: bool,
+    /// Compute configuration to apply to new instances.
+    config: BTreeMap<&'static str, ComputeParameter>,
     /// A response to handle on the next call to `ActiveComputeController::process`.
     stashed_response: Option<(ComputeInstanceId, ReplicaId, ComputeResponse<T>)>,
     /// Times we have last received responses from replicas.
@@ -314,6 +317,7 @@ impl<T> ComputeController<T> {
                 init_container_image,
             ),
             initialized: false,
+            config: BTreeMap::new(),
             stashed_response: None,
             replica_heartbeats: BTreeMap::new(),
             replica_metrics: BTreeMap::new(),
@@ -413,7 +417,6 @@ where
         &mut self,
         id: ComputeInstanceId,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
-        max_result_size: u32,
     ) -> Result<(), InstanceExists> {
         if self.instances.contains_key(&id) {
             return Err(InstanceExists(id));
@@ -425,18 +428,18 @@ where
                 id,
                 self.build_info,
                 arranged_logs,
-                max_result_size,
                 self.orchestrator.clone(),
                 self.envd_epoch,
             ),
         );
 
+        let instance = self.instances.get_mut(&id).expect("instance just added");
         if self.initialized {
-            self.instances
-                .get_mut(&id)
-                .expect("instance just added")
-                .initialization_complete();
+            instance.initialization_complete();
         }
+
+        let config_params = self.config.values().cloned().collect();
+        instance.update_configuration(config_params);
 
         Ok(())
     }
@@ -449,6 +452,17 @@ where
     pub fn drop_instance(&mut self, id: ComputeInstanceId) {
         if let Some(compute_state) = self.instances.remove(&id) {
             compute_state.drop();
+        }
+    }
+
+    /// Update compute configuration.
+    pub fn update_configuration(&mut self, config_params: BTreeSet<ComputeParameter>) {
+        for instance in self.instances.values_mut() {
+            instance.update_configuration(config_params.clone());
+        }
+
+        for param in config_params {
+            self.config.insert(param.key(), param);
         }
     }
 
@@ -709,17 +723,6 @@ where
         policies: Vec<(GlobalId, ReadPolicy<T>)>,
     ) -> Result<(), CollectionUpdateError> {
         self.instance(instance_id)?.set_read_policy(policies)?;
-        Ok(())
-    }
-
-    /// Update the max size in bytes of any result.
-    pub fn update_max_result_size(
-        &mut self,
-        instance_id: ComputeInstanceId,
-        max_result_size: u32,
-    ) -> Result<(), InstanceMissing> {
-        self.instance(instance_id)?
-            .update_max_result_size(max_result_size);
         Ok(())
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -27,7 +27,7 @@ use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::{ReadPolicy, StorageController};
 
 use crate::logging::LogVariant;
-use crate::protocol::command::{ComputeCommand, ComputeParameter, ComputeStartupEpoch, Peek};
+use crate::protocol::command::{ComputeCommand, ComputeParameters, ComputeStartupEpoch, Peek};
 use crate::protocol::history::ComputeCommandHistory;
 use crate::protocol::response::{ComputeResponse, PeekResponse, SubscribeBatch, SubscribeResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
@@ -203,7 +203,7 @@ where
     }
 
     /// Update instance configuration.
-    pub fn update_configuration(&mut self, config_params: BTreeSet<ComputeParameter>) {
+    pub fn update_configuration(&mut self, config_params: ComputeParameters) {
         self.send(ComputeCommand::UpdateConfiguration(config_params));
     }
 

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -164,7 +164,6 @@ where
         instance_id: ComputeInstanceId,
         build_info: &'static BuildInfo,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
-        max_result_size: u32,
         orchestrator: ComputeOrchestrator,
         envd_epoch: NonZeroI64,
     ) -> Self {
@@ -200,10 +199,12 @@ where
         let dummy_logging_config = Default::default();
         instance.send(ComputeCommand::CreateInstance(dummy_logging_config));
 
-        let params = [ComputeParameter::MaxResultSize(max_result_size)].into();
-        instance.send(ComputeCommand::UpdateConfiguration(params));
-
         instance
+    }
+
+    /// Update instance configuration.
+    pub fn update_configuration(&mut self, config_params: BTreeSet<ComputeParameter>) {
+        self.send(ComputeCommand::UpdateConfiguration(config_params));
     }
 
     /// Marks the end of any initialization commands.
@@ -748,13 +749,6 @@ where
             self.update_read_capabilities(&mut read_capability_changes);
         }
         Ok(())
-    }
-
-    /// Update the max size in bytes of any result.
-    pub fn update_max_result_size(&mut self, max_result_size: u32) {
-        let params = [ComputeParameter::MaxResultSize(max_result_size)].into();
-        self.compute
-            .send(ComputeCommand::UpdateConfiguration(params));
     }
 
     /// Validate that a collection exists for all identifiers, and error if any do not.

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -77,5 +77,7 @@ message ProtoPeek {
 message ProtoComputeParameter {
     oneof kind {
         uint32 max_result_size = 1;
+        uint64 persist_blob_target_size = 2;
+        mz_proto.ProtoDuration persist_compaction_minimum_timeout = 3;
     }
 }

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -17,6 +17,7 @@ import "proto/src/proto.proto";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
 import "storage-client/src/client.proto";
+import "storage-client/src/types/parameters.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -41,10 +42,6 @@ message ProtoComputeCommand {
         ProtoComputeStartupEpoch epoch = 2;
     }
 
-    message ProtoUpdateConfiguration {
-        repeated ProtoComputeParameter params = 1;
-    }
-
     oneof kind {
         ProtoCreateTimely create_timely = 1;
         logging.ProtoLoggingConfig create_instance = 2;
@@ -53,7 +50,7 @@ message ProtoComputeCommand {
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
         google.protobuf.Empty initialization_complete = 7;
-        ProtoUpdateConfiguration update_configuration = 8;
+        ProtoComputeParameters update_configuration = 8;
     }
 }
 
@@ -74,10 +71,7 @@ message ProtoPeek {
     map<string, string> otel_ctx = 7;
 }
 
-message ProtoComputeParameter {
-    oneof kind {
-        uint32 max_result_size = 1;
-        uint64 persist_blob_target_size = 2;
-        mz_proto.ProtoDuration persist_compaction_minimum_timeout = 3;
-    }
+message ProtoComputeParameters {
+    optional uint32 max_result_size = 1;
+    mz_storage_client.types.parameters.ProtoPersistParameters persist = 2;
 }

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use timely::progress::Antichain;
 
-use super::command::{ComputeCommand, Peek};
+use super::command::{ComputeCommand, ComputeParameters, Peek};
 
 #[derive(Debug)]
 pub struct ComputeCommandHistory<T = mz_repr::Timestamp> {
@@ -81,7 +81,7 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         // Note that this is only correct as long as all config parameters apply globally. If we
         // ever introduce parameters that only affect subsequent commands, we will have to
         // reconsider this approach.
-        let mut final_configuration = BTreeMap::new();
+        let mut final_configuration = ComputeParameters::default();
 
         let mut initialization_complete = false;
 
@@ -100,9 +100,7 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
                     initialization_complete = true;
                 }
                 ComputeCommand::UpdateConfiguration(params) => {
-                    for param in params {
-                        final_configuration.insert(param.key(), param);
-                    }
+                    final_configuration.update(params);
                 }
                 ComputeCommand::CreateDataflows(dataflows) => {
                     live_dataflows.extend(dataflows);
@@ -169,7 +167,7 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         command_count += final_frontiers.len();
         command_count += live_peeks.len();
         command_count += live_cancels.len();
-        if !final_configuration.is_empty() {
+        if !final_configuration.all_unset() {
             command_count += 1;
         }
 
@@ -180,10 +178,9 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         if let Some(create_inst_command) = create_inst_command {
             self.commands.push(create_inst_command);
         }
-        if !final_configuration.is_empty() {
-            let params = final_configuration.into_values().collect();
+        if !final_configuration.all_unset() {
             self.commands
-                .push(ComputeCommand::UpdateConfiguration(params));
+                .push(ComputeCommand::UpdateConfiguration(final_configuration));
         }
         self.dataflow_count = live_dataflows.len();
         if !live_dataflows.is_empty() {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -162,6 +162,10 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 ComputeParameter::MaxResultSize(size) => {
                     self.compute_state.max_result_size = size;
                 }
+
+                // TODO(#16753): apply config to `self.compute_state.persist_clients`
+                ComputeParameter::PersistBlobTargetSize(_) => {}
+                ComputeParameter::PersistCompactionMinimumTimeout(_) => {}
             }
         }
     }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -359,7 +359,7 @@ impl PersistConfig {
         Self {
             build_version: build_info.semver_version(),
             now,
-            blob_target_size: 128 * MB,
+            blob_target_size: Self::DEFAULT_BLOB_TARGET_SIZE,
             batch_builder_max_outstanding_parts: 2,
             compaction_enabled: !compaction_disabled,
             compaction_memory_bound_bytes: 1024 * MB,
@@ -369,7 +369,7 @@ impl PersistConfig {
             compaction_concurrency_limit: 5,
             compaction_queue_size: 20,
             gc_batch_part_delete_concurrency_limit: 32,
-            compaction_minimum_timeout: Duration::from_secs(90),
+            compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
             consensus_connection_pool_max_size: 50,
             consensus_connection_pool_ttl: Duration::from_secs(300),
             consensus_connection_pool_ttl_stagger: Duration::from_secs(6),
@@ -400,6 +400,11 @@ impl PersistConfig {
 }
 
 impl PersistConfig {
+    /// Default value for [`PersistConfig::blob_target_size`].
+    pub const DEFAULT_BLOB_TARGET_SIZE: usize = 128 * MB;
+    /// Default value for [`PersistConfig::compaction_minimum_timeout`].
+    pub const DEFAULT_COMPACTION_MINIMUM_TIMEOUT: Duration = Duration::from_secs(90);
+
     // Move this to a PersistConfig field when we actually have read leases.
     //
     // MIGRATION: Remove this once we remove the ReaderState <->

--- a/src/storage-client/build.rs
+++ b/src/storage-client/build.rs
@@ -109,6 +109,7 @@ fn main() {
                 "storage-client/src/types/errors.proto",
                 "storage-client/src/types/connections/aws.proto",
                 "storage-client/src/types/hosts.proto",
+                "storage-client/src/types/parameters.proto",
                 "storage-client/src/types/sinks.proto",
                 "storage-client/src/types/sources.proto",
                 "storage-client/src/types/sources/encoding.proto",

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 import "proto/src/proto.proto";
 import "repr/src/antichain.proto";
 import "repr/src/global_id.proto";
+import "storage-client/src/types/parameters.proto";
 import "storage-client/src/types/sources.proto";
 import "storage-client/src/types/sinks.proto";
 
@@ -51,17 +52,6 @@ message ProtoCreateSinks {
     repeated ProtoCreateSinkCommand sinks = 1;
 }
 
-message ProtoStorageParameter {
-    oneof kind {
-        uint64 persist_blob_target_size = 1;
-        mz_proto.ProtoDuration persist_compaction_minimum_timeout = 2;
-    }
-}
-
-message ProtoUpdateConfiguration {
-    repeated ProtoStorageParameter params = 1;
-}
-
 message ProtoFrontierUppersKind {
     repeated ProtoTrace traces = 1;
 }
@@ -77,7 +67,7 @@ message ProtoStorageCommand {
         ProtoAllowCompaction allow_compaction = 2;
         google.protobuf.Empty initialization_complete = 3;
         ProtoCreateSinks create_sinks = 4;
-        ProtoUpdateConfiguration update_configuration = 5;
+        mz_storage_client.types.parameters.ProtoStorageParameters update_configuration = 5;
     }
 }
 

--- a/src/storage-client/src/client.proto
+++ b/src/storage-client/src/client.proto
@@ -51,6 +51,17 @@ message ProtoCreateSinks {
     repeated ProtoCreateSinkCommand sinks = 1;
 }
 
+message ProtoStorageParameter {
+    oneof kind {
+        uint64 persist_blob_target_size = 1;
+        mz_proto.ProtoDuration persist_compaction_minimum_timeout = 2;
+    }
+}
+
+message ProtoUpdateConfiguration {
+    repeated ProtoStorageParameter params = 1;
+}
+
 message ProtoFrontierUppersKind {
     repeated ProtoTrace traces = 1;
 }
@@ -66,6 +77,7 @@ message ProtoStorageCommand {
         ProtoAllowCompaction allow_compaction = 2;
         google.protobuf.Empty initialization_complete = 3;
         ProtoCreateSinks create_sinks = 4;
+        ProtoUpdateConfiguration update_configuration = 5;
     }
 }
 

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -14,10 +14,9 @@
 
 //! The public API of the storage layer.
 
-use std::collections::{BTreeSet, HashMap};
-use std::fmt::{self, Debug};
+use std::collections::HashMap;
+use std::fmt::Debug;
 use std::iter;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
@@ -39,6 +38,7 @@ use mz_timely_util::progress::any_antichain;
 use crate::client::proto_storage_client::ProtoStorageClient;
 use crate::client::proto_storage_server::ProtoStorage;
 use crate::controller::CollectionMetadata;
+use crate::types::parameters::StorageParameters;
 use crate::types::sinks::{MetadataFilled, StorageSinkDesc};
 use crate::types::sources::IngestionDescription;
 
@@ -105,7 +105,7 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// initial state.
     InitializationComplete,
     /// Update storage instance configuration.
-    UpdateConfiguration(BTreeSet<StorageParameter>),
+    UpdateConfiguration(StorageParameters),
     /// Create the enumerated sources, each associated with its identifier.
     CreateSources(Vec<CreateSourceCommand<T>>),
     /// Enable compaction in storage-managed collections.
@@ -114,66 +114,6 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// accumulations must be correct.
     AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
     CreateSinks(Vec<CreateSinkCommand<T>>),
-}
-
-/// Storage instance configuration parameters.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub enum StorageParameter {
-    /// Configures [`mz_persist_client::PersistConfig::blob_target_size`].
-    PersistBlobTargetSize(usize),
-    /// Configures [`mz_persist_client::PersistConfig::compaction_minimum_timeout`].
-    PersistCompactionMinimumTimeout(Duration),
-}
-
-impl StorageParameter {
-    pub fn key(&self) -> &'static str {
-        match self {
-            Self::PersistBlobTargetSize(_) => "persist_blob_target_size",
-            Self::PersistCompactionMinimumTimeout(_) => "persist_compaction_minimum_timeout",
-        }
-    }
-}
-
-impl fmt::Display for StorageParameter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::PersistBlobTargetSize(v) => write!(f, "persist_blob_target_size={v}"),
-            Self::PersistCompactionMinimumTimeout(v) => {
-                write!(f, "persist_compaction_minimum_timeout={v:?}")
-            }
-        }
-    }
-}
-
-impl RustType<ProtoStorageParameter> for StorageParameter {
-    fn into_proto(&self) -> ProtoStorageParameter {
-        use proto_storage_parameter::Kind::*;
-
-        ProtoStorageParameter {
-            kind: Some(match self {
-                StorageParameter::PersistBlobTargetSize(v) => PersistBlobTargetSize(v.into_proto()),
-                StorageParameter::PersistCompactionMinimumTimeout(v) => {
-                    PersistCompactionMinimumTimeout(v.into_proto())
-                }
-            }),
-        }
-    }
-
-    fn from_proto(proto: ProtoStorageParameter) -> Result<Self, TryFromProtoError> {
-        use proto_storage_parameter::Kind::*;
-
-        match proto.kind {
-            Some(PersistBlobTargetSize(v)) => {
-                Ok(StorageParameter::PersistBlobTargetSize(usize::cast_from(v)))
-            }
-            Some(PersistCompactionMinimumTimeout(v)) => Ok(
-                StorageParameter::PersistCompactionMinimumTimeout(v.into_rust()?),
-            ),
-            None => Err(TryFromProtoError::missing_field(
-                "ProtoComputeParameter::kind",
-            )),
-        }
-    }
 }
 
 /// A command that starts ingesting the given ingestion description
@@ -275,9 +215,7 @@ impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
             kind: Some(match self {
                 StorageCommand::InitializationComplete => InitializationComplete(()),
                 StorageCommand::UpdateConfiguration(params) => {
-                    UpdateConfiguration(ProtoUpdateConfiguration {
-                        params: params.into_proto(),
-                    })
+                    UpdateConfiguration(params.into_proto())
                 }
                 StorageCommand::CreateSources(sources) => CreateSources(ProtoCreateSources {
                     sources: sources.into_proto(),
@@ -298,7 +236,7 @@ impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
         use proto_storage_command::Kind::*;
         match proto.kind {
             Some(InitializationComplete(())) => Ok(StorageCommand::InitializationComplete),
-            Some(UpdateConfiguration(ProtoUpdateConfiguration { params })) => {
+            Some(UpdateConfiguration(params)) => {
                 Ok(StorageCommand::UpdateConfiguration(params.into_rust()?))
             }
             Some(CreateSources(ProtoCreateSources { sources })) => {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -55,12 +55,13 @@ use mz_stash::{self, PostgresFactory, StashError, TypedCollection};
 
 use crate::client::{
     CreateSinkCommand, CreateSourceCommand, ProtoStorageCommand, ProtoStorageResponse,
-    SourceStatisticsUpdate, StorageCommand, StorageParameter, StorageResponse, Update,
+    SourceStatisticsUpdate, StorageCommand, StorageResponse, Update,
 };
 use crate::controller::hosts::{StorageHosts, StorageHostsConfig};
 use crate::healthcheck;
 use crate::types::errors::DataflowError;
 use crate::types::hosts::StorageHostConfig;
+use crate::types::parameters::StorageParameters;
 use crate::types::sinks::{
     MetadataUnfilled, ProtoDurableExportMetadata, SinkAsOf, StorageSinkDesc,
 };
@@ -183,7 +184,7 @@ pub trait StorageController: Debug + Send {
     fn initialization_complete(&mut self);
 
     /// Update storage configuration.
-    fn update_configuration(&mut self, config_params: BTreeSet<StorageParameter>);
+    fn update_configuration(&mut self, config_params: StorageParameters);
 
     /// Acquire an immutable reference to the collection state, should it exist.
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<Self::Timestamp>, StorageError>;
@@ -788,7 +789,7 @@ where
         self.hosts.initialization_complete();
     }
 
-    fn update_configuration(&mut self, config_params: BTreeSet<StorageParameter>) {
+    fn update_configuration(&mut self, config_params: StorageParameters) {
         // TODO(#16753): apply config to `self.persist`
 
         self.hosts.update_configuration(config_params);

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -55,7 +55,7 @@ use mz_stash::{self, PostgresFactory, StashError, TypedCollection};
 
 use crate::client::{
     CreateSinkCommand, CreateSourceCommand, ProtoStorageCommand, ProtoStorageResponse,
-    SourceStatisticsUpdate, StorageCommand, StorageResponse, Update,
+    SourceStatisticsUpdate, StorageCommand, StorageParameter, StorageResponse, Update,
 };
 use crate::controller::hosts::{StorageHosts, StorageHostsConfig};
 use crate::healthcheck;
@@ -181,6 +181,9 @@ pub trait StorageController: Debug + Send {
     /// and so it is important for a user to invoke this method as soon as it is comfortable.
     /// This method can be invoked immediately, at the potential expense of performance.
     fn initialization_complete(&mut self);
+
+    /// Update storage configuration.
+    fn update_configuration(&mut self, config_params: BTreeSet<StorageParameter>);
 
     /// Acquire an immutable reference to the collection state, should it exist.
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<Self::Timestamp>, StorageError>;
@@ -783,6 +786,12 @@ where
 
     fn initialization_complete(&mut self) {
         self.hosts.initialization_complete();
+    }
+
+    fn update_configuration(&mut self, config_params: BTreeSet<StorageParameter>) {
+        // TODO(#16753): apply config to `self.persist`
+
+        self.hosts.update_configuration(config_params);
     }
 
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<Self::Timestamp>, StorageError> {

--- a/src/storage-client/src/controller/hosts.rs
+++ b/src/storage-client/src/controller/hosts.rs
@@ -20,7 +20,7 @@
 //! host. This policy is subject to change in the future.
 
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -38,11 +38,10 @@ use mz_persist_types::Codec64;
 use mz_proto::RustType;
 use mz_repr::GlobalId;
 
-use crate::client::{
-    ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageParameter, StorageResponse,
-};
+use crate::client::{ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageResponse};
 use crate::controller::rehydration::RehydratingStorageClient;
 use crate::types::hosts::{StorageHostConfig, StorageHostResourceAllocation};
+use crate::types::parameters::StorageParameters;
 
 /// The network address of a storage host.
 pub type StorageHostAddr = String;
@@ -80,7 +79,7 @@ pub struct StorageHosts<T> {
     /// Set to `true` once `initialization_complete` has been called.
     initialized: bool,
     /// Storage configuration to apply to newly provisioned hosts.
-    config: BTreeMap<&'static str, StorageParameter>,
+    config: StorageParameters,
     /// A handle to Persist
     persist: Arc<Mutex<PersistClientCache>>,
 }
@@ -114,7 +113,7 @@ where
             objects: Arc::new(std::sync::Mutex::new(HashMap::new())),
             hosts: HashMap::new(),
             initialized: false,
-            config: BTreeMap::new(),
+            config: Default::default(),
             persist,
         }
     }
@@ -133,14 +132,12 @@ where
     }
 
     /// Update the configuration of all hosts (existing and future).
-    pub fn update_configuration(&mut self, config_params: BTreeSet<StorageParameter>) {
+    pub fn update_configuration(&mut self, config_params: StorageParameters) {
         for client in self.clients() {
             client.send(StorageCommand::UpdateConfiguration(config_params.clone()));
         }
 
-        for param in config_params {
-            self.config.insert(param.key(), param);
-        }
+        self.config.update(config_params);
     }
 
     /// Creates a [`MetricsFetcher`] that can be used to repeatedly fetch
@@ -190,7 +187,7 @@ where
             }
         };
 
-        let config_params = self.config.values().cloned().collect();
+        let config_params = self.config.clone();
 
         let host = self.hosts.entry(host_addr.clone()).or_insert_with(|| {
             let mut client = RehydratingStorageClient::new(

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -7,11 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![allow(missing_docs)]
+syntax = "proto3";
 
-pub mod connections;
-pub mod errors;
-pub mod hosts;
-pub mod parameters;
-pub mod sinks;
-pub mod sources;
+import "proto/src/proto.proto";
+
+package mz_storage_client.types.parameters;
+
+message ProtoStorageParameters {
+    ProtoPersistParameters persist = 1;
+}
+
+message ProtoPersistParameters {
+    optional uint64 blob_target_size = 1;
+    mz_proto.ProtoDuration compaction_minimum_timeout = 2;
+}

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -1,0 +1,100 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Configuration parameter types.
+
+use std::time::Duration;
+
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+
+include!(concat!(
+    env!("OUT_DIR"),
+    "/mz_storage_client.types.parameters.rs"
+));
+
+/// Storage instance configuration parameters.
+///
+/// Parameters can be set (`Some`) or unset (`None`).
+/// Unset parameters should be interpreted to mean "use the previous value".
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StorageParameters {
+    /// Persist client configuration.
+    pub persist: PersistParameters,
+}
+
+impl StorageParameters {
+    /// Update the parameter values with the set ones from `other`.
+    pub fn update(&mut self, other: StorageParameters) {
+        self.persist.update(other.persist);
+    }
+}
+
+impl RustType<ProtoStorageParameters> for StorageParameters {
+    fn into_proto(&self) -> ProtoStorageParameters {
+        ProtoStorageParameters {
+            persist: Some(self.persist.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoStorageParameters) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            persist: proto
+                .persist
+                .into_rust_if_some("ProtoStorageParameters::persist")?,
+        })
+    }
+}
+
+/// Persist configuration parameters.
+///
+/// Parameters can be set (`Some`) or unset (`None`).
+/// Unset parameters should be interpreted to mean "use the previous value".
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Arbitrary)]
+pub struct PersistParameters {
+    /// Configures [`mz_persist_client::PersistConfig::blob_target_size`].
+    pub blob_target_size: Option<usize>,
+    /// Configures [`mz_persist_client::PersistConfig::compaction_minimum_timeout`].
+    pub compaction_minimum_timeout: Option<Duration>,
+}
+
+impl PersistParameters {
+    /// Update the parameter values with the set ones from `other`.
+    pub fn update(&mut self, other: PersistParameters) {
+        if let Some(v) = other.blob_target_size {
+            self.blob_target_size = Some(v);
+        }
+        if let Some(v) = other.compaction_minimum_timeout {
+            self.compaction_minimum_timeout = Some(v);
+        }
+    }
+
+    /// Return whether all parameters are unset.
+    pub fn all_unset(&self) -> bool {
+        self.blob_target_size.is_none() && self.compaction_minimum_timeout.is_none()
+    }
+}
+
+impl RustType<ProtoPersistParameters> for PersistParameters {
+    fn into_proto(&self) -> ProtoPersistParameters {
+        ProtoPersistParameters {
+            blob_target_size: self.blob_target_size.into_proto(),
+            compaction_minimum_timeout: self.compaction_minimum_timeout.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoPersistParameters) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            blob_target_size: proto.blob_target_size.into_rust()?,
+            compaction_minimum_timeout: proto.compaction_minimum_timeout.into_rust()?,
+        })
+    }
+}

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -28,7 +28,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::{PersistLocation, ShardId};
 use mz_repr::{Diff, GlobalId, Timestamp};
-use mz_storage_client::client::{StorageCommand, StorageParameter, StorageResponse};
+use mz_storage_client::client::{StorageCommand, StorageResponse};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
@@ -278,15 +278,10 @@ impl<'w, A: Allocate> Worker<'w, A> {
         match cmd {
             StorageCommand::InitializationComplete => (),
             StorageCommand::UpdateConfiguration(params) => {
-                for param in params {
-                    tracing::info!("Applying configuration update: {param}");
+                tracing::info!("Applying configuration update: {params:?}");
 
-                    match param {
-                        // TODO(#16753): apply config to `self.storage_state.persist_clients`
-                        StorageParameter::PersistBlobTargetSize(_) => {}
-                        StorageParameter::PersistCompactionMinimumTimeout(_) => {}
-                    }
-                }
+                // TODO(#16753): apply config to `self.storage_state.persist_clients`
+                let _ = params.persist;
             }
             StorageCommand::CreateSources(ingestions) => {
                 for ingestion in ingestions {


### PR DESCRIPTION
This PR introduces the first two persist config `SystemVar`s and plumbs their values through to the controllers and the compute/storage instances.

When selecting appropriate persist config parameters for this poc, I looked at what is available in `PersistConfig` and selected one parameter for each distinct value type. AFAICT, the relevant types are currently only `usize` and `Duration`. `PersistConfig` has fields with other types, but those don't look like ones that make sense to configure dynamically.

For passing the new config options to storage I had to introduce a new `UpdateConfiguration` storage command. For compute such a command already existed, but the controller API didn't allow configuring parameters other than `max_result_size`, so I had to make it more general.

The persist config options are not applied to the persist clients yet, as a mechanism for that is still missing. I marked the places where we'll want to apply the persist configuration once that mechanism exists with `TODO(#16753)` in the code.

### Motivation

  * This PR adds a known-desirable feature.

Advances #16753.

### Testing

I tested that connecting as `mz_system` and setting a persist config, like this:

```
ALTER SYSTEM SET persist_blob_target_size = 12345;
```

... makes both compute replicas and storage hosts print:

```
Applying configuration update: ComputeParameters { [...] persist: PersistParameters { blob_target_size: Some(123456), [...] } }
```

I verified that this is the case for:

* Existing compute/storage processes
* Newly created compute/storage processes
* Existing compute/storage processes after environmentd kill + restart
* Existing compute/storage processes after process kill + restart

I also verified on staging that the Launch Darkly integration works. There are now two Launch Darkly flags configured for the two new persist config options.

I don't know of a good way to write tests for this functionality. The only way to observe these config params being applied currently is by looking at log output, and having tests check log messages seems kind of hacky.

### Tips for reviewer

This PR touches adapter, storage, and compute, hence the long list of reviewers. I would like at least one review from each of the three teams!

I split the PR into commits that can be reviewed separately.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
