### PR TITLE
Persist output in-place compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,7 +4897,6 @@ dependencies = [
  "proptest",
  "serde",
  "timely",
- "timely_communication",
  "tokio",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=output_handle_cease#de1f20ec735c6fa3ebf4a214e2108c5a74bc260d"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7190,12 +7190,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=output_handle_cease#de1f20ec735c6fa3ebf4a214e2108c5a74bc260d"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=output_handle_cease#de1f20ec735c6fa3ebf4a214e2108c5a74bc260d"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7211,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=output_handle_cease#de1f20ec735c6fa3ebf4a214e2108c5a74bc260d"
 dependencies = [
  "columnation",
  "serde",
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/antiguru/timely-dataflow?branch=output_handle_cease#de1f20ec735c6fa3ebf4a214e2108c5a74bc260d"
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,6 @@ postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }
+
+[patch."https://github.com/TimelyDataflow/timely-dataflow"]
+timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "output_handle_cease" }

--- a/deny.toml
+++ b/deny.toml
@@ -209,4 +209,7 @@ allow-git = [
     # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
     # it into a release.
     "https://github.com/MaterializeInc/rust-server-sdk",
+
+    # TODO Remove
+    "https://github.com/antiguru/timely-dataflow",
 ]

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -28,11 +28,12 @@ use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, DatumVec, Diff, Row, Timestamp};
 use mz_timely_util::activator::RcActivator;
+use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 
 use crate::compute_state::ComputeState;
 use crate::logging::persist::persist_sink;
-use crate::logging::{ConsolidateBuffer, DifferentialLog, LogVariant};
+use crate::logging::{DifferentialLog, LogVariant};
 use crate::typedefs::{KeysValsHandle, RowSpine};
 
 /// Constructs the logging dataflow for differential logs.

--- a/src/compute/src/logging/mod.rs
+++ b/src/compute/src/logging/mod.rs
@@ -17,17 +17,8 @@ pub mod timely;
 
 use std::time::Duration;
 
-use ::timely::communication::Push;
-use ::timely::dataflow::channels::Bundle;
 use ::timely::dataflow::operators::capture::{Event, EventPusher};
-use ::timely::dataflow::operators::generic::OutputHandle;
-use ::timely::dataflow::operators::Capability;
-use ::timely::dataflow::operators::CapabilityRef;
 use ::timely::progress::Timestamp as TimelyTimestamp;
-use differential_dataflow::consolidation::consolidate_updates;
-use differential_dataflow::difference::Semigroup;
-use differential_dataflow::lattice::Lattice;
-use differential_dataflow::ExchangeData;
 
 use mz_compute_client::logging::{ComputeLog, DifferentialLog, LogVariant, TimelyLog};
 use mz_repr::Timestamp;
@@ -124,91 +115,5 @@ where
     fn drop(&mut self) {
         self.event_pusher
             .push(Event::Progress(vec![(self.time_ms, -1)]));
-    }
-}
-
-/// A buffer that consolidates updates
-///
-/// The buffer implements a wrapper around [OutputHandle] consolidating elements pushed to it. It is
-/// backed by a capacity-limited buffer, which means that compaction only occurs within the
-/// dimensions of the buffer, i.e. the number of unique keys is less than half of the buffer's
-/// capacity.
-///
-/// A cap is retained whenever the current time changes to be able to flush on drop or when the time
-/// changes again.
-///
-/// The buffer is filled with updates until it reaches its capacity. At this point, the updates are
-/// consolidated to free up space. This process repeats until the consolidation recovered less than
-/// half of the buffer's capacity, at which point the buffer will be shipped.
-///
-/// The buffer retains a capability to send data on flush. It will flush all data once dropped, if
-/// time changes, or if the buffer capacity is reached.
-pub struct ConsolidateBuffer<'a, T, D: ExchangeData, R: Semigroup, P>
-where
-    P: Push<Bundle<T, (D, T, R)>> + 'a,
-    T: Clone + Lattice + Ord + TimelyTimestamp + 'a,
-    D: 'a,
-{
-    // a buffer for records, to send at self.cap
-    // Invariant: Buffer only contains data if cap is Some.
-    buffer: Vec<(D, T, R)>,
-    output_handle: OutputHandle<'a, T, (D, T, R), P>,
-    cap: Option<Capability<T>>,
-    port: usize,
-}
-
-impl<'a, T, D: ExchangeData, R: Semigroup, P> ConsolidateBuffer<'a, T, D, R, P>
-where
-    T: Clone + Lattice + Ord + TimelyTimestamp + 'a,
-    P: Push<Bundle<T, (D, T, R)>> + 'a,
-{
-    /// Create a new [ConsolidateBuffer], wrapping the provided session.
-    ///
-    /// * `output_handle`: The output to send data to.
-    /// * 'port': The output port to retain capabilities for.
-    pub fn new(output_handle: OutputHandle<'a, T, (D, T, R), P>, port: usize) -> Self {
-        Self {
-            output_handle,
-            port,
-            cap: None,
-            buffer: Vec::with_capacity(::timely::container::buffer::default_capacity::<(D, T, R)>()),
-        }
-    }
-
-    /// Give an element to the buffer
-    pub fn give(&mut self, cap: &CapabilityRef<T>, data: (D, T, R)) {
-        // Retain a cap for the current time, which will be used on flush.
-        if self.cap.as_ref().map_or(true, |t| t.time() != cap.time()) {
-            // Flush on capability change
-            self.flush();
-            // Retain capability for the specified output port.
-            self.cap = Some(cap.delayed_for_output(cap.time(), self.port));
-        }
-        self.buffer.push(data);
-        if self.buffer.len() == self.buffer.capacity() {
-            // Consolidate while the consolidation frees at least half the buffer
-            consolidate_updates(&mut self.buffer);
-            if self.buffer.len() > self.buffer.capacity() / 2 {
-                self.flush();
-            }
-        }
-    }
-
-    /// Flush the internal buffer to the underlying session
-    pub fn flush(&mut self) {
-        if let Some(cap) = &self.cap {
-            self.output_handle.session(cap).give_vec(&mut self.buffer);
-        }
-    }
-}
-
-impl<'a, T, D: ExchangeData, R: Semigroup, P> Drop for ConsolidateBuffer<'a, T, D, R, P>
-where
-    P: Push<Bundle<T, (D, T, R)>> + 'a,
-    T: Clone + Lattice + Ord + TimelyTimestamp + 'a,
-    D: 'a,
-{
-    fn drop(&mut self) {
-        self.flush();
     }
 }

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -28,11 +28,12 @@ use mz_ore::cast::CastFrom;
 use mz_ore::iter::IteratorExt;
 use mz_repr::{Datum, Diff, Row, RowArena, Timestamp};
 use mz_timely_util::activator::RcActivator;
+use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 
 use crate::compute_state::ComputeState;
 use crate::logging::persist::persist_sink;
-use crate::logging::{ConsolidateBuffer, LogVariant, TimelyLog};
+use crate::logging::{LogVariant, TimelyLog};
 use crate::typedefs::{KeysValsHandle, RowSpine};
 
 /// Constructs the logging dataflow for reachability logs.

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -27,11 +27,12 @@ use mz_compute_client::logging::LoggingConfig;
 use mz_ore::cast::CastFrom;
 use mz_repr::{datum_list_size, datum_size, Datum, DatumVec, Diff, Row, Timestamp};
 use mz_timely_util::activator::RcActivator;
+use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 
 use crate::compute_state::ComputeState;
 use crate::logging::persist::persist_sink;
-use crate::logging::{ConsolidateBuffer, LogVariant, TimelyLog};
+use crate::logging::{LogVariant, TimelyLog};
 use crate::typedefs::{KeysValsHandle, RowSpine};
 
 /// Constructs the logging dataflow for timely logs.

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -74,46 +74,6 @@ where
     G: Scope<Timestamp = mz_repr::Timestamp>,
     YFn: Fn(Instant, usize) -> bool + 'static,
 {
-    let (updates, errs, token) = persist_source_core(
-        scope,
-        source_id,
-        persist_clients,
-        metadata,
-        as_of,
-        until,
-        map_filter_project,
-        flow_control,
-        yield_fn,
-    );
-    (updates, errs, token)
-}
-
-/// Creates a new source that reads from a persist shard, distributing the work
-/// of reading data to all timely workers.
-///
-/// All times emitted will have been [advanced by] the given `as_of` frontier.
-///
-/// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-#[allow(clippy::needless_borrow)]
-pub fn persist_source_core<G, YFn>(
-    scope: &G,
-    source_id: GlobalId,
-    persist_clients: Arc<Mutex<PersistClientCache>>,
-    metadata: CollectionMetadata,
-    as_of: Option<Antichain<Timestamp>>,
-    until: Antichain<Timestamp>,
-    map_filter_project: Option<&mut MfpPlan>,
-    flow_control: Option<FlowControl<G>>,
-    yield_fn: YFn,
-) -> (
-    Stream<G, (Row, Timestamp, Diff)>,
-    Stream<G, (DataflowError, Timestamp, Diff)>,
-    Rc<dyn Any>,
-)
-where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
-    YFn: Fn(Instant, usize) -> bool + 'static,
-{
     let name = source_id.to_string();
     let (fetched, token) = shard_source(
         scope,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -391,7 +391,7 @@ where
                     };
                     let (previous_ok_stream, previous_err_stream, previous_token) =
                         if let Some(previous_as_of) = previous_as_of {
-                            let (ok_stream, err_stream, tok) = persist_source::persist_source_core(
+                            let (ok_stream, err_stream, tok) = persist_source::persist_source(
                                 scope,
                                 id,
                                 persist_clients,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -389,9 +389,9 @@ where
                         }
                         Some(&t) => Some(t.saturating_sub(1)),
                     };
-                    let (previous_stream, previous_token) =
+                    let (previous_ok_stream, previous_err_stream, previous_token) =
                         if let Some(previous_as_of) = previous_as_of {
-                            let (stream, tok) = persist_source::persist_source_core(
+                            let (ok_stream, err_stream, tok) = persist_source::persist_source_core(
                                 scope,
                                 id,
                                 persist_clients,
@@ -410,15 +410,20 @@ where
                                 // Copy the logic in DeltaJoin/Get/Join to start.
                                 |_timer, count| count > 1_000_000,
                             );
-                            (stream, Some(tok))
+                            (ok_stream, err_stream, Some(tok))
                         } else {
-                            (std::iter::empty().to_stream(scope), None)
+                            (
+                                std::iter::empty().to_stream(scope),
+                                std::iter::empty().to_stream(scope),
+                                None,
+                            )
                         };
                     let (upsert_ok, upsert_err) = super::upsert::upsert(
                         &transformed_results,
                         resume_upper,
                         upsert_envelope.clone(),
-                        previous_stream,
+                        previous_ok_stream,
+                        previous_err_stream,
                         previous_token,
                     );
 

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -11,7 +11,6 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 futures-util = "0.3.25"
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-timely_communication = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"

--- a/src/timely-util/src/buffer.rs
+++ b/src/timely-util/src/buffer.rs
@@ -1,0 +1,110 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::ExchangeData;
+use timely::communication::Push;
+use timely::dataflow::channels::Bundle;
+use timely::dataflow::operators::generic::OutputHandle;
+use timely::dataflow::operators::{Capability, CapabilityRef};
+use timely::progress::Timestamp;
+
+/// A buffer that consolidates updates
+///
+/// The buffer implements a wrapper around [OutputHandle] consolidating elements pushed to it. It is
+/// backed by a capacity-limited buffer, which means that compaction only occurs within the
+/// dimensions of the buffer, i.e. the number of unique keys is less than half of the buffer's
+/// capacity.
+///
+/// A cap is retained whenever the current time changes to be able to flush on drop or when the time
+/// changes again.
+///
+/// The buffer is filled with updates until it reaches its capacity. At this point, the updates are
+/// consolidated to free up space. This process repeats until the consolidation recovered less than
+/// half of the buffer's capacity, at which point the buffer will be shipped.
+///
+/// The buffer retains a capability to send data on flush. It will flush all data once dropped, if
+/// time changes, or if the buffer capacity is reached.
+pub struct ConsolidateBuffer<'a, T, D: ExchangeData, R: Semigroup, P>
+where
+    P: Push<Bundle<T, (D, T, R)>> + 'a,
+    T: Clone + Lattice + Ord + Timestamp + 'a,
+    D: 'a,
+{
+    // a buffer for records, to send at self.cap
+    // Invariant: Buffer only contains data if cap is Some.
+    buffer: Vec<(D, T, R)>,
+    output_handle: OutputHandle<'a, T, (D, T, R), P>,
+    cap: Option<Capability<T>>,
+    port: usize,
+}
+
+impl<'a, T, D: ExchangeData, R: Semigroup, P> ConsolidateBuffer<'a, T, D, R, P>
+where
+    T: Clone + Lattice + Ord + Timestamp + 'a,
+    P: Push<Bundle<T, (D, T, R)>> + 'a,
+{
+    /// Create a new [ConsolidateBuffer], wrapping the provided session.
+    ///
+    /// * `output_handle`: The output to send data to.
+    /// * 'port': The output port to retain capabilities for.
+    pub fn new(output_handle: OutputHandle<'a, T, (D, T, R), P>, port: usize) -> Self {
+        Self {
+            output_handle,
+            port,
+            cap: None,
+            buffer: Vec::with_capacity(::timely::container::buffer::default_capacity::<(D, T, R)>()),
+        }
+    }
+
+    /// Give an element to the buffer
+    pub fn give(&mut self, cap: &CapabilityRef<T>, data: (D, T, R)) {
+        // Retain a cap for the current time, which will be used on flush.
+        if self.cap.as_ref().map_or(true, |t| t.time() != cap.time()) {
+            // Flush on capability change
+            self.flush();
+            // Retain capability for the specified output port.
+            self.cap = Some(cap.delayed_for_output(cap.time(), self.port));
+        }
+        self.buffer.push(data);
+        if self.buffer.len() == self.buffer.capacity() {
+            // Consolidate while the consolidation frees at least half the buffer
+            consolidate_updates(&mut self.buffer);
+            if self.buffer.len() > self.buffer.capacity() / 2 {
+                self.flush();
+            }
+        }
+    }
+
+    /// Flush the internal buffer to the underlying session
+    pub fn flush(&mut self) {
+        if let Some(cap) = &self.cap {
+            self.output_handle.session(cap).give_vec(&mut self.buffer);
+        }
+    }
+}
+
+impl<'a, T, D: ExchangeData, R: Semigroup, P> Drop for ConsolidateBuffer<'a, T, D, R, P>
+where
+    P: Push<Bundle<T, (D, T, R)>> + 'a,
+    T: Clone + Lattice + Ord + Timestamp + 'a,
+    D: 'a,
+{
+    fn drop(&mut self) {
+        self.flush();
+    }
+}

--- a/src/timely-util/src/buffer.rs
+++ b/src/timely-util/src/buffer.rs
@@ -96,6 +96,11 @@ where
             self.output_handle.session(cap).give_vec(&mut self.buffer);
         }
     }
+
+    pub fn cease(&mut self) {
+        self.flush();
+        self.output_handle.cease();
+    }
 }
 
 impl<'a, T, D: ExchangeData, R: Semigroup, P> Drop for ConsolidateBuffer<'a, T, D, R, P>

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -84,6 +84,7 @@
 
 pub mod activator;
 pub mod antichain;
+pub mod buffer;
 pub mod builder_async;
 pub mod capture;
 pub mod event;

--- a/src/timely-util/src/panic.rs
+++ b/src/timely-util/src/panic.rs
@@ -17,7 +17,7 @@ use std::panic;
 
 use mz_ore::halt;
 
-/// Intercepts expected [`timely_communication`] panics and downgrades them to
+/// Intercepts expected [`timely::communication`] panics and downgrades them to
 /// [`halt`]s.
 ///
 /// Because processes in a timely cluster are shared fate, once one process in


### PR DESCRIPTION
This is an experiment to see what changes if we consolidate output from persist differently than to wait for, say 1M rows and then consolidate, but rather use much smaller buffers. It's reusing the `ConsolidateBuffer` type, which wraps an output handle and compacts in-place.

The implementation isn't nice, partly due to `async`, and because it's late :) The main issue is that the session should not survive the `await` point, but this point is in a loop where it's used. There's probably a better way than using `ManuallyDrop`!

### Motivation

This tries to wire up an established pattern from log processing to use in persist.

### Tips to the reviewer

The first commit is only code movement. The second is the interesting one!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
