### PR TITLE
materialized: move embedded CockroachDB store to mzdata directory

### DIFF
--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -24,7 +24,8 @@ EOF
 
 COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true cockroach start-single-node \
     --insecure \
-    --background
+    --background \
+    --store=/mzdata/cockroach
 
 cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS consensus"
 cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS storage"

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -25,7 +25,6 @@ LINT_DEBEZIUM_VERSIONS = ["1.4", "1.5", "1.6"]
 
 DEFAULT_MZ_VOLUMES = [
     "mzdata:/mzdata",
-    "pgdata:/cockroach-data",
     "mydata:/var/lib/mysql-files",
     "tmp:/share/tmp",
 ]

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -270,4 +270,4 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.kill(*cleanup_list)
         c.rm(*cleanup_list, destroy_volumes=True)
 
-    c.rm_volumes("mzdata", "pgdata")
+    c.rm_volumes("mzdata")

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -149,7 +149,7 @@ def run_one_scenario(
         comparator.append(outcome)
         c.kill("materialized", "testdrive")
         c.rm("materialized", "testdrive")
-        c.rm_volumes("mzdata", "pgdata")
+        c.rm_volumes("mzdata")
 
     return comparator
 

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -197,4 +197,4 @@ def workflow_smoke_test(c: Composition) -> None:
     )
     c.kill("materialized")
     c.rm("materialized", "testdrive", "kafka", destroy_volumes=True)
-    c.rm_volumes("mzdata", "pgdata")
+    c.rm_volumes("mzdata")

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -68,4 +68,4 @@ def workflow_default(c: Composition) -> None:
                 "testdrive",
                 destroy_volumes=True,
             )
-            c.rm_volumes("mzdata", "pgdata", force=True)
+            c.rm_volumes("mzdata", force=True)

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -86,7 +86,7 @@ def workflow_kafka_sources(
 
     c.kill("materialized")
     c.rm("materialized", "testdrive", destroy_volumes=True)
-    c.rm_volumes("mzdata", "pgdata")
+    c.rm_volumes("mzdata")
 
 
 def workflow_user_tables(
@@ -119,7 +119,7 @@ def workflow_user_tables(
 
     c.kill("materialized")
     c.rm("materialized", "testdrive", destroy_volumes=True)
-    c.rm_volumes("mzdata", "pgdata")
+    c.rm_volumes("mzdata")
 
 
 def workflow_failpoints(c: Composition, parser: WorkflowArgumentParser) -> None:
@@ -162,7 +162,7 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
 
     c.kill("materialized")
     c.rm("materialized", "testdrive", destroy_volumes=True)
-    c.rm_volumes("mzdata", "pgdata")
+    c.rm_volumes("mzdata")
 
 
 def workflow_compaction(c: Composition) -> None:
@@ -178,4 +178,4 @@ def workflow_compaction(c: Composition) -> None:
 
     c.rm("materialized", "testdrive", destroy_volumes=True)
 
-    c.rm_volumes("mzdata", "pgdata")
+    c.rm_volumes("mzdata")

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -58,7 +58,7 @@ def setup(c: Composition) -> None:
 
 def teardown(c: Composition) -> None:
     c.rm(*[s.name for s in SERVICES], stop=True, destroy_volumes=True)
-    c.rm_volumes("mzdata", "pgdata", "tmp", force=True)
+    c.rm_volumes("mzdata", "tmp", force=True)
 
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -480,4 +480,4 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         cleanup_list = ["materialized", "testdrive", *[n.name for n in nodes]]
         c.kill(*cleanup_list)
         c.rm(*cleanup_list, destroy_volumes=True)
-        c.rm_volumes("mzdata", "pgdata")
+        c.rm_volumes("mzdata")

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -94,7 +94,7 @@ def workflow_stash(c: Composition) -> None:
         stop=True,
         destroy_volumes=True,
     )
-    c.rm_volumes("mzdata", "pgdata", force=True)
+    c.rm_volumes("mzdata", force=True)
 
     with c.override(Materialized(external_cockroach=True)):
         c.up("cockroach")

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -191,12 +191,6 @@ def test_upgrade_from_version(
 
     c.kill("materialized")
     c.rm("materialized", "testdrive")
-    # Remove the pgdata volume, which is where the CockroachDB embedded into
-    # the materialized image stores its state. We don't use the embedded
-    # CockroachDB in this test, and we might *downgrade* it, if the new version
-    # of Materialize reverts a version bump of CockroachDB, and that would
-    # result in the new container failing to start up.
-    c.rm_volumes("pgdata")
 
     c.up("materialized")
     c.wait_for_materialized("materialized")


### PR DESCRIPTION
So that users of the Docker image need to configure only one volume to persist all required Materialize state across container restarts. This is already the documented behavior of the image. We just weren't upholding the promise.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature. Tried to do this in https://github.com/MaterializeInc/materialize/pull/16866#issuecomment-1368144212 but got stymied by the test failures for a while.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
