### PR TITLE
feature-benchmark: Allow running individual scenarios

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -128,6 +128,7 @@ def run_one_scenario(
                 "-c",
                 "environmentd --version | grep environmentd",
                 entrypoint="bash",
+                rm=True,
             )
 
             c.start_and_wait_for_tcp(services=["materialized"])


### PR DESCRIPTION
For some reason, calling environmentd --version using 'docker-compose run' is leaving a volume behind
which in turn breaks the ability to run individual scenarios

Call mzcompose's run() method with rm=true to remove any volumes that were produced by the call to environmentd --version

### Motivation

  * This PR fixes a previously unreported bug.

Command lines of the form

```
bin/mzcompose --find feature-benchmark run default --scenario Update --other-tag=latest
```
were failing as the second Mz instance was unable to start due to a dangling volume left behind