### PR TITLE
sql: permit subqueries in SET clause of UPDATE

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -111,7 +111,9 @@ fn test_bind_params() {
 
     match client.query("SELECT ROW(1, 2) = $1", &[&"(1,2)"]) {
         Ok(_) => panic!("query with invalid parameters executed successfully"),
-        Err(err) => assert!(err.to_string().contains("no overload")),
+        Err(err) => assert!(err
+            .to_string()
+            .contains("No operator matches the given name and argument types")),
     }
 
     assert!(client
@@ -168,6 +170,13 @@ fn test_bind_params() {
             .unwrap();
         let val: i32 = client.query_one("SELECT * FROM t", &[]).unwrap().get(0);
         assert_eq!(val, 42);
+    }
+
+    // Test that `UPDATE` permits parameters
+    {
+        client.query("UPDATE t SET a = $1", &[&43_i32]).unwrap();
+        let val: i32 = client.query_one("SELECT * FROM t", &[]).unwrap().get(0);
+        assert_eq!(val, 43);
     }
 }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -619,7 +619,7 @@ pub fn plan_mutation_query_inner(
                     scope: &scope,
                     relation_type: &relation_type,
                     allow_aggregates: false,
-                    allow_subqueries: false,
+                    allow_subqueries: true,
                     allow_windows: false,
                 };
                 let expr = plan_expr(ecx, &value)?.cast_to(


### PR DESCRIPTION
These were disallowed in a conservative approach to handling ReadThenWritePlans. However, in the intervening time, we added rigorous safeguards to ensure that the "read" portion of these plans do not reference any potentially consistency-violating objects (#2b3f712dd5), so this approach is no longer necessary.

Additionally, this constraint prevents using parameters in update statements' set clauses, which is really annoying.

### Motivation

This PR fixes a previously unreported bug. You could not use parameters in the `SET` clause.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Allow parameters in the RHS of values in `UPDATE`'s `SET` clause.
