### PR TITLE
ci: Collect additional debugging information

### DIFF
--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -21,7 +21,20 @@ run() {
 
 run logs --no-color > services.log
 buildkite-agent artifact upload services.log
+
 buildkite-agent artifact upload /var/log/dmesg
+
+netstat -ant > netstat-ant.log
+buildkite-agent artifact upload netstat-ant.log
+
+netstat -panelot > netstat-panelot.log
+buildkite-agent artifact upload netstat-panelot.log
+
+ps aux > ps-aux.log
+buildkite-agent artifact upload ps-aux.log
+
+docker ps -a --no-trunc > docker-ps-a.log
+buildkite-agent artifact upload docker-ps-a.log
 
 # docker-compose kill may fail attempting to kill containers
 # that have just exited on their own because of the


### PR DESCRIPTION
Collect information about the state of containers and network connections in order to debug sporadic failures in Redpanda

### Motivation

  * This PR fixes a previously unreported bug.
This is needed  to debug:

- https://github.com/redpanda-data/redpanda/issues/7301