### PR TITLE
stash: add txn api

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3959,7 +3959,7 @@ impl Catalog {
         self.state.default_linked_cluster_size()
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(name = "catalog::transact", level = "debug", skip_all)]
     pub async fn transact<F, R>(
         &mut self,
         oracle_write_ts: mz_repr::Timestamp,

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -333,7 +333,9 @@ impl Usage {
                     let key = serde_json::from_value(key)?;
                     let value = serde_json::from_value(value)?;
                     let (prev, _next) = $col
-                        .upsert_key(stash, &key, |_| Ok::<_, std::convert::Infallible>(value))
+                        .upsert_key(stash, key, move |_| {
+                            Ok::<_, std::convert::Infallible>(value)
+                        })
                         .await??;
                     return Ok(prev.map(|v| serde_json::to_value(v).unwrap()));
                 }

--- a/src/stash/benches/postgres.rs
+++ b/src/stash/benches/postgres.rs
@@ -74,16 +74,14 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::iter::{repeat, repeat_with};
 use std::str::FromStr;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use once_cell::sync::Lazy;
-use timely::progress::Antichain;
 use tokio::runtime::Runtime;
 
 use mz_ore::metrics::MetricsRegistry;
-use mz_stash::{Stash, StashError, StashFactory};
+use mz_stash::{Stash, StashError, StashFactory, TypedCollection};
 
 pub static FACTORY: Lazy<StashFactory> = Lazy::new(|| StashFactory::new(&MetricsRegistry::new()));
 
@@ -104,122 +102,33 @@ fn init_bench() -> (Runtime, Stash) {
     (runtime, stash)
 }
 
-fn bench_update(c: &mut Criterion) {
-    c.bench_function("update", |b| {
-        b.iter(|| {
-            let (runtime, mut stash) = init_bench();
+pub static COLLECTION_ORDER: TypedCollection<i64, i64> = TypedCollection::new("orders");
 
-            let orders = runtime
-                .block_on(stash.collection::<String, String>("orders"))
-                .unwrap();
-            let mut ts = 1;
+fn bench_update(c: &mut Criterion) {
+    c.bench_function("upsert", |b| {
+        let (runtime, mut stash) = init_bench();
+        let mut i = 1;
+        b.iter(|| {
+            i += 1;
             runtime.block_on(async {
-                let data = ("widgets1".into(), "1".into());
-                stash.update(orders, data, ts, 1).await.unwrap();
-                ts += 1;
+                COLLECTION_ORDER.upsert(&mut stash, [(i, i)]).await.unwrap();
             })
         })
     });
 }
 
 fn bench_update_many(c: &mut Criterion) {
-    c.bench_function("update_many", |b| {
+    c.bench_function("upsert_key", |b| {
         let (runtime, mut stash) = init_bench();
-
-        let orders = runtime
-            .block_on(stash.collection::<String, String>("orders"))
-            .unwrap();
-        let mut ts = 1;
-        b.iter(|| {
+        let mut i = 1;
+        b.iter(move || {
             runtime.block_on(async {
-                let data = ("widgets2".into(), "1".into());
-                stash
-                    .update_many(orders, repeat((data, ts, 1)).take(10))
+                i += 1;
+                COLLECTION_ORDER
+                    .upsert_key(&mut stash, 1, move |_| Ok::<_, StashError>(i))
                     .await
+                    .unwrap()
                     .unwrap();
-                ts += 1;
-            })
-        })
-    });
-}
-
-fn bench_consolidation(c: &mut Criterion) {
-    c.bench_function("consolidation", |b| {
-        let (runtime, mut stash) = init_bench();
-
-        let orders = runtime
-            .block_on(stash.collection::<String, String>("orders"))
-            .unwrap();
-        let mut ts = 1;
-        b.iter(|| {
-            runtime.block_on(async {
-                let data = ("widgets3".into(), "1".into());
-                stash.update(orders, data.clone(), ts, 1).await.unwrap();
-                stash.update(orders, data, ts + 1, -1).await.unwrap();
-                let frontier = Antichain::from_elem(ts + 2);
-                stash.seal(orders, frontier.borrow()).await.unwrap();
-                stash.compact(orders, frontier.borrow()).await.unwrap();
-                stash.consolidate(orders.id).await.unwrap();
-                ts += 2;
-            })
-        })
-    });
-}
-
-fn bench_consolidation_large(c: &mut Criterion) {
-    c.bench_function("consolidation large", |b| {
-        let (runtime, mut stash) = init_bench();
-
-        let mut ts = 0;
-        let (orders, kv) = runtime.block_on(async {
-            let orders = stash.collection::<String, String>("orders").await.unwrap();
-
-            // Prepopulate the database with 100k records
-            let kv = ("widgets4".into(), "1".into());
-            stash
-                .update_many(
-                    orders,
-                    repeat_with(|| {
-                        let update = (kv.clone(), ts, 1);
-                        ts += 1;
-                        update
-                    })
-                    .take(100_000),
-                )
-                .await
-                .unwrap();
-            let frontier = Antichain::from_elem(ts);
-            stash.seal(orders, frontier.borrow()).await.unwrap();
-            (orders, kv)
-        });
-
-        let mut compact_ts = 0;
-        b.iter(|| {
-            runtime.block_on(async {
-                ts += 1;
-                // add 10k records
-                stash
-                    .update_many(
-                        orders,
-                        repeat_with(|| {
-                            let update = (kv.clone(), ts, 1);
-                            ts += 1;
-                            update
-                        })
-                        .take(10_000),
-                    )
-                    .await
-                    .unwrap();
-                let frontier = Antichain::from_elem(ts);
-                stash.seal(orders, frontier.borrow()).await.unwrap();
-                // compact + consolidate
-                compact_ts += 10_000;
-                let compact_frontier = Antichain::from_elem(compact_ts);
-                stash
-                    .compact(orders, compact_frontier.borrow())
-                    .await
-                    .unwrap();
-                stash.consolidate(orders.id).await.unwrap();
             })
         })
     });
@@ -238,7 +147,7 @@ fn bench_append(c: &mut Criterion) {
                 for i in 1..MAX {
                     orders.append_to_batch(&mut batch, &i.to_string(), &format!("_{i}"), 1);
                 }
-                stash.append(&[batch]).await?;
+                stash.append(vec![batch]).await?;
                 Result::<_, StashError>::Ok(orders)
             })
             .unwrap();
@@ -252,19 +161,12 @@ fn bench_append(c: &mut Criterion) {
                 // which is known to exist.
                 orders.append_to_batch(&mut batch, &j.to_string(), &format!("_{j}"), 1);
                 orders.append_to_batch(&mut batch, &k.to_string(), &format!("_{k}"), -1);
-                stash.append(&[batch]).await.unwrap();
+                stash.append(vec![batch]).await.unwrap();
                 i += 1;
             })
         })
     });
 }
 
-criterion_group!(
-    benches,
-    bench_append,
-    bench_update,
-    bench_update_many,
-    bench_consolidation,
-    bench_consolidation_large
-);
+criterion_group!(benches, bench_append, bench_update, bench_update_many);
 criterion_main!(benches);

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -82,15 +82,19 @@ use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
+use futures::Future;
 use mz_ore::soft_assert;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use timely::progress::Antichain;
 
 mod postgres;
+mod transaction;
 
 pub use crate::postgres::{Stash, StashFactory};
+pub use crate::transaction::Transaction;
 
 pub type Diff = i64;
 pub type Timestamp = i64;
@@ -115,9 +119,9 @@ impl<T: Serialize + for<'de> Deserialize<'de> + Ord + Send + Sync> Data for T {}
 /// frontier, call [`compact`]. To advance the upper frontier, call [`seal`]. To
 /// physically compact data beneath the since frontier, call [`consolidate`].
 ///
-/// [`compact`]: Stash::compact
+/// [`compact`]: Transaction::compact
 /// [`consolidate`]: Stash::consolidate
-/// [`seal`]: Stash::seal
+/// [`seal`]: Transaction::seal
 /// [correctness vocabulary document]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210831_correctness.md
 /// [`Collection`]: differential_dataflow::collection::Collection
 #[derive(Debug)]
@@ -271,19 +275,29 @@ pub struct AppendBatch {
     pub collection_id: Id,
     pub lower: Antichain<Timestamp>,
     pub upper: Antichain<Timestamp>,
-    pub compact: Antichain<Timestamp>,
     pub timestamp: Timestamp,
     pub entries: Vec<((Value, Value), Timestamp, Diff)>,
 }
 
-impl<K, V> StashCollection<K, V>
-where
-    K: Data,
-    V: Data,
-{
+impl<K, V> StashCollection<K, V> {
     /// Create a new AppendBatch for this collection from its current upper.
     pub async fn make_batch(&self, stash: &mut Stash) -> Result<AppendBatch, StashError> {
-        let lower = stash.upper(*self).await?;
+        let id = self.id;
+        let lower = stash
+            .with_transaction(move |tx| Box::pin(async move { tx.upper(id).await }))
+            .await?;
+        self.make_batch_lower(lower)
+    }
+
+    /// Create a new AppendBatch for this collection from its current upper.
+    pub async fn make_batch_tx(&self, tx: &Transaction<'_>) -> Result<AppendBatch, StashError> {
+        let id = self.id;
+        let lower = tx.upper(id).await?;
+        self.make_batch_lower(lower)
+    }
+
+    /// Create a new AppendBatch for this collection from its current upper.
+    pub fn make_batch_lower(&self, lower: Antichain<Timestamp>) -> Result<AppendBatch, StashError> {
         let timestamp: Timestamp = match lower.elements() {
             [ts] => *ts,
             _ => return Err("cannot determine batch timestamp".into()),
@@ -292,17 +306,21 @@ where
             Some(ts) => Antichain::from_elem(ts),
             None => return Err("cannot determine new upper".into()),
         };
-        let compact = Antichain::from_elem(timestamp);
         Ok(AppendBatch {
             collection_id: self.id,
             lower,
             upper,
-            compact,
             timestamp,
             entries: Vec::new(),
         })
     }
+}
 
+impl<K, V> StashCollection<K, V>
+where
+    K: Data,
+    V: Data,
+{
     pub fn append_to_batch(&self, batch: &mut AppendBatch, key: &K, value: &V, diff: Diff) {
         let key = serde_json::to_value(key).expect("must serialize");
         let value = serde_json::to_value(value).expect("must serialize");
@@ -344,35 +362,116 @@ where
     K: Data,
     V: Data,
 {
+    pub async fn transact<F, Fut, T>(&self, stash: &mut Stash, f: F) -> Result<T, StashError>
+    where
+        F: Fn(Transaction, StashCollection<K, V>) -> Fut + Clone + Send + Sync + 'static,
+        Fut: Future<Output = Result<T, StashError>> + Send,
+    {
+        let name = self.name;
+        stash
+            .with_transaction(move |tx| {
+                let f = f.clone();
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    f(tx, collection).await
+                })
+            })
+            .await
+    }
+    pub async fn make_batch(
+        &self,
+        stash: &mut Stash,
+    ) -> Result<(StashCollection<K, V>, AppendBatch), StashError> {
+        let name = self.name;
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    let lower = tx.upper(collection.id).await?;
+                    let batch = collection.make_batch_lower(lower)?;
+                    Ok((collection, batch))
+                })
+            })
+            .await
+    }
+
     pub async fn get(&self, stash: &mut Stash) -> Result<StashCollection<K, V>, StashError> {
         stash.collection(self.name).await
     }
 
     pub async fn upper(&self, stash: &mut Stash) -> Result<Antichain<Timestamp>, StashError> {
-        let collection = self.get(stash).await?;
-        stash.upper(collection).await
+        let name = self.name;
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    tx.upper(collection.id).await
+                })
+            })
+            .await
     }
 
     pub async fn iter(
         &self,
         stash: &mut Stash,
     ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError> {
-        let collection = self.get(stash).await?;
-        stash.iter(collection).await
+        let name = self.name;
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    tx.iter(collection).await
+                })
+            })
+            .await
+    }
+
+    pub async fn peek(&self, stash: &mut Stash) -> Result<Vec<(K, V, Diff)>, StashError>
+    where
+        K: Hash,
+    {
+        let name = self.name;
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    tx.peek(collection).await
+                })
+            })
+            .await
     }
 
     pub async fn peek_one(&self, stash: &mut Stash) -> Result<BTreeMap<K, V>, StashError>
     where
         K: Hash,
     {
-        let collection = self.get(stash).await?;
-        stash.peek_one(collection).await
+        let name = self.name;
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    tx.peek_one(collection).await
+                })
+            })
+            .await
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn peek_key_one(&self, stash: &mut Stash, key: &K) -> Result<Option<V>, StashError> {
-        let collection = self.get(stash).await?;
-        stash.peek_key_one(collection, key).await
+    pub async fn peek_key_one(&self, stash: &mut Stash, key: K) -> Result<Option<V>, StashError>
+    where
+        // TODO: Is it possible to remove the 'static?
+        K: 'static,
+    {
+        let name = self.name;
+        let key = Arc::new(key);
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    tx.peek_key_one(collection, &key).await
+                })
+            })
+            .await
     }
 
     /// Sets the given k,v pair, if not already set.
@@ -382,32 +481,48 @@ where
     pub async fn insert_key_without_overwrite(
         &self,
         stash: &mut Stash,
-        key: &K,
+        key: K,
         value: V,
-    ) -> Result<V, StashError> {
-        let collection = self.get(stash).await?;
-        let mut batch = collection.make_batch(stash).await?;
-        let prev = match stash.peek_key_one(collection, key).await {
-            Ok(prev) => prev,
-            Err(err) => match err.inner {
-                InternalStashError::PeekSinceUpper(_) => {
-                    // If the upper isn't > since, bump the upper and try again to find a sealed
-                    // entry. Do this by appending the empty batch which will advance the upper.
-                    stash.append(&[batch]).await?;
-                    batch = collection.make_batch(stash).await?;
-                    stash.peek_key_one(collection, key).await?
-                }
-                _ => return Err(err),
-            },
-        };
-        match prev {
-            Some(prev) => Ok(prev),
-            None => {
-                collection.append_to_batch(&mut batch, key, &value, 1);
-                stash.append(&[batch]).await?;
-                Ok(value)
-            }
-        }
+    ) -> Result<V, StashError>
+    where
+        // TODO: Is it possible to remove the 'statics?
+        K: 'static,
+        V: Clone + 'static,
+    {
+        let name = self.name;
+        let key = Arc::new(key);
+        let value = Arc::new(value);
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    let lower = tx.upper(collection.id).await?;
+                    let mut batch = collection.make_batch_lower(lower)?;
+                    let prev = match tx.peek_key_one(collection, &key).await {
+                        Ok(prev) => prev,
+                        Err(err) => match err.inner {
+                            InternalStashError::PeekSinceUpper(_) => {
+                                // If the upper isn't > since, bump the upper and try again to find a sealed
+                                // entry. Do this by appending the empty batch which will advance the upper.
+                                tx.append(vec![batch]).await?;
+                                let lower = tx.upper(collection.id).await?;
+                                batch = collection.make_batch_lower(lower)?;
+                                tx.peek_key_one(collection, &key).await?
+                            }
+                            _ => return Err(err),
+                        },
+                    };
+                    match prev {
+                        Some(prev) => Ok(prev),
+                        None => {
+                            collection.append_to_batch(&mut batch, &key, &value, 1);
+                            tx.append(vec![batch]).await?;
+                            Ok((*value).clone())
+                        }
+                    }
+                })
+            })
+            .await
     }
 
     /// Sets the given key value pairs, if not already set. If a new key appears
@@ -421,31 +536,44 @@ where
     ) -> Result<(), StashError>
     where
         I: IntoIterator<Item = (K, V)>,
-        K: Hash,
+        // TODO: Figure out if it's possible to remove the 'static bounds.
+        K: Clone + Hash + 'static,
+        V: Clone + 'static,
     {
-        let collection = self.get(stash).await?;
-        let mut batch = collection.make_batch(stash).await?;
-        let mut prev = match stash.peek_one(collection).await {
-            Ok(prev) => prev,
-            Err(err) => match err.inner {
-                InternalStashError::PeekSinceUpper(_) => {
-                    // If the upper isn't > since, bump the upper and try again to find a sealed
-                    // entry. Do this by appending the empty batch which will advance the upper.
-                    stash.append(&[batch]).await?;
-                    batch = collection.make_batch(stash).await?;
-                    stash.peek_one(collection).await?
-                }
-                _ => return Err(err),
-            },
-        };
-        for (k, v) in entries {
-            if !prev.contains_key(&k) {
-                collection.append_to_batch(&mut batch, &k, &v, 1);
-                prev.insert(k, v);
-            }
-        }
-        stash.append(&[batch]).await?;
-        Ok(())
+        let name = self.name;
+        let entries: Vec<_> = entries.into_iter().collect();
+        let entries = Arc::new(entries);
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    let lower = tx.upper(collection.id).await?;
+                    let mut batch = collection.make_batch_lower(lower)?;
+                    let mut prev = match tx.peek_one(collection).await {
+                        Ok(prev) => prev,
+                        Err(err) => match err.inner {
+                            InternalStashError::PeekSinceUpper(_) => {
+                                // If the upper isn't > since, bump the upper and try again to find a sealed
+                                // entry. Do this by appending the empty batch which will advance the upper.
+                                tx.append(vec![batch]).await?;
+                                let lower = tx.upper(collection.id).await?;
+                                batch = collection.make_batch_lower(lower)?;
+                                tx.peek_one(collection).await?
+                            }
+                            _ => return Err(err),
+                        },
+                    };
+                    for (k, v) in entries.iter() {
+                        if !prev.contains_key(k) {
+                            collection.append_to_batch(&mut batch, k, v, 1);
+                            prev.insert(k.clone(), v.clone());
+                        }
+                    }
+                    tx.append(vec![batch]).await?;
+                    Ok(())
+                })
+            })
+            .await
     }
 
     /// Sets a value for a key. `f` is passed the previous value, if any.
@@ -456,11 +584,12 @@ where
     pub async fn upsert_key<F, R>(
         &self,
         stash: &mut Stash,
-        key: &K,
+        key: K,
         f: F,
     ) -> Result<Result<(Option<V>, V), R>, StashError>
     where
-        F: FnOnce(Option<&V>) -> Result<V, R>,
+        F: FnOnce(Option<&V>) -> Result<V, R> + Clone + Send + Sync + 'static,
+        K: 'static,
     {
         let (prev, next, ids) = match self.upsert_key_no_consolidate(stash, key, f).await? {
             Ok(inner) => inner,
@@ -476,41 +605,52 @@ where
     pub async fn upsert_key_no_consolidate<F, R>(
         &self,
         stash: &mut Stash,
-        key: &K,
+        key: K,
         f: F,
     ) -> Result<Result<(Option<V>, V, Vec<Id>), R>, StashError>
     where
-        F: FnOnce(Option<&V>) -> Result<V, R>,
+        F: FnOnce(Option<&V>) -> Result<V, R> + Clone + Send + Sync + 'static,
+        K: 'static,
     {
-        let collection = self.get(stash).await?;
-        let mut batch = collection.make_batch(stash).await?;
-        let prev = match stash.peek_key_one(collection, key).await {
-            Ok(prev) => prev,
-            Err(err) => match err.inner {
-                InternalStashError::PeekSinceUpper(_) => {
-                    // If the upper isn't > since, bump the upper and try again to find a sealed
-                    // entry. Do this by appending the empty batch which will advance the upper.
-                    stash.append(&[batch]).await?;
-                    batch = collection.make_batch(stash).await?;
-                    stash.peek_key_one(collection, key).await?
-                }
-                _ => return Err(err),
-            },
-        };
-        let next = match f(prev.as_ref()) {
-            Ok(v) => v,
-            Err(e) => return Ok(Err(e)),
-        };
-        // Do nothing if the values are the same.
-        if Some(&next) == prev.as_ref() {
-            return Ok(Ok((prev, next, Vec::new())));
-        }
-        if let Some(prev) = &prev {
-            collection.append_to_batch(&mut batch, key, prev, -1);
-        }
-        collection.append_to_batch(&mut batch, key, &next, 1);
-        stash.append_batch(&[batch]).await?;
-        Ok(Ok((prev, next, vec![collection.id])))
+        let name = self.name;
+        let key = Arc::new(key);
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    let lower = tx.upper(collection.id).await?;
+                    let mut batch = collection.make_batch_lower(lower)?;
+                    let prev = match tx.peek_key_one(collection, &key).await {
+                        Ok(prev) => prev,
+                        Err(err) => match err.inner {
+                            InternalStashError::PeekSinceUpper(_) => {
+                                // If the upper isn't > since, bump the upper and try again to find a sealed
+                                // entry. Do this by appending the empty batch which will advance the upper.
+                                tx.append(vec![batch]).await?;
+                                let lower = tx.upper(collection.id).await?;
+                                batch = collection.make_batch_lower(lower)?;
+                                tx.peek_key_one(collection, &key).await?
+                            }
+                            _ => return Err(err),
+                        },
+                    };
+                    let next = match f(prev.as_ref()) {
+                        Ok(v) => v,
+                        Err(e) => return Ok(Err(e)),
+                    };
+                    // Do nothing if the values are the same.
+                    if Some(&next) == prev.as_ref() {
+                        return Ok(Ok((prev, next, Vec::new())));
+                    }
+                    if let Some(prev) = &prev {
+                        collection.append_to_batch(&mut batch, &key, prev, -1);
+                    }
+                    collection.append_to_batch(&mut batch, &key, &next, 1);
+                    tx.append(vec![batch]).await?;
+                    Ok(Ok((prev, next, vec![collection.id])))
+                })
+            })
+            .await
     }
 
     /// Sets the given key value pairs, removing existing entries match any key.
@@ -518,31 +658,43 @@ where
     pub async fn upsert<I>(&self, stash: &mut Stash, entries: I) -> Result<(), StashError>
     where
         I: IntoIterator<Item = (K, V)>,
-        K: Hash,
+        K: Hash + 'static,
+        V: 'static,
     {
-        let collection = self.get(stash).await?;
-        let mut batch = collection.make_batch(stash).await?;
-        let prev = match stash.peek_one(collection).await {
-            Ok(prev) => prev,
-            Err(err) => match err.inner {
-                InternalStashError::PeekSinceUpper(_) => {
-                    // If the upper isn't > since, bump the upper and try again to find a sealed
-                    // entry. Do this by appending the empty batch which will advance the upper.
-                    stash.append(&[batch]).await?;
-                    batch = collection.make_batch(stash).await?;
-                    stash.peek_one(collection).await?
-                }
-                _ => return Err(err),
-            },
-        };
-        for (k, v) in entries {
-            if let Some(prev_v) = prev.get(&k) {
-                collection.append_to_batch(&mut batch, &k, prev_v, -1);
-            }
-            collection.append_to_batch(&mut batch, &k, &v, 1);
-        }
-        stash.append(&[batch]).await?;
-        Ok(())
+        let name = self.name;
+        let entries: Vec<_> = entries.into_iter().collect();
+        let entries = Arc::new(entries);
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(name).await?;
+                    let lower = tx.upper(collection.id).await?;
+                    let mut batch = collection.make_batch_lower(lower)?;
+                    let prev = match tx.peek_one(collection).await {
+                        Ok(prev) => prev,
+                        Err(err) => match err.inner {
+                            InternalStashError::PeekSinceUpper(_) => {
+                                // If the upper isn't > since, bump the upper and try again to find a sealed
+                                // entry. Do this by appending the empty batch which will advance the upper.
+                                tx.append(vec![batch]).await?;
+                                let lower = tx.upper(collection.id).await?;
+                                batch = collection.make_batch_lower(lower)?;
+                                tx.peek_one(collection).await?
+                            }
+                            _ => return Err(err),
+                        },
+                    };
+                    for (k, v) in entries.iter() {
+                        if let Some(prev_v) = prev.get(k) {
+                            collection.append_to_batch(&mut batch, k, prev_v, -1);
+                        }
+                        collection.append_to_batch(&mut batch, k, v, 1);
+                    }
+                    tx.append(vec![batch]).await?;
+                    Ok(())
+                })
+            })
+            .await
     }
 }
 

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -8,35 +8,30 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::marker::PhantomData;
 use std::num::NonZeroI64;
 use std::sync::{Arc, Mutex};
-use std::{cmp, time::Duration};
+use std::time::Duration;
 
 use differential_dataflow::lattice::Lattice;
-use futures::future::{self, try_join3, try_join_all, BoxFuture};
-use futures::future::{try_join, TryFutureExt};
+use futures::future::TryFutureExt;
+use futures::future::{self, BoxFuture};
 use futures::{Future, StreamExt};
 use postgres_openssl::MakeTlsConnector;
 use prometheus::{IntCounter, IntCounterVec};
 use rand::Rng;
-use serde_json::Value;
-use timely::progress::frontier::AntichainRef;
+
 use timely::progress::Antichain;
-use timely::PartialOrder;
 use tokio::sync::mpsc;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::{Client, Statement};
 use tracing::{error, event, info, warn, Level};
 
-use mz_ore::collections::CollectionExt;
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::retry::Retry;
 
 use crate::{
-    consolidate_updates_kv, AntichainFormatter, AppendBatch, Data, Diff, Id, InternalStashError,
-    StashCollection, StashError, Timestamp,
+    AppendBatch, Data, Diff, Id, InternalStashError, StashCollection, StashError, Timestamp,
 };
 
 // TODO: Change the indexes on data to be more applicable to the current
@@ -141,7 +136,7 @@ impl PreparedStatements {
 }
 
 // Track statement execution counts.
-struct CountedStatements<'a> {
+pub(crate) struct CountedStatements<'a> {
     stmts: &'a PreparedStatements,
     // Due to our use of try_join and futures, this needs to be an Arc Mutex.
     // Use a BTreeMap for deterministic debug printing. Use an Option to avoid
@@ -161,7 +156,7 @@ impl<'a> CountedStatements<'a> {
         }
     }
 
-    fn inc(&self, name: &'static str) {
+    pub fn inc(&self, name: &'static str) {
         if let Some(counts) = &self.counts {
             let mut map = counts.lock().unwrap();
             *map.entry(name).or_default() += 1;
@@ -169,39 +164,39 @@ impl<'a> CountedStatements<'a> {
         }
     }
 
-    fn select_epoch(&self) -> &Statement {
+    pub fn select_epoch(&self) -> &Statement {
         self.inc("select_epoch");
         &self.stmts.select_epoch
     }
-    fn iter_key(&self) -> &Statement {
+    pub fn iter_key(&self) -> &Statement {
         self.inc("iter_key");
         &self.stmts.iter_key
     }
-    fn since(&self) -> &Statement {
+    pub fn since(&self) -> &Statement {
         self.inc("since");
         &self.stmts.since
     }
-    fn upper(&self) -> &Statement {
+    pub fn upper(&self) -> &Statement {
         self.inc("upper");
         &self.stmts.upper
     }
-    fn collection(&self) -> &Statement {
+    pub fn collection(&self) -> &Statement {
         self.inc("collection");
         &self.stmts.collection
     }
-    fn iter(&self) -> &Statement {
+    pub fn iter(&self) -> &Statement {
         self.inc("iter");
         &self.stmts.iter
     }
-    fn seal(&self) -> &Statement {
+    pub fn seal(&self) -> &Statement {
         self.inc("seal");
         &self.stmts.seal
     }
-    fn compact(&self) -> &Statement {
+    pub fn compact(&self) -> &Statement {
         self.inc("compact");
         &self.stmts.compact
     }
-    fn update_many(&self) -> &Statement {
+    pub fn update_many(&self) -> &Statement {
         self.inc("update_many");
         &self.stmts.update_many
     }
@@ -378,7 +373,7 @@ pub struct Stash {
     statements: Option<PreparedStatements>,
     epoch: Option<NonZeroI64>,
     nonce: [u8; 16],
-    sinces_tx: mpsc::UnboundedSender<(Id, Antichain<Timestamp>)>,
+    pub(crate) sinces_tx: mpsc::UnboundedSender<(Id, Antichain<Timestamp>)>,
     metrics: Arc<Metrics>,
 }
 
@@ -462,7 +457,8 @@ impl Stash {
             .retry_async(|_| async {
                 let count: i64 = client
                     .query_one("SELECT count(*) FROM data WHERE diff < 0", &[])
-                    .await?
+                    .await
+                    .expect("verify select count failed")
                     .get(0);
                 if count > 0 {
                     Err(format!("found {count} data rows with negative diff").into())
@@ -586,8 +582,8 @@ impl Stash {
     ///     .await
     //  }
     /// ```
-    #[tracing::instrument(level = "debug", skip_all)]
-    async fn transact<F, T>(&mut self, f: F) -> Result<T, StashError>
+    #[tracing::instrument(name = "stash::transact", level = "debug", skip_all)]
+    pub(crate) async fn transact<F, T>(&mut self, f: F) -> Result<T, StashError>
     where
         F: for<'a> Fn(
             &'a CountedStatements<'a>,
@@ -647,7 +643,7 @@ impl Stash {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(name = "stash::transact_inner", level = "debug", skip_all)]
     async fn transact_inner<F, T>(&mut self, f: &F) -> Result<T, StashError>
     where
         F: for<'a> Fn(
@@ -700,178 +696,6 @@ impl Stash {
         client.batch_execute(tx_end).await?;
         Ok(res)
     }
-
-    async fn since_tx(
-        stmts: &CountedStatements<'_>,
-        tx: &Client,
-        collection_id: Id,
-    ) -> Result<Antichain<Timestamp>, StashError> {
-        let since: Option<Timestamp> = tx
-            .query_one(stmts.since(), &[&collection_id])
-            .await?
-            .get("since");
-        Ok(Antichain::from_iter(since))
-    }
-
-    async fn upper_tx(
-        stmts: &CountedStatements<'_>,
-        tx: &Client,
-        collection_id: Id,
-    ) -> Result<Antichain<Timestamp>, StashError> {
-        let upper: Option<Timestamp> = tx
-            .query_one(stmts.upper(), &[&collection_id])
-            .await?
-            .get("upper");
-        Ok(Antichain::from_iter(upper))
-    }
-
-    /// `seals` has tuples of `(collection id, new upper, Option<current upper>)`. The
-    /// current upper can be `Some` if it is already known.
-    async fn seal_batch_tx<'a, I>(
-        stmts: &CountedStatements<'_>,
-        tx: &Client,
-        seals: I,
-    ) -> Result<(), StashError>
-    where
-        I: Iterator<Item = (Id, &'a Antichain<Timestamp>, Option<Antichain<Timestamp>>)>,
-    {
-        let futures = seals.map(|(collection_id, new_upper, upper)| {
-            try_join(
-                async move {
-                    let upper = match upper {
-                        Some(upper) => upper,
-                        None => Self::upper_tx(stmts, tx, collection_id).await?,
-                    };
-                    if PartialOrder::less_than(new_upper, &upper) {
-                        return Err(StashError::from(format!(
-                            "seal request {} is less than the current upper frontier {}",
-                            AntichainFormatter(new_upper),
-                            AntichainFormatter(&upper),
-                        )));
-                    }
-                    Ok(())
-                },
-                async move {
-                    tx.execute(stmts.seal(), &[&new_upper.as_option(), &collection_id])
-                        .map_err(StashError::from)
-                        .await
-                },
-            )
-        });
-        try_join_all(futures).await?;
-        Ok(())
-    }
-
-    /// `upper` can be `Some` if the collection's upper is already known.
-    async fn update_many_tx(
-        stmts: &CountedStatements<'_>,
-        tx: &Client,
-        collection_id: Id,
-        entries: &[((Value, Value), Timestamp, Diff)],
-        upper: Option<Antichain<Timestamp>>,
-    ) -> Result<(), StashError> {
-        let mut futures = Vec::with_capacity(entries.len());
-        for ((key, value), time, diff) in entries {
-            futures.push(async move {
-                tx.execute(
-                    stmts.update_many(),
-                    &[&collection_id, &key, &value, &time, &diff],
-                )
-                .map_err(|err| err.into())
-                .await
-            });
-        }
-        // Check the upper in a separate future so we can issue the updates without
-        // waiting for it first.
-        try_join(
-            async {
-                let upper = match upper {
-                    Some(upper) => upper,
-                    None => Self::upper_tx(stmts, tx, collection_id).await?,
-                };
-                for ((_key, _value), time, _diff) in entries {
-                    if !upper.less_equal(time) {
-                        return Err(StashError::from(format!(
-                            "entry time {} is less than the current upper frontier {}",
-                            time,
-                            AntichainFormatter(&upper)
-                        )));
-                    }
-                }
-                Ok(upper)
-            },
-            try_join_all(futures),
-        )
-        .await?;
-        Ok(())
-    }
-
-    /// `compactions` has tuples of `(collection id, new since, Option<current
-    /// upper>)`. The current upper can be `Some` if it is already known.
-    async fn compact_batch_tx<'a, I>(
-        stmts: &CountedStatements<'_>,
-        tx: &Client,
-        compactions: I,
-    ) -> Result<(), StashError>
-    where
-        I: Iterator<Item = (Id, &'a Antichain<Timestamp>, Option<Antichain<Timestamp>>)>,
-    {
-        let futures = compactions.map(|(collection_id, new_since, upper)| {
-            try_join3(
-                async move {
-                    let since = Self::since_tx(stmts, tx, collection_id).await?;
-                    if PartialOrder::less_than(new_since, &since) {
-                        return Err(StashError::from(format!(
-                            "compact request {} is less than the current since frontier {}",
-                            AntichainFormatter(new_since),
-                            AntichainFormatter(&since)
-                        )));
-                    }
-                    Ok(())
-                },
-                async move {
-                    let upper = match upper {
-                        Some(upper) => upper,
-                        None => Self::upper_tx(stmts, tx, collection_id).await?,
-                    };
-                    if PartialOrder::less_than(&upper, new_since) {
-                        return Err(StashError::from(format!(
-                            "compact request {} is greater than the current upper frontier {}",
-                            AntichainFormatter(new_since),
-                            AntichainFormatter(&upper)
-                        )));
-                    }
-                    Ok(())
-                },
-                async move {
-                    tx.execute(stmts.compact(), &[&new_since.as_option(), &collection_id])
-                        .map_err(StashError::from)
-                        .await
-                },
-            )
-        });
-        try_join_all(futures).await?;
-        Ok(())
-    }
-
-    /// Returns sinces for the requested collections.
-    async fn sinces_batch_tx(
-        stmts: &CountedStatements<'_>,
-        tx: &Client,
-        collections: &[Id],
-    ) -> Result<HashMap<Id, Antichain<Timestamp>>, StashError> {
-        let mut futures = Vec::with_capacity(collections.len());
-        for collection_id in collections {
-            futures.push(async move {
-                let since = Self::since_tx(stmts, tx, *collection_id).await?;
-                // Without this type assertion, we get a "type inside `async fn` body must be
-                // known in this context" error.
-                Result::<_, StashError>::Ok((*collection_id, since))
-            });
-        }
-        let sinces = HashMap::from_iter(try_join_all(futures).await?);
-        Ok(sinces)
-    }
 }
 
 impl Stash {
@@ -884,266 +708,13 @@ impl Stash {
         V: Data,
     {
         let name = name.to_string();
-        self.transact(move |stmts, tx| {
-            let name = name.clone();
-            Box::pin(async move {
-                let collection_id_opt: Option<_> = tx
-                    .query_one(stmts.collection(), &[&name])
-                    .await
-                    .map(|row| row.get("collection_id"))
-                    .ok();
-
-                let collection_id = match collection_id_opt {
-                    Some(id) => id,
-                    None => {
-                        let collection_id = tx
-                        .query_one(
-                            "INSERT INTO collections (name) VALUES ($1) RETURNING collection_id",
-                            &[&name],
-                        )
-                        .await?
-                        .get("collection_id");
-                        tx.execute(
-                            "INSERT INTO sinces (collection_id, since) VALUES ($1, $2)",
-                            &[&collection_id, &Timestamp::MIN],
-                        )
-                        .await?;
-                        tx.execute(
-                            "INSERT INTO uppers (collection_id, upper) VALUES ($1, $2)",
-                            &[&collection_id, &Timestamp::MIN],
-                        )
-                        .await?;
-                        collection_id
-                    }
-                };
-
-                Ok(StashCollection {
-                    id: collection_id,
-                    _kv: PhantomData,
-                })
-            })
-        })
-        .await
-    }
-
-    pub async fn collections(&mut self) -> Result<BTreeSet<String>, StashError> {
-        let names = self
-            .transact(move |_stmts, tx| {
-                Box::pin(async move {
-                    let rows = tx.query("SELECT name FROM collections", &[]).await?;
-                    Ok(rows.into_iter().map(|row| row.get(0)))
-                })
-            })
-            .await?;
-        Ok(BTreeSet::from_iter(names))
-    }
-
-    pub async fn iter<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.transact(move |stmts, tx| {
-            Box::pin(async move {
-                let since = match Self::since_tx(stmts, tx, collection.id)
-                    .await?
-                    .into_option()
-                {
-                    Some(since) => since,
-                    None => {
-                        return Err(StashError::from(
-                            "cannot iterate collection with empty since frontier",
-                        ));
-                    }
-                };
-                let rows = tx
-                    .query(stmts.iter(), &[&collection.id])
-                    .await?
-                    .into_iter()
-                    .map(|row| {
-                        let key: Value = row.try_get("key")?;
-                        let value: Value = row.try_get("value")?;
-                        let time = row.try_get("time")?;
-                        let diff: Diff = row.try_get("diff")?;
-                        Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
-                    })
-                    // The collect here isn't needed, we just want the short circuit return
-                    // behavior of ?. Is there a way to achieve that without allocating a Vec?
-                    .collect::<Result<Vec<_>, _>>()?;
-                let rows = consolidate_updates_kv(rows).collect();
-                Ok(rows)
-            })
-        })
-        .await
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn iter_key<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-        key: &K,
-    ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let key = serde_json::to_vec(key).expect("must serialize");
-        let key: Value = serde_json::from_slice(&key)?;
-        self.transact(move |stmts, tx| {
-            let key = key.clone();
-            Box::pin(async move {
-                let (since, rows) = future::try_join(
-                    Self::since_tx(stmts, tx, collection.id),
-                    tx.query(stmts.iter_key(), &[&collection.id, &key])
-                        .map_err(|err| err.into()),
-                )
-                .await?;
-                let since = match since.into_option() {
-                    Some(since) => since,
-                    None => {
-                        return Err(StashError::from(
-                            "cannot iterate collection with empty since frontier",
-                        ));
-                    }
-                };
-                let mut rows = rows
-                    .into_iter()
-                    .map(|row| {
-                        let value: Value = row.try_get("value")?;
-                        let value: V = serde_json::from_value(value)?;
-                        let time = row.try_get("time")?;
-                        let diff = row.try_get("diff")?;
-                        Ok::<_, StashError>((value, cmp::max(time, since), diff))
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                differential_dataflow::consolidation::consolidate_updates(&mut rows);
-                Ok(rows)
-            })
-        })
-        .await
-    }
-
-    /// Atomically adds a single entry to the arrangement.
-    ///
-    /// The entry's time must be greater than or equal to the upper frontier.
-    ///
-    /// If this method returns `Ok`, the entry has been made durable.
-    pub async fn update<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-        data: (K, V),
-        time: Timestamp,
-        diff: Diff,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.update_many(collection, [(data, time, diff)]).await
-    }
-
-    pub async fn update_many<K, V, I>(
-        &mut self,
-        collection: StashCollection<K, V>,
-        entries: I,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-        I: IntoIterator<Item = ((K, V), Timestamp, Diff)> + Send,
-        I::IntoIter: Send,
-    {
-        let entries = entries
-            .into_iter()
-            .map(|((key, value), time, diff)| {
-                let key = serde_json::to_value(&key).expect("must serialize");
-                let value = serde_json::to_value(&value).expect("must serialize");
-                ((key, value), time, diff)
-            })
-            .collect::<Vec<_>>();
-        self.transact(move |stmts, tx| {
-            let entries = entries.clone();
-            Box::pin(async move {
-                Self::update_many_tx(stmts, tx, collection.id, &entries, None).await?;
-                Ok(())
-            })
-        })
-        .await
-    }
-
-    pub async fn seal<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-        new_upper: AntichainRef<'_, Timestamp>,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.seal_batch(&[(collection, new_upper.to_owned())]).await
-    }
-
-    pub async fn seal_batch<K, V>(
-        &mut self,
-        seals: &[(StashCollection<K, V>, Antichain<Timestamp>)],
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let seals = seals
-            .iter()
-            .map(|(collection, frontier)| (collection.id, frontier.clone()))
-            .collect::<Vec<_>>();
-        self.transact(move |stmts, tx| {
-            let seals = seals.clone();
-            Box::pin(async move {
-                Self::seal_batch_tx(stmts, tx, seals.iter().map(|d| (d.0, &d.1, None))).await
-            })
-        })
-        .await
-    }
-
-    pub async fn compact<'a, K, V>(
-        &'a mut self,
-        collection: StashCollection<K, V>,
-        new_since: AntichainRef<'a, Timestamp>,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.compact_batch(&[(collection, new_since.to_owned())])
+        self.with_transaction(move |tx| Box::pin(async move { tx.collection(&name).await }))
             .await
     }
 
-    pub async fn compact_batch<K, V>(
-        &mut self,
-        compactions: &[(StashCollection<K, V>, Antichain<Timestamp>)],
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let compactions = compactions
-            .iter()
-            .map(|(collection, since)| (collection.id, since.clone()))
-            .collect::<Vec<_>>();
-        self.transact(|stmts, tx| {
-            let compactions = compactions.clone();
-            Box::pin(async move {
-                Self::compact_batch_tx(
-                    stmts,
-                    tx,
-                    compactions.iter().map(|(id, since)| (*id, since, None)),
-                )
-                .await
-            })
-        })
-        .await
+    pub async fn collections(&mut self) -> Result<BTreeSet<String>, StashError> {
+        self.with_transaction(move |tx| Box::pin(async move { tx.collections().await }))
+            .await
     }
 
     pub async fn consolidate(&mut self, collection: Id) -> Result<(), StashError> {
@@ -1153,9 +724,8 @@ impl Stash {
     pub async fn consolidate_batch(&mut self, collections: &[Id]) -> Result<(), StashError> {
         let collections = collections.to_vec();
         let sinces = self
-            .transact(|stmts, tx| {
-                let collections = collections.clone();
-                Box::pin(async move { Self::sinces_batch_tx(stmts, tx, &collections).await })
+            .with_transaction(move |tx| {
+                Box::pin(async move { tx.sinces_batch(&collections).await })
             })
             .await?;
         // On successful transact, send consolidation sinces to the
@@ -1168,36 +738,8 @@ impl Stash {
         Ok(())
     }
 
-    /// Reports the current since frontier.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn since<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Antichain<Timestamp>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.transact(|stmts, tx| Box::pin(Self::since_tx(stmts, tx, collection.id)))
-            .await
-    }
-
-    /// Reports the current upper frontier.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn upper<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Antichain<Timestamp>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.transact(|stmts, tx| Box::pin(Self::upper_tx(stmts, tx, collection.id)))
-            .await
-    }
-
     pub async fn confirm_leadership(&mut self) -> Result<(), StashError> {
-        self.transact(|_, _| Box::pin(async { Ok(()) })).await
+        self.with_transaction(|_| Box::pin(async { Ok(()) })).await
     }
 
     pub fn is_readonly(&self) -> bool {
@@ -1218,206 +760,19 @@ impl From<tokio_postgres::Error> for StashError {
 }
 
 impl Stash {
-    /// Returns the most recent timestamp at which sealed entries can be read.
-    pub async fn peek_timestamp<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Timestamp, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let since = self.since(collection).await?;
-        let upper = self.upper(collection).await?;
-        if PartialOrder::less_equal(&upper, &since) {
-            return Err(StashError {
-                inner: InternalStashError::PeekSinceUpper(format!(
-                    "collection {} since {} is not less than upper {}",
-                    collection.id,
-                    AntichainFormatter(&since),
-                    AntichainFormatter(&upper)
-                )),
-            });
-        }
-        match upper.as_option() {
-            Some(ts) => match ts.checked_sub(1) {
-                Some(ts) => Ok(ts),
-                None => Err("could not determine peek timestamp".into()),
-            },
-            None => Ok(Timestamp::MAX),
-        }
-    }
-
-    /// Returns the current value of sealed entries.
-    ///
-    /// Entries are iterated in `(key, value)` order and are guaranteed to be
-    /// consolidated.
-    ///
-    /// Sealed entries are those with timestamps less than the collection's upper
-    /// frontier.
-    pub async fn peek<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Vec<(K, V, Diff)>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let timestamp = self.peek_timestamp(collection).await?;
-        let mut rows: Vec<_> = self
-            .iter(collection)
-            .await?
-            .into_iter()
-            .filter_map(|((k, v), data_ts, diff)| {
-                if data_ts.less_equal(&timestamp) {
-                    Some((k, v, diff))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        differential_dataflow::consolidation::consolidate_updates(&mut rows);
-        Ok(rows)
-    }
-
-    /// Returns the current k,v pairs of sealed entries, erroring if there is more
-    /// than one entry for a given key or the multiplicity is not 1 for each key.
-    ///
-    /// Sealed entries are those with timestamps less than the collection's upper
-    /// frontier.
-    pub async fn peek_one<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<BTreeMap<K, V>, StashError>
-    where
-        K: Data + std::hash::Hash,
-        V: Data,
-    {
-        let rows = self.peek(collection).await?;
-        let mut res = BTreeMap::new();
-        for (k, v, diff) in rows {
-            if diff != 1 {
-                return Err("unexpected peek multiplicity".into());
-            }
-            if res.insert(k, v).is_some() {
-                return Err(format!("duplicate peek keys for collection {}", collection.id).into());
-            }
-        }
-        Ok(res)
-    }
-
-    /// Returns the current sealed value for the given key, erroring if there is
-    /// more than one entry for the key or its multiplicity is not 1.
-    ///
-    /// Sealed entries are those with timestamps less than the collection's upper
-    /// frontier.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn peek_key_one<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-        key: &K,
-    ) -> Result<Option<V>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let timestamp = self.peek_timestamp(collection).await?;
-        let mut rows: Vec<_> = self
-            .iter_key(collection, key)
-            .await?
-            .into_iter()
-            .filter_map(|(v, data_ts, diff)| {
-                if data_ts.less_equal(&timestamp) {
-                    Some((v, diff))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        differential_dataflow::consolidation::consolidate(&mut rows);
-        let v = match rows.len() {
-            1 => {
-                let (v, diff) = rows.into_element();
-                match diff {
-                    1 => Some(v),
-                    0 => None,
-                    _ => return Err("multiple values unexpected".into()),
-                }
-            }
-            0 => None,
-            _ => return Err("multiple values unexpected".into()),
-        };
-        Ok(v)
-    }
-}
-
-impl Stash {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn append_batch(&mut self, batches: &[AppendBatch]) -> Result<(), StashError> {
+    /// Like `append` but doesn't consolidate.
+    pub async fn append_batch(&mut self, batches: Vec<AppendBatch>) -> Result<(), StashError> {
         if batches.is_empty() {
             return Ok(());
         }
-        let batches = batches.to_vec();
-        self.transact(move |stmts, tx| {
-            let batches = batches.clone();
+        self.with_transaction(move |tx| {
             Box::pin(async move {
-                let futures = batches.into_iter().map(
-                    |AppendBatch {
-                         collection_id,
-                         lower,
-                         upper,
-                         compact,
-                         entries,
-                         ..
-                     }| {
-                        // Clone to appease rust async.
-                        let lower1 = lower.clone();
-                        let lower2 = lower.clone();
-                        let upper1 = upper.clone();
-                        try_join3(
-                            async move {
-                                // Verify the previous upper before compaction.
-                                let current_upper =
-                                    Self::upper_tx(stmts, tx, collection_id).await?;
-                                if current_upper != lower1 {
-                                    return Err(StashError::from(format!(
-                                        "unexpected lower, got {:?}, expected {:?}",
-                                        current_upper, lower1
-                                    )));
-                                }
-                                Self::compact_batch_tx(
-                                    stmts,
-                                    tx,
-                                    std::iter::once((collection_id, &compact, Some(upper))),
-                                )
-                                .await
-                            },
-                            async move {
-                                Self::update_many_tx(
-                                    stmts,
-                                    tx,
-                                    collection_id,
-                                    &entries,
-                                    Some(lower2),
-                                )
-                                .await
-                            },
-                            async move {
-                                Self::seal_batch_tx(
-                                    stmts,
-                                    tx,
-                                    std::iter::once((collection_id, &upper1, Some(lower))),
-                                )
-                                .await
-                            },
-                        )
-                    },
-                );
-                try_join_all(futures).await
+                let batches = batches.clone();
+                tx.append(batches).await
             })
         })
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Atomically adds entries, seals, compacts, and consolidates multiple
@@ -1429,12 +784,12 @@ impl Stash {
     ///
     /// If this method returns `Ok`, the entries have been made durable and uppers
     /// advanced, otherwise no changes were committed.
-    pub async fn append(&mut self, batches: &[AppendBatch]) -> Result<(), StashError> {
+    pub async fn append(&mut self, batches: Vec<AppendBatch>) -> Result<(), StashError> {
         if batches.is_empty() {
             return Ok(());
         }
-        self.append_batch(batches).await?;
         let ids: Vec<_> = batches.iter().map(|batch| batch.collection_id).collect();
+        self.append_batch(batches).await?;
         self.consolidate_batch(&ids).await?;
         Ok(())
     }

--- a/src/stash/src/transaction.rs
+++ b/src/stash/src/transaction.rs
@@ -1,0 +1,639 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    cmp,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    marker::PhantomData,
+    sync::{Arc, Mutex},
+};
+
+use futures::{
+    future::{self, try_join, try_join3, try_join_all, BoxFuture},
+    TryFutureExt,
+};
+use mz_ore::collections::CollectionExt;
+use serde_json::Value;
+use timely::{progress::Antichain, PartialOrder};
+use tokio::sync::mpsc;
+use tokio_postgres::Client;
+
+use crate::{
+    consolidate_updates_kv, postgres::CountedStatements, AntichainFormatter, AppendBatch, Data,
+    Diff, Id, InternalStashError, Stash, StashCollection, StashError, Timestamp,
+};
+
+impl Stash {
+    pub async fn with_transaction<F, T>(&mut self, f: F) -> Result<T, StashError>
+    where
+        F: FnOnce(Transaction) -> BoxFuture<Result<T, StashError>> + Clone + Sync + Send + 'static,
+    {
+        let (res, mut cons_rx) = self
+            .transact(|stmts, client| {
+                let f = f.clone();
+                let (cons_tx, cons_rx) = mpsc::unbounded_channel();
+                let tx = Transaction {
+                    stmts,
+                    client,
+                    consolidations: cons_tx,
+                    savepoint: Arc::new(Mutex::new(false)),
+                };
+                Box::pin(async move {
+                    let res = f(tx).await?;
+                    Ok((res, cons_rx))
+                })
+            })
+            .await?;
+        while let Some(cons) = cons_rx.recv().await {
+            self.sinces_tx
+                .send(cons)
+                .expect("consolidator unexpectedly gone");
+        }
+        Ok(res)
+    }
+}
+
+pub struct Transaction<'a> {
+    stmts: &'a CountedStatements<'a>,
+    client: &'a Client,
+    // The set of consolidations that need to be performed if the transaction
+    // succeeds.
+    consolidations: mpsc::UnboundedSender<(Id, Antichain<Timestamp>)>,
+    // Savepoint state to enforce the invariant that only one SAVEPOINT is
+    // active at once.
+    savepoint: Arc<Mutex<bool>>,
+}
+
+impl<'a> Transaction<'a> {
+    /// Executes f in a SAVEPOINT. RELEASE if f returns Ok, ROLLBACK if f
+    /// returns Err. This must be used for any fn that performs any falliable
+    /// operation after its first write. This includes multiple write operations
+    /// in a row (any function with multpile writes must use this function).
+    async fn in_savepoint<'res, F, T>(&self, f: F) -> Result<T, StashError>
+    where
+        F: FnOnce() -> BoxFuture<'res, Result<T, StashError>>,
+    {
+        // Savepoints cannot be used recursively, so panic if that happened.
+        {
+            // Put this in a block to convince the rust compiler that savepoint
+            // won't be used across the await.
+            let mut savepoint = self.savepoint.lock().unwrap();
+            if *savepoint {
+                panic!("cannot call savepoint recursively");
+            }
+            *savepoint = true;
+        };
+
+        self.client.batch_execute("SAVEPOINT txn_savepoint").await?;
+        let res = match f().await {
+            Ok(t) => {
+                self.client
+                    .batch_execute("RELEASE SAVEPOINT txn_savepoint")
+                    .await?;
+                Ok(t)
+            }
+            Err(err) => {
+                self.client
+                    .batch_execute("ROLLBACK TO SAVEPOINT txn_savepoint")
+                    .await?;
+                Err(err)
+            }
+        };
+
+        let mut savepoint = self.savepoint.lock().unwrap();
+        assert!(*savepoint);
+        *savepoint = false;
+
+        res
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn collection<K, V>(&self, name: &str) -> Result<StashCollection<K, V>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let collection_id_opt: Option<_> = self
+            .client
+            .query_one(self.stmts.collection(), &[&name])
+            .await
+            .map(|row| row.get("collection_id"))
+            .ok();
+
+        let collection_id = match collection_id_opt {
+            Some(id) => id,
+            None => {
+                let collection_id = self
+                    .client
+                    .query_one(
+                        "INSERT INTO collections (name) VALUES ($1) RETURNING collection_id",
+                        &[&name],
+                    )
+                    .await?
+                    .get("collection_id");
+                self.client
+                    .execute(
+                        "INSERT INTO sinces (collection_id, since) VALUES ($1, $2)",
+                        &[&collection_id, &Timestamp::MIN],
+                    )
+                    .await?;
+                self.client
+                    .execute(
+                        "INSERT INTO uppers (collection_id, upper) VALUES ($1, $2)",
+                        &[&collection_id, &Timestamp::MIN],
+                    )
+                    .await?;
+                collection_id
+            }
+        };
+
+        Ok(StashCollection {
+            id: collection_id,
+            _kv: PhantomData,
+        })
+    }
+
+    /// Returns the names of all collections.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn collections(&self) -> Result<BTreeSet<String>, StashError> {
+        let rows = self
+            .client
+            .query("SELECT name FROM collections", &[])
+            .await?;
+        let names = rows.into_iter().map(|row| row.get(0));
+        Ok(BTreeSet::from_iter(names))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn consolidate(&self, id: Id) -> Result<(), StashError> {
+        let since = self.since(id).await?;
+        self.consolidations.send((id, since)).unwrap();
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn upper(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
+        let upper: Option<Timestamp> = self
+            .client
+            .query_one(self.stmts.upper(), &[&collection_id])
+            .await?
+            .get("upper");
+        Ok(Antichain::from_iter(upper))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn since(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
+        let since: Option<Timestamp> = self
+            .client
+            .query_one(self.stmts.since(), &[&collection_id])
+            .await?
+            .get("since");
+        Ok(Antichain::from_iter(since))
+    }
+
+    /// Returns sinces for the requested collections.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn sinces_batch(
+        &self,
+        collections: &[Id],
+    ) -> Result<HashMap<Id, Antichain<Timestamp>>, StashError> {
+        let mut futures = Vec::with_capacity(collections.len());
+        for collection_id in collections {
+            futures.push(async move {
+                let since = self.since(*collection_id).await?;
+                // Without this type assertion, we get a "type inside `async fn` body must be
+                // known in this context" error.
+                Result::<_, StashError>::Ok((*collection_id, since))
+            });
+        }
+        let sinces = HashMap::from_iter(try_join_all(futures).await?);
+        Ok(sinces)
+    }
+
+    /// Iterates over a collection.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn iter<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let since = match self.since(collection.id).await?.into_option() {
+            Some(since) => since,
+            None => {
+                return Err(StashError::from(
+                    "cannot iterate collection with empty since frontier",
+                ));
+            }
+        };
+        let rows = self
+            .client
+            .query(self.stmts.iter(), &[&collection.id])
+            .await?
+            .into_iter()
+            .map(|row| {
+                let key: Value = row.try_get("key")?;
+                let value: Value = row.try_get("value")?;
+                let time = row.try_get("time")?;
+                let diff: Diff = row.try_get("diff")?;
+                Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let rows = consolidate_updates_kv(rows).collect();
+        Ok(rows)
+    }
+
+    /// Iterates over the values of a key.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn iter_key<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+        key: &K,
+    ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let key = serde_json::to_vec(key).expect("must serialize");
+        let key: Value = serde_json::from_slice(&key)?;
+        let (since, rows) = future::try_join(
+            self.since(collection.id),
+            self.client
+                .query(self.stmts.iter_key(), &[&collection.id, &key])
+                .map_err(|err| err.into()),
+        )
+        .await?;
+        let since = match since.into_option() {
+            Some(since) => since,
+            None => {
+                return Err(StashError::from(
+                    "cannot iterate collection with empty since frontier",
+                ));
+            }
+        };
+        let mut rows = rows
+            .into_iter()
+            .map(|row| {
+                let value: Value = row.try_get("value")?;
+                let value: V = serde_json::from_value(value)?;
+                let time = row.try_get("time")?;
+                let diff = row.try_get("diff")?;
+                Ok::<_, StashError>((value, cmp::max(time, since), diff))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        differential_dataflow::consolidation::consolidate_updates(&mut rows);
+        Ok(rows)
+    }
+
+    /// Returns the most recent timestamp at which sealed entries can be read.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn peek_timestamp<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Timestamp, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let (since, upper) = try_join(self.since(collection.id), self.upper(collection.id)).await?;
+        if PartialOrder::less_equal(&upper, &since) {
+            return Err(StashError {
+                inner: InternalStashError::PeekSinceUpper(format!(
+                    "collection {} since {} is not less than upper {}",
+                    collection.id,
+                    AntichainFormatter(&since),
+                    AntichainFormatter(&upper)
+                )),
+            });
+        }
+        match upper.as_option() {
+            Some(ts) => match ts.checked_sub(1) {
+                Some(ts) => Ok(ts),
+                None => Err("could not determine peek timestamp".into()),
+            },
+            None => Ok(Timestamp::MAX),
+        }
+    }
+
+    /// Returns the current value of sealed entries.
+    ///
+    /// Entries are iterated in `(key, value)` order and are guaranteed to be
+    /// consolidated.
+    ///
+    /// Sealed entries are those with timestamps less than the collection's upper
+    /// frontier.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn peek<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Vec<(K, V, Diff)>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let timestamp = self.peek_timestamp(collection).await?;
+        let mut rows: Vec<_> = self
+            .iter(collection)
+            .await?
+            .into_iter()
+            .filter_map(|((k, v), data_ts, diff)| {
+                if data_ts.less_equal(&timestamp) {
+                    Some((k, v, diff))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        differential_dataflow::consolidation::consolidate_updates(&mut rows);
+        Ok(rows)
+    }
+
+    /// Returns the current k,v pairs of sealed entries, erroring if there is more
+    /// than one entry for a given key or the multiplicity is not 1 for each key.
+    ///
+    /// Sealed entries are those with timestamps less than the collection's upper
+    /// frontier.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn peek_one<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<BTreeMap<K, V>, StashError>
+    where
+        K: Data + std::hash::Hash,
+        V: Data,
+    {
+        let rows = self.peek(collection).await?;
+        let mut res = BTreeMap::new();
+        for (k, v, diff) in rows {
+            if diff != 1 {
+                return Err("unexpected peek multiplicity".into());
+            }
+            if res.insert(k, v).is_some() {
+                return Err(format!("duplicate peek keys for collection {}", collection.id).into());
+            }
+        }
+        Ok(res)
+    }
+
+    /// Returns the current sealed value for the given key, erroring if there is
+    /// more than one entry for the key or its multiplicity is not 1.
+    ///
+    /// Sealed entries are those with timestamps less than the collection's upper
+    /// frontier.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn peek_key_one<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+        key: &K,
+    ) -> Result<Option<V>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let timestamp = self.peek_timestamp(collection).await?;
+        let mut rows: Vec<_> = self
+            .iter_key(collection, key)
+            .await?
+            .into_iter()
+            .filter_map(|(v, data_ts, diff)| {
+                if data_ts.less_equal(&timestamp) {
+                    Some((v, diff))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        differential_dataflow::consolidation::consolidate(&mut rows);
+        let v = match rows.len() {
+            1 => {
+                let (v, diff) = rows.into_element();
+                match diff {
+                    1 => Some(v),
+                    0 => None,
+                    _ => return Err("multiple values unexpected".into()),
+                }
+            }
+            0 => None,
+            _ => return Err("multiple values unexpected".into()),
+        };
+        Ok(v)
+    }
+
+    /// Applies batches to the current transaction. If any batch fails and in
+    /// error returned, all other applications are rolled back.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn append(&self, batches: Vec<AppendBatch>) -> Result<(), StashError> {
+        if batches.is_empty() {
+            return Ok(());
+        }
+
+        let consolidations = self
+            .in_savepoint(|| {
+                Box::pin(async move {
+                    let futures = batches.into_iter().map(
+                        |AppendBatch {
+                             collection_id,
+                             lower,
+                             upper,
+                             entries,
+                             ..
+                         }| async move {
+                            // Clone to appease rust async.
+                            let compact = lower.clone();
+                            let lower1 = lower.clone();
+                            let lower2 = lower.clone();
+                            let upper1 = upper.clone();
+                            // The new upper must be validated before being sealed.
+                            // Compaction can be done in any order because none of
+                            // update/seal care about what the since is. Update, although it
+                            // cares about the upper, can also be done in any order because
+                            // we pass in the old upper, so it's not a problem if the seal
+                            // has executed already since update won't query the current
+                            // upper.
+                            try_join3(
+                                    async move {
+                                        let current_upper = self.upper(collection_id).await?;
+                                        if current_upper != lower1 {
+                                            return Err(StashError::from(format!(
+                                                "unexpected lower, got {:?}, expected {:?}",
+                                                current_upper, lower1
+                                            )));
+                                        }
+
+                                        self.seal(collection_id, &upper1, Some(lower)).await
+                                    },
+                                    async move {
+                                        self.update(collection_id, &entries, Some(lower2)).await
+                                    },
+                                    async move {
+                                        self.compact(collection_id, &compact, Some(upper)).await
+                                    },
+                                )
+                                .await?;
+                            Ok::<_, StashError>((collection_id, self.since(collection_id).await?))
+                        },
+                    );
+                    try_join_all(futures).await
+                })
+            })
+            .await?;
+
+        for cons in consolidations {
+            self.consolidations.send(cons).unwrap();
+        }
+        Ok(())
+    }
+
+    /// Like update, but starts a savepoint.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn update_savepoint(
+        &self,
+        collection_id: Id,
+        entries: &[((Value, Value), Timestamp, Diff)],
+        upper: Option<Antichain<Timestamp>>,
+    ) -> Result<(), StashError> {
+        self.in_savepoint(|| Box::pin(async { self.update(collection_id, entries, upper).await }))
+            .await
+    }
+
+    /// Directly add k, v, ts, diff tuples to a collection.`upper` can be `Some`
+    /// if the collection's upper is already known. Caller must have already
+    /// called in_savepoint.
+    ///
+    /// This function should not be called outside of the stash crate since it
+    /// allows for arbitrary bytes, non-unit diffs in collections, and doesn't
+    /// support transaction safety. Use `TypedCollection`'s methods instead.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn update(
+        &self,
+        collection_id: Id,
+        entries: &[((Value, Value), Timestamp, Diff)],
+        upper: Option<Antichain<Timestamp>>,
+    ) -> Result<(), StashError> {
+        {
+            // Panic if the caller didn't initiate the savepoint.
+            let savepoint = self.savepoint.lock().unwrap();
+            assert!(*savepoint);
+        }
+
+        let mut futures = Vec::with_capacity(entries.len());
+        for ((key, value), time, diff) in entries {
+            futures.push(async move {
+                self.client
+                    .execute(
+                        self.stmts.update_many(),
+                        &[&collection_id, &key, &value, &time, &diff],
+                    )
+                    .map_err(|err| err.into())
+                    .await
+            });
+        }
+
+        // Check the upper in a separate future so we can issue the updates without
+        // waiting for it first.
+        try_join(
+            async {
+                let upper = match upper {
+                    Some(upper) => upper,
+                    None => self.upper(collection_id).await?,
+                };
+                for ((_key, _value), time, _diff) in entries {
+                    if !upper.less_equal(time) {
+                        return Err(StashError::from(format!(
+                            "entry time {} is less than the current upper frontier {}",
+                            time,
+                            AntichainFormatter(&upper)
+                        )));
+                    }
+                }
+                Ok(upper)
+            },
+            try_join_all(futures),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Sets the since of a collection. The current upper can be `Some` if it is
+    /// already known.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn compact<'ts>(
+        &self,
+        id: Id,
+        new_since: &'ts Antichain<Timestamp>,
+        upper: Option<Antichain<Timestamp>>,
+    ) -> Result<(), StashError> {
+        // Do all validation first.
+        try_join(
+            async move {
+                let since = self.since(id).await?;
+                if PartialOrder::less_than(new_since, &since) {
+                    return Err(StashError::from(format!(
+                        "compact request {} is less than the current since frontier {}",
+                        AntichainFormatter(new_since),
+                        AntichainFormatter(&since)
+                    )));
+                }
+                Ok(())
+            },
+            async move {
+                let upper = match upper {
+                    Some(upper) => upper,
+                    None => self.upper(id).await?,
+                };
+                if PartialOrder::less_than(&upper, new_since) {
+                    return Err(StashError::from(format!(
+                        "compact request {} is greater than the current upper frontier {}",
+                        AntichainFormatter(new_since),
+                        AntichainFormatter(&upper)
+                    )));
+                }
+                Ok(())
+            },
+        )
+        .await?;
+
+        // If successful, execute the change in the txn.
+        self.client
+            .execute(self.stmts.compact(), &[&new_since.as_option(), &id])
+            .map_err(StashError::from)
+            .await?;
+        Ok(())
+    }
+
+    /// Sets the upper of a collection. The current upper can be `Some` if it is
+    /// already known.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn seal(
+        &self,
+        id: Id,
+        new_upper: &Antichain<Timestamp>,
+        upper: Option<Antichain<Timestamp>>,
+    ) -> Result<(), StashError> {
+        let upper = match upper {
+            Some(upper) => upper,
+            None => self.upper(id).await?,
+        };
+        if PartialOrder::less_than(new_upper, &upper) {
+            return Err(StashError::from(format!(
+                "seal request {} is less than the current upper frontier {}",
+                AntichainFormatter(new_upper),
+                AntichainFormatter(&upper),
+            )));
+        }
+
+        self.client
+            .execute(self.stmts.seal(), &[&new_upper.as_option(), &id])
+            .map_err(StashError::from)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -90,6 +90,10 @@ use mz_stash::{
     Stash, StashCollection, StashError, StashFactory, TableTransaction, Timestamp, TypedCollection,
 };
 
+pub static C1: TypedCollection<i64, i64> = TypedCollection::new("c1");
+pub static C2: TypedCollection<i64, i64> = TypedCollection::new("c2");
+pub static C_SAVEPOINT: TypedCollection<i64, i64> = TypedCollection::new("c_savepoint");
+
 #[tokio::test]
 async fn test_stash_postgres() {
     mz_ore::test::init_logging();
@@ -152,7 +156,7 @@ async fn test_stash_postgres() {
         let col_rw = stash_rw.collection::<i64, i64>("c1").await.unwrap();
         let mut batch = col_rw.make_batch(&mut stash_rw).await.unwrap();
         col_rw.append_to_batch(&mut batch, &1, &2, 1);
-        stash_rw.append(&[batch]).await.unwrap();
+        stash_rw.append(vec![batch]).await.unwrap();
 
         // Now make a readonly stash. We should fail to create new collections,
         // but be able to read existing collections.
@@ -165,8 +169,10 @@ async fn test_stash_postgres() {
             res.unwrap_err().to_string(),
             "cannot execute INSERT in a read-only transaction"
         );
-        let col_ro = stash_ro.collection::<i64, i64>("c1").await.unwrap();
-        assert_eq!(stash_ro.peek(col_ro).await.unwrap(), vec![(1, 2, 1)],);
+        assert_eq!(
+            C1.peek_one(&mut stash_ro).await.unwrap(),
+            BTreeMap::from([(1, 2)])
+        );
 
         // The previous stash should still be the leader.
         assert!(stash_rw.confirm_leadership().await.is_ok());
@@ -179,7 +185,6 @@ async fn test_stash_postgres() {
             .await
             .unwrap();
         // Data still present from previous test.
-        let c1_rw = stash_rw.collection::<i64, i64>("c1").await.unwrap();
 
         // Now make a savepoint stash. We should be allowed to create anything
         // we want, but it shouldn't be viewable to other stashes.
@@ -190,13 +195,16 @@ async fn test_stash_postgres() {
         let c1_sp = stash_rw.collection::<i64, i64>("c1").await.unwrap();
         let mut batch = c1_sp.make_batch(&mut stash_sp).await.unwrap();
         c1_sp.append_to_batch(&mut batch, &5, &6, 1);
-        stash_sp.append(&[batch]).await.unwrap();
+        stash_sp.append(vec![batch]).await.unwrap();
         assert_eq!(
-            stash_sp.peek(c1_sp).await.unwrap(),
-            vec![(1, 2, 1), (5, 6, 1)]
+            C1.peek_one(&mut stash_sp).await.unwrap(),
+            BTreeMap::from([(1, 2), (5, 6)]),
         );
         // RW collection can't see the new row.
-        assert_eq!(stash_rw.peek(c1_rw).await.unwrap(), vec![(1, 2, 1)]);
+        assert_eq!(
+            C1.peek_one(&mut stash_rw).await.unwrap(),
+            BTreeMap::from([(1, 2)])
+        );
 
         // SP stash can create a new collection, append to it, peek it.
         let c_savepoint = stash_sp
@@ -205,8 +213,11 @@ async fn test_stash_postgres() {
             .unwrap();
         let mut batch = c_savepoint.make_batch(&mut stash_sp).await.unwrap();
         c_savepoint.append_to_batch(&mut batch, &3, &4, 1);
-        stash_sp.append(&[batch]).await.unwrap();
-        assert_eq!(stash_sp.peek(c_savepoint).await.unwrap(), vec![(3, 4, 1)]);
+        stash_sp.append(vec![batch]).await.unwrap();
+        assert_eq!(
+            C_SAVEPOINT.peek_one(&mut stash_sp).await.unwrap(),
+            BTreeMap::from([(3, 4)])
+        );
         // But the RW collection can't see it.
         assert_eq!(
             stash_rw.collections().await.unwrap(),
@@ -218,7 +229,10 @@ async fn test_stash_postgres() {
         // The previous stash should still be the leader.
         assert!(stash_rw.confirm_leadership().await.is_ok());
         // Verify c1 didn't change.
-        assert_eq!(stash_rw.peek(c1_rw).await.unwrap(), vec![(1, 2, 1)]);
+        assert_eq!(
+            C1.peek_one(&mut stash_rw).await.unwrap(),
+            BTreeMap::from([(1, 2)])
+        );
         stash_rw.verify().await.unwrap();
     }
 }
@@ -240,7 +254,7 @@ where
         .to_string()
         .contains("since {-9223372036854775808} is not less than upper {-9223372036854775808}"));
     TYPED
-        .upsert_key(&mut stash, &"k1".to_string(), |_| {
+        .upsert_key(&mut stash, "k1".to_string(), |_| {
             Ok::<_, Infallible>("v1".to_string())
         })
         .await
@@ -251,7 +265,7 @@ where
         BTreeMap::from([("k1".to_string(), "v1".to_string())])
     );
     TYPED
-        .upsert_key(&mut stash, &"k1".to_string(), |_| {
+        .upsert_key(&mut stash, "k1".to_string(), |_| {
             Ok::<_, Infallible>("v2".to_string())
         })
         .await
@@ -263,14 +277,14 @@ where
     );
     assert_eq!(
         TYPED
-            .peek_key_one(&mut stash, &"k1".to_string())
+            .peek_key_one(&mut stash, "k1".to_string())
             .await
             .unwrap(),
         Some("v2".to_string()),
     );
     assert_eq!(
         TYPED
-            .peek_key_one(&mut stash, &"k2".to_string())
+            .peek_key_one(&mut stash, "k2".to_string())
             .await
             .unwrap(),
         None
@@ -296,129 +310,163 @@ where
     // Test append across collections.
     let orders = stash.collection::<String, String>("orders").await.unwrap();
     let other = stash.collection::<String, String>("other").await.unwrap();
-    // Seal so we can invalidate the upper below.
+
     stash
-        .seal(other, Antichain::from_elem(1).borrow())
+        .with_transaction(move |tx| {
+            Box::pin(async move {
+                // Seal so we can invalidate the upper below.
+                tx.seal(other.id, &Antichain::from_elem(1), None)
+                    .await
+                    .unwrap();
+                let mut orders_batch = orders.make_batch_tx(&tx).await.unwrap();
+                orders.append_to_batch(&mut orders_batch, &"k1".to_string(), &"v1".to_string(), 1);
+                let mut other_batch = other.make_batch_tx(&tx).await.unwrap();
+                other.append_to_batch(&mut other_batch, &"k2".to_string(), &"v2".to_string(), 1);
+
+                // Invalidate one upper and ensure append doesn't commit partial batches.
+                let other_upper = other_batch.upper;
+                other_batch.upper = Antichain::from_elem(Timestamp::MIN);
+                assert_contains!(
+                    tx.append(vec![orders_batch.clone(), other_batch.clone()])
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "{-9223372036854775808}",
+                );
+                // Test batches in the other direction too.
+                assert_contains!(
+                    tx.append(vec![other_batch.clone(), orders_batch.clone()])
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "{-9223372036854775808}",
+                );
+
+                // Fix the upper, append should work now.
+                other_batch.upper = other_upper;
+                tx.append(vec![other_batch, orders_batch]).await.unwrap();
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[(("k1".into(), "v1".into()), -9223372036854775808, 1),]
+                );
+                assert_eq!(
+                    tx.iter(other).await.unwrap(),
+                    &[(("k2".into(), "v2".into()), 1, 1),]
+                );
+                assert_eq!(
+                    tx.peek_one(orders).await.unwrap(),
+                    BTreeMap::from([("k1".to_string(), "v1".to_string())])
+                );
+                assert_eq!(
+                    tx.peek_one(other).await.unwrap(),
+                    BTreeMap::from([("k2".to_string(), "v2".to_string())])
+                );
+
+                // Verify the upper got bumped.
+                assert_eq!(
+                    tx.since(orders.id).await.unwrap().into_option().unwrap(),
+                    tx.upper(orders.id).await.unwrap().into_option().unwrap() - 1
+                );
+                // Multiple empty batches should bump the upper and the since because append
+                // must also compact and consolidate.
+                for _ in 0..5 {
+                    let orders_batch = orders.make_batch_tx(&tx).await.unwrap();
+                    tx.append(vec![orders_batch]).await.unwrap();
+                    assert_eq!(
+                        tx.since(orders.id).await.unwrap().into_option().unwrap(),
+                        tx.upper(orders.id).await.unwrap().into_option().unwrap() - 1
+                    );
+                }
+                Ok(())
+            })
+        })
         .await
         .unwrap();
-    let mut orders_batch = orders.make_batch(&mut stash).await.unwrap();
-    orders.append_to_batch(&mut orders_batch, &"k1".to_string(), &"v1".to_string(), 1);
-    let mut other_batch = other.make_batch(&mut stash).await.unwrap();
-    other.append_to_batch(&mut other_batch, &"k2".to_string(), &"v2".to_string(), 1);
-
-    // Invalidate one upper and ensure append doesn't commit partial batches.
-    let other_upper = other_batch.upper;
-    other_batch.upper = Antichain::from_elem(Timestamp::MIN);
-    assert_eq!(
-          stash
-            .append(&[orders_batch.clone(), other_batch.clone()]).await
-            .unwrap_err()
-            .to_string(),
-        "stash error: seal request {-9223372036854775808} is less than the current upper frontier {1}",
-    );
-    // Test batches in the other direction too.
-    assert_eq!(
-        stash
-            .append(&[other_batch.clone(),orders_batch.clone() ]).await
-            .unwrap_err()
-            .to_string(),
-        "stash error: seal request {-9223372036854775808} is less than the current upper frontier {1}",
-    );
-
-    // Fix the upper, append should work now.
-    other_batch.upper = other_upper;
-    stash.append(&[other_batch, orders_batch]).await.unwrap();
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[(("k1".into(), "v1".into()), -9223372036854775808, 1),]
-    );
-    assert_eq!(
-        stash.iter(other).await.unwrap(),
-        &[(("k2".into(), "v2".into()), 1, 1),]
-    );
-    assert_eq!(
-        stash.peek_one(orders).await.unwrap(),
-        BTreeMap::from([("k1".to_string(), "v1".to_string())])
-    );
-    assert_eq!(
-        stash.peek_one(other).await.unwrap(),
-        BTreeMap::from([("k2".to_string(), "v2".to_string())])
-    );
-
-    // Verify the upper got bumped.
-    assert_eq!(
-        stash.since(orders).await.unwrap().into_option().unwrap(),
-        stash.upper(orders).await.unwrap().into_option().unwrap() - 1
-    );
-    // Multiple empty batches should bump the upper and the since because append
-    // must also compact and consolidate.
-    for _ in 0..5 {
-        let orders_batch = orders.make_batch(&mut stash).await.unwrap();
-        stash.append(&[orders_batch]).await.unwrap();
-        assert_eq!(
-            stash.since(orders).await.unwrap().into_option().unwrap(),
-            stash.upper(orders).await.unwrap().into_option().unwrap() - 1
-        );
-    }
-
-    // Don't attempt to verify persisted data for stashes that do not advertise it.
-    if stash.epoch().is_none() {
-        return stash;
-    }
 
     // Remake the stash and ensure data remains.
     let mut stash = f().await;
-    assert_eq!(
-        stash.peek_one(orders).await.unwrap(),
-        BTreeMap::from([("k1".to_string(), "v1".to_string())])
-    );
-    assert_eq!(
-        stash.peek_one(other).await.unwrap(),
-        BTreeMap::from([("k2".to_string(), "v2".to_string())])
-    );
+    stash
+        .with_transaction(move |tx| {
+            Box::pin(async move {
+                assert_eq!(
+                    tx.peek_one(orders).await.unwrap(),
+                    BTreeMap::from([("k1".to_string(), "v1".to_string())])
+                );
+                assert_eq!(
+                    tx.peek_one(other).await.unwrap(),
+                    BTreeMap::from([("k2".to_string(), "v2".to_string())])
+                );
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
     // Remake again, mutate before reading, then read.
     let mut stash = f().await;
     stash
-        .update_many(orders, [(("k3".into(), "v3".into()), 1, 1)])
-        .await
-        .unwrap();
-    stash
-        .seal(orders, Antichain::from_elem(2).borrow())
-        .await
-        .unwrap();
+        .with_transaction(move |tx| {
+            Box::pin(async move {
+                tx.update_savepoint(orders.id, &[(("k3".into(), "v3".into()), 1, 1)], None)
+                    .await
+                    .unwrap();
+                tx.seal(orders.id, &Antichain::from_elem(2), None)
+                    .await
+                    .unwrap();
 
-    assert_eq!(
-        stash.peek_one(orders).await.unwrap(),
-        BTreeMap::from([
-            ("k1".to_string(), "v1".to_string()),
-            ("k3".to_string(), "v3".to_string())
-        ])
-    );
+                assert_eq!(
+                    tx.peek_one(orders).await.unwrap(),
+                    BTreeMap::from([
+                        ("k1".to_string(), "v1".to_string()),
+                        ("k3".to_string(), "v3".to_string())
+                    ])
+                );
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
 
     // Remake the stash, mutate, then read.
     let mut stash = f().await;
-    let mut orders_batch = orders.make_batch(&mut stash).await.unwrap();
-    orders.append_to_batch(&mut orders_batch, &"k4".to_string(), &"v4".to_string(), 1);
-    stash.append(&[orders_batch]).await.unwrap();
-    assert_eq!(
-        stash.peek_one(orders).await.unwrap(),
-        BTreeMap::from([
-            ("k1".to_string(), "v1".to_string()),
-            ("k3".to_string(), "v3".to_string()),
-            ("k4".to_string(), "v4".to_string())
-        ])
-    );
+    stash
+        .with_transaction(move |tx| {
+            Box::pin(async move {
+                let mut orders_batch = orders.make_batch_tx(&tx).await.unwrap();
+                orders.append_to_batch(&mut orders_batch, &"k4".to_string(), &"v4".to_string(), 1);
+                tx.append(vec![orders_batch]).await.unwrap();
+                assert_eq!(
+                    tx.peek_one(orders).await.unwrap(),
+                    BTreeMap::from([
+                        ("k1".to_string(), "v1".to_string()),
+                        ("k3".to_string(), "v3".to_string()),
+                        ("k4".to_string(), "v4".to_string())
+                    ])
+                );
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
 
     // Remake and read again.
     let mut stash = f().await;
-    assert_eq!(
-        stash.peek_one(orders).await.unwrap(),
-        BTreeMap::from([
-            ("k1".to_string(), "v1".to_string()),
-            ("k3".to_string(), "v3".to_string()),
-            ("k4".to_string(), "v4".to_string())
-        ])
-    );
+    stash
+        .with_transaction(move |tx| {
+            Box::pin(async move {
+                assert_eq!(
+                    tx.peek_one(orders).await.unwrap(),
+                    BTreeMap::from([
+                        ("k1".to_string(), "v1".to_string()),
+                        ("k3".to_string(), "v3".to_string()),
+                        ("k4".to_string(), "v4".to_string())
+                    ])
+                );
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
 
     test_stash_table(&mut stash).await;
 
@@ -431,211 +479,200 @@ where
     F: Fn() -> O,
 {
     let mut stash = f().await;
-    // Create an arrangement, write some data into it, then read it back.
-    let orders = stash.collection::<String, String>("orders").await.unwrap();
     stash
-        .update(orders, ("widgets".into(), "1".into()), 1, 1)
-        .await
-        .unwrap();
-    stash
-        .update(orders, ("wombats".into(), "2".into()), 1, 2)
-        .await
-        .unwrap();
-    // Move this before iter to better test the memory stash's iter_key.
-    assert_eq!(
-        stash
-            .iter_key(orders, &"widgets".to_string())
-            .await
-            .unwrap(),
-        &[("1".into(), 1, 1)]
-    );
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[
-            (("widgets".into(), "1".into()), 1, 1),
-            (("wombats".into(), "2".into()), 1, 2),
-        ]
-    );
-    assert_eq!(
-        stash
-            .iter_key(orders, &"wombats".to_string())
-            .await
-            .unwrap(),
-        &[("2".into(), 1, 2)]
-    );
+        .with_transaction(move |tx| {
+            Box::pin(async move {
+                // Create an arrangement, write some data into it, then read it back.
+                let orders = tx.collection::<String, String>("orders").await.unwrap();
+                tx.update_savepoint(orders.id, &[(("widgets".into(), "1".into()), 1, 1)], None)
+                    .await
+                    .unwrap();
+                tx.update_savepoint(orders.id, &[(("wombats".into(), "2".into()), 1, 2)], None)
+                    .await
+                    .unwrap();
+                // Move this before iter to better test the memory tx's iter_key.
+                assert_eq!(
+                    tx.iter_key(orders, &"widgets".to_string()).await.unwrap(),
+                    &[("1".into(), 1, 1)]
+                );
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[
+                        (("widgets".into(), "1".into()), 1, 1),
+                        (("wombats".into(), "2".into()), 1, 2),
+                    ]
+                );
+                assert_eq!(
+                    tx.iter_key(orders, &"wombats".to_string()).await.unwrap(),
+                    &[("2".into(), 1, 2)]
+                );
 
-    // Write to another arrangement and ensure the data stays separate.
-    let other = stash.collection::<String, String>("other").await.unwrap();
-    stash
-        .update(other, ("foo".into(), "bar".into()), 1, 1)
+                // Write to another arrangement and ensure the data stays separate.
+                let other = tx.collection::<String, String>("other").await.unwrap();
+                tx.update_savepoint(other.id, &[(("foo".into(), "bar".into()), 1, 1)], None)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    tx.iter(other).await.unwrap(),
+                    &[(("foo".into(), "bar".into()), 1, 1)],
+                );
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[
+                        (("widgets".into(), "1".into()), 1, 1),
+                        (("wombats".into(), "2".into()), 1, 2),
+                    ]
+                );
+
+                // Check that consolidation happens immediately...
+                tx.update_savepoint(orders.id, &[(("wombats".into(), "2".into()), 1, -1)], None)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[
+                        (("widgets".into(), "1".into()), 1, 1),
+                        (("wombats".into(), "2".into()), 1, 1),
+                    ]
+                );
+
+                // ...even when it results in a entry's removal.
+                tx.update_savepoint(orders.id, &[(("wombats".into(), "2".into()), 1, -1)], None)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[(("widgets".into(), "1".into()), 1, 1),]
+                );
+
+                // Check that logical compaction applies immediately.
+                tx.update_savepoint(
+                    orders.id,
+                    &[
+                        (("widgets".into(), "1".into()), 2, 1),
+                        (("widgets".into(), "1".into()), 3, 1),
+                        (("widgets".into(), "1".into()), 4, 1),
+                    ],
+                    None,
+                )
+                .await
+                .unwrap();
+                tx.seal(orders.id, &Antichain::from_elem(3), None)
+                    .await
+                    .unwrap();
+                // Peek should not observe widgets from timestamps 3 or 4.
+                assert_eq!(tx.peek_timestamp(orders).await.unwrap(), 2);
+                assert_eq!(
+                    tx.peek(orders).await.unwrap(),
+                    vec![("widgets".into(), "1".into(), 2)]
+                );
+                assert_eq!(
+                    tx.peek_one(orders).await.unwrap_err().to_string(),
+                    "stash error: unexpected peek multiplicity"
+                );
+                tx.compact(orders.id, &Antichain::from_elem(3), None)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[
+                        (("widgets".into(), "1".into()), 3, 3),
+                        (("widgets".into(), "1".into()), 4, 1),
+                    ]
+                );
+
+                // Check that physical compaction does not change the collection's contents.
+                tx.consolidate(orders.id).await.unwrap();
+                assert_eq!(
+                    tx.iter(orders).await.unwrap(),
+                    &[
+                        (("widgets".into(), "1".into()), 3, 3),
+                        (("widgets".into(), "1".into()), 4, 1),
+                    ]
+                );
+
+                // Test invalid seals, compactions, and updates.
+                assert_eq!(
+                    tx.seal(orders.id, &Antichain::from_elem(2), None)
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "stash error: seal request {2} is less than the current upper frontier {3}",
+                );
+                assert_eq!(
+                    tx.compact(orders.id, &Antichain::from_elem(2), None)
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "stash error: compact request {2} is less than the current since frontier {3}",
+                );
+                assert_eq!(
+                    tx.compact(orders.id, &Antichain::from_elem(4), None)
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "stash error: compact request {4} is greater than the current upper frontier {3}",
+                );
+                assert_eq!(
+                    tx.update_savepoint(orders.id, &[(("wodgets".into(), "1".into()), 2, 1)], None)
+                        .await
+                        .unwrap_err()
+                        .to_string(),
+                    "stash error: entry time 2 is less than the current upper frontier {3}",
+                );
+
+                // Test advancing since and upper to the empty frontier.
+                tx.seal(orders.id, &Antichain::new(), None).await.unwrap();
+                tx.compact(orders.id, &Antichain::new(), None)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    match tx.iter(orders).await {
+                        Ok(_) => panic!("call to iter unexpectedly succeeded"),
+                        Err(e) => e.to_string(),
+                    },
+                    "stash error: cannot iterate collection with empty since frontier",
+                );
+                assert_eq!(
+                    match tx.iter_key(orders, &"wombats".to_string()).await {
+                        Ok(_) => panic!("call to iter_key unexpectedly succeeded"),
+                        Err(e) => e.to_string(),
+                    },
+                    "stash error: cannot iterate collection with empty since frontier",
+                );
+                tx.consolidate(orders.id).await.unwrap();
+
+                // Double check that the other collection is still untouched.
+                assert_eq!(
+                    tx.iter(other).await.unwrap(),
+                    &[(("foo".into(), "bar".into()), 1, 1)],
+                );
+                assert_eq!(
+                    tx.since(other.id).await.unwrap(),
+                    Antichain::from_elem(Timestamp::MIN)
+                );
+                assert_eq!(
+                    tx.upper(other.id).await.unwrap(),
+                    Antichain::from_elem(Timestamp::MIN)
+                );
+
+                // Test peek_one.
+                tx.seal(other.id, &Antichain::from_elem(2), None)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    tx.peek_one(other).await.unwrap(),
+                    BTreeMap::from([("foo".to_string(), "bar".to_string())])
+                );
+                assert_eq!(
+                    tx.peek_key_one(other, &"foo".to_string()).await.unwrap(),
+                    Some("bar".to_string())
+                );
+                Ok(())
+            })
+        })
         .await
         .unwrap();
-    assert_eq!(
-        stash.iter(other).await.unwrap(),
-        &[(("foo".into(), "bar".into()), 1, 1)],
-    );
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[
-            (("widgets".into(), "1".into()), 1, 1),
-            (("wombats".into(), "2".into()), 1, 2),
-        ]
-    );
-
-    // Check that consolidation happens immediately...
-    stash
-        .update(orders, ("wombats".into(), "2".into()), 1, -1)
-        .await
-        .unwrap();
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[
-            (("widgets".into(), "1".into()), 1, 1),
-            (("wombats".into(), "2".into()), 1, 1),
-        ]
-    );
-
-    // ...even when it results in a entry's removal.
-    stash
-        .update(orders, ("wombats".into(), "2".into()), 1, -1)
-        .await
-        .unwrap();
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[(("widgets".into(), "1".into()), 1, 1),]
-    );
-
-    // Check that logical compaction applies immediately.
-    stash
-        .update_many(
-            orders,
-            [
-                (("widgets".into(), "1".into()), 2, 1),
-                (("widgets".into(), "1".into()), 3, 1),
-                (("widgets".into(), "1".into()), 4, 1),
-            ],
-        )
-        .await
-        .unwrap();
-    stash
-        .seal(orders, Antichain::from_elem(3).borrow())
-        .await
-        .unwrap();
-    // Peek should not observe widgets from timestamps 3 or 4.
-    assert_eq!(stash.peek_timestamp(orders).await.unwrap(), 2);
-    assert_eq!(
-        stash.peek(orders).await.unwrap(),
-        vec![("widgets".into(), "1".into(), 2)]
-    );
-    assert_eq!(
-        stash.peek_one(orders).await.unwrap_err().to_string(),
-        "stash error: unexpected peek multiplicity"
-    );
-    stash
-        .compact(orders, Antichain::from_elem(3).borrow())
-        .await
-        .unwrap();
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[
-            (("widgets".into(), "1".into()), 3, 3),
-            (("widgets".into(), "1".into()), 4, 1),
-        ]
-    );
-
-    // Check that physical compaction does not change the collection's contents.
-    stash.consolidate(orders.id).await.unwrap();
-    assert_eq!(
-        stash.iter(orders).await.unwrap(),
-        &[
-            (("widgets".into(), "1".into()), 3, 3),
-            (("widgets".into(), "1".into()), 4, 1),
-        ]
-    );
-
-    // Test invalid seals, compactions, and updates.
-    assert_eq!(
-        stash
-            .seal(orders, Antichain::from_elem(2).borrow())
-            .await
-            .unwrap_err()
-            .to_string(),
-        "stash error: seal request {2} is less than the current upper frontier {3}",
-    );
-    assert_eq!(
-        stash
-            .compact(orders, Antichain::from_elem(2).borrow())
-            .await
-            .unwrap_err()
-            .to_string(),
-        "stash error: compact request {2} is less than the current since frontier {3}",
-    );
-    assert_eq!(
-        stash
-            .compact(orders, Antichain::from_elem(4).borrow())
-            .await
-            .unwrap_err()
-            .to_string(),
-        "stash error: compact request {4} is greater than the current upper frontier {3}",
-    );
-    assert_eq!(
-        stash
-            .update(orders, ("wodgets".into(), "1".into()), 2, 1)
-            .await
-            .unwrap_err()
-            .to_string(),
-        "stash error: entry time 2 is less than the current upper frontier {3}",
-    );
-
-    // Test advancing since and upper to the empty frontier.
-    stash.seal(orders, Antichain::new().borrow()).await.unwrap();
-    stash
-        .compact(orders, Antichain::new().borrow())
-        .await
-        .unwrap();
-    assert_eq!(
-        match stash.iter(orders).await {
-            Ok(_) => panic!("call to iter unexpectedly succeeded"),
-            Err(e) => e.to_string(),
-        },
-        "stash error: cannot iterate collection with empty since frontier",
-    );
-    assert_eq!(
-        match stash.iter_key(orders, &"wombats".to_string()).await {
-            Ok(_) => panic!("call to iter_key unexpectedly succeeded"),
-            Err(e) => e.to_string(),
-        },
-        "stash error: cannot iterate collection with empty since frontier",
-    );
-    stash.consolidate(orders.id).await.unwrap();
-
-    // Double check that the other collection is still untouched.
-    assert_eq!(
-        stash.iter(other).await.unwrap(),
-        &[(("foo".into(), "bar".into()), 1, 1)],
-    );
-    assert_eq!(
-        stash.since(other).await.unwrap(),
-        Antichain::from_elem(Timestamp::MIN)
-    );
-    assert_eq!(
-        stash.upper(other).await.unwrap(),
-        Antichain::from_elem(Timestamp::MIN)
-    );
-
-    // Test peek_one.
-    stash
-        .seal(other, Antichain::from_elem(2).borrow())
-        .await
-        .unwrap();
-    assert_eq!(
-        stash.peek_one(other).await.unwrap(),
-        BTreeMap::from([("foo".to_string(), "bar".to_string())])
-    );
-    assert_eq!(
-        stash.peek_key_one(other, &"foo".to_string()).await.unwrap(),
-        Some("bar".to_string())
-    );
 
     stash
 }
@@ -656,12 +693,12 @@ async fn test_stash_table(stash: &mut Stash) {
         for (k, v, diff) in pending {
             collection.append_to_batch(&mut batch, &k, &v, diff);
         }
-        stash.append(&[batch]).await.unwrap();
+        stash.append(vec![batch]).await.unwrap();
         Ok(())
     }
 
     TABLE
-        .upsert_key(stash, &1i64.to_le_bytes().to_vec(), |_| {
+        .upsert_key(stash, 1i64.to_le_bytes().to_vec(), |_| {
             Ok::<_, Infallible>("v1".to_string())
         })
         .await
@@ -811,7 +848,7 @@ async fn test_stash_table(stash: &mut Stash) {
         .insert(1i64.to_le_bytes().to_vec(), "v5".to_string())
         .unwrap();
     commit(stash, collection, table.pending()).await.unwrap();
-    let items = stash.peek(collection).await.unwrap();
+    let items = TABLE.peek(stash).await.unwrap();
     assert_eq!(
         items,
         vec![(1i64.to_le_bytes().to_vec(), "v5".to_string(), 1)]

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1300,7 +1300,7 @@ where
             let as_of = MetadataExportFetcher::get_stash_collection()
                 .insert_key_without_overwrite(
                     &mut self.state.stash,
-                    &id,
+                    id,
                     DurableExportMetadata {
                         initial_as_of: description.sink.as_of,
                     },
@@ -1946,7 +1946,7 @@ where
         new_metadata: DurableCollectionMetadata,
     ) {
         let current_metadata = METADATA_COLLECTION
-            .peek_key_one(&mut self.state.stash, &id)
+            .peek_key_one(&mut self.state.stash, id)
             .await
             .expect("connect to stash");
 


### PR DESCRIPTION
Most uses of the stash previously used TypedCollection which would do a variety of stash operations in its functions. Each stash operation was a full sql transaction, which meant begin, commit, epoch select, and then whatever else the operation needed (so a minimum of 3 serial statements per txn). The repeated begin, commit, epoch select and general txn overhead could all be amortized if the stash presented a lower layer of operation: the transaction.

Add a Transaction type to the stash crate that directly exposes the existing transaction functions. Teach TypedCollection to use these, resulting in greatly reduced executed statement count and improved performance.

adapter catalog benchmark:

```
transact                time:   [68.683 ms 72.001 ms 75.321 ms]
                        change: [-17.407% -11.937% -6.2696%] (p = 0.00 < 0.05)
                        Performance has improved.
```

See #16531

Fixes #16927

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a