### PR TITLE
Fix lowertest parse error msgs

### DIFF
--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -292,7 +292,10 @@ impl MirScalarExprDeserializeContext {
                 literal.to_string().parse::<usize>().map_err_to_string()?,
             ));
         }
-        Err(format!("Invalid column specification {:?}", token))
+        Err(format!(
+            "Invalid column specification {:?}",
+            token.map(|token_tree| format!("`{}`", token_tree))
+        ))
     }
 
     fn build_literal_if_able<I>(
@@ -309,11 +312,11 @@ impl MirScalarExprDeserializeContext {
                 let first_arg = if let Some(first_arg) = rest_of_stream.next() {
                     first_arg
                 } else {
-                    return Err(format!("expected literal after {:?}", i));
+                    return Err(format!("expected literal after Ident: `{}`", i));
                 };
                 match self.build_literal_ok_if_able(first_arg, rest_of_stream) {
                     Ok(Some(l)) => Ok(Some(l)),
-                    _ => Err(format!("expected literal after {:?}", i)),
+                    _ => Err(format!("expected literal after Ident: `{}`", i)),
                 }
             }
             TokenTree::Ident(i) if i.to_string().to_ascii_lowercase() == "err" => {
@@ -499,7 +502,7 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
                     rows.push((row, 1));
                 }
             }
-            invalid => return Err(format!("invalid rows spec for constant {:?}", invalid)),
+            invalid => return Err(format!("invalid rows spec for constant `{}`", invalid)),
         };
         Ok(MirRelationExpr::Constant {
             rows: Ok(rows),
@@ -535,7 +538,10 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
                     },
                 }
             }
-            invalid_token => Err(format!("Invalid get specification {:?}", invalid_token)),
+            invalid_token => Err(format!(
+                "Invalid get specification {:?}",
+                invalid_token.map(|token_tree| format!("`{}`", token_tree))
+            )),
         }
     }
 
@@ -545,7 +551,10 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
     {
         let name = match stream_iter.next() {
             Some(TokenTree::Ident(ident)) => Ok(ident.to_string()),
-            invalid_token => Err(format!("Invalid let specification {:?}", invalid_token)),
+            invalid_token => Err(format!(
+                "Invalid let specification {:?}",
+                invalid_token.map(|token_tree| format!("`{}`", token_tree))
+            )),
         }?;
 
         let value: MirRelationExpr = deserialize(stream_iter, "MirRelationExpr", self)?;
@@ -631,7 +640,10 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                                     return Ok(Some(literal.to_string()))
                                 }
                                 invalid => {
-                                    return Err(format!("invalid column value {:?}", invalid))
+                                    return Err(format!(
+                                        "invalid column value {:?}",
+                                        invalid.map(|token_tree| format!("`{}`", token_tree))
+                                    ))
                                 }
                             }
                         }

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -21,7 +21,7 @@ build
   [[#0]]
   [int64])
 ----
-error: Punct { char: '#', spacing: Alone, span: bytes(536..537) } cannot be interpreted as a literal.
+error: TokenTree `#` cannot be interpreted as a literal.
 
 build
 (arrange_by

--- a/src/expr-test-util/tests/testdata/scalar
+++ b/src/expr-test-util/tests/testdata/scalar
@@ -80,12 +80,12 @@ build-scalar
 build-scalar
 (ok)
 ----
-error: expected literal after Ident { sym: ok, span: bytes(4055..4057) }
+error: expected literal after Ident: `ok`
 
 build-scalar
 (ok (ok true))
 ----
-error: expected literal after Ident { sym: ok, span: bytes(4061..4063) }
+error: expected literal after Ident: `ok`
 
 build-scalar
 (err)

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -242,7 +242,7 @@ where
                 // Must error instead of handling the tokens using default
                 // behavior since `stream_iter` has advanced.
                 Some(other) => Err(format!(
-                    "{}{:?} is not a valid literal",
+                    "`{}` `{}` is not a valid literal",
                     punct.as_char(),
                     other
                 )),
@@ -264,14 +264,17 @@ pub fn parse_vec_of_literals(token: &TokenTree) -> Result<Vec<String>, String> {
                 match extract_literal_string(&symbol, &mut inner_iter)? {
                     Some(dat) => result.push(dat),
                     None => {
-                        return Err(format!("{:?} cannot be interpreted as a literal.", symbol));
+                        return Err(format!(
+                            "TokenTree `{}` cannot be interpreted as a literal.",
+                            symbol
+                        ));
                     }
                 }
             }
             Ok(result)
         }
         invalid => Err(format!(
-            "{:?} cannot be parsed as a vec of literals",
+            "TokenTree `{}` cannot be parsed as a vec of literals",
             invalid
         )),
     }


### PR DESCRIPTION
Fixing https://materializeinc.slack.com/archives/CM7ATT65S/p1673468816712609

There are some tests that include Lowertest error msgs verbatim. Some of these Lowertest error msgs were using `{:?}` on some 3rd party structs, which had the effect that the error msgs changed when those 3rd party libs changed their internals, and thus the tests had to be rewritten. Even worse, after a certain such internal 3rd party change, some struct had a new field (`span`) appear that was recording some unstable information that was changing wildly due to random reasons. (Not exactly the same, but in a similar fashion to how [iteration orders of a HashMap can change due to random reasons](https://github.com/MaterializeInc/materialize/issues/14587).)

This PR changes those error msgs to `{}`, and rewrites the tests one final time.

### Motivation

  * This PR fixes a recognized bug: Fixing https://materializeinc.slack.com/archives/CM7ATT65S/p1673468816712609

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  - [ ] It's fixing the testing of some tests...
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
