### PR TITLE
Fix minor formatting issue in formalism.md

### DIFF
--- a/doc/developer/platform/formalism.md
+++ b/doc/developer/platform/formalism.md
@@ -421,7 +421,7 @@ This allows us to fold updates to the same data together after sliding updates
 forward to the same time. Where `diff1 + diff2 = 0`, we can discard `u1` and
 `u2` altogether.
 
-In summary: `compact(ptvc, since') advances `ptvc`'s `since` to `since'`,
+In summary: `compact(ptvc, since')` advances `ptvc`'s `since` to `since'`,
 slides some of `ptvc`'s updates forward to new times (when doing so would not
 affect the computes states at or after `since`), and merges some those updates
 together by summing `diff`s for the same `data` and `time`. The resulting pTVC


### PR DESCRIPTION
Added a missing ` in the pTVC compaction section. This is just updating the documentation, no code change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - none
