### PR TITLE
sql: remove unused `typemap_rev` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,7 +4542,6 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
- "typemap_rev",
  "uncased",
  "uuid",
  "workspace-hack",

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -46,7 +46,6 @@ thiserror = "1.0.37"
 tokio = { version = "1.23.0", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
 tracing = "0.1.37"
-typemap_rev = "0.3.0"
 uncased = "0.9.7"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }


### PR DESCRIPTION
Forgot to remove `typemap_rev` as part of #17139.

### Motivation

  * This PR fixes a recognized bug.

Without this [the "Unused deps" in the nightlies build is failing](https://buildkite.com/materialize/nightlies/builds/1665#0185bd24-b51d-450c-9ac3-c0d994bb313b)

### Tips for reviewer

N/A

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
