### PR TITLE
adapter: remove `window_functions` feature flag

### DIFF
--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -194,9 +194,6 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Returns the configuration of the catalog.
     fn config(&self) -> &CatalogConfig;
 
-    /// Check if window functions are supported by the current system configuration.
-    fn window_functions(&self) -> bool;
-
     /// Returns the number of milliseconds since the system epoch. For normal use
     /// this means the Unix epoch. This can safely be mocked in tests and start
     /// at 0.
@@ -920,10 +917,6 @@ impl SessionCatalog for DummyCatalog {
 
     fn config(&self) -> &CatalogConfig {
         &DUMMY_CONFIG
-    }
-
-    fn window_functions(&self) -> bool {
-        true
     }
 
     fn now(&self) -> EpochMillis {

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -7,11 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_expr::visit::{Visit, VisitChildren};
-
 ///! This module defines the API and logic for running optimization pipelines.
 use crate::plan::expr::HirRelationExpr;
-use crate::plan::HirScalarExpr;
 use crate::query_model::{Model, QGMError};
 
 use super::{PlanError, StatementContext};
@@ -20,7 +17,6 @@ use super::{PlanError, StatementContext};
 #[derive(Debug)]
 pub struct OptimizerConfig {
     pub qgm_optimizations: bool,
-    pub window_functions: bool,
 }
 
 /// Convert a reference to a [`StatementContext`] to an [`OptimizerConfig`].
@@ -32,11 +28,9 @@ impl<'a> From<&StatementContext<'a>> for OptimizerConfig {
         match scx.pcx() {
             Ok(pcx) => OptimizerConfig {
                 qgm_optimizations: pcx.qgm_optimizations,
-                window_functions: scx.catalog.window_functions(),
             },
             Err(..) => OptimizerConfig {
                 qgm_optimizations: false,
-                window_functions: scx.catalog.window_functions(),
             },
         }
     }
@@ -50,35 +44,6 @@ impl HirRelationExpr {
         self,
         config: &OptimizerConfig,
     ) -> Result<mz_expr::MirRelationExpr, PlanError> {
-        if !config.window_functions {
-            // None - there are no Get(GlobalId) nodes / Some - all Get(GlobalId) nodes are for system IDs
-            let mut all_system_global_ids = None;
-            // there are no windowing expressions
-            let mut has_windowing_exprs = false;
-
-            // look for Get(GlobalId) or HirScalarExpr::Windowig in the entire tree
-            self.try_visit_pre(&mut |expr: &HirRelationExpr| {
-                use mz_expr::Id::Global;
-                // update all_global_ids_system accumulator for each encountered Get(GlobalId) node
-                if let HirRelationExpr::Get { id: Global(id), .. } = expr {
-                    let v = all_system_global_ids.get_or_insert(true);
-                    *v &= id.is_system();
-                }
-                // update has_windowing_exprs accumulator for each encountered HirScalarExpr::Windowig node
-                expr.try_visit_children(|expr: &HirScalarExpr| {
-                    expr.visit_pre(&mut |expr: &HirScalarExpr| {
-                        if let HirScalarExpr::Windowing(_) = expr {
-                            has_windowing_exprs = true;
-                        }
-                    })
-                })
-            })?;
-
-            if has_windowing_exprs && !all_system_global_ids.unwrap_or(false) {
-                bail_unsupported!("window functions");
-            }
-        }
-
         if config.qgm_optimizations {
             // try to go through the QGM path
             self.try_qgm_path().map_err(Into::into)

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -299,10 +299,6 @@ impl SessionCatalog for TestCatalog {
         &DUMMY_CONFIG
     }
 
-    fn window_functions(&self) -> bool {
-        true
-    }
-
     fn now(&self) -> EpochMillis {
         (self.config().now)()
     }

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -47,7 +47,6 @@ standard_conforming_strings             on                     "Causes '...' str
 statement_timeout                       "10 s"                 "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
 TimeZone                                UTC                    "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation                   "strict serializable"  "Sets the current transaction's isolation level (PostgreSQL)."
-window_functions                        on                     "Feature flag indicating whether window functions are enabled (Materialize)."
 
 > SET application_name = 'foo'
 


### PR DESCRIPTION
Removes the `window_functions` parameter introduced in #15969.

### Motivation

   * This PR refactors existing code.

Remove a feature flag that is no longer needed.

### Tips for reviewer

* We need to ensure that `ALTER SYSTEM RESET window_functions` is executed on every environment before rolling out this change.
* @benesch can you review the second commit (see the commit message for details)? Operationally it makes sense to me, but there are also some arguments for keeping things as they are.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, [there is a companion cloud issue](https://github.com/MaterializeInc/cloud/issues/5090) to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
