### PR TITLE
bump kubernetes api version to 1.24

### DIFF
--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.59"
-k8s-openapi = { version = "0.16.0", features = ["v1_23"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "openssl-tls", "ws"] }
 mz-repr = { path = "../repr" }
 schemars = { version = "0.8", features = ["uuid1"] }

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -18,7 +18,7 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
-k8s-openapi = { version = "0.16.0", features = ["v1_23"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["runtime", "ws"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -50,7 +50,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
 hyper = { version = "0.14.23", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
-k8s-openapi = { version = "0.16.0", features = ["v1_23"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
 kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.77.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
@@ -148,7 +148,7 @@ globset = { version = "0.4.9", features = ["serde1"] }
 hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
 hyper = { version = "0.14.23", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
-k8s-openapi = { version = "0.16.0", features = ["v1_23"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
 kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
 kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
 kube-core = { version = "0.77.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }


### PR DESCRIPTION
### Motivation

https://github.com/MaterializeInc/cloud/issues/4905, following up on https://github.com/MaterializeInc/cloud/pull/5170

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
