### PR TITLE
zippy: Increase the timeout used when waiting for Mz to restart

### DIFF
--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -27,7 +27,7 @@ class MzStart(Action):
     def run(self, c: Composition) -> None:
         c.up("materialized")
         # Loaded Mz environments take a while to start up
-        c.wait_for_materialized(timeout_secs=300)
+        c.wait_for_materialized(timeout_secs=600)
 
         for config_param in [
             "max_tables",


### PR DESCRIPTION
Mz restart times get progressively slower as a test proceeds, exceeding the previous timeout of 5 minutes. Increase the timeout to 10 minutes to allow the tests to make further progress.

### Motivation

  * This PR fixes a previously unreported bug.

Zippy Release Qualification is failing with a timeout when attempting to restart Mz.