### PR TITLE
adapter: add raw column to mz_audit_events

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -34,6 +34,8 @@ Field           | Type                         | Meaning
 `details`       | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
 `user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred. Guaranteed to be in order of event creation. Events created in the same transaction will have identical values.
+`raw`           | [`bytea`]                    | The raw, versioned event data.
+
 
 ### `mz_aws_privatelink_connections`
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1600,7 +1600,8 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("object_type", ScalarType::String.nullable(false))
         .with_column("details", ScalarType::Jsonb.nullable(false))
         .with_column("user", ScalarType::String.nullable(true))
-        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
+        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
+        .with_column("raw", ScalarType::Bytes.nullable(false)),
     is_retained_metrics_relation: false,
 });
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -844,6 +844,7 @@ impl CatalogState {
                     None => Datum::Null,
                 },
                 Datum::TimestampTz(DateTime::from_utc(dt, Utc).try_into().expect("must fit")),
+                Datum::Bytes(&event.serialize()),
             ]),
             diff: 1,
         })

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -129,3 +129,9 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 44  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
 45  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_id":"4","replica_name":"r"}  materialize
 46  drop  cluster  {"id":"u2","name":"foo"}  materialize
+
+# Check the details field only to ignore the changing occurred_at timestamp.
+query IT
+SELECT id, encode(raw, 'escape')::jsonb->'V1'->'details' FROM mz_audit_events ORDER BY id LIMIT 1;
+----
+1  {"IdNameV1":{"id":"1","name":"materialize"}}


### PR DESCRIPTION
Expose the raw data for use with the audit log crate.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a