### PR TITLE
storage: don't use `halt!` in sinks

### DIFF
--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -26,7 +26,12 @@ use crate::storage_state::Worker;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum InternalStorageCommand {
     /// Suspend and restart the dataflow identified by the `GlobalId`.
-    SuspendAndRestart(GlobalId),
+    SuspendAndRestart {
+        /// The id of the dataflow that should be restarted.
+        id: GlobalId,
+        /// The reason for the restart request.
+        reason: String,
+    },
     /// Render an ingestion dataflow at the given resumption frontier.
     CreateIngestionDataflow {
         /// ID of the ingestion/sourve.

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -9,13 +9,13 @@
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
-use std::cmp;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::future::Future;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{cmp, future};
 
 use anyhow::{anyhow, bail, Context};
 use differential_dataflow::{Collection, Hashable};
@@ -51,7 +51,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_ore::retry::{Retry, RetryResult};
-use mz_ore::{halt, task};
+use mz_ore::task;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::errors::DataflowError;
@@ -61,6 +61,7 @@ use mz_storage_client::types::sinks::{
 };
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 
+use crate::internal_control::{InternalCommandSender, InternalStorageCommand};
 use crate::render::sinks::{HealthcheckerArgs, SinkRender};
 use crate::sink::{Healthchecker, KafkaBaseMetrics, SinkStatus};
 use crate::storage_state::StorageState;
@@ -120,6 +121,13 @@ where
             Antichain::new()
         }));
 
+        let internal_cmd_tx = Rc::clone(
+            storage_state
+                .internal_cmd_tx
+                .as_ref()
+                .expect("missing internal command sender"),
+        );
+
         let token = kafka(
             sinked_collection,
             sink_id,
@@ -130,6 +138,7 @@ where
             &storage_state.sink_metrics.kafka,
             &storage_state.connection_context,
             healthchecker_args,
+            internal_cmd_tx,
         );
 
         storage_state
@@ -363,6 +372,7 @@ impl KafkaTxProducer {
 }
 
 struct KafkaSinkState {
+    sink_id: GlobalId,
     name: String,
     topic: String,
     metrics: Arc<SinkMetrics>,
@@ -376,6 +386,7 @@ struct KafkaSinkState {
     progress_client: Option<Arc<BaseConsumer<BrokerRewritingClientContext<SinkConsumerContext>>>>,
 
     healthchecker: Arc<Mutex<Option<Healthchecker>>>,
+    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
     gate_ts: Rc<Cell<Option<Timestamp>>>,
 
     /// Timestamp of the latest progress record that was written out to Kafka.
@@ -419,6 +430,7 @@ impl KafkaSinkState {
         metrics: &KafkaBaseMetrics,
         connection_context: &ConnectionContext,
         gate_ts: Rc<Cell<Option<Timestamp>>>,
+        internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
     ) -> Self {
         let metrics = Arc::new(SinkMetrics::new(
             metrics,
@@ -504,6 +516,7 @@ impl KafkaSinkState {
             .expect("creating Kafka progress client for sink failed");
 
         KafkaSinkState {
+            sink_id: sink_id.clone(),
             name: sink_name,
             topic: connection.topic,
             metrics,
@@ -515,6 +528,7 @@ impl KafkaSinkState {
             progress_key: format!("mz-sink-{sink_id}"),
             progress_client: Some(Arc::new(progress_client)),
             healthchecker,
+            internal_cmd_tx,
             gate_ts,
             latest_progress_ts: Timestamp::minimum(),
             write_frontier,
@@ -900,7 +914,16 @@ impl KafkaSinkState {
             Err(msg) => {
                 self.update_status(SinkStatus::Stalled(msg.to_string()))
                     .await;
-                halt!("{msg:?}")
+                self.internal_cmd_tx.borrow_mut().broadcast(
+                    InternalStorageCommand::SuspendAndRestart {
+                        id: self.sink_id.clone(),
+                        reason: msg.to_string(),
+                    },
+                );
+
+                // Make sure to never return, preventing the sink from writing
+                // out anything it might regret in the future.
+                future::pending().await
             }
         }
     }
@@ -924,6 +947,7 @@ fn kafka<G>(
     metrics: &KafkaBaseMetrics,
     connection_context: &ConnectionContext,
     healthchecker_args: HealthcheckerArgs,
+    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
 ) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -991,6 +1015,7 @@ where
         metrics,
         connection_context,
         healthchecker_args,
+        internal_cmd_tx,
     )
 }
 
@@ -1016,6 +1041,7 @@ pub fn produce_to_kafka<G>(
     metrics: &KafkaBaseMetrics,
     connection_context: &ConnectionContext,
     healthchecker_args: HealthcheckerArgs,
+    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
 ) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -1032,6 +1058,7 @@ where
         metrics,
         connection_context,
         Rc::clone(&shared_gate_ts),
+        internal_cmd_tx,
     );
 
     let mut vector = Vec::new();

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -959,7 +959,7 @@ where
                 // We should definitely do that, but this is okay for a PoC.
                 if let Some(halt_with) = halt_with {
                     info!("Broadcasting suspend-and-restart command because of {:?}", halt_with);
-                    internal_cmd_tx.borrow_mut().broadcast(InternalStorageCommand::SuspendAndRestart(source_id));
+                    internal_cmd_tx.borrow_mut().broadcast(InternalStorageCommand::SuspendAndRestart{id: source_id, reason: format!("{:?}", halt_with)});
                 }
             }
         }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -400,7 +400,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
             {
                 let mut command_sequencer = command_sequencer.borrow_mut();
                 while let Some(internal_cmd) = command_sequencer.next() {
-                    self.handle_internal_storage_command(&mut async_worker, internal_cmd);
+                    self.handle_internal_storage_command(
+                        &mut *command_sequencer,
+                        &mut async_worker,
+                        internal_cmd,
+                    );
                 }
             }
         }
@@ -437,13 +441,19 @@ impl<'w, A: Allocate> Worker<'w, A> {
     /// Entry point for applying an internal storage command.
     pub fn handle_internal_storage_command(
         &mut self,
+        internal_cmd_tx: &mut dyn InternalCommandSender,
         async_worker: &mut AsyncStorageWorker<mz_repr::Timestamp>,
         internal_cmd: InternalStorageCommand,
     ) {
         match internal_cmd {
-            InternalStorageCommand::SuspendAndRestart(id) => {
-                let maybe_ingestion = self.storage_state.ingestions.get(&id).cloned();
+            InternalStorageCommand::SuspendAndRestart { id, reason } => {
+                info!(
+                    "worker {}/{} initiating suspend-and-restart for {id} because of: {reason}",
+                    self.timely_worker.index(),
+                    self.timely_worker.peers(),
+                );
 
+                let maybe_ingestion = self.storage_state.ingestions.get(&id).cloned();
                 if let Some(ingestion_description) = maybe_ingestion {
                     // Yank the token of the previously existing source
                     // dataflow.
@@ -475,7 +485,33 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     return;
                 }
 
-                panic!("got InternalStorageCommand::SuspendAndRestart for something that is not a source: {id}");
+                let maybe_sink = self.storage_state.exports.get(&id).cloned();
+                if let Some(sink_description) = maybe_sink {
+                    // Yank the token of the previously existing sink
+                    // dataflow.
+                    let maybe_token = self.storage_state.sink_tokens.remove(&id);
+
+                    if maybe_token.is_none() {
+                        // Something has dropped the sink. Make sure we don't
+                        // accidentally re-create it.
+                        return;
+                    }
+
+                    // This needs to be broadcast by one worker and go through
+                    // the internal command fabric, to ensure consistent
+                    // ordering of dataflow rendering across all workers.
+                    if self.timely_worker.index() == 0 {
+                        internal_cmd_tx.broadcast(InternalStorageCommand::CreateSinkDataflow(
+                            id,
+                            sink_description,
+                        ));
+                    }
+
+                    // Continue with other commands.
+                    return;
+                }
+
+                panic!("got InternalStorageCommand::SuspendAndRestart for something that is not a source or sink: {id}");
             }
             InternalStorageCommand::CreateIngestionDataflow {
                 id: ingestion_id,

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -267,6 +267,7 @@ where
 
                 let mut async_storage_worker =
                     AsyncStorageWorker::new(thread::current(), Arc::clone(&persist_clients));
+                let internal_command_fabric = &mut HaltingInternalCommandSender::new();
 
                 // NOTE: We only feed internal commands into the worker,
                 // bypassing "external" StorageCommand and the async worker that
@@ -274,6 +275,7 @@ where
                 // encounter weird behaviour from this test, this might be the
                 // reason.
                 worker.handle_internal_storage_command(
+                    &mut *internal_command_fabric.as_mut().unwrap().borrow_mut(),
                     &mut async_storage_worker,
                     InternalStorageCommand::CreateIngestionDataflow {
                         id,


### PR DESCRIPTION
### Motivation

Part of #16773 
Closes #17208 

### TODO

This might not work, because tests assume the halting behaviour. Let's see what CI says. We then also have to make sure to give @philip-stoev  the right tools/failpoints to make his testing easier.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
