### PR TITLE
dbt-materialize: release v1.3.4

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,9 +1,9 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.3.4 - 2023-01-19
 
-* Fix a bug where the adapter would fail if the `default` cluster doesn't exist
-  in Materialize (i.e. in case it was dropped by the user).
+* Fix a bug where the adapter would fail if the pre-installed `default` cluster
+  doesn't exist in Materialize (i.e. in case it was dropped by the user).
 
 ## 1.3.3 - 2023-01-05
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.3.3"
+version = "1.3.4"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.3.3",
+    version="1.3.4",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a new release of `dbt-materialize` with a bugfix for the issue reported [here](https://materializeinc.slack.com/archives/C03REC5MEKU/p1674029082384549).