### PR TITLE
storage: reduce the size of DataflowError

### DIFF
--- a/src/storage/src/render/debezium.rs
+++ b/src/storage/src/render/debezium.rs
@@ -72,7 +72,7 @@ where
                                     Ok(b) => b,
                                     Err(err) => {
                                         session.give((
-                                            Err(DataflowError::EnvelopeError(err)),
+                                            Err(DataflowError::from(err)),
                                             cap.time().clone(),
                                             1,
                                         ));
@@ -215,7 +215,7 @@ where
                             for (row, time, diff) in tx_data.drain(..) {
                                 if diff != 1 {
                                     output.session(&tx_metadata_cap).give((
-                                        Err(DataflowError::EvalError(EvalError::Internal(
+                                        Err(DataflowError::from(EvalError::Internal(
                                             format!("Transaction metadata supplied diff value {:?}", diff),
                                         ))),
                                         time,
@@ -320,7 +320,7 @@ where
                                             // We could theoretically use tx_cap_map.get(tx_id) here but for sake of
                                             // consistency, we output all errors at the data_cap time.
                                             output.session(&data_cap).give((
-                                                Err(DataflowError::EnvelopeError(err)),
+                                                Err(DataflowError::from(err)),
                                                 *data_cap.time(),
                                                 1,
                                             ));

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -191,7 +191,7 @@ where
         // whose contents will be concatenated and inserted along the collection.
         // All subsources include the non-definite errors of the ingestion
         let error_collections = vec![err_source
-            .map(DataflowError::SourceError)
+            .map(DataflowError::from)
             .pass_through("source-errors", 1)
             .as_collection()];
 
@@ -617,7 +617,7 @@ fn raise_key_value_errors(
         (Some(Err(e)), _) => Some(Err(e.into())),
         (None, None) => None,
         // TODO(petrosagg): these errors would be better grouped under an EnvelopeError enum
-        _ => Some(Err(DataflowError::EnvelopeError(EnvelopeError::Flat(
+        _ => Some(Err(DataflowError::from(EnvelopeError::Flat(
             "Value not present for message".to_string(),
         )))),
     }


### PR DESCRIPTION
This PR boxes all the variants of `DataflowError`, to reduce the type's size in memory. This reduces the size of `Result<Row, DataflowError>` values from 80 bytes (the previous size of `DataflowError`) to 40 bytes (the size of `Row` + `Result` tag).

`Result<Row, DataflowError>` is useful for encoding fallible updates produced by dataflows. However, prior to this change, its size was significantly larger than the `Row` type used for non-fallible updates. This could lead to memory waste and performance degradations when working with collections of updates.

The intention of this PR is to entirely remove this performance trap, and to free developers from having to think about whether their specific use of `Result<Row, DataflowError>` is justifiable or not.

### Drawbacks

I don't see any significant drawbacks to this approach of boxing the `DataflowError` variants. It does make creating and accessing `DataflowError`s more expensive, due to the added allocation and pointer indirection. But the overall performance impact of this likely negligible, as we are not producing large quantities of errors normally.

Destructuring of the boxed variants is annoying because you cannot `match` through `Box`es, so you have to perform a nested `match` instead. Perhaps surprisingly, there is only a single instance in our code where this is relevant.

### Alternatives

Plausible alternatives to this change are:

* Boxing the whole `DataflowError` instead, i.e. using `Result<Row, Box<DataflowError>>`. The benefit of this would be that the `DataflowError` type could still be used in a stand-alone fashion without any (additional) allocations. The drawback is that it is easy for developers to forget `Box`ing the result type. This could be solved by introducing a `DataflowResult` alias, but it seems hard to ensure that that would be used consistently without some form of additional linting.
* Don't use `Result<Row, DataflowError>` if it affects performance. This is the approach we (implicitly) take right now. I don't think it is a good one, as it requires every developer to a) be aware of the memory footprint of `Result<Row, DataflowError>` and be b) be aware of the (current and future) performance characteristics of the code they are writing.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
