### PR TITLE
doc/user: push down cast to query for a more clear example

### DIFF
--- a/doc/user/content/sql/patterns/ttl.md
+++ b/doc/user/content/sql/patterns/ttl.md
@@ -55,9 +55,9 @@ For a real-world example of the pattern, let's build a task tracking system. It 
       CREATE MATERIALIZED VIEW tracking_tasks AS
       SELECT
         name,
-        extract(epoch from (created_ts + ttl)) * 1000 as expiration_time
+        created_ts + ttl as expiration_time
       FROM tasks
-      WHERE mz_now() < extract(epoch from (created_ts + ttl)) * 1000;
+      WHERE mz_now() < created_ts + ttl;
     ```
 
     The filter clause will discard any row with an **expiration time** less than or equal to `mz_now()`.
@@ -65,9 +65,9 @@ For a real-world example of the pattern, let's build a task tracking system. It 
 
 ### Usage examples
 
-- Run a query to know the time to live for a row:
+- Query the time to live for a row:
   ```sql
-    SELECT expiration_time - mz_now()::text::numeric AS remaining_ttl_in_ms
+    SELECT expiration_time - to_timestamp(mz_now()::text::numeric / 1000) AS remaining_ttl
     FROM tracking_tasks
     WHERE name = 'time_to_eat';
   ```


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Makes the TTL pattern example more straightforward avoiding cast `mz_now()` during the view creation matching the initial sample for the pattern.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Affects only the TTL pattern page.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
