### PR TITLE
nightly: Add a canary deploy to the staging cloud

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -134,7 +134,7 @@ case "$cmd" in
         docker push materialize/ci-builder:"$cache_tag"
         ;;
     run)
-        mkdir -p target-xcompile ~/.kube
+        mkdir -p target-xcompile ~/.kube ~/.config/mz
         args=(
             --cidfile "$cid_file"
             --rm --interactive
@@ -151,6 +151,7 @@ case "$cmd" in
             --env GPG_KEY
             --env LAUNCHDARKLY_API_TOKEN
             --env LAUNCHDARKLY_SDK_KEY
+            --env NIGHTLY_CANARY_APP_PASSWORD
             --env PYPI_TOKEN
         )
         for env in $(printenv | grep '^BUILDKITE' | sed 's/=.*//'); do
@@ -165,6 +166,10 @@ case "$cmd" in
             # deletion of config.lock.
             --volume "$HOME/.kube:/kube"
             --env "KUBECONFIG=/kube/config"
+        )
+        # Forward the hosts' .config/mz
+        args+=(
+            --volume "$HOME/.config/mz:/home/materialize/.config/mz"
         )
         # Forward the host's SSH agent, if available.
         if [[ "${SSH_AUTH_SOCK:-}" ]]; then

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -95,6 +95,8 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     lld \
     make \
     openssh-client \
+    postgresql-client-common \
+    postgresql-client-14 \
     pkg-config \
     python3 \
     python3-dev \

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -64,6 +64,7 @@ steps:
           - { value: unused-deps }
           - { value: launchdarkly }
           - { value: bounded-memory }
+          - { value: cloud-canary }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -586,3 +587,13 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: bounded-memory
+
+  - id: cloud-canary
+    label: "Canary Deploy in Staging Cloud"
+    artifact_paths: junit_mzcompose_*.xml
+    timeout_in_minutes: 1200
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: cloud-canary

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -608,6 +608,8 @@ class Testdrive(Service):
         name: str = "testdrive",
         mzbuild: str = "testdrive",
         materialize_url: str = "postgres://materialize@materialized:6875",
+        materialize_username: Optional[str] = None,
+        materialize_password: Optional[str] = None,
         materialize_url_internal: str = "postgres://materialize@materialized:6877",
         materialize_params: Dict[str, str] = {},
         kafka_url: str = "kafka:9092",
@@ -658,6 +660,13 @@ class Testdrive(Service):
                 f"--materialize-url={materialize_url}",
                 f"--materialize-internal-url={materialize_url_internal}",
             ]
+
+        if materialize_username:
+            entrypoint += [f"--materialize-username={materialize_username}"]
+
+        # Pass the password via an environment variable for some extra security
+        if materialize_password:
+            environment += [f"TESTDRIVE_MATERIALIZE_PASSWORD={materialize_password}"]
 
         if aws_region:
             entrypoint.append(f"--aws-region={aws_region}")

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -100,6 +100,10 @@ pub struct Config {
     /// The pgwire connection parameters for the Materialize instance that
     /// testdrive will connect to.
     pub materialize_pgconfig: tokio_postgres::Config,
+    /// The pgwire username to use
+    pub materialize_username: Option<String>,
+    /// The pgwire password to use
+    pub materialize_password: Option<String>,
     /// The internal pgwire connection parameters for the Materialize instance that
     /// testdrive will connect to.
     pub materialize_internal_pgconfig: tokio_postgres::Config,
@@ -843,6 +847,12 @@ pub async fn create_state(
             .retry_async_canceling(|_| async move {
                 let mut pgconfig = config.materialize_pgconfig.clone();
                 pgconfig.connect_timeout(config.default_timeout);
+                if let Some(username) = &config.materialize_username {
+                    pgconfig.user(username);
+                }
+                if let Some(password) = &config.materialize_password {
+                    pgconfig.password(password);
+                }
                 let tls = make_tls(&pgconfig)?;
                 pgconfig.connect(tls).await.map_err(|e| anyhow!(e))
             })

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -185,6 +185,12 @@ struct Args {
         value_name = "URL"
     )]
     materialize_url: tokio_postgres::Config,
+    /// Username to use when connecting
+    #[clap(long, value_name = "USER")]
+    materialize_username: Option<String>,
+    /// Password to use when connecting
+    #[clap(long, env = "TESTDRIVE_MATERIALIZE_PASSWORD", value_name = "PASSWORD")]
+    materialize_password: Option<String>,
     /// materialize internal SQL connection string.
     #[clap(
         long,
@@ -381,6 +387,8 @@ async fn main() {
 
         // === Materialize options. ===
         materialize_pgconfig: args.materialize_url,
+        materialize_username: args.materialize_username,
+        materialize_password: args.materialize_password,
         materialize_internal_pgconfig: args.materialize_internal_url,
         materialize_http_port: args.materialize_http_port,
         materialize_internal_http_port: args.materialize_internal_http_port,

--- a/test/cloud-canary/canary-clusters.td
+++ b/test/cloud-canary/canary-clusters.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP CLUSTER IF EXISTS cluster1 CASCADE;
+
+> CREATE CLUSTER cluster1 REPLICAS (replica1 (SIZE '3xsmall'), replica2 (SIZE '3xsmall'));
+
+> SET cluster=cluster1;
+
+> SHOW CLUSTERS;
+mz_system
+mz_introspection
+default
+cluster1
+
+> SHOW CLUSTER REPLICAS WHERE cluster = 'cluster1';
+cluster1 replica1 3xsmall true
+cluster1 replica2 3xsmall true
+
+> CREATE MATERIALIZED VIEW cluster_view1 AS SELECT COUNT(*) AS cnt FROM mz_internal.mz_tables;
+
+> SELECT cnt FROM cluster_view1;
+true
+
+> DROP CLUSTER cluster1 CASCADE;

--- a/test/cloud-canary/canary-sources.td
+++ b/test/cloud-canary/canary-sources.td
@@ -1,0 +1,19 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP SOURCE IF EXISTS source1 CASCADE;
+
+> CREATE SOURCE source1 FROM LOAD GENERATOR COUNTER WITH (SIZE '3xsmall');
+
+> CREATE MATERIALIZED VIEW source_view1 AS SELECT COUNT(*) AS cnt FROM source1;
+
+> SELECT cnt > 0 FROM source_view1;
+true
+
+> DROP SOURCE source1 CASCADE;

--- a/test/cloud-canary/canary-tables.td
+++ b/test/cloud-canary/canary-tables.td
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP TABLE IF EXISTS table1 CASCADE;
+
+> CREATE TABLE table1 (f1 INTEGER);
+
+> INSERT INTO table1 VALUES (1);
+
+> CREATE MATERIALIZED VIEW table_view1 AS SELECT COUNT(*) FROM table1;
+
+> INSERT INTO table1 VALUES (2);
+
+> SELECT * FROM table_view1;
+2
+
+> DROP TABLE table1 CASCADE;

--- a/test/cloud-canary/mzcompose
+++ b/test/cloud-canary/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+import ssl
+import subprocess
+import time
+from pathlib import Path
+from textwrap import dedent
+
+import pg8000
+
+from materialize.mzcompose import Composition, _wait_for_pg
+from materialize.mzcompose.services import Materialized, Testdrive
+
+SERVICES = [Materialized(), Testdrive()]
+
+REGION = "aws/us-east-1"
+ENVIRONMENT = "staging"
+USERNAME = "infra+nightly-canary@materialize.com"
+APP_PASSWORD = os.environ["NIGHTLY_CANARY_APP_PASSWORD"]
+VERSION = "unstable-" + os.environ["BUILDKITE_COMMIT"]
+
+
+def disable_region() -> None:
+    print(f"Shuting down region {REGION} ...")
+
+    subprocess.run(
+        ["bin/ci-builder", "run", "stable", "bin/mz", "region", "disable", REGION]
+    )
+
+
+def workflow_default(c: Composition) -> None:
+    """Deploy the current source to the cloud and run a smoke test."""
+
+    print("Obtaining mz_version() string from local instance ...")
+    c.start_and_wait_for_tcp(services=["materialized"])
+    c.wait_for_materialized()
+    local_version = c.sql_query("SELECT mz_version();")[0][0]
+
+    print("Prepare configuration file for bin/mz")
+    mz_profiles = Path.home() / ".config" / "mz" / "profiles.toml"
+    mz_profiles.parent.mkdir(parents=True, exist_ok=True)
+    with open(mz_profiles, "w+") as o:
+        o.write(
+            dedent(
+                f"""
+                current_profile = 'default'
+                [profiles.default]
+                email = '{USERNAME}'
+                app-password = '{APP_PASSWORD}'
+                region = '{REGION}'
+                endpoint = 'https://{ENVIRONMENT}.cloud.materialize.com/'
+                """
+            )
+        )
+
+    disable_region()
+
+    test_failed = True
+    try:
+        print(f"Enabling region using Mz version {VERSION} ...")
+        subprocess.run(
+            [
+                "bin/ci-builder",
+                "run",
+                "stable",
+                "bin/mz",
+                "region",
+                "enable",
+                REGION,
+                f"--version={VERSION}",
+            ]
+        )
+        time.sleep(10)
+
+        print("Obtaining hostname of cloud instance ...")
+        hostname = subprocess.check_output(
+            f"bin/ci-builder run stable bin/mz region status {REGION} | sed -n '2p' | cut -d ':' -f 2",
+            shell=True,
+            encoding="utf-8",
+        ).strip()
+        assert "materialize.cloud" in hostname
+
+        print("Waiting for cloud cluster to come up ...")
+        _wait_for_pg(
+            host=hostname,
+            user=USERNAME,
+            password=APP_PASSWORD,
+            port=6875,
+            query="SELECT 1",
+            expected=[[1]],
+            timeout_secs=600,
+            dbname="materialize",
+            ssl_context=ssl.SSLContext(),
+        )
+
+        print("Obtaining mz_version() string from the cloud ...")
+        # Fetch the version string on the cloud and confirm it is the same as the desired one
+        cloud_cursor = pg8000.connect(
+            host=hostname,
+            user=USERNAME,
+            password=APP_PASSWORD,
+            port=6875,
+            ssl_context=ssl.SSLContext(),
+        ).cursor()
+        cloud_cursor.execute("SELECT mz_version()")
+        cloud_version = cloud_cursor.fetchone()[0]
+        assert (
+            local_version == cloud_version
+        ), f"local version: {local_version} is not identical to cloud version: {cloud_version}"
+
+        print("Running smoke tests ...")
+        with c.override(
+            Testdrive(
+                default_timeout="300s",
+                materialize_url="postgres://{hostname}:6875",
+                materialize_username=USERNAME,
+                materialize_password=APP_PASSWORD,
+                no_reset=True,
+            )
+        ):
+            c.run("testdrive", "*.td", rm=True)
+        test_failed = False
+
+    finally:
+        disable_region()
+        # Clean up
+        assert not test_failed


### PR DESCRIPTION
* Deploy Mz to the staging cloud and create tables, sources, views and clusters
* Allow the Mz username and password to be passed to testdrive via a command-line option. tokio_postgres does not handle usernames containing '@' if passed as part of the connection URL.

Fixes cloud#5153

### Motivation

  * This PR adds a known-desirable feature.
- https://github.com/MaterializeInc/cloud/issues/5153


### Tips for reviewer


@benesch I chose to use mzcompose + testdrive so that those tests look as close as possible to any other test/ workflow. This will allow it to be quickly expanded with more stuff in the future if needed.