### PR TITLE
adapter: de-mut readonly get_local_read_ts

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -375,19 +375,11 @@ impl<S: Append + 'static> Coordinator<S> {
         self.get_timestamp_oracle(&Timeline::EpochMilliseconds)
     }
 
-    /// Returns a mutable reference to the timestamp oracle used for reads and writes
-    /// from/to a local input.
-    pub(crate) fn get_local_timestamp_oracle_mut(
-        &mut self,
-    ) -> &mut DurableTimestampOracle<Timestamp> {
-        self.get_timestamp_oracle_mut(&Timeline::EpochMilliseconds)
-    }
-
     /// Assign a timestamp for a read from a local input. Reads following writes
     /// must be at a time >= the write's timestamp; we choose "equal to" for
     /// simplicity's sake and to open as few new timestamps as possible.
-    pub(crate) fn get_local_read_ts(&mut self) -> Timestamp {
-        self.get_local_timestamp_oracle_mut().read_ts()
+    pub(crate) fn get_local_read_ts(&self) -> Timestamp {
+        self.get_local_timestamp_oracle().read_ts()
     }
 
     /// Assign a timestamp for a write to a local input and increase the local ts.


### PR DESCRIPTION
This lets us remove a now unused fn.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a