### PR TITLE
Fix upgrade tests

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -33,7 +33,7 @@ from materialize.mzcompose.services import Materialized
 size = Materialized.Size.DEFAULT_SIZE
 environment_extra = [
     f'MZ_STORAGE_HOST_SIZES={{"{size}":{{"workers":{size}}}}}',
-    f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
+    f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}":{{"workers":"1","scale":{size}}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
 ]
 
 released_versions = util.released_materialize_versions()

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -166,7 +166,7 @@ def test_upgrade_from_version(
         size = Materialized.Size.DEFAULT_SIZE
         environment_extra = [
             f'MZ_STORAGE_HOST_SIZES={{"{size}":{{"workers":{size}}}}}',
-            f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
+            f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}":{{"workers":1,"scale":{size}}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
             "SSL_KEY_PASSWORD=mzmzmz",
         ]
 


### PR DESCRIPTION
Since we are now creating a replica with the same size for every source, the source size name we use must also be a valid replica size name.

### Motivation

  * This PR fixes a previously unreported bug.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
