### PR TITLE
Allow mz_introspection user to query any cluster's system catalog

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -62,8 +62,8 @@ use mz_storage_client::types::sinks::StorageSinkConnectionBuilder;
 use mz_storage_client::types::sources::{IngestionDescription, SourceExport};
 
 use crate::catalog::builtin::{
-    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_INTROSPECTION_COMPUTE_INSTANCE,
-    MZ_INTROSPECTION_ROLE, MZ_SYSTEM_COMPUTE_INSTANCE, PG_CATALOG_SCHEMA,
+    INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_INTROSPECTION_ROLE,
+    PG_CATALOG_SCHEMA,
 };
 use crate::catalog::{
     self, Catalog, CatalogItem, ComputeInstance, Connection, DataSourceDesc, Ingestion,
@@ -3871,18 +3871,6 @@ impl Coordinator {
                 return Err(AdapterError::Unauthorized(
                     "user 'mz_introspection' is unauthorized to perform this action".into(),
                 ))
-            }
-        }
-
-        if let Ok(active_compute_instance) = self.catalog.active_compute_instance(session) {
-            let active_compute_instance = active_compute_instance.name();
-            if (matches!(plan, Plan::Peek(_)) || matches!(plan, Plan::Subscribe(_)))
-                && active_compute_instance != MZ_INTROSPECTION_COMPUTE_INSTANCE.name
-                && active_compute_instance != MZ_SYSTEM_COMPUTE_INSTANCE.name
-            {
-                return Err(AdapterError::Unauthorized(format!(
-                    "user 'mz_introspection' is unauthorized to use cluster {active_compute_instance}",
-                )));
             }
         }
 

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1976,15 +1976,16 @@ fn test_introspection_user_permissions() {
     introspection_client
         .batch_execute("SET CLUSTER TO 'default'")
         .unwrap();
+    assert!(introspection_client.query("SELECT * FROM t1", &[]).is_err());
     assert!(introspection_client
         .query("SELECT * FROM mz_internal.mz_view_keys", &[])
-        .is_err());
+        .is_ok());
     assert!(introspection_client
         .query("SELECT * FROM mz_catalog.mz_tables", &[])
-        .is_err());
+        .is_ok());
     assert!(introspection_client
         .query("SELECT * FROM pg_catalog.pg_namespace", &[])
-        .is_err());
+        .is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Remove logic that blocks `mz_introspection` user from querying on any clusters beyond the introspection and system clusters.
We still prevent the `mz_introspection` user from querying any user tables, so this is low risk and unblocks running replica-targeted queries in our internal observability.

Resolves
* #17157


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
