### PR TITLE
test/upgrade: fix cluster replica sizing

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -27,14 +27,6 @@ from materialize.checks.mzcompose_actions import (
     UseClusterdCompute,
 )
 from materialize.checks.scenarios import Scenario
-from materialize.mzcompose.services import Materialized
-
-# Older Mz versions are not configured to know SIZE '4-4' clusters by default
-size = Materialized.Size.DEFAULT_SIZE
-environment_extra = [
-    f'MZ_STORAGE_HOST_SIZES={{"{size}":{{"workers":{size}}}}}',
-    f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
-]
 
 released_versions = util.released_materialize_versions()
 
@@ -54,7 +46,7 @@ class UpgradeEntireMz(Scenario):
     def actions(self) -> List[Action]:
         print(f"Upgrading from tag {self.tag()}")
         return [
-            StartMz(tag=self.tag(), environment_extra=environment_extra),
+            StartMz(tag=self.tag()),
             Initialize(self.checks),
             Manipulate(self.checks, phase=1),
             KillMz(),
@@ -89,7 +81,7 @@ class UpgradeClusterdComputeLast(Scenario):
 
     def actions(self) -> List[Action]:
         return [
-            StartMz(tag=last_version, environment_extra=environment_extra),
+            StartMz(tag=last_version),
             StartClusterdCompute(tag=last_version),
             UseClusterdCompute(),
             Initialize(self.checks),
@@ -118,7 +110,7 @@ class UpgradeClusterdComputeFirst(Scenario):
 
     def actions(self) -> List[Action]:
         return [
-            StartMz(tag=last_version, environment_extra=environment_extra),
+            StartMz(tag=last_version),
             StartClusterdCompute(tag=last_version),
             UseClusterdCompute(),
             Initialize(self.checks),

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -51,9 +51,6 @@ SERVICES = [
     Postgres(),
     Materialized(
         options=list(mz_options.values()),
-        environment_extra=[
-            "SSL_KEY_PASSWORD=mzmzmz",
-        ],
         volumes_extra=["secrets:/share/secrets"],
     ),
     # N.B.: we need to use `validate_postgres_stash=False` because testdrive uses
@@ -161,15 +158,6 @@ def test_upgrade_from_version(
     )
 
     if from_version != "current_source":
-        # Older Mz versions are not configured to know SIZE '4-4' clusters by default
-        # so we need to compose MZ_STORAGE_HOST_SIZES and MZ_CLUSTER_REPLICA_SIZES
-        size = Materialized.Size.DEFAULT_SIZE
-        environment_extra = [
-            f'MZ_STORAGE_HOST_SIZES={{"{size}":{{"workers":{size}}}}}',
-            f'MZ_CLUSTER_REPLICA_SIZES={{"1":{{"workers":1,"scale":1}},"{size}-{size}":{{"workers":{size},"scale":{size}}}}}',
-            "SSL_KEY_PASSWORD=mzmzmz",
-        ]
-
         mz_from = Materialized(
             image=f"materialize/materialized:{from_version}",
             options=[
@@ -177,7 +165,6 @@ def test_upgrade_from_version(
                 for start_version, opt in mz_options.items()
                 if from_version[1:] >= start_version
             ],
-            environment_extra=environment_extra,
             volumes_extra=["secrets:/share/secrets"],
         )
         with c.override(mz_from):


### PR DESCRIPTION
The comment is no longer relevant, as we no longer care about such old versions of Materialize. Remove the override, as it is breaking the upgrade tests.
