### PR TITLE
optimizer: replace more Hash collections with BTree equivalents

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -14,7 +14,7 @@
 //! and indicate which identifiers have arrangements available. This module
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 use differential_dataflow::lattice::Lattice;
 use timely::progress::Antichain;
@@ -464,7 +464,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
 
                     // Inspect global ids that occur in the Gets in view_expr, and collect the ids
                     // of monotonic (materialized) views and sources (but not indexes).
-                    let mut monotonic_ids = HashSet::new();
+                    let mut monotonic_ids = BTreeSet::new();
                     let recursion_result: Result<(), RecursionLimitError> = view_expr
                         .try_visit_post(&mut |e| {
                             if let MirRelationExpr::Get {
@@ -501,7 +501,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                     mz_transform::monotonic::MonotonicFlag::default().apply(
                         &mut view_expr,
                         &monotonic_ids,
-                        &mut HashSet::new(),
+                        &mut BTreeSet::new(),
                     )
                 }
                 CatalogItem::Secret(_)

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -74,7 +74,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use proc_macro2::TokenTree;
 use serde::{Deserialize, Serialize};
@@ -167,8 +167,8 @@ pub fn json_to_spec(rel_json: &str, catalog: &TestCatalog) -> (String, Vec<Strin
 /// later.
 #[derive(Debug, Default)]
 pub struct TestCatalog {
-    objects: HashMap<String, (GlobalId, RelationType)>,
-    names: HashMap<GlobalId, String>,
+    objects: BTreeMap<String, (GlobalId, RelationType)>,
+    names: BTreeMap<GlobalId, String>,
 }
 
 /// Contains the arguments for a command for [TestCatalog].
@@ -776,8 +776,8 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
 /// in the body of the `let`.
 #[derive(Debug, Default)]
 struct Scope {
-    objects: HashMap<String, (Id, RelationType)>,
-    names: HashMap<Id, String>,
+    objects: BTreeMap<String, (Id, RelationType)>,
+    names: BTreeMap<Id, String>,
 }
 
 impl Scope {

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -24,7 +24,7 @@
 //! printed in contexts where trailing whitespace is unacceptable, like
 //! sqllogictest files.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::iter;
 
@@ -46,11 +46,11 @@ pub struct ViewExplanation<'a> {
     /// left-to-right post-order.
     nodes: Vec<ExplanationNode<'a>>,
     /// Records the chain ID that was assigned to each expression.
-    expr_chains: HashMap<*const MirRelationExpr, usize>,
+    expr_chains: BTreeMap<*const MirRelationExpr, usize>,
     /// Records the chain ID that was assigned to each let.
-    local_id_chains: HashMap<LocalId, usize>,
+    local_id_chains: BTreeMap<LocalId, usize>,
     /// Records the local ID that corresponds to a chain ID, if any.
-    chain_local_ids: HashMap<usize, LocalId>,
+    chain_local_ids: BTreeMap<usize, LocalId>,
     /// The ID of the current chain. Incremented while constructing the
     /// `Explanation`.
     chain: usize,
@@ -171,9 +171,9 @@ impl<'a> ViewExplanation<'a> {
         let mut explanation = ViewExplanation {
             expr_humanizer,
             nodes: vec![],
-            expr_chains: HashMap::new(),
-            local_id_chains: HashMap::new(),
-            chain_local_ids: HashMap::new(),
+            expr_chains: BTreeMap::new(),
+            local_id_chains: BTreeMap::new(),
+            chain_local_ids: BTreeMap::new(),
             chain: 0,
         };
         walk(expr, &mut explanation);

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -6,7 +6,7 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 
 use proptest::prelude::*;
@@ -472,7 +472,7 @@ impl MapFilterProject {
         });
 
         // Determine extended input columns used by temporal filters.
-        let mut support = HashSet::new();
+        let mut support = BTreeSet::new();
         for predicate in temporal_predicates.iter() {
             support.extend(predicate.support());
         }
@@ -527,7 +527,7 @@ impl MapFilterProject {
                 // unimplemented!()
 
                 // Then, look for unused columns and project them away.
-                let mut common_demand = HashSet::new();
+                let mut common_demand = BTreeSet::new();
                 for mfp in mfps.iter() {
                     common_demand.extend(mfp.demand());
                 }
@@ -654,7 +654,7 @@ impl MapFilterProject {
         let mut after_proj = Vec::new();
 
         // Track which output columns must be preserved in the output of `before`.
-        let mut demanded = HashSet::new();
+        let mut demanded = BTreeSet::new();
         demanded.extend(0..self.input_arity);
         demanded.extend(self.projection.iter());
 
@@ -794,8 +794,8 @@ impl MapFilterProject {
     /// It is entirely appropriate to determine the demand of an instance
     /// and then both apply a projection to the subject of the instance and
     /// `self.permute` this instance.
-    pub fn demand(&self) -> HashSet<usize> {
-        let mut demanded = HashSet::new();
+    pub fn demand(&self) -> BTreeSet<usize> {
+        let mut demanded = BTreeSet::new();
         for (_index, pred) in self.predicates.iter() {
             demanded.extend(pred.support());
         }
@@ -1239,7 +1239,7 @@ impl MapFilterProject {
     /// ```
     pub fn remove_undemanded(&mut self) {
         // Determine the demanded expressions to remove irrelevant ones.
-        let mut demand = std::collections::HashSet::new();
+        let mut demand = BTreeSet::new();
         for (_index, pred) in self.predicates.iter() {
             demand.extend(pred.support());
         }
@@ -1337,7 +1337,7 @@ pub fn memoize_expr(
 }
 
 pub mod util {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::BTreeMap;
 
     use crate::MirScalarExpr;
 
@@ -1355,7 +1355,7 @@ pub mod util {
         key: &[MirScalarExpr],
         unthinned_arity: usize,
     ) -> (BTreeMap<usize, usize>, Vec<usize>) {
-        let columns_in_key: HashMap<_, _> = key
+        let columns_in_key: BTreeMap<_, _> = key
             .iter()
             .enumerate()
             .filter_map(|(i, key_col)| key_col.as_column().map(|c| (c, i)))

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -11,7 +11,7 @@
 //! into canonical form.
 
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use mz_repr::{ColumnType, Datum, ScalarType};
 
@@ -224,7 +224,7 @@ pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, column_types
     // 3) Make non-null requirements explicit as predicates in order for
     // step 4) to be able to simplify AND/OR expressions with IS NULL
     // sub-predicates. This redundancy is removed later by step 5).
-    let mut non_null_columns = HashSet::new();
+    let mut non_null_columns = BTreeSet::new();
     for p in predicates.iter() {
         p.non_null_requirements(&mut non_null_columns);
     }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1079,13 +1079,15 @@ where
 
 /// Identify whether the given aggregate function is Lag or Lead, since they share
 /// implementations.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub enum LagLeadType {
     Lag,
     Lead,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub enum AggregateFunc {
     MaxNumeric,
     MaxInt16,
@@ -2069,7 +2071,9 @@ impl fmt::Display for AggregateFunc {
     }
 }
 
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct CaptureGroupDesc {
     pub index: u32,
     pub name: Option<String>,
@@ -2094,7 +2098,9 @@ impl RustType<ProtoCaptureGroupDesc> for CaptureGroupDesc {
     }
 }
 
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct AnalyzedRegex(
     #[proptest(strategy = "mz_repr::adt::regex::any_regex()")] ReprRegex,
     Vec<CaptureGroupDesc>,
@@ -2178,7 +2184,9 @@ fn wrap<'a>(datums: &'a [Datum<'a>], width: usize) -> impl Iterator<Item = (Row,
     datums.chunks(width).map(|chunk| (Row::pack(chunk), 1))
 }
 
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub enum TableFunc {
     JsonbEach {
         stringify: bool,

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{HashSet, BTreeSet};
+use std::collections::BTreeSet;
 use std::ops::Range;
 
 use core::option::Option;
@@ -120,7 +120,7 @@ impl JoinInputMapper {
         // for inputs `1..self.total_inputs()`, store a set of columns from that
         // input that exist in join constraints that have expressions belonging to
         // earlier inputs.
-        let mut column_with_prior_bound_by_input = vec![HashSet::new(); self.total_inputs() - 1];
+        let mut column_with_prior_bound_by_input = vec![BTreeSet::new(); self.total_inputs() - 1];
         for equivalence in equivalences {
             // do a scan to find the first input represented in the constraint
             let min_bound_input = equivalence

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, BTreeSet};
 use std::ops::Range;
 
 use core::option::Option;
@@ -216,14 +216,14 @@ impl JoinInputMapper {
         column + self.prior_arities[index]
     }
 
-    /// Takes a HashSet of columns in the global context and splits it into
-    /// a `Vec` containing `self.total_inputs()` HashSets, each containing
+    /// Takes a sequence of columns in the global context and splits it into
+    /// a `Vec` containing `self.total_inputs()` `BTreeSet`s, each containing
     /// the localized columns that belong to the particular input.
-    pub fn split_column_set_by_input<'a, I>(&self, columns: I) -> Vec<HashSet<usize>>
+    pub fn split_column_set_by_input<'a, I>(&self, columns: I) -> Vec<BTreeSet<usize>>
     where
         I: Iterator<Item = &'a usize>,
     {
-        let mut new_columns = vec![HashSet::new(); self.total_inputs()];
+        let mut new_columns = vec![BTreeSet::new(); self.total_inputs()];
         for column in columns {
             let (new_col, input) = self.map_column_to_local(*column);
             new_columns[input].extend(std::iter::once(new_col));

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -399,7 +399,7 @@ impl MirRelationExpr {
                 // Augment non-nullability of columns, by observing either
                 // 1. Predicates that explicitly test for null values, and
                 // 2. Columns that if null would make a predicate be null.
-                let mut nonnull_required_columns = HashSet::new();
+                let mut nonnull_required_columns = BTreeSet::new();
                 for predicate in predicates {
                     // Add any columns that being null would force the predicate to be null.
                     // Should that happen, the row would be discarded.

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs)]
 
 use std::cmp::{max, Ordering};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::fmt;
 use std::num::NonZeroUsize;
 
@@ -500,7 +500,7 @@ impl MirRelationExpr {
             } => {
                 let n_cols = typ.arity();
                 // If the `i`th entry is `Some`, then we have not yet observed non-uniqueness in the `i`th column.
-                let mut unique_values_per_col = vec![Some(HashSet::<Datum>::default()); n_cols];
+                let mut unique_values_per_col = vec![Some(BTreeSet::<Datum>::default()); n_cols];
                 for (row, diff) in rows {
                     for (i, datum) in row.iter().enumerate() {
                         if datum != Datum::Dummy {
@@ -670,12 +670,12 @@ impl MirRelationExpr {
                     });
 
                     // Keep doing replacements until the number of keys settles
-                    let mut prev_keys: HashSet<_> = input.drain(..).collect();
+                    let mut prev_keys: BTreeSet<_> = input.drain(..).collect();
                     let mut prev_keys_size = 0;
                     while prev_keys_size != prev_keys.len() {
                         prev_keys_size = prev_keys.len();
                         for (c1, c2) in classes.clone() {
-                            let mut new_keys = HashSet::new();
+                            let mut new_keys = BTreeSet::new();
                             for key in prev_keys.into_iter() {
                                 let contains_c1 = key.contains(&c1);
                                 let contains_c2 = key.contains(&c2);
@@ -1727,7 +1727,7 @@ impl MirRelationExpr {
     /// identifiers are rewritten to be the constant collection.
     /// This makes the computation perform exactly "one" iteration.
     pub fn make_nonrecursive(self: &mut MirRelationExpr) {
-        let mut deadlist = std::collections::HashSet::new();
+        let mut deadlist = BTreeSet::new();
         let mut worklist = vec![self];
         while let Some(expr) = worklist.pop() {
             if let MirRelationExpr::LetRec { ids, values, body } = expr {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -77,7 +77,7 @@ pub trait CollectionPlan {
 ///
 /// The AST is meant to reflect the capabilities of the `differential_dataflow::Collection` type,
 /// written generically enough to avoid run-time compilation work.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub enum MirRelationExpr {
     /// A constant relation containing specified rows.
     ///
@@ -1943,7 +1943,9 @@ impl VisitChildren<Self> for MirRelationExpr {
 }
 
 /// Specification for an ordering by a column.
-#[derive(Arbitrary, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct ColumnOrder {
     /// The column index.
     pub column: usize,
@@ -1990,7 +1992,9 @@ impl fmt::Display for ColumnOrder {
 }
 
 /// Describes an aggregation expression.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct AggregateExpr {
     /// Names the aggregation function.
     pub func: AggregateFunc,
@@ -2466,7 +2470,7 @@ impl fmt::Display for AggregateExpr {
 }
 
 /// Describe a join implementation in dataflow.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub enum JoinImplementation {
     /// Perform a sequence of binary differential dataflow joins.
     ///
@@ -2813,7 +2817,9 @@ where
 ///
 /// Window frames define a subset of the partition , and only a subset of
 /// window functions make use of the window frame.
-#[derive(Arbitrary, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct WindowFrame {
     /// ROWS, RANGE or GROUPS
     pub units: WindowFrameUnits,
@@ -2905,7 +2911,9 @@ impl RustType<ProtoWindowFrame> for WindowFrame {
 }
 
 /// Describe how frame bounds are interpreted
-#[derive(Arbitrary, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub enum WindowFrameUnits {
     /// Each row is treated as the unit of work for bounds
     Rows,

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use mz_repr::adt::date::DateError;
 use mz_repr::adt::timestamp::TimestampError;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::fmt;
 use std::mem;
@@ -1681,7 +1682,7 @@ impl MirScalarExpr {
     /* #endregion */
 
     /// Adds any columns that *must* be non-Null for `self` to be non-Null.
-    pub fn non_null_requirements(&self, columns: &mut HashSet<usize>) {
+    pub fn non_null_requirements(&self, columns: &mut BTreeSet<usize>) {
         match self {
             MirScalarExpr::Column(col) => {
                 columns.insert(*col);

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -48,7 +48,7 @@ pub mod like_pattern;
 
 include!(concat!(env!("OUT_DIR"), "/mz_expr.scalar.rs"));
 
-#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, MzReflect)]
 pub enum MirScalarExpr {
     /// A column of the input row
     Column(usize),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -10,9 +10,7 @@
 use itertools::Itertools;
 use mz_repr::adt::date::DateError;
 use mz_repr::adt::timestamp::TimestampError;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::mem;
 use std::ops::BitOrAssign;
@@ -572,8 +570,8 @@ impl MirScalarExpr {
         });
     }
 
-    pub fn support(&self) -> HashSet<usize> {
-        let mut support = HashSet::new();
+    pub fn support(&self) -> BTreeSet<usize> {
+        let mut support = BTreeSet::new();
         #[allow(deprecated)]
         self.visit_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(i) = e {
@@ -1099,7 +1097,7 @@ impl MirScalarExpr {
                             }
 
                             // Deduplicate arguments in cases like `coalesce(#0, #0)`.
-                            let mut prior_exprs = HashSet::new();
+                            let mut prior_exprs = BTreeSet::new();
                             exprs.retain(|e| prior_exprs.insert(e.clone()));
 
                             if let Some(expr) = exprs.iter_mut().find(|e| e.is_literal_err()) {

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -101,8 +101,8 @@ pub fn mzreflect_derive(input: TokenStream) -> TokenStream {
     //    {
     //       // if the object is an enum
     //       if rti.enum_dict.contains_key(#name) { return; }
-    //       use std::collections::HashMap;
-    //       let mut result = HashMap::new();
+    //       use std::collections::BTreeMap;
+    //       let mut result = BTreeMap::new();
     //       // repeat line below for all variants
     //       result.insert(variant_name, (<field_names>, <field_types>));
     //       rti.enum_dist.insert(<enum_name>, result);
@@ -137,8 +137,8 @@ pub fn mzreflect_derive(input: TokenStream) -> TokenStream {
             .collect::<Vec<_>>();
         quote! {
             if rti.enum_dict.contains_key(#object_name_as_string) { return; }
-            use std::collections::HashMap;
-            let mut result = HashMap::new();
+            use std::collections::BTreeMap;
+            let mut result = BTreeMap::new();
             #(#variants)*
             rti.enum_dict.insert(#object_name_as_string, result);
         }

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! See [README.md].
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 use serde::de::DeserializeOwned;
@@ -115,8 +115,8 @@ impl<T: MzReflect> MzReflect for Vec<T> {
 #[derive(Debug, Default)]
 pub struct ReflectedTypeInfo {
     pub enum_dict:
-        HashMap<&'static str, HashMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>>,
-    pub struct_dict: HashMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>,
+        BTreeMap<&'static str, BTreeMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>>,
+    pub struct_dict: BTreeMap<&'static str, (Vec<&'static str>, Vec<&'static str>)>,
 }
 
 /* #endregion */

--- a/src/repr/src/explain_new/mod.rs
+++ b/src/repr/src/explain_new/mod.rs
@@ -30,7 +30,8 @@
 //! constructor for [`Explain`] to indicate that the implementation does
 //! not support this `$format`.
 
-use std::{collections::HashSet, fmt};
+use std::collections::BTreeSet;
+use std::fmt;
 
 use mz_ore::{stack::RecursionLimitError, str::Indent, str::IndentLike};
 
@@ -388,9 +389,9 @@ impl ExplainConfig {
     }
 }
 
-impl TryFrom<HashSet<String>> for ExplainConfig {
+impl TryFrom<BTreeSet<String>> for ExplainConfig {
     type Error = anyhow::Error;
-    fn try_from(mut flags: HashSet<String>) -> Result<Self, anyhow::Error> {
+    fn try_from(mut flags: BTreeSet<String>) -> Result<Self, anyhow::Error> {
         // If `WITH(raw)` is specified, ensure that the config will be as
         // representative for the original plan as possible.
         if flags.remove("raw") {

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -141,7 +141,9 @@ impl RustType<ProtoColumnType> for ColumnType {
 }
 
 /// The type of a relation.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct RelationType {
     /// The type for each column, in order.
     pub column_types: Vec<ColumnType>,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -13,7 +13,7 @@
 //! `INSERT`, `SELECT`, `SUBSCRIBE`, and `COPY`.
 
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use mz_expr::MirRelationExpr;
 use mz_ore::collections::CollectionExt;
@@ -336,7 +336,7 @@ pub fn plan_explain(
     let config_flags = config_flags
         .iter()
         .map(|ident| ident.to_string().to_lowercase())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
     let config = ExplainConfig::try_from(config_flags)?;
 
     let format = match format {

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -9,7 +9,7 @@
 
 //! Derived attributes framework and definitions.
 
-use std::{collections::HashMap, marker::PhantomData};
+use std::{collections::BTreeMap, marker::PhantomData};
 
 use mz_repr::explain_new::ExplainConfig;
 use num_traits::FromPrimitive;
@@ -75,8 +75,8 @@ impl<A: Attribute + 'static> TypeMapKey for AsKey<A> {
 #[derive(Default)]
 #[allow(missing_debug_implementations)]
 pub struct Env<A: Attribute> {
-    /// The [`HashMap`] backing this environment.
-    env: HashMap<LocalId, A::Value>,
+    /// The [`BTreeMap`] backing this environment.
+    env: BTreeMap<LocalId, A::Value>,
     // A stack of tasks to maintain the `env` map.
     env_tasks: Vec<EnvTask<A::Value>>,
 }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -9,7 +9,7 @@
 
 //! Transformations based on pulling information about individual columns from sources.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use itertools::Itertools;
 
@@ -57,7 +57,7 @@ impl crate::Transform for ColumnKnowledge {
     ) -> Result<(), TransformError> {
         let mut knowledge_stack = Vec::<DatumKnowledge>::new();
         let result = self
-            .harvest(expr, &mut HashMap::new(), &mut knowledge_stack)
+            .harvest(expr, &mut BTreeMap::new(), &mut knowledge_stack)
             .map(|_| ());
         mz_repr::explain_new::trace_plan(&*expr);
         result
@@ -71,7 +71,7 @@ impl ColumnKnowledge {
     fn harvest(
         &self,
         expr: &mut MirRelationExpr,
-        knowledge: &mut HashMap<mz_expr::Id, Vec<DatumKnowledge>>,
+        knowledge: &mut BTreeMap<mz_expr::Id, Vec<DatumKnowledge>>,
         knowledge_stack: &mut Vec<DatumKnowledge>,
     ) -> Result<Vec<DatumKnowledge>, TransformError> {
         self.checked_recur(|_| {

--- a/src/transform/src/cse/relation_cse.rs
+++ b/src/transform/src/cse/relation_cse.rs
@@ -14,7 +14,7 @@
 //! The resulting expressions likely have an excess of `Let` expressions, and therefore
 //! we automatically run the `NormalizeLets` transformation to remove those that are not necessary.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use mz_expr::visit::VisitChildren;
 use mz_expr::{Id, LocalId, MirRelationExpr, RECURSION_LIMIT};
@@ -73,9 +73,9 @@ impl crate::Transform for RelationCSE {
 #[derive(Debug)]
 pub struct Bindings {
     /// A list of let-bound expressions and their order / identifier.
-    bindings: HashMap<MirRelationExpr, u64>,
+    bindings: BTreeMap<MirRelationExpr, u64>,
     /// Mapping from conventional local `Get` identifiers to new ones.
-    rebindings: HashMap<LocalId, LocalId>,
+    rebindings: BTreeMap<LocalId, LocalId>,
     // A guard for tracking the maximum depth of recursive tree traversal.
     recursion_guard: RecursionGuard,
 }
@@ -83,8 +83,8 @@ pub struct Bindings {
 impl Default for Bindings {
     fn default() -> Bindings {
         Bindings {
-            bindings: HashMap::new(),
-            rebindings: HashMap::new(),
+            bindings: BTreeMap::new(),
+            rebindings: BTreeMap::new(),
             recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
         }
     }

--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -10,7 +10,7 @@
 //! Replace operators on constants collections with constant collections.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 use std::iter;
 
@@ -502,7 +502,7 @@ impl FoldConstants {
                                 agg.func.eval(
                                     vals.iter()
                                         .map(|val| val[i].unpack_first())
-                                        .collect::<HashSet<_>>()
+                                        .collect::<BTreeSet<_>>()
                                         .into_iter(),
                                     &temp_storage,
                                 )

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -325,7 +325,7 @@ impl JoinImplementation {
 }
 
 mod index_map {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use mz_expr::{Id, LocalId, MirScalarExpr};
 
@@ -335,7 +335,7 @@ mod index_map {
     /// a `MirRelationExpr`.
     #[derive(Debug)]
     pub struct IndexMap<'a> {
-        local: HashMap<LocalId, Vec<Vec<MirScalarExpr>>>,
+        local: BTreeMap<LocalId, Vec<Vec<MirScalarExpr>>>,
         global: &'a dyn IndexOracle,
     }
 
@@ -344,7 +344,7 @@ mod index_map {
         /// indexes.
         pub fn new(global: &dyn IndexOracle) -> IndexMap {
             IndexMap {
-                local: HashMap::new(),
+                local: BTreeMap::new(),
                 global,
             }
         }

--- a/src/transform/src/literal_lifting.rs
+++ b/src/transform/src/literal_lifting.rs
@@ -20,7 +20,7 @@
 //! This type of transformation is difficult to make otherwise, as it
 //! is not easy to locally change the shape of relations.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use itertools::Itertools;
 
@@ -64,7 +64,7 @@ impl crate::Transform for LiteralLifting {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        let literals = self.action(relation, &mut HashMap::new())?;
+        let literals = self.action(relation, &mut BTreeMap::new())?;
         if !literals.is_empty() {
             // Literals return up the root should be re-installed.
             *relation = relation.take_dangerous().map(literals);
@@ -132,7 +132,7 @@ impl LiteralLifting {
         &self,
         relation: &mut MirRelationExpr,
         // Map from names to literals required for appending.
-        gets: &mut HashMap<Id, Vec<MirScalarExpr>>,
+        gets: &mut BTreeMap<Id, Vec<MirScalarExpr>>,
     ) -> Result<Vec<MirScalarExpr>, crate::TransformError> {
         self.checked_recur(|_| {
             match relation {

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -12,7 +12,7 @@ use mz_expr::visit::VisitChildren;
 use mz_expr::{Id, LocalId, MirRelationExpr, RECURSION_LIMIT};
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_repr::GlobalId;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 /// A struct that holds a recursive function that determines if a
 /// relation is monotonic, and applies any optimizations along the way.
@@ -41,8 +41,8 @@ impl MonotonicFlag {
     pub fn apply(
         &self,
         expr: &mut MirRelationExpr,
-        mon_ids: &HashSet<GlobalId>,
-        locals: &mut HashSet<LocalId>,
+        mon_ids: &BTreeSet<GlobalId>,
+        locals: &mut BTreeSet<LocalId>,
     ) -> Result<bool, crate::RecursionLimitError> {
         self.checked_recur(|_| {
             let is_monotonic = match expr {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -74,7 +74,7 @@
 //! assert_eq!(expected_expr, expr)
 //! ```
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{TransformArgs, TransformError};
 use itertools::Itertools;
@@ -118,7 +118,7 @@ impl crate::Transform for PredicatePushdown {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), TransformError> {
-        let mut empty = HashMap::new();
+        let mut empty = BTreeMap::new();
         let result = self.action(relation, &mut empty);
         mz_repr::explain_new::trace_plan(&*relation);
         result
@@ -139,7 +139,7 @@ impl PredicatePushdown {
     pub fn action(
         &self,
         relation: &mut MirRelationExpr,
-        get_predicates: &mut HashMap<Id, HashSet<MirScalarExpr>>,
+        get_predicates: &mut BTreeMap<Id, BTreeSet<MirScalarExpr>>,
     ) -> Result<(), TransformError> {
         self.checked_recur(|_| {
             // In the case of Filter or Get we have specific work to do;
@@ -428,7 +428,7 @@ impl PredicatePushdown {
                     // Purge all predicates associated with the id.
                     get_predicates
                         .entry(*id)
-                        .or_insert_with(HashSet::new)
+                        .or_insert_with(BTreeSet::new)
                         .clear();
 
                     Ok(())

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -11,7 +11,7 @@
 //!
 //! Projections can be re-introduced in the physical planning stage.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::mem;
 
 use crate::TransformArgs;
@@ -50,7 +50,7 @@ impl crate::Transform for ProjectionLifting {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        let result = self.action(relation, &mut HashMap::new());
+        let result = self.action(relation, &mut BTreeMap::new());
         mz_repr::explain_new::trace_plan(&*relation);
         result
     }
@@ -62,7 +62,7 @@ impl ProjectionLifting {
         &self,
         relation: &mut MirRelationExpr,
         // Map from names to new get type and projection required at use.
-        gets: &mut HashMap<Id, (mz_repr::RelationType, Vec<usize>)>,
+        gets: &mut BTreeMap<Id, (mz_repr::RelationType, Vec<usize>)>,
     ) -> Result<(), crate::TransformError> {
         self.checked_recur(|_| {
             match relation {

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -30,7 +30,7 @@
 //! and thus currently exists outside of both the physical and logical
 //! optimizers.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use mz_expr::visit::Visit;
 use mz_expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
@@ -57,7 +57,7 @@ impl crate::Transform for ProjectionPushdown {
         let result = self.action(
             relation,
             &(0..relation.arity()).collect(),
-            &mut HashMap::new(),
+            &mut BTreeMap::new(),
         );
         mz_repr::explain_new::trace_plan(&*relation);
         result
@@ -75,7 +75,7 @@ impl ProjectionPushdown {
         &self,
         relation: &mut MirRelationExpr,
         desired_projection: &Vec<usize>,
-        gets: &mut HashMap<Id, BTreeSet<usize>>,
+        gets: &mut BTreeMap<Id, BTreeSet<usize>>,
     ) -> Result<(), TransformError> {
         // First, try to push the desired projection down through `relation`.
         // In the process `relation` is transformed to a `MirRelationExpr`
@@ -115,7 +115,7 @@ impl ProjectionPushdown {
                 let new_type = value.typ();
                 self.update_projection_around_get(
                     body,
-                    &HashMap::from_iter(std::iter::once((
+                    &BTreeMap::from_iter(std::iter::once((
                         id,
                         (desired_value_projection, new_type),
                     ))),
@@ -360,7 +360,7 @@ impl ProjectionPushdown {
     pub fn update_projection_around_get(
         &self,
         relation: &mut MirRelationExpr,
-        applied_projections: &HashMap<Id, (Vec<usize>, mz_repr::RelationType)>,
+        applied_projections: &BTreeMap<Id, (Vec<usize>, mz_repr::RelationType)>,
     ) -> Result<(), TransformError> {
         relation.visit_mut_pre(&mut |e| {
             if let MirRelationExpr::Project { input, outputs } = e {
@@ -419,7 +419,7 @@ where
     let reverse_col_map = permutation
         .enumerate()
         .map(|(idx, c)| (*c, idx))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
     for c in columns {
         *c = reverse_col_map[c];
     }

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -47,7 +47,7 @@
 //! work around condition 1 by pushing down an inner reduce through the join
 //! while retaining the original outer reduce.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::iter::FromIterator;
 
 use crate::TransformArgs;
@@ -194,7 +194,7 @@ fn try_push_reduce_through_join(
     let mut components = (0..inputs.len()).map(Component::new).collect::<Vec<_>>();
     for equivalence in component_equivalences {
         // a) Find the inputs referenced by the constraint.
-        let inputs_to_connect = HashSet::<usize>::from_iter(
+        let inputs_to_connect = BTreeSet::<usize>::from_iter(
             equivalence
                 .iter()
                 .flat_map(|expr| old_join_mapper.lookup_inputs(expr)),
@@ -226,7 +226,7 @@ fn try_push_reduce_through_join(
     // ```
 
     // Maps (input idxs from old join) -> (idx of component it belongs to)
-    let input_component_map = HashMap::from_iter(
+    let input_component_map = BTreeMap::from_iter(
         components
             .iter()
             .enumerate()
@@ -344,14 +344,14 @@ fn try_push_reduce_through_join(
 fn lookup_corresponding_component(
     expr: &MirScalarExpr,
     old_join_mapper: &JoinInputMapper,
-    input_component_map: &HashMap<usize, usize>,
+    input_component_map: &BTreeMap<usize, usize>,
 ) -> Option<usize> {
     let mut dedupped = old_join_mapper
         .lookup_inputs(expr)
         .map(|i| input_component_map[&i])
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
     if dedupped.len() == 1 {
-        dedupped.drain().next()
+        dedupped.pop_first()
     } else {
         None
     }

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -22,7 +22,7 @@
 // that replace simple and common alternatives frustrate developers.
 #![allow(clippy::comparison_chain, clippy::filter_next)]
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use itertools::Itertools;
 use mz_expr::visit::Visit;
@@ -63,7 +63,7 @@ impl crate::Transform for RedundantJoin {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        let result = self.action(relation, &mut HashMap::new()).map(|_| ());
+        let result = self.action(relation, &mut BTreeMap::new()).map(|_| ());
         mz_repr::explain_new::trace_plan(&*relation);
         result
     }
@@ -86,7 +86,7 @@ impl RedundantJoin {
     pub fn action(
         &self,
         relation: &mut MirRelationExpr,
-        lets: &mut HashMap<Id, Vec<ProvInfo>>,
+        lets: &mut BTreeMap<Id, Vec<ProvInfo>>,
     ) -> Result<Vec<ProvInfo>, crate::TransformError> {
         self.checked_recur(|_| {
             match relation {

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -83,7 +83,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::fmt::Write;
 
     use anyhow::{anyhow, Error};
@@ -438,14 +438,14 @@ mod tests {
     ) -> Result<String, String> {
         match transform {
             "filter" => {
-                let mut predicates = HashMap::new();
+                let mut predicates = BTreeMap::new();
                 match optimize_dataflow_filters_inner(dataflow.iter_mut().map(|(id, rel)| (Id::Global(*id), rel)).rev(), &mut predicates) {
                     Ok(()) => Ok(format!("Pushed-down predicates:\n{}", log_pushed_outside_of_dataflow(predicates, cat))),
                     Err(e) => Err(e.to_string()),
                 }
             }
             "project" => {
-                let mut demand = HashMap::new();
+                let mut demand = BTreeMap::new();
                 if let Some((id, rel)) = dataflow.last() {
                     demand.insert(Id::Global(*id), (0..rel.arity()).collect());
                 }
@@ -462,7 +462,7 @@ mod tests {
     }
 
     /// Converts a map of (source) -> (information pushed to source) into a string.
-    fn log_pushed_outside_of_dataflow<D>(map: HashMap<Id, D>, cat: &TestCatalog) -> String
+    fn log_pushed_outside_of_dataflow<D>(map: BTreeMap<Id, D>, cat: &TestCatalog) -> String
     where
         D: std::fmt::Debug + Clone,
     {


### PR DESCRIPTION
This PR replaces most uses of Hash collections in the optimizer-adjacent crates with their BTree equivalents.

The only Hash collections not converted are the `args` maps created by the third-party `datadriven` crate. We could convert those into `BTreeMap`s easily, but it looks like their usage as pure lookup tables also allows wrapping them into a `StableMap` type, once we've added that, which seems preferable because it avoids allocations.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
