### PR TITLE
adapter: Send notice for unimplemented isolation levels

### DIFF
--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 use chrono::{DateTime, Utc};
 
+use crate::session::vars::IsolationLevel;
 use mz_compute_client::controller::ComputeInstanceStatus;
 use mz_ore::str::StrExt;
 use mz_repr::strconv;
@@ -66,6 +67,9 @@ pub enum AdapterNotice {
     },
     QueryTrace {
         trace_id: opentelemetry::trace::TraceId,
+    },
+    UnimplementedIsolationLevel {
+        isolation_level: String,
     },
 }
 
@@ -150,6 +154,13 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::QueryTrace { trace_id } => {
                 write!(f, "trace id: {}", trace_id)
+            }
+            AdapterNotice::UnimplementedIsolationLevel { isolation_level } => {
+                write!(
+                    f,
+                    "transaction isolation level {isolation_level} is unimplemented, the session will be upgraded to {}",
+                    IsolationLevel::Serializable.as_str()
+                )
             }
         }
     }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -205,8 +205,9 @@ const TIMEZONE: ServerVar<TimeZone> = ServerVar {
     internal: false,
 };
 
+pub const TRANSACTION_ISOLATION_VAR_NAME: &UncasedStr = UncasedStr::new("transaction_isolation");
 const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
-    name: UncasedStr::new("transaction_isolation"),
+    name: TRANSACTION_ISOLATION_VAR_NAME,
     value: &IsolationLevel::StrictSerializable,
     description: "Sets the current transaction's isolation level (PostgreSQL).",
     internal: false,

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2264,15 +2264,12 @@ fn test_isolation_level_notice() {
     Retry::default()
         .max_duration(Duration::from_secs(10))
         .retry(|_| match rx.try_next() {
-            Ok(Some(msg)) => {
-                return notice_re
-                    .captures(msg.message())
-                    .ok_or("wrong message")
-                    .map(|_| ());
-            }
-
+            Ok(Some(msg)) => notice_re
+                .captures(msg.message())
+                .ok_or("wrong message")
+                .map(|_| ()),
             Ok(None) => panic!("unexpected channel close"),
-            Err(_) => return Err("no messages available"),
+            Err(_) => Err("no messages available"),
         })
         .unwrap();
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2236,3 +2236,43 @@ fn test_emit_timestamp_notice() {
         })
         .unwrap();
 }
+
+#[test]
+fn test_isolation_level_notice() {
+    let config = util::Config::default();
+    let server = util::start_server(config).unwrap();
+
+    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+
+    let mut client = server
+        .pg_config()
+        .notice_callback(move |notice| {
+            tx.unbounded_send(notice).unwrap();
+        })
+        .connect(postgres::NoTls)
+        .unwrap();
+
+    client
+        .batch_execute("SET TRANSACTION_ISOLATION TO 'READ UNCOMMITTED'")
+        .unwrap();
+
+    let notice_re = Regex::new(
+        "transaction isolation level .* is unimplemented, the session will be upgraded to .*",
+    )
+    .unwrap();
+
+    Retry::default()
+        .max_duration(Duration::from_secs(10))
+        .retry(|_| match rx.try_next() {
+            Ok(Some(msg)) => {
+                return notice_re
+                    .captures(msg.message())
+                    .ok_or("wrong message")
+                    .map(|_| ());
+            }
+
+            Ok(None) => panic!("unexpected channel close"),
+            Err(_) => return Err("no messages available"),
+        })
+        .unwrap();
+}

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -415,6 +415,7 @@ impl ErrorResponse {
             AdapterNotice::QueryTimestamp { .. } => SqlState::WARNING,
             AdapterNotice::EqualSubscribeBounds { .. } => SqlState::WARNING,
             AdapterNotice::QueryTrace { .. } => SqlState::WARNING,
+            AdapterNotice::UnimplementedIsolationLevel { .. } => SqlState::WARNING,
         };
         ErrorResponse {
             severity: Severity::for_adapter_notice(&notice),
@@ -569,6 +570,7 @@ impl Severity {
             AdapterNotice::QueryTimestamp { .. } => Severity::Notice,
             AdapterNotice::EqualSubscribeBounds { .. } => Severity::Notice,
             AdapterNotice::QueryTrace { .. } => Severity::Notice,
+            AdapterNotice::UnimplementedIsolationLevel { .. } => Severity::Notice,
         }
     }
 }


### PR DESCRIPTION
Fixes #13712

### Motivation
 This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
