### PR TITLE
persist/storage/compute: add required schema parameter to persist handle constructors, and populate it correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,6 +4777,7 @@ dependencies = [
  "mz-ssh-util",
  "mz-stash",
  "mz-timely-util",
+ "once_cell",
  "proptest",
  "proptest-derive",
  "prost",

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -34,6 +34,7 @@ use mz_sql::catalog::{
     CatalogItemType, CatalogType, CatalogTypeDetails, NameReference, TypeReference,
 };
 use mz_storage_client::controller::IntrospectionType;
+use mz_storage_client::healthcheck::{MZ_SINK_STATUS_HISTORY_DESC, MZ_SOURCE_STATUS_HISTORY_DESC};
 
 use crate::catalog::{DEFAULT_CLUSTER_REPLICA_NAME, INTROSPECTION_USER, SYSTEM_USER};
 
@@ -1608,12 +1609,7 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     name: "mz_source_status_history",
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::SourceStatusHistory),
-    desc: RelationDesc::empty()
-        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
-        .with_column("source_id", ScalarType::String.nullable(false))
-        .with_column("status", ScalarType::String.nullable(false))
-        .with_column("error", ScalarType::String.nullable(true))
-        .with_column("details", ScalarType::Jsonb.nullable(true)),
+    desc: MZ_SOURCE_STATUS_HISTORY_DESC.clone(),
     is_retained_metrics_relation: false,
 });
 
@@ -1645,12 +1641,7 @@ pub static MZ_SINK_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSou
     name: "mz_sink_status_history",
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::SinkStatusHistory),
-    desc: RelationDesc::empty()
-        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
-        .with_column("sink_id", ScalarType::String.nullable(false))
-        .with_column("status", ScalarType::String.nullable(false))
-        .with_column("error", ScalarType::String.nullable(true))
-        .with_column("details", ScalarType::Jsonb.nullable(true)),
+    desc: MZ_SINK_STATUS_HISTORY_DESC.clone(),
     is_retained_metrics_relation: false,
 });
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -134,6 +134,7 @@ impl Coordinator {
                     // return it below, so that its usage is recorded in the
                     // `mz_storage_usage_by_shard` table.
                     persist_location: _,
+                    relation_desc: _,
                 } = &collection.collection_metadata;
                 [*data_shard, *remap_shard].into_iter().chain(*status_shard)
             })

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -259,6 +259,7 @@ where
 
     let persist_location = target.persist_location.clone();
     let shard_id = target.data_shard;
+    let target_relation_desc = target.relation_desc.clone();
 
     // Only one worker is responsible for determining batch descriptions. All
     // workers must write batches with the same description, to ensure that they
@@ -306,9 +307,10 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff>(
+            .open_writer::<SourceData, (), Timestamp, Diff, _>(
                 shard_id,
                 &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
+                target_relation_desc,
             )
             .await
             .expect("could not open persist shard");
@@ -511,6 +513,7 @@ where
 {
     let persist_location = target.persist_location.clone();
     let shard_id = target.data_shard;
+    let target_relation_desc = target.relation_desc.clone();
 
     let scope = desired_stream.scope();
     let worker_index = scope.index();
@@ -573,9 +576,10 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff>(
+            .open_writer::<SourceData, (), Timestamp, Diff, _>(
                 shard_id,
                 &format!("compute::persist_sink::write_batches {}", sink_id),
+                target_relation_desc,
             )
             .await
             .expect("could not open persist shard");
@@ -829,6 +833,7 @@ where
 
     let persist_location = target.persist_location.clone();
     let shard_id = target.data_shard;
+    let target_relation_desc = target.relation_desc.clone();
 
     let operator_name = format!("{} append_batches", operator_name);
     let mut append_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
@@ -892,9 +897,10 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff>(
+            .open_writer::<SourceData, (), Timestamp, Diff,_>(
                 shard_id,
                 &format!("persist_sink::append_batches {}", sink_id),
+                target_relation_desc,
             )
             .await
             .expect("could not open persist shard");

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -203,7 +203,11 @@ pub fn bench_snapshot(
         let shard_id = ShardId::new();
         let (_, as_of) = runtime.block_on(async {
             let mut write = client
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(shard_id, "bench")
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+                    shard_id,
+                    "bench",
+                    PersistClient::TEST_SCHEMA,
+                )
                 .await
                 .expect("failed to open shard");
             load(&mut write, data).await

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -64,7 +64,11 @@ async fn bench_writes_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let mut write = client
-        .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new(), "bench")
+        .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+            ShardId::new(),
+            "bench",
+            PersistClient::TEST_SCHEMA,
+        )
         .await?;
 
     // Write the data as fast as we can while keeping each batch in its own
@@ -113,7 +117,7 @@ async fn bench_write_to_listen_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let (mut write, read) = client
-        .open::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new(), "bench")
+        .open::<Vec<u8>, Vec<u8>, u64, i64, _>(ShardId::new(), "bench", PersistClient::TEST_SCHEMA)
         .await?;
 
     // Start the listener in a task before the write so it can't "cheat" by
@@ -219,7 +223,11 @@ async fn bench_snapshot_one_iter(
     as_of: &Antichain<u64>,
 ) -> Result<(), anyhow::Error> {
     let mut read = client
-        .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64>(*shard_id, "bench")
+        .open_leased_reader::<Vec<u8>, Vec<u8>, u64, i64, _>(
+            *shard_id,
+            "bench",
+            PersistClient::TEST_SCHEMA,
+        )
         .await?;
 
     let x = read

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -133,7 +133,9 @@ impl Transactor {
             .parse::<u64>()
             .expect("maelstrom node_id should be n followed by an integer");
 
-        let (mut write, mut read) = client.open(shard_id, "maelstrom long-lived").await?;
+        let (mut write, mut read) = client
+            .open(shard_id, "maelstrom long-lived", PersistClient::TEST_SCHEMA)
+            .await?;
         // Use the CONTROLLER_CRITICAL_SINCE id for all nodes so we get coverage
         // of contending traffic.
         let since = client
@@ -257,7 +259,11 @@ impl Transactor {
             // state and exercise some more code paths.
             let mut read = self
                 .client
-                .open_leased_reader(self.shard_id, "maelstrom short-lived")
+                .open_leased_reader(
+                    self.shard_id,
+                    "maelstrom short-lived",
+                    PersistClient::TEST_SCHEMA,
+                )
                 .await
                 .expect("codecs should match");
 

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -508,7 +508,7 @@ mod raw_persist_benchmark {
         let mut readers = vec![];
         for _ in 0..num_readers {
             let (_writer, reader) = persist
-                .open::<Vec<u8>, Vec<u8>, u64, i64>(id, "open loop")
+                .open::<Vec<u8>, Vec<u8>, u64, i64, _>(id, "open loop", PersistClient::TEST_SCHEMA)
                 .await?;
 
             let listen = reader
@@ -538,7 +538,11 @@ mod raw_persist_benchmark {
             let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel(10);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id, "open loop")
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+                    id,
+                    "open loop",
+                    PersistClient::TEST_SCHEMA,
+                )
                 .await?;
 
             // Intentionally create the span outside the task to set the parent.
@@ -582,7 +586,11 @@ mod raw_persist_benchmark {
             handles.push(handle);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id, "open loop")
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64, _>(
+                    id,
+                    "open loop",
+                    PersistClient::TEST_SCHEMA,
+                )
                 .await?;
 
             // Intentionally create the span outside the task to set the parent.

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1608,7 +1608,11 @@ pub mod datadriven {
         let as_of = args.expect_antichain("as_of");
         let read = datadriven
             .client
-            .open_leased_reader::<String, (), u64, i64>(datadriven.shard_id, "")
+            .open_leased_reader::<String, (), u64, i64, _>(
+                datadriven.shard_id,
+                "",
+                PersistClient::TEST_SCHEMA,
+            )
             .await
             .expect("invalid shard types");
         let listen = read

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -442,7 +442,8 @@ impl ConsensusKnobs for PersistConfig {
 /// # let timeout: std::time::Duration = unimplemented!();
 /// # let id = mz_persist_client::ShardId::new();
 /// # async {
-/// tokio::time::timeout(timeout, client.open::<String, String, u64, i64>(id, "desc")).await
+/// tokio::time::timeout(timeout, client.open::<String, String, u64, i64, _>(id, "desc",
+///     mz_persist_client::PersistClient::TEST_SCHEMA)).await
 /// # };
 /// ```
 #[derive(Debug, Clone)]
@@ -455,6 +456,9 @@ pub struct PersistClient {
 }
 
 impl PersistClient {
+    /// A "fake" object used to fill `schema` parameters for opening handles in tests.
+    pub const TEST_SCHEMA: () = ();
+
     /// Returns a new client for interfacing with persist shards made durable to
     /// the given [Blob] and [Consensus].
     ///
@@ -491,33 +495,44 @@ impl PersistClient {
     /// If `shard_id` has never been used before, initializes a new shard and
     /// returns handles with `since` and `upper` frontiers set to initial values
     /// of `Antichain::from_elem(T::minimum())`.
+    ///
+    /// The `schema` parameter is currently unused, but should be an object
+    /// that represents the schema of the data in the shard. This will be required
+    /// in the future.
     #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
-    pub async fn open<K, V, T, D>(
+    pub async fn open<K, V, T, D, S>(
         &self,
         shard_id: ShardId,
         purpose: &str,
+        schema: S,
     ) -> Result<(WriteHandle<K, V, T, D>, ReadHandle<K, V, T, D>), InvalidUsage<T>>
     where
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64 + Send + Sync,
+        S: Clone,
     {
         Ok((
-            self.open_writer(shard_id, purpose).await?,
-            self.open_leased_reader(shard_id, purpose).await?,
+            self.open_writer(shard_id, purpose, schema.clone()).await?,
+            self.open_leased_reader(shard_id, purpose, schema).await?,
         ))
     }
 
-    /// [Self::open], but returning only a [ReadHandle].
+    /// [Self::open], but returning only a [/eadHandle].
     ///
     /// Use this to save latency and a bit of persist traffic if you're just
     /// going to immediately drop or expire the [WriteHandle].
+    ///
+    /// The `_schema` parameter is currently unused, but should be an object
+    /// that represents the schema of the data in the shard. This will be required
+    /// in the future.
     #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
-    pub async fn open_leased_reader<K, V, T, D>(
+    pub async fn open_leased_reader<K, V, T, D, S>(
         &self,
         shard_id: ShardId,
         purpose: &str,
+        _schema: S,
     ) -> Result<ReadHandle<K, V, T, D>, InvalidUsage<T>>
     where
         K: Debug + Codec,
@@ -566,10 +581,15 @@ impl PersistClient {
     }
 
     /// Creates and returns a [BatchFetcher] for the given shard id.
+    ///
+    /// The `_schema` parameter is currently unused, but should be an object
+    /// that represents the schema of the data in the shard. This will be required
+    /// in the future.
     #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
-    pub async fn create_batch_fetcher<K, V, T, D>(
+    pub async fn create_batch_fetcher<K, V, T, D, S>(
         &self,
         shard_id: ShardId,
+        _schema: S,
     ) -> BatchFetcher<K, V, T, D>
     where
         K: Debug + Codec,
@@ -694,11 +714,16 @@ impl PersistClient {
     ///
     /// Use this to save latency and a bit of persist traffic if you're just
     /// going to immediately drop or expire the [ReadHandle].
+    ///
+    /// The `_schema` parameter is currently unused, but should be an object
+    /// that represents the schema of the data in the shard. This will be required
+    /// in the future.
     #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
-    pub async fn open_writer<K, V, T, D>(
+    pub async fn open_writer<K, V, T, D, S>(
         &self,
         shard_id: ShardId,
         purpose: &str,
+        _schema: S,
     ) -> Result<WriteHandle<K, V, T, D>, InvalidUsage<T>>
     where
         K: Debug + Codec,
@@ -767,7 +792,9 @@ impl PersistClient {
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64 + Send + Sync,
     {
-        self.open(shard_id, "tests").await.expect("codec mismatch")
+        self.open(shard_id, "tests", Self::TEST_SCHEMA)
+            .await
+            .expect("codec mismatch")
     }
 
     /// Return the metrics being used by this client.
@@ -943,19 +970,27 @@ mod tests {
         let shard_id = ShardId::new();
         let client = new_test_client().await;
         let mut write1 = client
-            .open_writer::<String, String, u64, i64>(shard_id, "")
+            .open_writer::<String, String, u64, i64, _>(shard_id, "", PersistClient::TEST_SCHEMA)
             .await
             .expect("codec mismatch");
         let mut read1 = client
-            .open_leased_reader::<String, String, u64, i64>(shard_id, "")
+            .open_leased_reader::<String, String, u64, i64, _>(
+                shard_id,
+                "",
+                PersistClient::TEST_SCHEMA,
+            )
             .await
             .expect("codec mismatch");
         let mut read2 = client
-            .open_leased_reader::<String, String, u64, i64>(shard_id, "")
+            .open_leased_reader::<String, String, u64, i64, _>(
+                shard_id,
+                "",
+                PersistClient::TEST_SCHEMA,
+            )
             .await
             .expect("codec mismatch");
         let mut write2 = client
-            .open_writer::<String, String, u64, i64>(shard_id, "")
+            .open_writer::<String, String, u64, i64, _>(shard_id, "", PersistClient::TEST_SCHEMA)
             .await
             .expect("codec mismatch");
 
@@ -997,7 +1032,7 @@ mod tests {
 
             assert_eq!(
                 client
-                    .open::<Vec<u8>, String, u64, i64>(shard_id0, "")
+                    .open::<Vec<u8>, String, u64, i64, _>(shard_id0, "", PersistClient::TEST_SCHEMA)
                     .await
                     .unwrap_err(),
                 InvalidUsage::CodecMismatch(Box::new(CodecMismatch {
@@ -1007,7 +1042,7 @@ mod tests {
             );
             assert_eq!(
                 client
-                    .open::<String, Vec<u8>, u64, i64>(shard_id0, "")
+                    .open::<String, Vec<u8>, u64, i64, _>(shard_id0, "", PersistClient::TEST_SCHEMA)
                     .await
                     .unwrap_err(),
                 InvalidUsage::CodecMismatch(Box::new(CodecMismatch {
@@ -1017,7 +1052,7 @@ mod tests {
             );
             assert_eq!(
                 client
-                    .open::<String, String, i64, i64>(shard_id0, "")
+                    .open::<String, String, i64, i64, _>(shard_id0, "", PersistClient::TEST_SCHEMA)
                     .await
                     .unwrap_err(),
                 InvalidUsage::CodecMismatch(Box::new(CodecMismatch {
@@ -1027,7 +1062,7 @@ mod tests {
             );
             assert_eq!(
                 client
-                    .open::<String, String, u64, u64>(shard_id0, "")
+                    .open::<String, String, u64, u64, _>(shard_id0, "", PersistClient::TEST_SCHEMA)
                     .await
                     .unwrap_err(),
                 InvalidUsage::CodecMismatch(Box::new(CodecMismatch {
@@ -1041,7 +1076,11 @@ mod tests {
             // set.
             assert_eq!(
                 client
-                    .open_leased_reader::<Vec<u8>, String, u64, i64>(shard_id0, "")
+                    .open_leased_reader::<Vec<u8>, String, u64, i64, _>(
+                        shard_id0,
+                        "",
+                        PersistClient::TEST_SCHEMA
+                    )
                     .await
                     .unwrap_err(),
                 InvalidUsage::CodecMismatch(Box::new(CodecMismatch {
@@ -1051,7 +1090,11 @@ mod tests {
             );
             assert_eq!(
                 client
-                    .open_writer::<Vec<u8>, String, u64, i64>(shard_id0, "")
+                    .open_writer::<Vec<u8>, String, u64, i64, _>(
+                        shard_id0,
+                        "",
+                        PersistClient::TEST_SCHEMA
+                    )
                     .await
                     .unwrap_err(),
                 InvalidUsage::CodecMismatch(Box::new(CodecMismatch {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -458,6 +458,8 @@ pub struct PersistClient {
 impl PersistClient {
     /// A "fake" object used to fill `schema` parameters for opening handles in tests.
     pub const TEST_SCHEMA: () = ();
+    /// Same as `TEST_SCHEMA_DESC`, but to be deleted over the course of a stack of commits.
+    pub const TO_REPLACE_SCHEMA: () = ();
 
     /// Returns a new client for interfacing with persist shards made durable to
     /// the given [Blob] and [Consensus].

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -458,7 +458,8 @@ pub struct PersistClient {
 impl PersistClient {
     /// A "fake" object used to fill `schema` parameters for opening handles in tests.
     pub const TEST_SCHEMA: () = ();
-    /// Same as `TEST_SCHEMA_DESC`, but to be deleted over the course of a stack of commits.
+    /// Same as `TEST_SCHEMA`, but to be deleted over the course of a stack of commits, and
+    /// after some migrations are done.
     pub const TO_REPLACE_SCHEMA: () = ();
 
     /// Returns a new client for interfacing with persist shards made durable to

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -23,6 +23,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 http = "0.2.8"
 http-serde = "1.1.2"
 itertools = { version = "0.10.5" }
+once_cell = "1.16.0"
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-cloud-resources = { path = "../cloud-resources" }

--- a/src/storage-client/src/controller.proto
+++ b/src/storage-client/src/controller.proto
@@ -11,6 +11,8 @@
 
 syntax = "proto3";
 
+import "repr/src/relation_and_scalar.proto";
+
 package mz_storage_client.controller;
 
 message ProtoCollectionMetadata {
@@ -19,6 +21,8 @@ message ProtoCollectionMetadata {
     string data_shard = 3;
     string remap_shard = 4;
     optional string status_shard = 5;
+
+    mz_repr.relation_and_scalar.ProtoRelationDesc relation_desc = 6;
 }
 
 message ProtoDurableCollectionMetadata {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -928,7 +928,11 @@ where
 
                 let purpose = format!("controller data {}", id);
                 let write = persist_client
-                    .open_writer(metadata.data_shard, &purpose)
+                    .open_writer(
+                        metadata.data_shard,
+                        &purpose,
+                        metadata.relation_desc.clone(),
+                    )
                     .await
                     .expect("invalid persist usage");
 
@@ -1384,9 +1388,10 @@ where
         // heartbeat continously. The assumption is that calls to snapshot are rare and therefore
         // worth it to always create a new handle.
         let mut read_handle = persist_client
-            .open_leased_reader::<SourceData, (), _, _>(
+            .open_leased_reader::<SourceData, (), _, _, _>(
                 metadata.data_shard,
                 &format!("snapshot {}", id),
+                metadata.relation_desc.clone(),
             )
             .await
             .expect("invalid persist usage");
@@ -1971,9 +1976,10 @@ where
 
         for (shard_id, shard_purpose) in shards {
             let (mut write, mut read) = persist_client
-                .open::<crate::types::sources::SourceData, (), T, Diff>(
+                .open::<crate::types::sources::SourceData, (), T, Diff, _>(
                     *shard_id,
                     shard_purpose.as_str(),
+                    PersistClient::TO_REPLACE_SCHEMA,
                 )
                 .await
                 .expect("invalid persist usage");

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -426,16 +426,18 @@ impl<T: Timestamp> ReadPolicy<T> {
 }
 
 /// Metadata required by a storage instance to read a storage collection
-#[derive(Arbitrary, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollectionMetadata {
-    /// The persist location where the shards are located
+    /// The persist location where the shards are located.
     pub persist_location: PersistLocation,
-    /// The persist shard id of the remap collection used to reclock this collection
+    /// The persist shard id of the remap collection used to reclock this collection.
     pub remap_shard: ShardId,
-    /// The persist shard containing the contents of this storage collection
+    /// The persist shard containing the contents of this storage collection.
     pub data_shard: ShardId,
-    /// The persist shard containing the status updates for this storage collection
+    /// The persist shard containing the status updates for this storage collection.
     pub status_shard: Option<ShardId>,
+    /// The `RelationDesc` that describes the contents of the `data_shard`.
+    pub relation_desc: RelationDesc,
 }
 
 impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
@@ -446,6 +448,7 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
             data_shard: self.data_shard.to_string(),
             remap_shard: self.remap_shard.to_string(),
             status_shard: self.status_shard.map(|s| s.to_string()),
+            relation_desc: Some(self.relation_desc.into_proto()),
         }
     }
 
@@ -467,6 +470,9 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
                 .status_shard
                 .map(|s| s.parse().map_err(TryFromProtoError::InvalidShardId))
                 .transpose()?,
+            relation_desc: value
+                .relation_desc
+                .into_rust_if_some("ProtoCollectionMetadata::relation_desc")?,
         })
     }
 }
@@ -891,6 +897,7 @@ where
                 remap_shard: collection_shards.remap_shard,
                 data_shard: collection_shards.data_shard,
                 status_shard,
+                relation_desc: description.desc.clone(),
             };
 
             Ok((id, description, metadata))
@@ -1014,6 +1021,9 @@ where
                     // Each ingestion is augmented with the collection metadata.
                     let mut source_imports = BTreeMap::new();
                     for (id, _) in ingestion.source_imports {
+                        // This _requires_ that the sub-source collection (with
+                        // `DataSource::Other`) was registered BEFORE we process this, the
+                        // top-level collection.
                         let metadata = self.collection(id)?.collection_metadata.clone();
                         source_imports.insert(id, metadata);
                     }
@@ -1024,6 +1034,8 @@ where
 
                     let mut source_exports = BTreeMap::new();
                     for (id, export) in ingestion.source_exports {
+                        // Note that these metadata's have been previously enriched with the
+                        // required `RelationDesc` for each sub-source above!
                         let storage_metadata = self.collection(id)?.collection_metadata.clone();
                         source_exports.insert(
                             id,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1979,6 +1979,8 @@ where
                 .open::<crate::types::sources::SourceData, (), T, Diff, _>(
                     *shard_id,
                     shard_purpose.as_str(),
+                    // We have to _read_ the shard to figure out if its been migrated or not, so we
+                    // hedge on setting a `RelationDesc`.
                     PersistClient::TO_REPLACE_SCHEMA,
                 )
                 .await

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -211,9 +211,17 @@ where
                 .await
                 .expect("error creating persist client");
             let from_read_handle = persist_client
-                .open_leased_reader::<SourceData, (), T, Diff>(
+                .open_leased_reader::<SourceData, (), T, Diff, _>(
                     export.description.from_storage_metadata.data_shard,
                     "rehydration since",
+                    // This is also `from_desc`, but this would be the _only_ usage
+                    // of `from_desc` in storage, and we try to be consistent about
+                    // where we get `RelationDesc`s for perist clients
+                    export
+                        .description
+                        .from_storage_metadata
+                        .relation_desc
+                        .clone(),
                 )
                 .await
                 .expect("from collection disappeared");

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -8,7 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use mz_repr::{Datum, GlobalId, Row};
+use once_cell::sync::Lazy;
+
+use mz_repr::{Datum, GlobalId, RelationDesc, Row, ScalarType};
 
 pub fn pack_status_row(
     collection_id: GlobalId,
@@ -37,3 +39,21 @@ pub fn pack_status_row(
     let metadata = Datum::Null;
     Row::pack_slice(&[timestamp, collection_id, status, error, metadata])
 }
+
+pub static MZ_SINK_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
+        .with_column("sink_id", ScalarType::String.nullable(false))
+        .with_column("status", ScalarType::String.nullable(false))
+        .with_column("error", ScalarType::String.nullable(true))
+        .with_column("details", ScalarType::Jsonb.nullable(true))
+});
+
+pub static MZ_SOURCE_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))
+        .with_column("source_id", ScalarType::String.nullable(false))
+        .with_column("status", ScalarType::String.nullable(false))
+        .with_column("error", ScalarType::String.nullable(true))
+        .with_column("details", ScalarType::Jsonb.nullable(true))
+});

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -127,6 +127,7 @@ where
         as_of,
         until.clone(),
         flow_control,
+        metadata.relation_desc,
     );
     let rows = decode_and_mfp(&fetched, &name, until, map_filter_project, yield_fn);
     (rows, token)

--- a/src/storage-client/src/types/sinks.rs
+++ b/src/storage-client/src/types/sinks.rs
@@ -11,13 +11,13 @@
 
 use std::fmt::Debug;
 
-use mz_persist_client::ShardId;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use timely::PartialOrder;
 
+use mz_persist_client::ShardId;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc};
 

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -102,6 +102,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
                 data_shard,
                 // The status shard only contains non-definite status updates
                 status_shard: _,
+                relation_desc: _,
             } = &export.storage_metadata;
             let handle = client_cache
                 .open(persist_location.clone())
@@ -122,6 +123,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             data_shard: _,
             // The status shard only contains non-definite status updates
             status_shard: _,
+            relation_desc: _,
         } = &self.ingestion_metadata;
         let remap_handle = client_cache
             .open(persist_location.clone())

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -22,6 +22,7 @@ use dec::OrderedDecimal;
 use differential_dataflow::lattice::Lattice;
 use globset::{Glob, GlobBuilder};
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
@@ -118,13 +119,22 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             handles.push(handle);
         }
 
+        let remap_relation_desc = match self.desc.connection {
+            GenericSourceConnection::Kafka(_) => KAFKA_PROGRESS_DESC.clone(),
+            GenericSourceConnection::Kinesis(_) => KINESIS_PROGRESS_DESC.clone(),
+            GenericSourceConnection::S3(_) => S3_PROGRESS_DESC.clone(),
+            GenericSourceConnection::Postgres(_) => PG_PROGRESS_DESC.clone(),
+            GenericSourceConnection::LoadGenerator(_) => LOADGEN_PROGRESS_DESC.clone(),
+            GenericSourceConnection::TestScript(_) => TESTSCRIPT_PROGRESS_DESC.clone(),
+        };
+
         let CollectionMetadata {
             persist_location,
             remap_shard,
             data_shard: _,
             // The status shard only contains non-definite status updates
             status_shard: _,
-            relation_desc,
+            relation_desc: _,
         } = &self.ingestion_metadata;
         let remap_handle = client_cache
             .open(persist_location.clone())
@@ -134,7 +144,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             .open_writer::<SourceData, (), T, Diff, _>(
                 *remap_shard,
                 "resumption remap",
-                relation_desc.clone(),
+                remap_relation_desc,
             )
             .await
             .unwrap();
@@ -1359,6 +1369,18 @@ impl SourceConnection for KafkaSourceConnection {
     }
 }
 
+pub static KAFKA_PROGRESS_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column(
+            "partition",
+            ScalarType::Range {
+                element_type: Box::new(ScalarType::Int32),
+            }
+            .nullable(false),
+        )
+        .with_column("offset", ScalarType::UInt64.nullable(true))
+});
+
 impl Arbitrary for KafkaSourceConnection {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
@@ -1825,6 +1847,15 @@ impl SourceConnection for KinesisSourceConnection {
     }
 }
 
+pub static KINESIS_PROGRESS_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    /* In the future, kinesis will have a more complex ts
+    RelationDesc::empty()
+        .with_column("shard_id", ScalarType::Int32.nullable(false))
+        .with_column("sequence_number", ScalarType::UInt64.nullable(true))
+    */
+    RelationDesc::empty().with_column("offset", ScalarType::UInt64.nullable(true))
+});
+
 impl RustType<ProtoKinesisSourceConnection> for KinesisSourceConnection {
     fn into_proto(&self) -> ProtoKinesisSourceConnection {
         ProtoKinesisSourceConnection {
@@ -1857,6 +1888,9 @@ pub struct PostgresSourceConnection {
     pub publication: String,
     pub publication_details: PostgresSourcePublicationDetails,
 }
+
+pub static PG_PROGRESS_DESC: Lazy<RelationDesc> =
+    Lazy::new(|| RelationDesc::empty().with_column("lsn", ScalarType::UInt64.nullable(true)));
 
 impl Arbitrary for PostgresSourceConnection {
     type Strategy = BoxedStrategy<Self>;
@@ -1998,6 +2032,10 @@ impl SourceConnection for LoadGeneratorSourceConnection {
         "load-generator"
     }
 }
+
+pub static LOADGEN_PROGRESS_DESC: Lazy<RelationDesc> =
+    Lazy::new(|| RelationDesc::empty().with_column("offset", ScalarType::UInt64.nullable(true)));
+
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LoadGenerator {
     Auction,
@@ -2291,6 +2329,9 @@ impl SourceConnection for TestScriptSourceConnection {
     }
 }
 
+pub static TESTSCRIPT_PROGRESS_DESC: Lazy<RelationDesc> =
+    Lazy::new(|| RelationDesc::empty().with_column("offset", ScalarType::UInt64.nullable(true)));
+
 impl RustType<ProtoTestScriptSourceConnection> for TestScriptSourceConnection {
     fn into_proto(&self) -> ProtoTestScriptSourceConnection {
         ProtoTestScriptSourceConnection {
@@ -2319,6 +2360,10 @@ impl SourceConnection for S3SourceConnection {
         "s3"
     }
 }
+
+pub static S3_PROGRESS_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty().with_column("byte_offset", ScalarType::UInt64.nullable(true))
+});
 
 fn any_glob() -> impl Strategy<Value = Glob> {
     r"[a-z][a-z0-9]{0,10}/?([a-z0-9]{0,5}/?){0,3}".prop_map(|s| {

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -102,15 +102,16 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
                 data_shard,
                 // The status shard only contains non-definite status updates
                 status_shard: _,
-                relation_desc: _,
+                relation_desc,
             } = &export.storage_metadata;
             let handle = client_cache
                 .open(persist_location.clone())
                 .await
                 .expect("error creating persist client")
-                .open_writer::<SourceData, (), T, Diff>(
+                .open_writer::<SourceData, (), T, Diff, _>(
                     *data_shard,
                     &format!("resumption data {}", id),
+                    relation_desc.clone(),
                 )
                 .await
                 .unwrap();
@@ -123,14 +124,18 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             data_shard: _,
             // The status shard only contains non-definite status updates
             status_shard: _,
-            relation_desc: _,
+            relation_desc,
         } = &self.ingestion_metadata;
         let remap_handle = client_cache
             .open(persist_location.clone())
             .await
             .expect("error creating persist client")
             // TODO: Any way to plumb the GlobalId to this?
-            .open_writer::<SourceData, (), T, Diff>(*remap_shard, "resumption remap")
+            .open_writer::<SourceData, (), T, Diff, _>(
+                *remap_shard,
+                "resumption remap",
+                relation_desc.clone(),
+            )
             .await
             .unwrap();
         handles.push(remap_handle);

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -14,7 +14,7 @@ use mz_ore::now::NowFn;
 use timely::progress::Antichain;
 
 use mz_persist_client::{PersistClient, ShardId};
-use mz_repr::{GlobalId, Timestamp};
+use mz_repr::{GlobalId, RelationDesc, Timestamp};
 use mz_storage_client::types::sources::SourceData;
 
 pub async fn write_to_persist(
@@ -24,6 +24,7 @@ pub async fn write_to_persist(
     now: NowFn,
     client: &PersistClient,
     status_shard: ShardId,
+    relation_desc: &RelationDesc,
 ) {
     let now_ms = now();
     let row = mz_storage_client::healthcheck::pack_status_row(
@@ -37,7 +38,7 @@ pub async fn write_to_persist(
         .open_writer(
             status_shard,
             &format!("healthcheck::write_to_persist {}", collection_id),
-            PersistClient::TO_REPLACE_SCHEMA,
+            relation_desc.clone(),
         )
         .await
         .expect(

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -33,9 +33,17 @@ pub async fn write_to_persist(
         now_ms,
     );
 
-    let mut handle = client.open_writer(status_shard, &format!("healthcheck::write_to_persist {}", collection_id)).await.expect(
-        "Invalid usage of the persist client for collection {collection_id} status history shard",
-    );
+    let mut handle = client
+        .open_writer(
+            status_shard,
+            &format!("healthcheck::write_to_persist {}", collection_id),
+            PersistClient::TO_REPLACE_SCHEMA,
+        )
+        .await
+        .expect(
+            "Invalid usage of the persist \
+            client for collection {collection_id} status history shard",
+        );
 
     let mut recent_upper = handle.upper().clone();
     let mut append_ts = Timestamp::from(now_ms);

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -110,9 +110,10 @@ where
             .open(metadata.persist_location)
             .await
             .expect("could not open persist client")
-            .open_writer::<SourceData, (), Timestamp, Diff>(
+            .open_writer::<SourceData, (), Timestamp, Diff, _>(
                 metadata.data_shard,
                 &format!("storage::persist_sink {}", src_id),
+                metadata.relation_desc.clone(),
             )
             .await
             .expect("could not open persist shard");

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -19,6 +19,7 @@ use mz_ore::now::NowFn;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_repr::GlobalId;
+use mz_storage_client::healthcheck::MZ_SINK_STATUS_HISTORY_DESC;
 
 use crate::healthcheck::write_to_persist;
 
@@ -84,6 +85,7 @@ impl Healthchecker {
                 self.now.clone(),
                 &self.persist_client,
                 self.status_shard,
+                &*MZ_SINK_STATUS_HISTORY_DESC,
             )
             .await;
 
@@ -470,7 +472,7 @@ mod tests {
             .open(
                 shard_id,
                 "tests::dump_storage_collection",
-                PersistClient::TO_REPLACE_SCHEMA,
+                MZ_SINK_STATUS_HISTORY_DESC.clone(),
             )
             .await
             .unwrap();

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -467,7 +467,11 @@ mod tests {
             .unwrap();
 
         let (write_handle, mut read_handle) = persist_client
-            .open(shard_id, "tests::dump_storage_collection")
+            .open(
+                shard_id,
+                "tests::dump_storage_collection",
+                PersistClient::TO_REPLACE_SCHEMA,
+            )
             .await
             .unwrap();
 

--- a/src/storage/src/source/delimited_value_reader.rs
+++ b/src/storage/src/source/delimited_value_reader.rs
@@ -13,10 +13,11 @@
 use timely::scheduling::activate::SyncActivator;
 
 use mz_expr::PartitionId;
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, RelationDesc};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
 use mz_storage_client::types::sources::{MzOffset, SourceConnection};
+use once_cell::sync::Lazy;
 
 use crate::source::types::{
     NextMessage, SourceConnectionBuilder, SourceMessage, SourceMessageType, SourceReader,
@@ -43,6 +44,8 @@ where
 {
     type Reader = DelimitedValueSourceReader<C::Reader>;
     type OffsetCommitter = C::OffsetCommitter;
+
+    const REMAP_RELATION_DESC: Lazy<RelationDesc> = Lazy::new(|| C::REMAP_RELATION_DESC.clone());
 
     fn into_reader(
         self,

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -9,14 +9,16 @@
 
 use std::time::{Duration, Instant};
 
+use once_cell::sync::Lazy;
 use timely::scheduling::SyncActivator;
 
 use mz_expr::PartitionId;
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sources::GeneratorMessageType;
 use mz_storage_client::types::sources::{
-    encoding::SourceDataEncoding, Generator, LoadGenerator, LoadGeneratorSourceConnection, MzOffset,
+    encoding::SourceDataEncoding, Generator, LoadGenerator, LoadGeneratorSourceConnection,
+    MzOffset, LOADGEN_PROGRESS_DESC,
 };
 
 use super::metrics::SourceBaseMetrics;
@@ -77,6 +79,8 @@ pub struct LoadGeneratorSourceReader {
 impl SourceConnectionBuilder for LoadGeneratorSourceConnection {
     type Reader = LoadGeneratorSourceReader;
     type OffsetCommitter = LogCommitter;
+
+    const REMAP_RELATION_DESC: Lazy<RelationDesc> = Lazy::new(|| LOADGEN_PROGRESS_DESC.clone());
 
     fn into_reader(
         self,

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -31,11 +31,11 @@ use mz_expr::{MirScalarExpr, PartitionId};
 use mz_ore::display::DisplayExt;
 use mz_ore::task;
 use mz_postgres_util::desc::PostgresTableDesc;
-use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row};
+use mz_repr::{Datum, DatumVec, Diff, GlobalId, RelationDesc, Row};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::SourceErrorDetails;
 use mz_storage_client::types::sources::{
-    encoding::SourceDataEncoding, MzOffset, PostgresSourceConnection,
+    encoding::SourceDataEncoding, MzOffset, PostgresSourceConnection, PG_PROGRESS_DESC,
 };
 
 use self::metrics::PgSourceMetrics;
@@ -213,6 +213,8 @@ struct PostgresTaskInfo {
 impl SourceConnectionBuilder for PostgresSourceConnection {
     type Reader = PostgresSourceReader;
     type OffsetCommitter = PgOffsetCommitter;
+
+    const REMAP_RELATION_DESC: Lazy<RelationDesc> = Lazy::new(|| PG_PROGRESS_DESC.clone());
 
     fn into_reader(
         self,

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -620,7 +620,7 @@ mod tests {
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
-    use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
+    use mz_persist_client::{PersistClient, PersistConfig, PersistLocation, ShardId};
     use mz_repr::{GlobalId, RelationDesc, Timestamp};
     use mz_storage_client::controller::CollectionMetadata;
     use mz_storage_client::types::sources::{MzOffset, SourceData};
@@ -1346,7 +1346,11 @@ mod tests {
         drop(persist_clients);
 
         let read_handle = persist_client
-            .open_leased_reader::<SourceData, (), Timestamp, Diff>(binding_shard, "test_since_hold")
+            .open_leased_reader::<SourceData, (), Timestamp, Diff, _>(
+                binding_shard,
+                "test_since_hold",
+                PersistClient::TO_REPLACE_SCHEMA,
+            )
             .await
             .expect("error opening persist shard");
 

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -620,7 +620,7 @@ mod tests {
     use mz_ore::metrics::MetricsRegistry;
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
-    use mz_persist_client::{PersistClient, PersistConfig, PersistLocation, ShardId};
+    use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
     use mz_repr::{GlobalId, RelationDesc, Timestamp};
     use mz_storage_client::controller::CollectionMetadata;
     use mz_storage_client::types::sources::{MzOffset, SourceData};
@@ -677,6 +677,7 @@ mod tests {
             "unittest",
             0,
             1,
+            mz_storage_client::types::sources::KAFKA_PROGRESS_DESC.clone(),
         )
         .await
         .unwrap();
@@ -1349,7 +1350,7 @@ mod tests {
             .open_leased_reader::<SourceData, (), Timestamp, Diff, _>(
                 binding_shard,
                 "test_since_hold",
-                PersistClient::TO_REPLACE_SCHEMA,
+                mz_storage_client::types::sources::KAFKA_PROGRESS_DESC.clone(),
             )
             .await
             .expect("error opening persist shard");

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -621,7 +621,7 @@ mod tests {
     use mz_ore::now::SYSTEM_TIME;
     use mz_persist_client::cache::PersistClientCache;
     use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
-    use mz_repr::{GlobalId, Timestamp};
+    use mz_repr::{GlobalId, RelationDesc, Timestamp};
     use mz_storage_client::controller::CollectionMetadata;
     use mz_storage_client::types::sources::{MzOffset, SourceData};
     use mz_storage_client::util::remap_handle::RemapHandle;
@@ -660,6 +660,7 @@ mod tests {
             remap_shard: shard,
             data_shard: ShardId::new(),
             status_shard: None,
+            relation_desc: RelationDesc::empty(),
         };
 
         let clock_stream = futures::stream::iter((0..).map(|seconds| {

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -32,7 +32,7 @@ use mz_persist_client::read::ListenEvent;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::PersistClient;
 use mz_persist_types::Codec64;
-use mz_repr::{Diff, GlobalId};
+use mz_repr::{Diff, GlobalId, RelationDesc};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::controller::PersistEpoch;
 use mz_storage_client::types::sources::{MzOffset, SourceData, SourceTimestamp};
@@ -135,6 +135,13 @@ where
         operator: &str,
         worker_id: usize,
         worker_count: usize,
+        // Must match the `FromTime`. Ideally we would be able to discover this
+        // from `SourceTimestamp`, but each source would need a specific `SourceTimestamp`
+        // implementation, as they do not share remap `RelationDesc`'s (columns names
+        // are different).
+        //
+        // TODO(guswynn): use the type-system to prevent misuse here.
+        remap_relation_desc: RelationDesc,
     ) -> anyhow::Result<Self> {
         let mut persist_clients = persist_clients.lock().await;
         let persist_client = persist_clients
@@ -158,7 +165,7 @@ where
             .open(
                 metadata.remap_shard.clone(),
                 &format!("reclock {}", id),
-                PersistClient::TO_REPLACE_SCHEMA,
+                remap_relation_desc,
             )
             .await
             .context("error opening persist shard")?;

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -155,7 +155,11 @@ where
         let since = since_handle.since();
 
         let (write_handle, mut read_handle) = persist_client
-            .open(metadata.remap_shard.clone(), &format!("reclock {}", id))
+            .open(
+                metadata.remap_shard.clone(),
+                &format!("reclock {}", id),
+                PersistClient::TO_REPLACE_SCHEMA,
+            )
             .await
             .context("error opening persist shard")?;
 

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -59,6 +59,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{Diff, GlobalId, Timestamp};
 use mz_storage_client::client::SourceStatisticsUpdate;
 use mz_storage_client::controller::{CollectionMetadata, ResumptionFrontierCalculator};
+use mz_storage_client::healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC;
 use mz_storage_client::source::util::async_source;
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::SourceError;
@@ -922,7 +923,15 @@ where
         if is_active_worker {
             if let Some(status_shard) = storage_metadata.status_shard {
                 info!("Health for source {source_id} being written to {status_shard}");
-                write_to_persist(source_id, last_reported_status.name(), last_reported_status.error(), now.clone(), &persist_client, status_shard).await;
+                write_to_persist(
+                    source_id,
+                    last_reported_status.name(),
+                    last_reported_status.error(),
+                    now.clone(),
+                    &persist_client,
+                    status_shard,
+                    &*MZ_SOURCE_STATUS_HISTORY_DESC
+                ).await;
             } else {
                 info!("Health for source {source_id} not being written to status shard");
             }
@@ -950,7 +959,15 @@ where
                 if &last_reported_status != new_status {
                     info!("Health transition for source {source_id}: {last_reported_status:?} -> {new_status:?}");
                     if let Some(status_shard) = storage_metadata.status_shard {
-                        write_to_persist(source_id, new_status.name(), new_status.error(), now.clone(), &persist_client, status_shard).await;
+                        write_to_persist(
+                            source_id,
+                            new_status.name(),
+                            new_status.error(),
+                            now.clone(),
+                            &persist_client,
+                            status_shard,
+                            &*MZ_SOURCE_STATUS_HISTORY_DESC
+                        ).await;
                     }
 
                     last_reported_status = new_status.clone();

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -9,14 +9,17 @@
 
 use std::time::Duration;
 
+use once_cell::sync::Lazy;
 use timely::scheduling::SyncActivator;
 use tokio::time::sleep;
 
 use mz_expr::PartitionId;
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, RelationDesc};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
-use mz_storage_client::types::sources::{MzOffset, TestScriptSourceConnection};
+use mz_storage_client::types::sources::{
+    MzOffset, TestScriptSourceConnection, TESTSCRIPT_PROGRESS_DESC,
+};
 
 use crate::source::commit::LogCommitter;
 use crate::source::types::SourceConnectionBuilder;
@@ -51,6 +54,8 @@ pub struct TestScriptSourceReader {
 impl SourceConnectionBuilder for TestScriptSourceConnection {
     type Reader = TestScriptSourceReader;
     type OffsetCommitter = LogCommitter;
+
+    const REMAP_RELATION_DESC: Lazy<RelationDesc> = Lazy::new(|| TESTSCRIPT_PROGRESS_DESC.clone());
 
     fn into_reader(
         self,

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use differential_dataflow::Hashable;
 use futures::stream::LocalBoxStream;
+use once_cell::sync::Lazy;
 use prometheus::core::{AtomicI64, AtomicU64};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract};
@@ -28,7 +29,7 @@ use timely::Data;
 
 use mz_expr::PartitionId;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
-use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_repr::{Diff, GlobalId, RelationDesc, Row, Timestamp};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::{DecodeError, SourceErrorDetails};
 use mz_storage_client::types::sources::encoding::SourceDataEncoding;
@@ -42,6 +43,8 @@ use crate::source::source_reader_pipeline::HealthStatus;
 pub trait SourceConnectionBuilder {
     type Reader: SourceReader + 'static;
     type OffsetCommitter: OffsetCommitter + Send + Sync + 'static;
+
+    const REMAP_RELATION_DESC: Lazy<RelationDesc>;
 
     /// Turn this connection into a new source reader.
     ///

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -306,9 +306,12 @@ where
                 (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
                     loop {
                         let (mut data_write_handle, data_read_handle) = persist_client
-                            .open::<SourceData, (), Timestamp, Diff>(
+                            .open::<SourceData, (), Timestamp, Diff, _>(
                                 data_shard.clone(),
                                 "tests::check_loop",
+                                // TODO(guswynn|danhhz): replace this with a real desc when persist requires a
+                                // schema.
+                                RelationDesc::empty(),
                             )
                             .await
                             .unwrap();

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -93,7 +93,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task::RuntimeExt;
 use mz_repr::TimestampManipulation;
-use mz_repr::{Diff, GlobalId, Timestamp};
+use mz_repr::{Diff, GlobalId, RelationDesc, Timestamp};
 use mz_storage::sink::SinkBaseMetrics;
 use mz_storage::source::metrics::SourceBaseMetrics;
 use mz_storage::source::testscript::ScriptCommand;
@@ -252,6 +252,9 @@ where
                 remap_shard: mz_persist_client::ShardId::new(),
                 data_shard: mz_persist_client::ShardId::new(),
                 status_shard: None,
+                // TODO(guswynn|danhhz): replace this with a real desc when persist requires a
+                // schema.
+                relation_desc: RelationDesc::empty(),
             };
             let data_shard = collection_metadata.data_shard.clone();
             let id = GlobalId::User(1);


### PR DESCRIPTION
Persist is in the process of being _scheme-aware_, to support schema migrations across the stack. This means that ultimately, _all uses of persist will require information about the schema of the data in the shard_. While persist iterates on this internally, we want a head-start on the api-level change that will be required, so that the work to pipe `RelationDesc`s through can be done in parallel to the internal changes happening within persist.

This pr adds an _unbounded_ generic parameter to all persist methods that create read and write handles, and, in later commits, pipes the `RelationDesc` through in places that are required. There are 3 main ways this is done:

- trivially, like in compute, where the `RelationDesc` of the shard data is readily available
- with some refactoring, like how we have to enrich the `CollectionMetadata` in storage with the shard `RelationDesc`
- skipped, like the remap migration, where _at least some parts of the process cant describe the data with a `RelationDesc`, so we just don't bother.

This pr is intentionally scoped down, and does no testing (at the compiler or runtime level) to ensure that schema's are the correct type or value, besides visual review. This is because this pr is designed to minimize (but not entirely eliminate) churn when persist starts to _enforce_ the schema of data in all shards.


### Motivation

  * This PR adds a known-desirable feature.


### Tips for reviewer

I highly recommend at least reading the commits separately at first.

There are some places (notably in `mz_storage::source` that have suboptimal type-system-level protection against misuse of apis. These can be cleaned up in the future.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - [ ] It just needs to compile
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

