### PR TITLE
[persist] Admin GC command

### DIFF
--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -303,6 +303,10 @@ pub async fn force_compaction(
     }
 }
 
+/// Wrap a lower-level service (Blob or Consensus) to make it read only.
+/// This is probably not elaborate enough to work in general -- folks may expect to read
+/// their own writes, among other things -- but it should handle the case of GC, where
+/// all reads finish before the writes begin.
 #[derive(Debug)]
 struct ReadOnly<T>(T);
 

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -237,7 +237,18 @@ where
         let mut live_diffs = 0;
         let mut seqno_held_parts = HashSet::new();
 
+        let mut state_count = 0;
+
         while let Some(state) = states.next() {
+            if state_count % 1000 == 0 {
+                let batch_count = state.collections.trace.batches().into_iter().count();
+                debug!(
+                    "gc {} state includes {batch_count} batches after applying {state_count} diffs (seqno {:?})",
+                    req.shard_id, state.seqno
+                );
+            }
+            state_count += 1;
+
             match state.seqno.cmp(&req.new_seqno_since) {
                 Ordering::Less => {
                     state.collections.trace.map_batches(|b| {

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -307,6 +307,7 @@ where
                 .state_versions
                 .delete_rollup(&req.shard_id, key)
                 .await;
+            debug!("gc {} deleted rollup blob {key}", req.shard_id);
         }
         debug!("gc {} deleted rollup blobs", req.shard_id);
 

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -975,7 +975,7 @@ where
             .expect("State should have at least one rollup if seqno > minimum")
     }
 
-    pub(super) fn seqno_since(&self) -> SeqNo {
+    pub(crate) fn seqno_since(&self) -> SeqNo {
         let mut seqno_since = self.seqno;
         for cap in self.collections.leased_readers.values() {
             seqno_since = std::cmp::min(seqno_since, cap.seqno);


### PR DESCRIPTION
### Motivation

We'd like to be able to manually run garbage collection for a specific shard. (Today, to diagnose a case where building the spine goes badly wrong, but it seems to be a generally useful operational tool as well.)

### Tips for reviewer

There's a fair bit of duplication between commands here, in particular when first instantiating the `Machine`. I may try and tidy that up before merging.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
