### PR TITLE
zippy: Add a scenario using the 'latest' Cockroach Docker image

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -38,6 +38,7 @@ steps:
           - { value: zippy-postgres-cdc }
           - { value: zippy-cluster-replicas }
           - { value: zippy-crdb-minio-restart }
+          - { value: zippy-crdb-latest-restart }
           - { value: secrets }
           - { value: checks-oneatatime-drop-create-default-replica }
           - { value: checks-oneatatime-restart-clusterd-compute }
@@ -310,6 +311,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=CrdbMinioRestart, --actions=1000]
+
+  - id: zippy-crdb-latest-restart
+    label: "Zippy CRDB restarts w/ latest CRDB"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=CrdbRestart, --actions=1000, --cockroach-tag=latest]
 
   - id: secrets
     label: "Secrets"

--- a/misc/cockroach/setup_materialize.sql
+++ b/misc/cockroach/setup_materialize.sql
@@ -15,6 +15,6 @@
 -- production.
 SET CLUSTER SETTING sql.stats.forecasts.enabled = false;
 
-CREATE SCHEMA consensus;
-CREATE SCHEMA adapter;
-CREATE SCHEMA storage;
+CREATE SCHEMA IF NOT EXISTS consensus;
+CREATE SCHEMA IF NOT EXISTS adapter;
+CREATE SCHEMA IF NOT EXISTS storage;

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -388,12 +388,19 @@ class MySql(Service):
 
 
 class Cockroach(Service):
+    DEFAULT_COCKROACH_TAG = "v22.2.0"
+
     def __init__(
         self,
         name: str = "cockroach",
-        setup_materialize: bool = False,
+        image: Optional[str] = None,
+        setup_materialize: bool = True,
     ):
         volumes = []
+
+        if image is None:
+            image = f"cockroachdb/cockroach:{Cockroach.DEFAULT_COCKROACH_TAG}"
+
         if setup_materialize:
             path = os.path.relpath(
                 ROOT / "misc" / "cockroach" / "setup_materialize.sql",
@@ -403,7 +410,7 @@ class Cockroach(Service):
         super().__init__(
             name=name,
             config={
-                "image": "cockroachdb/cockroach:v22.2.0",
+                "image": image,
                 "ports": [26257],
                 "command": ["start-single-node", "--insecure"],
                 "volumes": volumes,

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -212,6 +212,29 @@ class CrdbMinioRestart(Scenario):
         }
 
 
+class CrdbRestart(Scenario):
+    """A Zippy test that restarts Cockroach."""
+
+    def bootstrap(self) -> List[ActionOrFactory]:
+        return DEFAULT_BOOTSTRAP
+
+    def config(self) -> Dict[ActionOrFactory, float]:
+        return {
+            CreateTopicParameterized(): 5,
+            CreateSourceParameterized(): 5,
+            CreateViewParameterized(max_inputs=2): 5,
+            CreateSinkParameterized(): 5,
+            Ingest: 50,
+            CreateTableParameterized(): 10,
+            DML: 50,
+            ValidateView: 15,
+            MzRestart: 5,
+            KillClusterd: 5,
+            StoragedRestart: 10,
+            CockroachRestart: 15,
+        }
+
+
 class KafkaSourcesLarge(Scenario):
     """A Zippy test using a large number of Kafka sources, views and sinks."""
 

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -86,6 +86,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="SIZE to use for sources, sinks, materialized views and clusters",
     )
 
+    parser.add_argument(
+        "--cockroach-tag",
+        type=str,
+        default=Cockroach.DEFAULT_COCKROACH_TAG,
+        help="Cockroach DockerHub tag to use.",
+    )
+
     args = parser.parse_args()
     scenario_class = globals()[args.scenario]
 
@@ -94,6 +101,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     random.seed(args.seed)
 
     with c.override(
+        Cockroach(image=f"cockroachdb/cockroach:{args.cockroach_tag}"),
         Testdrive(
             no_reset=True,
             seed=1,


### PR DESCRIPTION
- Make the docker image used for Cockroach configurable
- Add a Nightly Zippy scenario that uses that image
- always create the required database schemas in Cockroach in order to prevent extra head-butting, as the error in case the schemas do not exist is not informative.

### Motivation

Doing this was discussed previously with Cockroach and I figured I can quickly get it to run.