### PR TITLE
persist: Convert the multi-node Maelstrom CI job to Cockroach

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -531,7 +531,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persist
-          args: [--node-count=4, --consensus=postgres, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+          args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
   - id: persistence-failpoints
     label: Persistence failpoints


### PR DESCRIPTION
Persist is no longer compatible with Postgres -- it attempts to issue Cockroach-specific queries. Therefore, the multi-node Maelstrom test must also use Cockroach

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI is failing.

@mjibson FYI, this started failing after 

```
commit 463c8a478d52bbb9297d2d962d1aa242a8f912aa
Author: Matt Jibson <matt.jibson@gmail.com>
Date:   Thu Jan 5 12:13:37 2023 -0700

    *: remove is_cockroach special casing
    
    Now that we use cockroach in all testing we can remove the ability to
    work with postgres and assume cockroach.
```