### PR TITLE
Avoid multiple InspectBatch probing operators

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -541,19 +541,15 @@ where
                 Id::Global(idx_id)
             )
         });
-        let arrangement = bundle.arrangement(&idx.key);
 
-        // Set up probes to notify on index frontier advancement.
-        if let Some(arr) = &arrangement {
-            let (collection, _) = arr.as_collection();
-            let stream = collection.inner;
-            stream.probe_notify_with(probes.clone());
-        }
+        compute_state
+            .flow_control_probes
+            .insert(idx_id, probes.clone());
 
-        compute_state.flow_control_probes.insert(idx_id, probes);
-
-        match arrangement {
+        match bundle.arrangement(&idx.key) {
             Some(ArrangementFlavor::Local(oks, errs)) => {
+                // Set up probes to notify on index frontier advancement.
+                oks.stream.probe_notify_with(probes);
                 compute_state.traces.set(
                     idx_id,
                     TraceBundle::new(oks.trace, errs.trace).with_drop(needed_tokens),
@@ -610,24 +606,19 @@ where
                 Id::Global(idx_id)
             )
         });
-        let arrangement = bundle.arrangement(&idx.key);
 
-        // Set up probes to notify on index frontier advancement.
-        if let Some(arr) = &arrangement {
-            let (collection, _) = arr.as_collection();
-            let stream = collection.leave().inner;
-            stream.probe_notify_with(probes.clone());
-        }
+        compute_state
+            .flow_control_probes
+            .insert(idx_id, probes.clone());
 
-        compute_state.flow_control_probes.insert(idx_id, probes);
-
-        match arrangement {
+        match bundle.arrangement(&idx.key) {
             Some(ArrangementFlavor::Local(oks, errs)) => {
                 use differential_dataflow::operators::arrange::Arrange;
                 let oks = oks
                     .as_collection(|k, v| (k.clone(), v.clone()))
                     .leave()
                     .arrange();
+                oks.stream.probe_notify_with(probes);
                 let errs = errs
                     .as_collection(|k, v| (k.clone(), v.clone()))
                     .leave()

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -526,7 +526,7 @@ where
         import_ids: BTreeSet<GlobalId>,
         idx_id: GlobalId,
         idx: &IndexDesc,
-        mut probes: Vec<probe::Handle<mz_repr::Timestamp>>,
+        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) {
         // put together tokens that belong to the export
         let mut needed_tokens = Vec::new();
@@ -547,9 +547,7 @@ where
         if let Some(arr) = &arrangement {
             let (collection, _) = arr.as_collection();
             let stream = collection.inner;
-            for handle in probes.iter_mut() {
-                stream.probe_notify_with(handle);
-            }
+            stream.probe_notify_with(probes.clone());
         }
 
         compute_state.flow_control_probes.insert(idx_id, probes);
@@ -597,7 +595,7 @@ where
         import_ids: BTreeSet<GlobalId>,
         idx_id: GlobalId,
         idx: &IndexDesc,
-        mut probes: Vec<probe::Handle<mz_repr::Timestamp>>,
+        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) {
         // put together tokens that belong to the export
         let mut needed_tokens = Vec::new();
@@ -618,9 +616,7 @@ where
         if let Some(arr) = &arrangement {
             let (collection, _) = arr.as_collection();
             let stream = collection.leave().inner;
-            for handle in probes.iter_mut() {
-                stream.probe_notify_with(handle);
-            }
+            stream.probe_notify_with(probes.clone());
         }
 
         compute_state.flow_control_probes.insert(idx_id, probes);

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -216,7 +216,7 @@ where
 
     append_frontier_stream.connect_loop(persist_feedback_handle);
 
-    append_frontier_stream.probe_notify_with(probes.clone());
+    append_frontier_stream.probe_notify_with(probes);
 
     let token = Rc::new((mint_token, write_token, append_token));
 

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -154,7 +154,7 @@ fn install_desired_into_persist<G>(
     persist_collection: Collection<G, Result<Row, DataflowError>, Diff>,
     as_of: Antichain<Timestamp>,
     compute_state: &mut crate::compute_state::ComputeState,
-    mut probes: Vec<probe::Handle<Timestamp>>,
+    probes: Vec<probe::Handle<Timestamp>>,
 ) -> Option<Rc<dyn Any>>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -216,9 +216,7 @@ where
 
     append_frontier_stream.connect_loop(persist_feedback_handle);
 
-    for handle in &mut probes {
-        append_frontier_stream.probe_notify_with(handle);
-    }
+    append_frontier_stream.probe_notify_with(probes.clone());
 
     let token = Rc::new((mint_token, write_token, append_token));
 

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -85,7 +85,7 @@ fn subscribe<G>(
     as_of: SinkAsOf,
     up_to: Antichain<G::Timestamp>,
     subscribe_protocol_handle: Rc<RefCell<Option<SubscribeProtocol>>>,
-    mut probes: Vec<probe::Handle<Timestamp>>,
+    probes: Vec<probe::Handle<Timestamp>>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -142,9 +142,7 @@ fn subscribe<G>(
         },
     );
 
-    for handle in &mut probes {
-        progress_stream.probe_notify_with(handle);
-    }
+    progress_stream.probe_notify_with(probes.clone());
 }
 
 /// A type that guides the transmission of rows back to the coordinator.

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -142,7 +142,7 @@ fn subscribe<G>(
         },
     );
 
-    progress_stream.probe_notify_with(probes.clone());
+    progress_stream.probe_notify_with(probes);
 }
 
 /// A type that guides the transmission of rows back to the coordinator.

--- a/src/timely-util/src/probe.rs
+++ b/src/timely-util/src/probe.rs
@@ -31,26 +31,31 @@ pub trait ProbeNotify<G: Scope, D: Data> {
     /// Constructs a progress probe which indicates which timestamps have elapsed at the operator.
     fn probe_notify(&self) -> Handle<G::Timestamp>;
 
-    /// Inserts a progress probe in a stream.
-    fn probe_notify_with(&self, handle: &mut Handle<G::Timestamp>) -> Stream<G, D>;
+    /// Inserts a collection of progress probe in a stream.
+    fn probe_notify_with(&self, handles: Vec<Handle<G::Timestamp>>) -> Stream<G, D>;
 }
 
 impl<G: Scope, D: Data> ProbeNotify<G, D> for Stream<G, D> {
     fn probe_notify(&self) -> Handle<G::Timestamp> {
-        let mut handle = Handle::default();
-        self.probe_notify_with(&mut handle);
+        let handle = Handle::default();
+        self.probe_notify_with(vec![handle.clone()]);
         handle
     }
 
-    fn probe_notify_with(&self, handle: &mut Handle<G::Timestamp>) -> Stream<G, D> {
-        let mut handle = handle.clone();
+    fn probe_notify_with(&self, mut handles: Vec<Handle<G::Timestamp>>) -> Stream<G, D> {
         // We need to reset the handle's frontier from the empty one to the minimal one, to enable
         // downgrading.
-        handle.update_frontier(&[Timestamp::minimum()]);
+        for handle in &mut handles {
+            handle.update_frontier(&[Timestamp::minimum()]);
+        }
 
+        // TODO: This causes the input data to be copied for this operator, only to immediately
+        // discard it. Instead, it should only observe progress statements.
         self.inspect_container(move |update| {
             if let Err(frontier) = update {
-                handle.update_frontier(frontier);
+                for handle in &mut handles {
+                    handle.update_frontier(frontier);
+                }
             }
         })
     }


### PR DESCRIPTION
Attaching a probe to a stream could only update a single handle. In many cases, this meant that we would attach multiple InspectBatch operators to a dataflow's output. This change alters this to only use a single operator for a collection of probes.

Using the InspectBatch operator is not ideal because it forces the system to create a complete copy of the input data, which is then immediately discarded because we're only interested in progress statements. The fix at hands reduces the number of InspectBatch operators, but does not avoid the unnecessary copying of data.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
