### PR TITLE
testdrive: Do not run linked-clusters.td with more than 1 replica

### DIFF
--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -7,6 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# The expected number of rows in system tables depends on the number of replicas
+$ skip-if
+SELECT ${arg.replicas} > 1;
+
 $ set-sql-timeout duration=1s
 
 # Create a basic view for use throughout the test.


### PR DESCRIPTION
The test contains introspection queries whose result depends on the number of replicas in the default cluster

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI replicas 4 was failing.