### PR TITLE
test: Fix flaky storage usage collection test

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -462,10 +462,12 @@ fn test_storage_usage_collection_interval() {
             .max_duration(Duration::from_secs(10))
             .retry(|_| {
                 let row = client.query_one(
-                    "SELECT max(collection_timestamp) FROM mz_internal.mz_storage_usage_by_shard",
+                    "SELECT max(collection_timestamp)
+                    FROM mz_internal.mz_storage_usage_by_shard",
                     &[],
                 )?;
-                let ts = row.get::<_, DateTime<Utc>>("max");
+                // mz_storage_usage_by_shard may not be populated yet, which would result in a NULL ts.
+                let ts = row.try_get::<_, DateTime<Utc>>("max")?;
                 if ts <= last_timestamp {
                     bail!("next collection has not yet occurred")
                 }


### PR DESCRIPTION
mz_storage_usage_by_shard is not automatically populated on startup. As a result, when querying the table you may get empty or NULL values. This commit updates the tests to handle this scenario instead of panicking on NULL values.

### Motivation
 This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
