### PR TITLE
dbt-materialize: handle absence of cluster `default` on connection

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,13 +1,18 @@
 # dbt-materialize Changelog
 
+## Unreleased
+
+* Fix a bug where the adapter would fail if the `default` cluster doesn't exist
+  in Materialize (i.e. in case it was dropped by the user).
+
 ## 1.3.3 - 2023-01-05
 
 * Remove the 63-character limitation on relation names. Materialize does not
   have this limitation, unlike PostgreSQL (see [dbt-core #2727](https://github.com/dbt-labs/dbt-core/pull/2727)).
 
 * Produce an error message when attempting to use the [`listagg`](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#listagg)
-  cross-database macro. Materialize has native support for [`list_agg()`](https://materialize.com/docs/sql/functions/list_agg/), which should be used
-  instead.
+  cross-database macro. Materialize has native support for [`list_agg()`](https://materialize.com/docs/sql/functions/list_agg/),
+  which should be used instead.
 
 * Remove the deprecated `mz_generate_name` macro.
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -19,10 +19,13 @@ from typing import Optional
 
 import dbt.exceptions
 from dbt.adapters.postgres import PostgresConnectionManager, PostgresCredentials
+from dbt.events import AdapterLogger
 from dbt.semver import versions_compatible
 
 # If you bump this version, bump it in README.md too.
 SUPPORTED_MATERIALIZE_VERSIONS = ">=0.28.0"
+
+logger = AdapterLogger("Materialize")
 
 
 @dataclass
@@ -60,6 +63,15 @@ class MaterializeConnectionManager(PostgresConnectionManager):
         connection.handle.autocommit = True
 
         cursor = connection.handle.cursor()
+
+        # Upon connection, dbt performs introspection queries that should run in
+        # the mz_introspection cluster for optimal performance. Each materialization
+        # should then handle falling back to the default connection cluster if no
+        # cluster configuration is specified at the model level.
+        mz_introspection_cluster = "mz_introspection"
+        logger.debug("Switching to cluster '{}'".format(mz_introspection_cluster))
+        cursor.execute("SET cluster = %s" % mz_introspection_cluster)
+
         cursor.execute("SELECT mz_version()")
         mz_version = cursor.fetchone()[0].split()[0].strip("v")
         if not versions_compatible(mz_version, SUPPORTED_MATERIALIZE_VERSIONS):
@@ -67,14 +79,6 @@ class MaterializeConnectionManager(PostgresConnectionManager):
                 f"Detected unsupported Materialize version {mz_version}\n"
                 f"  Supported versions: {SUPPORTED_MATERIALIZE_VERSIONS}"
             )
-
-        # Upon connection, dbt performs introspection queries that should run in
-        # the mz_introspection cluster for optimal performance. Each materialization
-        # should then handle falling back to the default connection cluster if no
-        # cluster configuration is specified at the model level.
-        mz_introspection_cluster = "mz_introspection"
-
-        cursor.execute("SET cluster = %s" % mz_introspection_cluster)
 
         return connection
 

--- a/misc/dbt-materialize/tests/conftest.py
+++ b/misc/dbt-materialize/tests/conftest.py
@@ -30,6 +30,5 @@ def dbt_profile_target():
         "user": "materialize",
         "pass": "password",
         "database": "materialize",
-        "cluster": "default",
         "port": "{{ env_var('DBT_PORT', 6875) }}",
     }


### PR DESCRIPTION
If a user drops the `default` cluster in Materialize, the adapter will fail with:

```sql
ERROR:  unknown cluster 'default'
```

AFAIU, we’re hardcoding `default` as the default cluster variable in the [session connection code](https://github.com/MaterializeInc/materialize/blob/7837c81192363e5f24ffd1e580cdf4cef71500b7/src/adapter/src/session/vars.rs#L70). We should make sure that the connection switches to the `mz_introspection` cluster before dbt tries to run **any** commands (not just introspection), to avoid getting caught in this situation:

```sql
materialize=> SHOW CLUSTER;
 cluster
---------
 default
(1 row)

materialize=> SHOW CLUSTERS;
ERROR:  unknown cluster 'default'
materialize=> SELECT 1;
ERROR:  unknown cluster 'default'
```