### PR TITLE
stash: don't set zone in readonly

### DIFF
--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -107,13 +107,7 @@ async fn test_stash_postgres() {
             .contains("stash error: postgres: error connecting to server"));
     }
 
-    let connstr = match std::env::var("COCKROACH_URL") {
-        Ok(s) => s,
-        Err(_) => {
-            println!("skipping test_stash_postgres because COCKROACH_URL is not set");
-            return;
-        }
-    };
+    let connstr = std::env::var("COCKROACH_URL").expect("COCKROACH_URL must be set");
     async fn connect(
         factory: &StashFactory,
         connstr: &str,


### PR DESCRIPTION
Also force COCKROACH_URL presence now that it's in CI.

I do not know how the stash tests are currently passing in main because they don't for me!

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a