### PR TITLE
ore: add a tracing layer for LaunchDarkly monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "launchdarkly-server-sdk"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/rust-server-sdk#d866421dbcaeee81679d06861594493797a8e7be"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk#dcda26dad12a871795a6958ef238536c27c67164"
 dependencies = [
  "built",
  "chrono",

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -7,12 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{collections::BTreeMap, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use derivative::Derivative;
 use launchdarkly_server_sdk as ld;
+use prometheus::IntCounter;
 use tokio::time;
 
+use mz_ore::{metric, metrics::MetricsRegistry};
 use mz_sql::catalog::{CloudProvider, EnvironmentId};
 
 use super::SynchronizedParameters;
@@ -31,16 +33,34 @@ pub struct SystemParameterFrontend {
     /// to use when populating the the [SynchronizedParameters]
     /// instance in [SystemParameterFrontend::pull].
     ld_key_map: BTreeMap<String, String>,
+    /// Frontend metrics.
+    ld_metrics: Metrics,
 }
 
 impl SystemParameterFrontend {
     /// Construct a new [SystemParameterFrontend] instance.
     pub fn new(
         env_id: EnvironmentId,
+        registry: &MetricsRegistry,
         ld_sdk_key: &str,
         ld_key_map: BTreeMap<String, String>,
     ) -> Result<Self, anyhow::Error> {
-        let ld_config = ld::ConfigBuilder::new(ld_sdk_key).build();
+        let ld_metrics = Metrics::register_into(registry);
+        let ld_config = ld::ConfigBuilder::new(ld_sdk_key)
+            .event_processor(ld::EventProcessorBuilder::new().on_success({
+                let last_known_time_seconds = ld_metrics.last_known_time_seconds.clone();
+                Arc::new(move |result| {
+                    if let Ok(t_next) = u64::try_from(result.time_from_server / 1000) {
+                        let t_curr = last_known_time_seconds.get();
+                        if t_next > t_curr {
+                            last_known_time_seconds.inc_by(t_next - t_curr);
+                        }
+                    } else {
+                        tracing::warn!("Cannot convert time_from_server / 1000 from u128 to u64");
+                    }
+                })
+            }))
+            .build();
         let ld_client = ld::Client::build(ld_config)?;
         let ld_ctx = if env_id.cloud_provider() != &CloudProvider::Local {
             ld::ContextBuilder::new(env_id.to_string())
@@ -71,6 +91,7 @@ impl SystemParameterFrontend {
             ld_client,
             ld_ctx,
             ld_key_map,
+            ld_metrics,
         })
     }
 
@@ -119,9 +140,32 @@ impl SystemParameterFrontend {
                 ld::FlagValue::Json(v) => v.to_string(),
             };
 
-            changed |= params.modify(param_name, flag_str.as_str());
+            let change = params.modify(param_name, flag_str.as_str());
+            self.ld_metrics.params_changed.inc_by(u64::from(change));
+            changed |= change;
         }
 
         changed
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Metrics {
+    pub last_known_time_seconds: IntCounter,
+    pub params_changed: IntCounter,
+}
+
+impl Metrics {
+    fn register_into(registry: &MetricsRegistry) -> Self {
+        Self {
+            last_known_time_seconds: registry.register(metric!(
+                name: "mz_parameter_frontend_last_known_time_seconds",
+                help: "The last known time of the LaunchDarkly frontend (as unix timestamp).",
+            )),
+            params_changed: registry.register(metric!(
+                name: "mz_parameter_frontend_params_changed",
+                help: "The number of parameter changes pulled from the LaunchDarkly frontend.",
+            )),
+        }
     }
 }


### PR DESCRIPTION
We want to export a Prometheus metric of the last known time when our LaunchDarkly client has communicated with the server in order to create a Grafana monitor for the availability of LaunchDarkly.

### Motivation

  * This PR adds a known-desirable feature.

Resolves #16708

### Tips for reviewer

Originally I was planning to piggy-back on `tracing` with a custom subscriber layer. This was a 2 LOC diff in our LD fork, but turned out to be very impractical for our codebase. I therefore abandoned this and went for a variant based on a slightly bigger diff in the LD fork.

The PR now consists of a single commit that:

- Adds a new `Metrics` struct in `adapter::config::frontend`. The above struct has two metrics:
  - `last_known_time_seconds` one for reporting the last known communication time with the LD server.
  - `params_changed` reports the number of parameter value changes pulled from the LaunchDarkly frontend since the last `environmentd` restart.

Note that with the current setup the metrics will only be reported if the `SystemParameterFrontend` is instantiated (that is, if `MZ_LAUNCHDARKLY_SDK_KEY` is present). This might not be the case in case for operational reasons we decide to turn sync off.


### Checklist

- [ ] ~This PR has adequate test coverage~ / QA involvement has been duly considered. I have only verified that the metrics work as expected manually. @umanwizard let me know if there is a standard way to test metrics.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
