### PR TITLE
Remove wrapping token in Rc, irrelevant now

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -100,7 +100,6 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
-use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -242,10 +241,6 @@ pub fn build_compute_dataflow<A: Allocate>(
                         &ok_stream, logger, *source_id, export_ids,
                     );
                 }
-
-                // TODO(petrosagg): this is just wrapping an Arc<T> into an Rc<Arc<T>> to make the
-                // type checker happy. We should decide what we want our tokens to look like
-                let token: Rc<dyn Any> = Rc::new(token);
 
                 let (oks, errs) = (
                     ok_stream.as_collection().leave_region(),


### PR DESCRIPTION
Remove an artifact from when tokens where `Arc` instead of `Rc`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
