### PR TITLE
doc/user: add a source troubleshooting guide

### DIFF
--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -309,14 +309,7 @@ First, look for errors in [`mz_source_statuses`](/sql/system-catalog/mz_internal
 
 ```sql
 SELECT * FROM mz_internal.mz_source_statuses
-WHERE id = <SOURCE_ID>;
-```
-
-You can get your source's id with:
-
-```sql
-SELECT id FROM mz_sources
-WHERE name = '<your source name>';
+WHERE name = <SOURCE_NAME>;
 ```
 
 If your source reports a status of `stalled` or `failed`, you likely have a
@@ -337,7 +330,7 @@ Query the `snapshot_comitted` field of the
 ```sql
 SELECT bool_and(snapshot_committed) as snapshot_committed
 FROM mz_internal.mz_source_statistics
-WHERE source_id = <SOURCE ID>;
+WHERE id = <SOURCE ID>;
 ```
 
 You generally want to aggregate the `snapshot_committed` field across all worker
@@ -380,37 +373,30 @@ advance. This is expected, and not a cause for concern.
 
 After the initial snapshot, there should be relatively little skew between
 `updates_staged` and `updates_committed`. A large gap is usually an indication
-that the source has fallen behind, and that you likely need to provision
-more scale up your source.
+that the source has fallen behind, and that you likely need to scale up your
+source.
 
 `messages_received` does not necessarily correspond with `updates_staged`
 and `updates_commmited`. For example, an `UPSERT` envelope can have _more_
 updates than messages, because messages can cause both deletions and insertions
-(i.e. then they update a value for a key), which are both counted in the
+(i.e. when they update a value for a key), which are both counted in the
 `updates_*` statistics. There can also be _fewer_ updates than messages, as
 many messages for a single key can be consolidated if they occur within a (small)
-internally configured windows. That said, `messages_received` making
-steady progress, while `updates_staged`/`updates_committed` don't is also
+internally configured window. That said, `messages_received` making
+steady progress, while `updates_staged`/`updates_committed` doesn't is also
 evidence that a source has fallen behind, and may need to be scaled up.
 
 Beware that these statistics periodically reset to zero, as internal components
-of the system restart. This is expected behavior. As a result, should restrict
-your attention to how these statistics evolve over time, and not their absolute
-values at any moment in time.
+of the system restart. This is expected behavior. As a result, you should
+restrict your attention to how these statistics evolve over time, and not their
+absolute values at any moment in time.
 
 ## Why isn't my sink exporting data?
 First, look for errors in [`mz_sink_statuses`](/sql/system-catalog/mz_internal/#mz_sink_statuses):
 
 ```sql
 SELECT * FROM mz_internal.mz_sink_statuses
-WHERE id = <SINK_ID>;
-```
-
-You can get your sink's id with:
-
-```sql
-SELECT id FROM mz_sinks
-WHERE name = '<your sink name>';
+WHERE name = <SINK_NAME>;
 ```
 
 If your sink reports a status of `stalled` or `failed`, you likely have a
@@ -428,9 +414,9 @@ table and look for ingestion statistics that advance over time:
 ```sql
 SELECT
     SUM(messages_staged) AS messages_staged,
-    SUM(messaged_committed) AS messages_committed,
+    SUM(messages_committed) AS messages_committed,
     SUM(bytes_staged) AS bytes_staged,
-    SUM(bytes_committed) AS bytes_committed,
+    SUM(bytes_committed) AS bytes_committed
 FROM mz_internal.mz_sink_statistics
 WHERE id = <SINK ID>;
 ```
@@ -439,23 +425,22 @@ WHERE id = <SINK ID>;
 whether ingestion progress is skewed, but it's generally simplest to start
 by looking at the aggregate statistics for the whole source.)
 
-The `messages_staged` and `bytes_staged` statistics should roughly
-correspond what materialize has written (but not necessarily committed)
-to the external service. For example, the `bytes_staged` and
-`messages_staged` fields for a Kafka sink should roughly correspond
-with how many messages materialize has written to the kafka topic, and
-how big they are (including the key), but we may not have committed
-the kafka transaction for those messages.
+The `messages_staged` and `bytes_staged` statistics should roughly correspond
+with what materialize has written (but not necessarily committed) to the
+external service. For example, the `bytes_staged` and `messages_staged` fields
+for a Kafka sink should roughly correspond with how many messages materialize
+has written to the Kafka topic, and how big they are (including the key), but
+the Kafka transaction for those messages might not have been committed yet.
 
 `messages_committed` and `bytes_committed` correspond to the number of messages
-we have committed to the external service. These numbers can be _smaller_
-than the `*_staged` statistics, because materialize might fail to write transactions
-and retry them.
+committed to the external service. These numbers can be _smaller_ than the
+`*_staged` statistics, because Materialize might fail to write transactions and
+retry them.
 
-If any of these 4 statistics are not making progress, your sink might be stalled
+If any of these statistics are not making progress, your sink might be stalled
 or need to be scaled up.
 
 If the `*_staged` statistics are making progress, but the `*_committed` ones
 are not, there may be a configuration issues with the external service that is
-preventing materialize from committing transactions. Check the `reason`
-column in `mz_sink_statuses`, which might have more information.
+preventing Materialize from committing transactions. Check the `reason`
+column in `mz_sink_statuses`, which can provide more information.

--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -302,3 +302,160 @@ SELECT DISTINCT
 FROM dependencies D
 JOIN mz_objects O ON (D.import_id = O.id);
 ```
+
+## Why isn't my source ingesting data?
+
+First, look for errors in [`mz_source_statuses`](/sql/system-catalog/mz_internal/#mz_source_statuses):
+
+```sql
+SELECT * FROM mz_internal.mz_source_statuses
+WHERE id = <SOURCE_ID>;
+```
+
+You can get your source's id with:
+
+```sql
+SELECT id FROM mz_sources
+WHERE name = '<your source name>';
+```
+
+If your source reports a status of `stalled` or `failed`, you likely have a
+configuration issue. The returned `error` field will provide details.
+
+If your source reports a status of `starting` for more than a few minutes,
+[contact support](/support).
+
+If your source reports a status of `running`, but you are not receiving data
+when you query the source, the source may still be ingesting its initial
+snapshot. See the next section.
+
+## Has my source ingested its initial snapshot?
+
+Query the `snapshot_comitted` field of the
+[`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics) table:
+
+```sql
+SELECT bool_and(snapshot_committed) as snapshot_committed
+FROM mz_internal.mz_source_statistics
+WHERE source_id = <SOURCE ID>;
+```
+
+You generally want to aggregate the `snapshot_committed` field across all worker
+threads, as done in the above query. The snapshot is only considered committed
+for the source as a whole once all worker threads have committed their
+components of the snapshot.
+
+Even if your source has not yet committed its initial snapshot, you can still
+monitor its progress. See the next section.
+
+## How do I monitor source ingestion progress?
+
+Repeatedly query the
+[`mz_source_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
+table and look for ingestion statistics that advance over time:
+
+```sql
+SELECT
+    SUM(bytes_received) AS bytes_received,
+    SUM(messages_received) AS messages_received,
+    SUM(updates_staged) AS updates_staged,
+    SUM(updates_committed) AS updates_committed
+FROM mz_internal.mz_source_statistics
+WHERE id = <SOURCE ID>;
+```
+
+(You can also look at statistics for individual worker threads to evaluate
+whether ingestion progress is skewed, but it's generally simplest to start
+by looking at the aggregate statistics for the whole source.)
+
+The `bytes_received` and `messages_received` statistics should roughly
+correspond with the external system's measure of progress. For example, the
+`bytes_received` and `messages_received` fields for a Kafka source should
+roughly correspond to what the upstream Kafka broker reports as the number of
+bytes (including the key) and number of messages transmitted, respectively.
+
+During the initial snapshot, `updates_committed` will remain at zero until all
+messages in the snapshot have been staged. Only then will `updates_committed`
+advance. This is expected, and not a cause for concern.
+
+After the initial snapshot, there should be relatively little skew between
+`updates_staged` and `updates_committed`. A large gap is usually an indication
+that the source has fallen behind, and that you likely need to provision
+more scale up your source.
+
+`messages_received` does not necessarily correspond with `updates_staged`
+and `updates_commmited`. For example, an `UPSERT` envelope can have _more_
+updates than messages, because messages can cause both deletions and insertions
+(i.e. then they update a value for a key), which are both counted in the
+`updates_*` statistics. There can also be _fewer_ updates than messages, as
+many messages for a single key can be consolidated if they occur within a (small)
+internally configured windows. That said, `messages_received` making
+steady progress, while `updates_staged`/`updates_committed` don't is also
+evidence that a source has fallen behind, and may need to be scaled up.
+
+Beware that these statistics periodically reset to zero, as internal components
+of the system restart. This is expected behavior. As a result, should restrict
+your attention to how these statistics evolve over time, and not their absolute
+values at any moment in time.
+
+## Why isn't my sink exporting data?
+First, look for errors in [`mz_sink_statuses`](/sql/system-catalog/mz_internal/#mz_sink_statuses):
+
+```sql
+SELECT * FROM mz_internal.mz_sink_statuses
+WHERE id = <SINK_ID>;
+```
+
+You can get your sink's id with:
+
+```sql
+SELECT id FROM mz_sinks
+WHERE name = '<your sink name>';
+```
+
+If your sink reports a status of `stalled` or `failed`, you likely have a
+configuration issue. The returned `error` field will provide details.
+
+If your sink reports a status of `starting` for more than a few minutes,
+[contact support](/support).
+
+## How do I monitor sink ingestion progress?
+
+Repeatedly query the
+[`mz_sink_statistics`](/sql/system-catalog/mz_internal/#mz_source_statistics)
+table and look for ingestion statistics that advance over time:
+
+```sql
+SELECT
+    SUM(messages_staged) AS messages_staged,
+    SUM(messaged_committed) AS messages_committed,
+    SUM(bytes_staged) AS bytes_staged,
+    SUM(bytes_committed) AS bytes_committed,
+FROM mz_internal.mz_sink_statistics
+WHERE id = <SINK ID>;
+```
+
+(You can also look at statistics for individual worker threads to evaluate
+whether ingestion progress is skewed, but it's generally simplest to start
+by looking at the aggregate statistics for the whole source.)
+
+The `messages_staged` and `bytes_staged` statistics should roughly
+correspond what materialize has written (but not necessarily committed)
+to the external service. For example, the `bytes_staged` and
+`messages_staged` fields for a Kafka sink should roughly correspond
+with how many messages materialize has written to the kafka topic, and
+how big they are (including the key), but we may not have committed
+the kafka transaction for those messages.
+
+`messages_committed` and `bytes_committed` correspond to the number of messages
+we have committed to the external service. These numbers can be _smaller_
+than the `*_staged` statistics, because materialize might fail to write transactions
+and retry them.
+
+If any of these 4 statistics are not making progress, your sink might be stalled
+or need to be scaled up.
+
+If the `*_staged` statistics are making progress, but the `*_committed` ones
+are not, there may be a configuration issues with the external service that is
+preventing materialize from committing transactions. Check the `reason`
+column in `mz_sink_statuses`, which might have more information.

--- a/doc/user/content/support.md
+++ b/doc/user/content/support.md
@@ -7,11 +7,12 @@ menu:
     weight: 30
 ---
 
-If you're using the source-available version of Materialize, the best place to get help and support from Materialize employees and other users is the [Materialize Community](https://materialize.com/s/chat).
+## Getting help
 
-If you're already a paying customer, refer to our [customer support portal](https://support.materialize.com/).
+If you run into a snag or need support during the trial period, join the [Materialize Slack community](https://materialize.com/s/chat) or [open an issue](https://github.com/MaterializeInc/materialize/issues/new/choose). Slack is the best place to get timely help from Materialize employees and other users!
 
-Check the current status of our services on our [status page](https://status.materialize.com). We announce both planned and unplanned maintenance windows.
+If you're a paying customer, you can also refer to our [customer support portal](https://support.materialize.com/).
 
-You can also use our [status page API](https://status.materialize.com/api) to
-programmatically access the information on our status page.
+## Checking service status
+
+Check the current status of our services on the [status page](https://status.materialize.com), where we announce both planned and unplanned maintenance windows. You can also use the [status page API](https://status.materialize.com/api) to programmatically access the information on the status page.

--- a/doc/user/content/support.md
+++ b/doc/user/content/support.md
@@ -7,7 +7,7 @@ menu:
     weight: 30
 ---
 
-If you're using the Source-Available version of Materialize, the best place to get help and support from Materialize employees and other users is the [Materialize Community](https://materialize.com/s/chat).
+If you're using the source-available version of Materialize, the best place to get help and support from Materialize employees and other users is the [Materialize Community](https://materialize.com/s/chat).
 
 If you're already a paying customer, refer to our [customer support portal](https://support.materialize.com/).
 

--- a/test/testdrive/source-statistics.td
+++ b/test/testdrive/source-statistics.td
@@ -68,8 +68,9 @@ goofus,gallant
 # NOTE: These queries are slow to succeed because the default metrics scraping
 # interval is 30 seconds.
 
-# MIN is a sneaky way to `AND` booleans :)
-> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
+> SELECT s.name,
+  bool_and(u.snapshot_committed),
+  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('metrics_test_source')
@@ -82,7 +83,9 @@ metrics_test_source true 2 2 2 true
 # Note that only the base-source has `messages_received`, but the sub-sources have `messages_committed`.
 # Committed will usually, for auction sources, add up to received, but we don't test this (right now) because of
 # jitter on when metrics are produced for each sub-source.
-> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0
+> SELECT s.name,
+  bool_and(u.snapshot_committed),
+  SUM(u.messages_received) > 0, SUM(u.updates_staged) > 0, SUM(u.updates_committed) > 0, SUM(u.bytes_received) > 0
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('accounts', 'auction_house', 'auctions', 'bids', 'organizations', 'users')
@@ -106,7 +109,7 @@ users          true      false   true  true  false
 # We can't control this, so have to accept the range.
 > SELECT
     s.name,
-    MIN(u.snapshot_committed),
+    bool_and(u.snapshot_committed),
     SUM(u.messages_received),
     SUM(u.updates_staged) BETWEEN 3 AND 11,
     SUM(u.updates_committed) BETWEEN 3 AND 11,
@@ -131,7 +134,9 @@ SELECT
 $ kafka-ingest format=avro topic=upsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "mammalmore"} {"f1":"moose2", "f2": 2}
 
-> SELECT s.name, MIN(u.snapshot_committed), SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
+> SELECT s.name,
+  bool_and(u.snapshot_committed),
+  SUM(u.messages_received), SUM(u.updates_staged), SUM(u.updates_committed), SUM(u.bytes_received) > 0
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
   WHERE s.name IN ('upsert')


### PR DESCRIPTION
Take @guswynn's excellent advice on how to use the
`mz_source_statistics` table, which I excised from https://github.com/MaterializeInc/materialize/pull/16937, and expand it
into a full-fledged source troubleshooting guide.

### Motivation

   * This PR adds documentation.

### Tips for reviewer

Still a bunch of TODOs to resolve, but I thought it'd be fun to iterate on this together! @guswynn I hope you're not too miffed that I pulled this out of #16937—I just feel like it's so much more natural to talk about these things inline with real usage examples of the `mz_internal.mz_source_statistics` table.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
