### PR TITLE
storage: shard finalization WAL

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1046,6 +1046,10 @@ impl Coordinator {
         self.send_builtin_table_updates(builtin_table_updates, BuiltinTableUpdateSource::DDL)
             .await;
 
+        // Signal to the storage controller that it is now free to reconcile its
+        // state with what it has learned from the adapter.
+        self.controller.storage.reconcile_state().await;
+
         info!("coordinator init: bootstrap complete");
         Ok(())
     }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2000,10 +2000,7 @@ where
             .await
             .expect("connect to stash");
 
-        // ???: If we crash after this do we have any means of reaping the
-        // leaked shards?
-
-        self.truncate_shards(&to_delete_shards).await;
+        self.finalize_shards(&to_delete_shards).await;
 
         let DurableCollectionMetadata {
             remap_shard,
@@ -2020,8 +2017,12 @@ where
         metadata.collection_metadata.remap_shard = remap_shard;
     }
 
+    /// Closes the identified shards from further reads or writes.
+    ///
+    /// The string accompanying the `ShardId` is the shard's "purpose",
+    /// necessary to open read and write handles to the shard.
     #[allow(dead_code)]
-    async fn truncate_shards(&mut self, shards: &[(ShardId, String)]) {
+    async fn finalize_shards(&mut self, shards: &[(ShardId, String)]) {
         // Open a persist client to delete unused shards.
         let persist_client = self
             .persist

--- a/src/storage-client/src/controller/command_wals.rs
+++ b/src/storage-client/src/controller/command_wals.rs
@@ -109,6 +109,7 @@ where
             .map(
                 |(
                     id,
+                    // TODO(guswynn): produce the schema for each shard.
                     super::DurableCollectionMetadata {
                         remap_shard,
                         data_shard,

--- a/src/storage-client/src/controller/command_wals.rs
+++ b/src/storage-client/src/controller/command_wals.rs
@@ -1,0 +1,154 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tracks persist shards ready to be finalized, i.e. remove the ability to read
+//! or write them. This identifies shards we no longer use, but did not have the
+//! opportunity to finalize before e.g. crashing.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use differential_dataflow::lattice::Lattice;
+use timely::order::TotalOrder;
+use timely::progress::Timestamp;
+
+use mz_ore::now::EpochMillis;
+use mz_persist_client::ShardId;
+use mz_persist_types::Codec64;
+use mz_proto::RustType;
+use mz_repr::TimestampManipulation;
+use mz_stash::{self, TypedCollection};
+
+use crate::client::{StorageCommand, StorageResponse};
+use crate::controller::{ProtoStorageCommand, ProtoStorageResponse};
+
+use super::Controller;
+
+pub(super) static SHARD_FINALIZATION: TypedCollection<ShardId, ()> =
+    TypedCollection::new("storage-shards-to-finalize");
+
+impl<T> Controller<T>
+where
+    T: Timestamp + Lattice + TotalOrder + Codec64 + From<EpochMillis> + TimestampManipulation,
+    StorageCommand<T>: RustType<ProtoStorageCommand>,
+    StorageResponse<T>: RustType<ProtoStorageResponse>,
+
+    Self: super::StorageController<Timestamp = T>,
+{
+    /// `true` if shard is in register for shards marked for finalization.
+    pub(super) async fn is_shard_registered_for_finalization(&mut self, shard: ShardId) -> bool {
+        SHARD_FINALIZATION
+            .peek_key_one(&mut self.state.stash, shard)
+            .await
+            .expect("must be able to connect to stash")
+            .is_some()
+    }
+
+    /// Register shards for finalization. This must be called if you intend to
+    /// finalize shards, before you perform any work to e.g. replace one shard
+    /// with another.
+    ///
+    /// The reasoning behind this is that we need to identify the intent to
+    /// finalize a shard so we can perform the finalization on reboot if we
+    /// crash and do not find the shard in use in any collection.
+    #[allow(dead_code)]
+    pub(super) async fn register_shards_for_finalization<I>(&mut self, entries: I)
+    where
+        I: IntoIterator<Item = ShardId>,
+    {
+        SHARD_FINALIZATION
+            .insert_without_overwrite(
+                &mut self.state.stash,
+                entries.into_iter().map(|key| (key, ())),
+            )
+            .await
+            .expect("must be able to write to stash")
+    }
+
+    /// Removes the shard from the finalization register.
+    ///
+    /// This is appropriate to do if you can guarantee that the shard has been
+    /// finalized or find the shard is still in use by some collection.
+    pub(super) async fn clear_from_shard_finalization_register(
+        &mut self,
+        shards: BTreeSet<ShardId>,
+    ) {
+        SHARD_FINALIZATION
+            .delete(&mut self.state.stash, move |k, _v| shards.contains(k))
+            .await
+            .expect("must be able to write to stash")
+    }
+
+    /// Reconcile the state of `SHARD_FINALIZATION_WAL` with
+    /// `super::METADATA_COLLECTION` on boot.
+    pub(super) async fn reconcile_shards(&mut self) {
+        // Get all shards in the WAL.
+        let registered_shards: BTreeSet<_> = SHARD_FINALIZATION
+            .peek_one(&mut self.state.stash)
+            .await
+            .expect("must be able to read from stash")
+            .into_iter()
+            .map(|(shard_id, _)| shard_id)
+            .collect();
+
+        if registered_shards.is_empty() {
+            return;
+        }
+
+        // Get all shards we're aware of from stash.
+        let all_shard_data: BTreeMap<_, _> = super::METADATA_COLLECTION
+            .peek_one(&mut self.state.stash)
+            .await
+            .expect("must be able to read from stash")
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    super::DurableCollectionMetadata {
+                        remap_shard,
+                        data_shard,
+                    },
+                )| { [(id, [remap_shard, data_shard])] },
+            )
+            .flatten()
+            .collect();
+
+        // Consider shards in use if they are still attached to a collection.
+        let in_use_shards: BTreeSet<_> = all_shard_data
+            .into_iter()
+            .filter_map(|(id, shards)| {
+                self.state
+                    .collections
+                    .get(&id)
+                    .map(|_| Some(shards.to_vec()))
+            })
+            .flatten()
+            .flatten()
+            .collect();
+
+        // Determine all shards that were marked to drop but are still in use by
+        // some present collection.
+        let shard_ids_to_keep = registered_shards
+            .intersection(&in_use_shards)
+            .cloned()
+            .collect();
+
+        // Remove any shards that are currently in use from shard finalization register.
+        self.clear_from_shard_finalization_register(shard_ids_to_keep)
+            .await;
+
+        // Determine all shards that are registered that are not in use.
+        let shard_id_desc_to_truncate: Vec<_> = registered_shards
+            .difference(&in_use_shards)
+            .cloned()
+            .map(|shard_id| (shard_id, "finalizing unused shard".to_string()))
+            .collect();
+
+        self.finalize_shards(&shard_id_desc_to_truncate).await;
+    }
+}

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1189,7 +1189,6 @@ where
 
                     cap_set.downgrade(remap_trace_batch.upper);
 
-
                     let mut remap_trace_batch = timestamper.advance().await;
 
                     // Out of an abundance of caution, do not hold the output handle


### PR DESCRIPTION
Supersedes #16869

### Motivation

This PR adds a known-desirable feature. Makes dropping shards more robust in the face of arbitrary failures.

When dropping a shard from `METADATA_COLLECTION`, we need to ensure that the dropped shard's read and write handles are downgraded to the empty antichain. To support this, introduce a WAL for all shards that should be finalized.

- If we crash before rewriting `METADATA_COLLECTION`, the WAL will be cleared of this entry on reboot.
- If we crash any time after rewriting `METADATA_COLLECTION` before we clear the entry, we will finalize the shard on reboot.

Finalization is an idempotent operation so double-finalizing a shard is fine.

Note that this feature is not meaningfully tested because it does not yet execute under any code paths; however, it will execute during an upcoming PR for queryable remap shards.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a