### PR TITLE
zippy: Add a no-killings Release Qualification Scenario

### DIFF
--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -21,6 +21,7 @@ steps:
           - { value: zippy-dataflows-large }
           - { value: zippy-pg-cdc-large }
           - { value: zippy-cluster-replicas-large }
+          - { value: zippy-no-killing }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -82,3 +83,13 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=ClusterReplicas, --actions=100000]
+
+  - id: zippy-no-killing
+    label: "Long Zippy scenario with no killing"
+    timeout_in_minutes: 2880
+    agents:
+      queue: linux-x86_64-large
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=NoKilling, --actions=100000]

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -283,3 +283,24 @@ class DataflowsLarge(Scenario):
             Ingest: 50,
             DML: 50,
         }
+
+
+class NoKilling(Scenario):
+    """A Zippy scenario that does not involve any killing."""
+
+    def bootstrap(self) -> List[ActionOrFactory]:
+        return DEFAULT_BOOTSTRAP
+
+    def config(self) -> Dict[ActionOrFactory, float]:
+        return {
+            CreateTableParameterized(max_tables=2): 10,
+            CreateTopicParameterized(max_topics=2, envelopes=[Envelope.UPSERT]): 10,
+            CreateSourceParameterized(max_sources=10): 10,
+            CreateViewParameterized(
+                max_views=5, expensive_aggregates=True, max_inputs=5
+            ): 10,
+            CreateSinkParameterized(max_sinks=10): 10,
+            ValidateView: 10,
+            Ingest: 50,
+            DML: 50,
+        }


### PR DESCRIPTION
Zippy scenarios traditionally perform a lot of killing, which may mask long-running issues such as memory leaks.

Create a dedicated scenario that involves tables, sources, views and sinks but does not kill any of the components of the system.