### PR TITLE
test/cluster: fix a flaky part of the remote storage test

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -551,8 +551,8 @@ def workflow_test_remote_storage(c: Composition) -> None:
         Materialized(external_cockroach=True),
     ):
         dependencies = [
-            "materialized",
             "cockroach",
+            "materialized",
             "storage",
             "zookeeper",
             "kafka",


### PR DESCRIPTION
start cockroach _before_ materialize was sometimes wiping out the schemas, or mz was mad that a schema didnt exist, and generally caused chaos 

### Motivation
  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):


