### PR TITLE
Attempt canonicalization of `Union`

### DIFF
--- a/src/transform/src/fusion/union.rs
+++ b/src/transform/src/fusion/union.rs
@@ -51,6 +51,7 @@ impl Union {
         if let MirRelationExpr::Union { inputs, .. } = relation {
             let mut list: Vec<MirRelationExpr> = Vec::with_capacity(1 + inputs.len());
             Self::unfold_unions_into(relation.take_dangerous(), &mut list);
+            list.sort();
             *relation = MirRelationExpr::Union {
                 base: Box::new(list.remove(0)),
                 inputs: list,

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -854,18 +854,39 @@ Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
-        Filter (bigint_to_numeric(#1) > (bigint_to_numeric(#2) * 0.005)) // { arity: 3 }
+        Filter (bigint_to_numeric(#1) > #2) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0[×] » %1[×]UA
+              %1[×] » %0[×]A
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
                 Get l0 // { arity: 2 }
             ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum(#0)] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (error("more than one record produced in subquery")) // { arity: 1 }
+                  Project () // { arity: 0 }
+                    Filter (#0 > 1) // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
+                        Project () // { arity: 0 }
+                          Get l2 // { arity: 1 }
     With
+      cte l2 =
+        Project (#1) // { arity: 1 }
+          Map ((bigint_to_numeric(#0) * 0.005)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l1 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l1 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l1 =
+        Reduce aggregates=[sum(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 2 }
       cte l0 =
         Project (#0, #14) // { arity: 2 }
           Join on=(#17 = #18 AND #19 = #20) type=differential // { arity: 21 }
@@ -954,13 +975,13 @@ Explained Query:
                 Get l0 // { arity: 23 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Get materialize.public.customer // { arity: 22 }
                   Negate // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21] // { arity: 22 }
                         Project (#0..=#21) // { arity: 22 }
                           Get l0 // { arity: 23 }
-                  Project (#0) // { arity: 1 }
-                    Get materialize.public.customer // { arity: 22 }
     With
       cte l0 =
         Project (#0..=#22) // { arity: 23 }
@@ -1061,18 +1082,38 @@ Explained Query:
       Project (#0..=#3, #5) // { arity: 5 }
         Join on=(#0 = #4 AND #5 = #6) type=differential // { arity: 7 }
           implementation
-            %1:l0[#0] » %0:supplier[#0]UKA » %2[#0]UKA
+            %2[#0] » %1:l0[#1]KA » %0:supplier[#0]UKA
           ArrangeBy keys=[[#0]] // { arity: 4 }
             Project (#0..=#2, #4) // { arity: 4 }
               Get materialize.public.supplier // { arity: 7 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
-            Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#1]] // { arity: 2 }
+            Filter (#1) IS NOT NULL // { arity: 2 }
+              Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Filter (#0) IS NOT NULL // { arity: 1 }
-              Reduce aggregates=[max(#0)] // { arity: 1 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
+            Union // { arity: 1 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 1 }
+                Get l2 // { arity: 1 }
     With
+      cte l2 =
+        Union // { arity: 1 }
+          Get l1 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l1 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+      cte l1 =
+        Reduce aggregates=[max(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 2 }
       cte l0 =
         Reduce group_by=[#1] aggregates=[sum(#0)] // { arity: 2 }
           Project (#2, #5) // { arity: 2 }
@@ -1123,6 +1164,7 @@ Explained Query:
               Get l0 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Union // { arity: 1 }
+                Get l1 // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
                     Join on=(#0 = #1) type=differential // { arity: 2 }
@@ -1134,7 +1176,6 @@ Explained Query:
                         Project (#0) // { arity: 1 }
                           Filter "%bad%" ~~(padchar(#6)) // { arity: 7 }
                             Get materialize.public.supplier // { arity: 7 }
-                Get l1 // { arity: 1 }
     With
       cte l1 =
         Distinct group_by=[#0] // { arity: 1 }
@@ -1441,6 +1482,7 @@ Explained Query:
               Get l0 // { arity: 5 }
             ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 4 }
               Union // { arity: 4 }
+                Get l1 // { arity: 4 }
                 Negate // { arity: 4 }
                   Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
@@ -1452,7 +1494,6 @@ Explained Query:
                             Get l1 // { arity: 4 }
                           ArrangeBy keys=[[#2, #1, #0]] // { arity: 10 }
                             Get materialize.public.orderline // { arity: 10 }
-                Get l1 // { arity: 4 }
     With
       cte l1 =
         Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
@@ -1521,43 +1562,65 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
-              %1[#0, #1, #2] » %0:l1[#0, #1, #2]UKKKA
+              %1[#0, #1, #2] » %0:l3[#0, #1, #2]KKKA
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
-              Get l1 // { arity: 5 }
+              Get l3 // { arity: 5 }
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
               Union // { arity: 3 }
+                Get l4 // { arity: 3 }
                 Negate // { arity: 3 }
                   Project (#0..=#2) // { arity: 3 }
                     Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                       implementation
-                        %1[#0, #1, #2] » %0:l2[#0, #1, #2]UKKKA
+                        %1[#0, #1, #2] » %0:l4[#0, #1, #2]UKKKA
                       ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-                        Get l2 // { arity: 3 }
+                        Get l4 // { arity: 3 }
                       ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                         Distinct group_by=[#2, #0, #1] // { arity: 3 }
                           Project (#1..=#3) // { arity: 3 }
                             Filter (#3) IS NOT NULL // { arity: 8 }
                               Get materialize.public.order // { arity: 8 }
-                Get l2 // { arity: 3 }
     With
-      cte l2 =
-        Project (#0..=#2) // { arity: 3 }
-          Get l1 // { arity: 5 }
-      cte l1 =
+      cte l4 =
+        Distinct group_by=[#0, #1, #2] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Get l3 // { arity: 5 }
+      cte l3 =
         Project (#0..=#4) // { arity: 5 }
-          Filter (numeric_to_double(#4) > (numeric_to_double(#5) / bigint_to_double(case when (#6 = 0) then null else #6 end))) // { arity: 7 }
-            CrossJoin type=differential // { arity: 7 }
+          Filter (numeric_to_double(#4) > #5) // { arity: 6 }
+            CrossJoin type=differential // { arity: 6 }
               implementation
-                %0:l0[×] » %1[×]UAef
+                %1[×] » %0:l0[×]Aef
               ArrangeBy keys=[[]] // { arity: 5 }
                 Project (#0..=#2, #9, #16) // { arity: 5 }
                   Filter ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
                     Get l0 // { arity: 23 }
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
-                  Project (#16) // { arity: 1 }
-                    Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
-                      Get l0 // { arity: 23 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l2 // { arity: 1 }
+                  Map (error("more than one record produced in subquery")) // { arity: 1 }
+                    Project () // { arity: 0 }
+                      Filter (#0 > 1) // { arity: 1 }
+                        Reduce aggregates=[count(*)] // { arity: 1 }
+                          Project () // { arity: 0 }
+                            Get l2 // { arity: 1 }
+      cte l2 =
+        Project (#2) // { arity: 1 }
+          Map ((numeric_to_double(#0) / bigint_to_double(case when (#1 = 0) then null else #1 end))) // { arity: 3 }
+            Union // { arity: 2 }
+              Get l1 // { arity: 2 }
+              Map (null, 0) // { arity: 2 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l1 // { arity: 2 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l1 =
+        Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
+          Project (#16) // { arity: 1 }
+            Filter (#16 > 0) AND ((#22 = "1") OR (#22 = "2") OR (#22 = "3") OR (#22 = "4") OR (#22 = "5") OR (#22 = "6") OR (#22 = "7")) // { arity: 23 }
+              Get l0 // { arity: 23 }
       cte l0 =
         Map (substr(char_to_text(#11), 1, 1)) // { arity: 23 }
           Get materialize.public.customer // { arity: 22 }

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -69,13 +69,13 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1)
 Explained Query:
   Return // { arity: 4 }
     Union // { arity: 4 }
+      Get l1 // { arity: 4 }
       Map (null, null) // { arity: 4 }
         Union // { arity: 2 }
+          Get l0 // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Get l1 // { arity: 4 }
-          Get l0 // { arity: 2 }
-      Get l1 // { arity: 4 }
   With
     cte l1 =
       CrossJoin type=differential // { arity: 4 }
@@ -103,13 +103,13 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t
 Explained Query:
   Return // { arity: 3 }
     Union // { arity: 3 }
+      Get l1 // { arity: 3 }
       Map (null) // { arity: 3 }
         Union // { arity: 2 }
+          Get l0 // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Get l1 // { arity: 3 }
-          Get l0 // { arity: 2 }
-      Get l1 // { arity: 3 }
   With
     cte l1 =
       CrossJoin type=differential // { arity: 3 }
@@ -227,10 +227,10 @@ Explained Query:
           Get l2 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
+              Get l0 // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
                   Get l2 // { arity: 1 }
-              Get l0 // { arity: 0 }
   With
     cte l2 =
       CrossJoin type=differential // { arity: 1 }

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -74,6 +74,9 @@ Explained Query:
           Get materialize.public.table_f1 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 3 }
           Union // { arity: 3 }
+            Filter (#0 = #1) AND (#0 = #2) // { arity: 3 }
+              Get l0 // { arity: 3 }
+            Get l1 // { arity: 3 }
             Negate // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Join on=(#0 = #3) type=differential // { arity: 4 }
@@ -86,9 +89,6 @@ Explained Query:
                       Distinct group_by=[#1, #0] // { arity: 2 }
                         Project (#1, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
-            Get l1 // { arity: 3 }
-            Filter (#0 = #1) AND (#0 = #2) // { arity: 3 }
-              Get l0 // { arity: 3 }
   With
     cte l1 =
       Filter (#0 = #1) AND (#0 = #2) AND (#1 = #2) // { arity: 3 }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -318,8 +318,11 @@ SELECT * FROM l LEFT JOIN r ON l.la = r.ra
 Explained Query:
   Return // { arity: 4 }
     Union // { arity: 4 }
+      Project (#0, #1, #0, #2) // { arity: 4 }
+        Get l0 // { arity: 3 }
       Map (null, null) // { arity: 4 }
         Union // { arity: 2 }
+          Get materialize.public.l // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -331,9 +334,6 @@ Explained Query:
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l0 // { arity: 3 }
-          Get materialize.public.l // { arity: 2 }
-      Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #1, #3) // { arity: 3 }
@@ -359,9 +359,12 @@ SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
 Explained Query:
   Return // { arity: 4 }
     Union // { arity: 4 }
+      Project (#0, #1, #0, #2) // { arity: 4 }
+        Get l0 // { arity: 3 }
       Project (#2, #3, #0, #1) // { arity: 4 }
         Map (null, null) // { arity: 4 }
           Union // { arity: 2 }
+            Get materialize.public.r // { arity: 2 }
             Negate // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -373,9 +376,6 @@ Explained Query:
                     Distinct group_by=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l0 // { arity: 3 }
-            Get materialize.public.r // { arity: 2 }
-      Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #1, #3) // { arity: 3 }
@@ -401,9 +401,12 @@ SELECT * FROM l FULL JOIN r ON l.la = r.ra
 Explained Query:
   Return // { arity: 4 }
     Union // { arity: 4 }
+      Project (#0, #1, #0, #2) // { arity: 4 }
+        Get l0 // { arity: 3 }
       Project (#2, #3, #0, #1) // { arity: 4 }
         Map (null, null) // { arity: 4 }
           Union // { arity: 2 }
+            Get materialize.public.r // { arity: 2 }
             Negate // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
                 Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -412,9 +415,9 @@ Explained Query:
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     Get materialize.public.r // { arity: 2 }
                   Get l1 // { arity: 1 }
-            Get materialize.public.r // { arity: 2 }
       Map (null, null) // { arity: 4 }
         Union // { arity: 2 }
+          Get materialize.public.l // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -423,9 +426,6 @@ Explained Query:
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   Get materialize.public.l // { arity: 2 }
                 Get l1 // { arity: 1 }
-          Get materialize.public.l // { arity: 2 }
-      Project (#0, #1, #0, #2) // { arity: 4 }
-        Get l0 // { arity: 3 }
   With
     cte l1 =
       ArrangeBy keys=[[#0]] // { arity: 1 }

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -369,29 +369,74 @@ EXPLAIN WITH(types, no_fast_path) SELECT 1 = SOME (VALUES(col_null)), 1 = SOME (
 ----
 Explained Query:
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-    Project (#5, #4, #7, #8, #6, #6) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-      Map ((#0 = 1), (#0 = #1), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean?)" }
-        Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer, boolean)" }
-          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
+    Project (#3, #6, #13, #14, #9, #12) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
+      Map (null, null) // { types: "(integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?, boolean?, boolean?)" }
+        Join on=(eq(#0, #2, #4, #7, #10) AND eq(#1, #5, #8, #11)) type=differential // { types: "(integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer?, integer)" }
             Get materialize.public.int_table // { types: "(integer?, integer)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer?, boolean?)" }
+            Union // { types: "(integer?, boolean?)" }
+              Get l1 // { types: "(integer?, boolean?)" }
+              Map (null) // { types: "(integer?, boolean?)" }
+                Union // { types: "(integer?)" }
+                  Get l0 // { types: "(integer?)" }
+                  Negate // { types: "(integer?)" }
+                    Distinct group_by=[#0] // { types: "(integer?)" }
+                      Project (#0) // { types: "(integer?)" }
+                        Get l1 // { types: "(integer?, boolean?)" }
           ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean)" }
             Union // { types: "(integer?, integer, boolean)" }
               Project (#0, #2, #3) // { types: "(integer?, integer, boolean)" }
                 Filter (#1 = 1) // { types: "(integer?, integer, integer, boolean)" }
                   Map (1, true) // { types: "(integer?, integer, integer, boolean)" }
-                    Get l0 // { types: "(integer?, integer)" }
+                    Get l2 // { types: "(integer?, integer)" }
               Map (false) // { types: "(integer?, integer, boolean)" }
                 Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
                   Map (1) // { types: "(integer?, integer)" }
                     Negate // { types: "(integer?)" }
                       Project (#0) // { types: "(integer?)" }
                         Filter (#1 = 1) // { types: "(integer?, integer)" }
-                          Get l0 // { types: "(integer?, integer)" }
-                  Get l0 // { types: "(integer?, integer)" }
+                          Get l2 // { types: "(integer?, integer)" }
+          Get l4 // { types: "(integer?, integer, boolean?)" }
+          Get l4 // { types: "(integer?, integer, boolean?)" }
   With
-    cte l0 =
+    cte l4 =
+      ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean?)" }
+        Union // { types: "(integer?, integer, boolean?)" }
+          Get l3 // { types: "(integer?, integer, boolean?)" }
+          Map (null) // { types: "(integer?, integer, boolean?)" }
+            Union // { types: "(integer?, integer)" }
+              Get l2 // { types: "(integer?, integer)" }
+              Negate // { types: "(integer?, integer)" }
+                Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                  Project (#0, #1) // { types: "(integer?, integer)" }
+                    Get l3 // { types: "(integer?, integer, boolean?)" }
+    cte l3 =
+      Union // { types: "(integer?, integer, boolean?)" }
+        Map ((#0 = #1)) // { types: "(integer?, integer, boolean?)" }
+          Get l2 // { types: "(integer?, integer)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer?, integer, boolean)" }
+          Project (#0, #1) // { types: "(integer?, integer)" }
+            Filter (#2 > 1) // { types: "(integer?, integer, bigint)" }
+              Reduce group_by=[#0, #1] aggregates=[count(*)] // { types: "(integer?, integer, bigint)" }
+                Get l2 // { types: "(integer?, integer)" }
+    cte l2 =
       Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
         Get materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Union // { types: "(integer?, boolean?)" }
+        Map ((#0 = 1)) // { types: "(integer?, boolean?)" }
+          Get l0 // { types: "(integer?)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer?, boolean)" }
+          Project (#0) // { types: "(integer?)" }
+            Filter (#1 > 1) // { types: "(integer?, bigint)" }
+              Reduce group_by=[#0] aggregates=[count(*)] // { types: "(integer?, bigint)" }
+                Get l0 // { types: "(integer?)" }
+    cte l0 =
+      Distinct group_by=[#0] // { types: "(integer?)" }
+        Project (#0) // { types: "(integer?)" }
+          Get materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF
 
@@ -401,26 +446,85 @@ EXPLAIN WITH(types, no_fast_path) SELECT 1 > ANY (VALUES(col_null)), 1 > ANY (VA
 ----
 Explained Query:
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-    Project (#7, #4, #8, #9, #5, #6) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-      Map ((#0 > #1), (#1 > #0), (1 > #0), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean?, boolean?)" }
-        Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer, boolean)" }
-          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
+    Project (#3, #6, #13, #14, #9, #12) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
+      Map (null, null) // { types: "(integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?, boolean?, boolean?)" }
+        Join on=(eq(#0, #2, #4, #7, #10) AND eq(#1, #5, #8, #11)) type=differential // { types: "(integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer?, integer)" }
             Get materialize.public.int_table // { types: "(integer?, integer)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer?, boolean?)" }
+            Union // { types: "(integer?, boolean?)" }
+              Get l1 // { types: "(integer?, boolean?)" }
+              Map (null) // { types: "(integer?, boolean?)" }
+                Union // { types: "(integer?)" }
+                  Get l0 // { types: "(integer?)" }
+                  Negate // { types: "(integer?)" }
+                    Distinct group_by=[#0] // { types: "(integer?)" }
+                      Project (#0) // { types: "(integer?)" }
+                        Get l1 // { types: "(integer?, boolean?)" }
           ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean)" }
             Union // { types: "(integer?, integer, boolean)" }
-              Filter (1 > #1) // { types: "(integer?, integer, boolean)" }
-                Map (true) // { types: "(integer?, integer, boolean)" }
-                  Get l0 // { types: "(integer?, integer)" }
               Map (false) // { types: "(integer?, integer, boolean)" }
                 Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
                   Negate // { types: "(integer?, integer)" }
                     Filter (1 > #1) // { types: "(integer?, integer)" }
-                      Get l0 // { types: "(integer?, integer)" }
-                  Get l0 // { types: "(integer?, integer)" }
+                      Get l2 // { types: "(integer?, integer)" }
+              Filter (1 > #1) // { types: "(integer?, integer, boolean)" }
+                Map (true) // { types: "(integer?, integer, boolean)" }
+                  Get l2 // { types: "(integer?, integer)" }
+          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean?)" }
+            Union // { types: "(integer?, integer, boolean?)" }
+              Get l4 // { types: "(integer?, integer, boolean?)" }
+              Map (null) // { types: "(integer?, integer, boolean?)" }
+                Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
+                  Negate // { types: "(integer?, integer)" }
+                    Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                      Project (#0, #1) // { types: "(integer?, integer)" }
+                        Get l4 // { types: "(integer?, integer, boolean?)" }
+          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean?)" }
+            Union // { types: "(integer?, integer, boolean?)" }
+              Get l5 // { types: "(integer?, integer, boolean?)" }
+              Map (null) // { types: "(integer?, integer, boolean?)" }
+                Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
+                  Negate // { types: "(integer?, integer)" }
+                    Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                      Project (#0, #1) // { types: "(integer?, integer)" }
+                        Get l5 // { types: "(integer?, integer, boolean?)" }
   With
-    cte l0 =
+    cte l5 =
+      Union // { types: "(integer?, integer, boolean?)" }
+        Get l3 // { types: "(integer?, integer, boolean)" }
+        Map ((#1 > #0)) // { types: "(integer?, integer, boolean?)" }
+          Get l2 // { types: "(integer?, integer)" }
+    cte l4 =
+      Union // { types: "(integer?, integer, boolean?)" }
+        Get l3 // { types: "(integer?, integer, boolean)" }
+        Map ((#0 > #1)) // { types: "(integer?, integer, boolean?)" }
+          Get l2 // { types: "(integer?, integer)" }
+    cte l3 =
+      Map (error("more than one record produced in subquery")) // { types: "(integer?, integer, boolean)" }
+        Project (#0, #1) // { types: "(integer?, integer)" }
+          Filter (#2 > 1) // { types: "(integer?, integer, bigint)" }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { types: "(integer?, integer, bigint)" }
+              Get l2 // { types: "(integer?, integer)" }
+    cte l2 =
       Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
         Get materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Union // { types: "(integer?, boolean?)" }
+        Map ((1 > #0)) // { types: "(integer?, boolean?)" }
+          Get l0 // { types: "(integer?)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer?, boolean)" }
+          Project (#0) // { types: "(integer?)" }
+            Filter (#1 > 1) // { types: "(integer?, bigint)" }
+              Reduce group_by=[#0] aggregates=[count(*)] // { types: "(integer?, bigint)" }
+                Get l0 // { types: "(integer?)" }
+    cte l0 =
+      Distinct group_by=[#0] // { types: "(integer?)" }
+        Project (#0) // { types: "(integer?)" }
+          Get materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF
 
@@ -429,26 +533,85 @@ EXPLAIN WITH(types, no_fast_path) SELECT 1 < ALL (VALUES(col_null)), 1 < ALL (VA
 ----
 Explained Query:
   Return // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-    Project (#7..=#10, #5, #6) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
-      Map ((#0 < #1), (#1 < #0), (1 < #0), NOT(#4), null, null) // { types: "(integer?, integer, integer?, integer, boolean, boolean?, boolean?, boolean?, boolean, boolean?, boolean?)" }
-        Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer, boolean)" }
-          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
+    Project (#3, #13..=#15, #9, #12) // { types: "(boolean?, boolean, boolean?, boolean?, boolean?, boolean?)" }
+      Map (NOT(#6), null, null) // { types: "(integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?, boolean, boolean?, boolean?)" }
+        Join on=(eq(#0, #2, #4, #7, #10) AND eq(#1, #5, #8, #11)) type=differential // { types: "(integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer?, integer)" }
             Get materialize.public.int_table // { types: "(integer?, integer)" }
+          ArrangeBy keys=[[#0]] // { types: "(integer?, boolean?)" }
+            Union // { types: "(integer?, boolean?)" }
+              Get l1 // { types: "(integer?, boolean?)" }
+              Map (null) // { types: "(integer?, boolean?)" }
+                Union // { types: "(integer?)" }
+                  Get l0 // { types: "(integer?)" }
+                  Negate // { types: "(integer?)" }
+                    Distinct group_by=[#0] // { types: "(integer?)" }
+                      Project (#0) // { types: "(integer?)" }
+                        Get l1 // { types: "(integer?, boolean?)" }
           ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean)" }
             Union // { types: "(integer?, integer, boolean)" }
-              Filter (1 >= #1) // { types: "(integer?, integer, boolean)" }
-                Map (true) // { types: "(integer?, integer, boolean)" }
-                  Get l0 // { types: "(integer?, integer)" }
               Map (false) // { types: "(integer?, integer, boolean)" }
                 Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
                   Negate // { types: "(integer?, integer)" }
                     Filter (1 >= #1) // { types: "(integer?, integer)" }
-                      Get l0 // { types: "(integer?, integer)" }
-                  Get l0 // { types: "(integer?, integer)" }
+                      Get l2 // { types: "(integer?, integer)" }
+              Filter (1 >= #1) // { types: "(integer?, integer, boolean)" }
+                Map (true) // { types: "(integer?, integer, boolean)" }
+                  Get l2 // { types: "(integer?, integer)" }
+          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean?)" }
+            Union // { types: "(integer?, integer, boolean?)" }
+              Get l4 // { types: "(integer?, integer, boolean?)" }
+              Map (null) // { types: "(integer?, integer, boolean?)" }
+                Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
+                  Negate // { types: "(integer?, integer)" }
+                    Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                      Project (#0, #1) // { types: "(integer?, integer)" }
+                        Get l4 // { types: "(integer?, integer, boolean?)" }
+          ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer, boolean?)" }
+            Union // { types: "(integer?, integer, boolean?)" }
+              Get l5 // { types: "(integer?, integer, boolean?)" }
+              Map (null) // { types: "(integer?, integer, boolean?)" }
+                Union // { types: "(integer?, integer)" }
+                  Get l2 // { types: "(integer?, integer)" }
+                  Negate // { types: "(integer?, integer)" }
+                    Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                      Project (#0, #1) // { types: "(integer?, integer)" }
+                        Get l5 // { types: "(integer?, integer, boolean?)" }
   With
-    cte l0 =
+    cte l5 =
+      Union // { types: "(integer?, integer, boolean?)" }
+        Get l3 // { types: "(integer?, integer, boolean)" }
+        Map ((#1 < #0)) // { types: "(integer?, integer, boolean?)" }
+          Get l2 // { types: "(integer?, integer)" }
+    cte l4 =
+      Union // { types: "(integer?, integer, boolean?)" }
+        Get l3 // { types: "(integer?, integer, boolean)" }
+        Map ((#0 < #1)) // { types: "(integer?, integer, boolean?)" }
+          Get l2 // { types: "(integer?, integer)" }
+    cte l3 =
+      Map (error("more than one record produced in subquery")) // { types: "(integer?, integer, boolean)" }
+        Project (#0, #1) // { types: "(integer?, integer)" }
+          Filter (#2 > 1) // { types: "(integer?, integer, bigint)" }
+            Reduce group_by=[#0, #1] aggregates=[count(*)] // { types: "(integer?, integer, bigint)" }
+              Get l2 // { types: "(integer?, integer)" }
+    cte l2 =
       Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
         Get materialize.public.int_table // { types: "(integer?, integer)" }
+    cte l1 =
+      Union // { types: "(integer?, boolean?)" }
+        Map ((1 < #0)) // { types: "(integer?, boolean?)" }
+          Get l0 // { types: "(integer?)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer?, boolean)" }
+          Project (#0) // { types: "(integer?)" }
+            Filter (#1 > 1) // { types: "(integer?, bigint)" }
+              Reduce group_by=[#0] aggregates=[count(*)] // { types: "(integer?, bigint)" }
+                Get l0 // { types: "(integer?)" }
+    cte l0 =
+      Distinct group_by=[#0] // { types: "(integer?)" }
+        Project (#0) // { types: "(integer?)" }
+          Get materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF
 
@@ -481,44 +644,64 @@ Explained Query:
           Get l0 // { types: "(integer)" }
         ArrangeBy keys=[[#0]] // { types: "(integer, boolean?)" }
           Union // { types: "(integer, boolean?)" }
-            Get l4 // { types: "(integer, boolean?)" }
+            Get l5 // { types: "(integer, boolean?)" }
             Map (null) // { types: "(integer, boolean?)" }
               Union // { types: "(integer)" }
-                Negate // { types: "(integer)" }
-                  Project (#0) // { types: "(integer)" }
-                    Get l4 // { types: "(integer, boolean?)" }
                 Get l1 // { types: "(integer)" }
+                Negate // { types: "(integer)" }
+                  Distinct group_by=[#0] // { types: "(integer)" }
+                    Project (#0) // { types: "(integer)" }
+                      Get l5 // { types: "(integer, boolean?)" }
         ArrangeBy keys=[[#0]] // { types: "(integer, boolean?)" }
           Union // { types: "(integer, boolean?)" }
-            Get l6 // { types: "(integer, boolean?)" }
+            Get l8 // { types: "(integer, boolean?)" }
             Map (null) // { types: "(integer, boolean?)" }
               Union // { types: "(integer)" }
-                Negate // { types: "(integer)" }
-                  Project (#0) // { types: "(integer)" }
-                    Get l6 // { types: "(integer, boolean?)" }
                 Get l1 // { types: "(integer)" }
+                Negate // { types: "(integer)" }
+                  Distinct group_by=[#0] // { types: "(integer)" }
+                    Project (#0) // { types: "(integer)" }
+                      Get l8 // { types: "(integer, boolean?)" }
   With
-    cte l6 =
+    cte l8 =
       Union // { types: "(integer, boolean?)" }
-        Get l5 // { types: "(integer, boolean?)" }
+        Get l7 // { types: "(integer, boolean?)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer, boolean)" }
+          Project (#0) // { types: "(integer)" }
+            Filter (#1 > 1) // { types: "(integer, bigint)" }
+              Reduce group_by=[#0] aggregates=[count(*)] // { types: "(integer, bigint)" }
+                Project (#0) // { types: "(integer)" }
+                  Get l7 // { types: "(integer, boolean?)" }
+    cte l7 =
+      Union // { types: "(integer, boolean?)" }
+        Get l6 // { types: "(integer, boolean?)" }
         Map (true) // { types: "(integer, boolean)" }
           Union // { types: "(integer)" }
+            Get l1 // { types: "(integer)" }
             Negate // { types: "(integer)" }
               Project (#0) // { types: "(integer)" }
-                Get l5 // { types: "(integer, boolean?)" }
-            Get l1 // { types: "(integer)" }
-    cte l5 =
+                Get l6 // { types: "(integer, boolean?)" }
+    cte l6 =
       Reduce group_by=[#0] aggregates=[all((#1 = 1))] // { types: "(integer, boolean?)" }
         Get l2 // { types: "(integer, integer?)" }
+    cte l5 =
+      Union // { types: "(integer, boolean?)" }
+        Get l4 // { types: "(integer, boolean?)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer, boolean)" }
+          Project (#0) // { types: "(integer)" }
+            Filter (#1 > 1) // { types: "(integer, bigint)" }
+              Reduce group_by=[#0] aggregates=[count(*)] // { types: "(integer, bigint)" }
+                Project (#0) // { types: "(integer)" }
+                  Get l4 // { types: "(integer, boolean?)" }
     cte l4 =
       Union // { types: "(integer, boolean?)" }
         Get l3 // { types: "(integer, boolean?)" }
         Map (false) // { types: "(integer, boolean)" }
           Union // { types: "(integer)" }
+            Get l1 // { types: "(integer)" }
             Negate // { types: "(integer)" }
               Project (#0) // { types: "(integer)" }
                 Get l3 // { types: "(integer, boolean?)" }
-            Get l1 // { types: "(integer)" }
     cte l3 =
       Reduce group_by=[#0] aggregates=[any((#1 = 1))] // { types: "(integer, boolean?)" }
         Get l2 // { types: "(integer, integer?)" }
@@ -666,31 +849,41 @@ Explained Query:
                   Get l1 // { types: "(integer?, integer)" }
             Map (false) // { types: "(integer?, integer, boolean)" }
               Union // { types: "(integer?, integer)" }
+                Get l1 // { types: "(integer?, integer)" }
                 Map (1) // { types: "(integer?, integer)" }
                   Negate // { types: "(integer?)" }
                     Project (#0) // { types: "(integer?)" }
                       Filter (#1 = 1) // { types: "(integer?, integer)" }
                         Get l1 // { types: "(integer?, integer)" }
-                Get l1 // { types: "(integer?, integer)" }
         ArrangeBy keys=[[#0]] // { types: "(integer?, boolean?)" }
           Union // { types: "(integer?, boolean?)" }
-            Get l4 // { types: "(integer?, boolean?)" }
+            Get l5 // { types: "(integer?, boolean?)" }
             Map (null) // { types: "(integer?, boolean?)" }
               Union // { types: "(integer?)" }
-                Negate // { types: "(integer?)" }
-                  Project (#0) // { types: "(integer?)" }
-                    Get l4 // { types: "(integer?, boolean?)" }
                 Get l2 // { types: "(integer?)" }
+                Negate // { types: "(integer?)" }
+                  Distinct group_by=[#0] // { types: "(integer?)" }
+                    Project (#0) // { types: "(integer?)" }
+                      Get l5 // { types: "(integer?, boolean?)" }
   With
+    cte l5 =
+      Union // { types: "(integer?, boolean?)" }
+        Get l4 // { types: "(integer?, boolean?)" }
+        Map (error("more than one record produced in subquery")) // { types: "(integer?, boolean)" }
+          Project (#0) // { types: "(integer?)" }
+            Filter (#1 > 1) // { types: "(integer?, bigint)" }
+              Reduce group_by=[#0] aggregates=[count(*)] // { types: "(integer?, bigint)" }
+                Project (#0) // { types: "(integer?)" }
+                  Get l4 // { types: "(integer?, boolean?)" }
     cte l4 =
       Union // { types: "(integer?, boolean?)" }
         Get l3 // { types: "(integer?, boolean?)" }
         Map (false) // { types: "(integer?, boolean)" }
           Union // { types: "(integer?)" }
+            Get l2 // { types: "(integer?)" }
             Negate // { types: "(integer?)" }
               Project (#0) // { types: "(integer?)" }
                 Get l3 // { types: "(integer?, boolean?)" }
-            Get l2 // { types: "(integer?)" }
     cte l3 =
       Reduce group_by=[#0] aggregates=[any((#0 = #1))] // { types: "(integer?, boolean?)" }
         CrossJoin type=differential // { types: "(integer?, integer)" }
@@ -775,12 +968,12 @@ Explained Query:
           Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer)" }
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Union // { types: "(integer?, integer)" }
+                Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                  Get materialize.public.int_table // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
                   Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
                     Project (#0, #1) // { types: "(integer?, integer)" }
                       Get l0 // { types: "(integer?, integer, integer)" }
-                Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
-                  Get materialize.public.int_table // { types: "(integer?, integer)" }
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Get materialize.public.int_table // { types: "(integer?, integer)" }
   With
@@ -807,22 +1000,22 @@ Explained Query:
           Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer)" }
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Union // { types: "(integer?, integer)" }
+                Get l2 // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
                   Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
                     Project (#0, #1) // { types: "(integer?, integer)" }
                       Get l1 // { types: "(integer?, integer, integer?, integer)" }
-                Get l2 // { types: "(integer?, integer)" }
             Get l3 // { types: "(integer?, integer)" }
       Project (#4, #1) // { types: "(integer?, integer)" }
         Map (null) // { types: "(integer?, integer, integer?, integer, integer?)" }
           Join on=(#0 = #2 AND #1 = #3) type=differential // { types: "(integer?, integer, integer?, integer)" }
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Union // { types: "(integer?, integer)" }
+                Get l2 // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
                   Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
                     Project (#2, #3) // { types: "(integer?, integer)" }
                       Get l1 // { types: "(integer?, integer, integer?, integer)" }
-                Get l2 // { types: "(integer?, integer)" }
             Get l3 // { types: "(integer?, integer)" }
   With
     cte l3 =
@@ -866,9 +1059,9 @@ EXPLAIN WITH(types, no_fast_path) SELECT col_not_null FROM int_table UNION ALL S
 ----
 Explained Query:
   Union // { types: "(integer?)" }
-    Project (#1) // { types: "(integer)" }
-      Get materialize.public.int_table // { types: "(integer?, integer)" }
     Project (#0) // { types: "(integer?)" }
+      Get materialize.public.int_table // { types: "(integer?, integer)" }
+    Project (#1) // { types: "(integer)" }
       Get materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -68,14 +68,14 @@ foo_raw left join bar on foo_raw.a = bar.a;
 Explained Query:
   Return
     Union
+      Project (#0..=#2, #0, #3)
+        Get l0
       Map (null, null)
         Union
+          Get materialize.public.foo_raw
           Negate
             Project (#0..=#2)
               Get l0
-          Get materialize.public.foo_raw
-      Project (#0..=#2, #0, #3)
-        Get l0
   With
     cte l0 =
       Project (#0..=#2, #4)
@@ -105,6 +105,7 @@ Explained Query:
       Project (#3, #4, #0..=#2)
         Map (null, null)
           Union
+            Get materialize.public.foo_raw
             Negate
               Project (#0..=#2)
                 Join on=(#0 = #3) type=differential
@@ -112,7 +113,6 @@ Explained Query:
                   ArrangeBy keys=[[#0]]
                     Project (#0)
                       Get l1
-            Get materialize.public.foo_raw
       Project (#0, #1, #0, #3, #4)
         Join on=(#0 = #2) type=differential
           ArrangeBy keys=[[#0]]
@@ -143,14 +143,14 @@ foo left join bar on foo.a = bar.a
 Explained Query:
   Return
     Union
+      Project (#0..=#7, #6, #8)
+        Get l4
       Map (null, null)
         Union
+          Get l3
           Negate
             Project (#0..=#7)
               Get l4
-          Get l3
-      Project (#0..=#7, #6, #8)
-        Get l4
   With
     cte l4 =
       Project (#0..=#7, #9)
@@ -162,14 +162,14 @@ Explained Query:
             Get materialize.public.quux
     cte l3 =
       Union
+        Project (#0..=#4, #1, #5, #6)
+          Get l2
         Map (null, null, null)
           Union
+            Get l1
             Negate
               Project (#0..=#4)
                 Get l2
-            Get l1
-        Project (#0..=#4, #1, #5, #6)
-          Get l2
     cte l2 =
       Project (#0..=#4, #6, #7)
         Join on=(#1 = #5) type=differential
@@ -179,14 +179,14 @@ Explained Query:
             Get materialize.public.baz
     cte l1 =
       Union
+        Project (#0..=#2, #0, #3)
+          Get l0
         Map (null, null)
           Union
+            Get materialize.public.foo
             Negate
               Project (#0..=#2)
                 Get l0
-            Get materialize.public.foo
-        Project (#0..=#2, #0, #3)
-          Get l0
     cte l0 =
       Project (#0..=#2, #4)
         Join on=(#0 = #3) type=differential
@@ -226,14 +226,14 @@ Explained Query:
       Reduce aggregates=[count(*)]
         Project ()
           Union
+            Get l0
             Map (null)
               Union
+                Project ()
+                  Get materialize.public.foo
                 Negate
                   Project ()
                     Get l0
-                Project ()
-                  Get materialize.public.foo
-            Get l0
     cte l0 =
       Project (#2)
         Join on=(#0 = #1) type=differential
@@ -260,14 +260,14 @@ where foo.a = 7;
 Explained Query:
   Return
     Union
+      Project (#0..=#5, #4, #6)
+        Get l3
       Map (null, null)
         Union
+          Get l2
           Negate
             Project (#0..=#5)
               Get l3
-          Get l2
-      Project (#0..=#5, #4, #6)
-        Get l3
   With
     cte l3 =
       Project (#0..=#5, #7)
@@ -279,14 +279,14 @@ Explained Query:
             Get materialize.public.quux
     cte l2 =
       Union
+        Project (#0..=#2, #1, #3, #4)
+          Get l1
         Map (null, null, null)
           Union
+            Get l0
             Negate
               Project (#0..=#2)
                 Get l1
-            Get l0
-        Project (#0..=#2, #1, #3, #4)
-          Get l1
     cte l1 =
       Project (#0..=#2, #4, #5)
         Join on=(#1 = #3) type=differential

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -580,6 +580,7 @@ SELECT f1 FROM t1 WHERE f1 = 1
 Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
+      Get l1 // { arity: 1 }
       CrossJoin type=differential // { arity: 1 }
         implementation
           %1[×] » %0:t1[×]A
@@ -597,7 +598,6 @@ Explained Query:
                       Get l2 // { arity: 1 }
                 Constant // { arity: 0 }
                   - ()
-      Get l1 // { arity: 1 }
   With
     cte l2 =
       Union // { arity: 1 }
@@ -663,14 +663,15 @@ SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)
 Explained Query:
   Return // { arity: 3 }
     Union // { arity: 3 }
-      Get l2 // { arity: 3 }
+      Get l1 // { arity: 3 }
       Get l1 // { arity: 3 }
       Get l2 // { arity: 3 }
-      Get l1 // { arity: 3 }
+      Get l2 // { arity: 3 }
   With
     cte l2 =
       Map (null) // { arity: 3 }
         Union // { arity: 2 }
+          Get materialize.public.t1 // { arity: 2 }
           Negate // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Join on=(#0 = #2) type=differential // { arity: 3 }
@@ -681,7 +682,6 @@ Explained Query:
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l1 // { arity: 3 }
-          Get materialize.public.t1 // { arity: 2 }
     cte l1 =
       Project (#0, #1, #3) // { arity: 3 }
         Filter (#0) IS NOT NULL // { arity: 4 }
@@ -979,8 +979,8 @@ Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
-      Get l1 // { arity: 1 }
       Get l0 // { arity: 1 }
+      Get l1 // { arity: 1 }
       Get l1 // { arity: 1 }
   With
     cte l1 =
@@ -1370,6 +1370,7 @@ Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l1 // { arity: 1 }
+      Get l2 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
@@ -1377,7 +1378,6 @@ Explained Query:
               Get l1 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-      Get l2 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
@@ -1411,6 +1411,7 @@ Explained Query:
   Return // { arity: 1 }
     Union // { arity: 1 }
       Get l0 // { arity: 1 }
+      Get l1 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }
@@ -1418,7 +1419,6 @@ Explained Query:
               Get l0 // { arity: 1 }
           Constant // { arity: 0 }
             - ()
-      Get l1 // { arity: 1 }
       Map (null) // { arity: 1 }
         Union // { arity: 0 }
           Negate // { arity: 0 }

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -101,11 +101,11 @@ Explained Query:
             Get l2 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l2 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
     cte l2 =
       Union // { arity: 2 }
@@ -163,11 +163,11 @@ Explained Query:
             Get l4 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
     cte l4 =
       Union // { arity: 2 }
@@ -230,21 +230,21 @@ Explained Query:
             Get l4 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
-                Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Union // { arity: 2 }
             Get l6 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l6 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
     cte l6 =
       Union // { arity: 2 }
@@ -323,32 +323,32 @@ Explained Query:
             Get l3 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l3 // { arity: 2 }
-                Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Union // { arity: 2 }
             Get l4 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
     cte l4 =
       Union // { arity: 2 }
+        Get l2 // { arity: 2 }
         Map ((#0 + 2)) // { arity: 2 }
           Get l1 // { arity: 1 }
-        Get l2 // { arity: 2 }
     cte l3 =
       Union // { arity: 2 }
+        Get l2 // { arity: 2 }
         Map ((#0 + 1)) // { arity: 2 }
           Get l1 // { arity: 1 }
-        Get l2 // { arity: 2 }
     cte l2 =
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
@@ -389,51 +389,71 @@ Explained Query:
     Project (#2, #4) // { arity: 2 }
       Join on=(eq(#0, #1, #3)) type=delta // { arity: 5 }
         implementation
-          %0:t2 » %1[#0]UKA » %2[#0]UKA
-          %1 » %2[#0]UKA » %0:t2[#0]KA
-          %2 » %1[#0]UKA » %0:t2[#0]KA
+          %0:t2 » %1[#0]KA » %2[#0]KA
+          %1 » %0:t2[#0]KA » %2[#0]KA
+          %2 » %0:t2[#0]KA » %1[#0]KA
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get materialize.public.t2 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Union // { arity: 2 }
-            Get l3 // { arity: 2 }
+            Get l4 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Get l3 // { arity: 2 }
                 Get l0 // { arity: 1 }
+                Negate // { arity: 1 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l4 // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 2 }
           Union // { arity: 2 }
-            Get l5 // { arity: 2 }
+            Get l7 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Get l5 // { arity: 2 }
                 Get l0 // { arity: 1 }
+                Negate // { arity: 1 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l7 // { arity: 2 }
   With
-    cte l5 =
+    cte l7 =
       Union // { arity: 2 }
-        Get l4 // { arity: 2 }
+        Get l6 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l6 // { arity: 2 }
+    cte l6 =
+      Union // { arity: 2 }
+        Get l5 // { arity: 2 }
         Map (null) // { arity: 2 }
           Union // { arity: 1 }
+            Get l0 // { arity: 1 }
             Negate // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Get l4 // { arity: 2 }
-            Get l0 // { arity: 1 }
-    cte l4 =
+                Get l5 // { arity: 2 }
+    cte l5 =
       Reduce group_by=[#0] aggregates=[max(#0)] // { arity: 2 }
         Get l1 // { arity: 1 }
+    cte l4 =
+      Union // { arity: 2 }
+        Get l3 // { arity: 2 }
+        Map (error("more than one record produced in subquery")) // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l3 // { arity: 2 }
     cte l3 =
       Union // { arity: 2 }
         Get l2 // { arity: 2 }
         Map (null) // { arity: 2 }
           Union // { arity: 1 }
+            Get l0 // { arity: 1 }
             Negate // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Get l2 // { arity: 2 }
-            Get l0 // { arity: 1 }
     cte l2 =
       Reduce group_by=[#0] aggregates=[min(#0)] // { arity: 2 }
         Get l1 // { arity: 1 }
@@ -483,11 +503,11 @@ Explained Query:
             Get l6 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l6 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
     cte l6 =
       Union // { arity: 2 }
@@ -510,11 +530,11 @@ Explained Query:
               Get l4 // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
+                  Get l2 // { arity: 1 }
                   Negate // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 2 }
-                  Get l2 // { arity: 1 }
     cte l4 =
       Union // { arity: 2 }
         Project (#0, #0) // { arity: 2 }
@@ -597,11 +617,11 @@ Explained Query:
                 Get l7 // { arity: 2 }
                 Map (null) // { arity: 2 }
                   Union // { arity: 1 }
+                    Get l5 // { arity: 1 }
                     Negate // { arity: 1 }
                       Distinct group_by=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l7 // { arity: 2 }
-                    Get l5 // { arity: 1 }
     cte l7 =
       Union // { arity: 2 }
         Project (#0, #0) // { arity: 2 }
@@ -635,11 +655,11 @@ Explained Query:
               Get l3 // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
+                  Get l0 // { arity: 1 }
                   Negate // { arity: 1 }
                     Distinct group_by=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l3 // { arity: 2 }
-                  Get l0 // { arity: 1 }
     cte l3 =
       Union // { arity: 2 }
         Project (#0, #0) // { arity: 2 }
@@ -699,11 +719,11 @@ Explained Query:
             Get l2 // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l2 // { arity: 2 }
-                Get l0 // { arity: 1 }
   With
     cte l2 =
       Union // { arity: 2 }
@@ -774,11 +794,11 @@ Explained Query:
             Get l3 // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
+                Get l1 // { arity: 2 }
                 Negate // { arity: 2 }
                   Distinct group_by=[#0, #1] // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
                       Get l3 // { arity: 3 }
-                Get l1 // { arity: 2 }
   With
     cte l3 =
       Union // { arity: 3 }

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -449,9 +449,9 @@ Explained Query:
               Get l1 // { arity: 1 }
             Map (false) // { arity: 2 }
               Union // { arity: 1 }
+                Get l0 // { arity: 1 }
                 Negate // { arity: 1 }
                   Get l1 // { arity: 1 }
-                Get l0 // { arity: 1 }
   With
     cte l1 =
       Project (#0) // { arity: 1 }
@@ -487,9 +487,9 @@ Explained Query:
                 Get l1 // { arity: 1 }
               Map (false) // { arity: 2 }
                 Union // { arity: 1 }
+                  Get l0 // { arity: 1 }
                   Negate // { arity: 1 }
                     Get l1 // { arity: 1 }
-                  Get l0 // { arity: 1 }
   With
     cte l1 =
       Project (#0) // { arity: 1 }
@@ -526,9 +526,9 @@ Explained Query:
                 Get l1 // { arity: 1 }
               Map (false) // { arity: 2 }
                 Union // { arity: 1 }
+                  Get l0 // { arity: 1 }
                   Negate // { arity: 1 }
                     Get l1 // { arity: 1 }
-                  Get l0 // { arity: 1 }
   With
     cte l1 =
       Distinct group_by=[#0] // { arity: 1 }

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -86,13 +86,13 @@ Explained Query:
         Get l0 // { arity: 2 }
       Map (null) // { arity: 2 }
         Union // { arity: 1 }
+          Distinct group_by=[#0] // { arity: 1 }
+            Project (#1) // { arity: 1 }
+              Get materialize.public.cities // { arity: 3 }
           Negate // { arity: 1 }
             Distinct group_by=[#0] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Get l0 // { arity: 2 }
-          Distinct group_by=[#0] // { arity: 1 }
-            Project (#1) // { arity: 1 }
-              Get materialize.public.cities // { arity: 3 }
   With
     cte l0 =
       Project (#0, #1) // { arity: 2 }

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -243,29 +243,50 @@ Explained Query:
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
         Join on=(#0 = #9 AND #7 = #10) type=differential // { arity: 11 }
           implementation
-            %0:l4[#0, #7] » %1[#0, #1]UKKA
+            %1[#0, #1] » %0:l4[#0, #7]KKA
           ArrangeBy keys=[[#0, #7]] // { arity: 9 }
             Get l4 // { arity: 9 }
           ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-              Project (#0, #4) // { arity: 2 }
-                Filter (#18 = "EUROPE") // { arity: 20 }
-                  Join on=(#0 = #1 AND #2 = #6 AND #9 = #13 AND #15 = #17) type=delta // { arity: 20 }
-                    implementation
-                      %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                      %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
-                      %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
-                      %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                      %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
-                        Project (#0) // { arity: 1 }
-                          Get l4 // { arity: 9 }
-                    Get l1 // { arity: 5 }
-                    Get l0 // { arity: 7 }
-                    Get l2 // { arity: 4 }
-                    Get l3 // { arity: 3 }
+            Union // { arity: 2 }
+              Map (error("more than one record produced in subquery")) // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Filter error("more than one record produced in subquery") AND (#1 > 1) // { arity: 2 }
+                    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                      Project (#0) // { arity: 1 }
+                        Get l7 // { arity: 2 }
+              Filter (#1) IS NOT NULL // { arity: 2 }
+                Get l7 // { arity: 2 }
     With
+      cte l7 =
+        Union // { arity: 2 }
+          Get l6 // { arity: 2 }
+          Map (null) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l5 // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Get l6 // { arity: 2 }
+      cte l6 =
+        Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+          Project (#0, #4) // { arity: 2 }
+            Filter (#18 = "EUROPE") // { arity: 20 }
+              Join on=(#0 = #1 AND #2 = #6 AND #9 = #13 AND #15 = #17) type=delta // { arity: 20 }
+                implementation
+                  %0:l5 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                  %1:l1 » %0:l5[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                  %2:l0 » %1:l1[#1]KA » %0:l5[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
+                  %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0:l5[#0]UKA
+                  %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0:l5[#0]UKA
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Get l5 // { arity: 1 }
+                Get l1 // { arity: 5 }
+                Get l0 // { arity: 7 }
+                Get l2 // { arity: 4 }
+                Get l3 // { arity: 3 }
+      cte l5 =
+        Distinct group_by=[#0] // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Get l4 // { arity: 9 }
       cte l4 =
         Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
           Filter (#5 = 15) AND (#26 = "EUROPE") AND "%BRASS" ~~(varchar_to_text(#4)) // { arity: 28 }
@@ -866,18 +887,39 @@ Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
       Project (#0, #1) // { arity: 2 }
-        Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
+        Filter (#1 > #2) // { arity: 3 }
           CrossJoin type=differential // { arity: 3 }
             implementation
-              %0[×] » %1[×]UA
+              %1[×] » %0[×]A
             ArrangeBy keys=[[]] // { arity: 2 }
               Reduce group_by=[#0] aggregates=[sum((#2 * integer_to_numeric(#1)))] // { arity: 2 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum((#1 * integer_to_numeric(#0)))] // { arity: 1 }
-                Project (#1, #2) // { arity: 2 }
-                  Get l0 // { arity: 3 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Map (error("more than one record produced in subquery")) // { arity: 1 }
+                  Project () // { arity: 0 }
+                    Filter (#0 > 1) // { arity: 1 }
+                      Reduce aggregates=[count(*)] // { arity: 1 }
+                        Project () // { arity: 0 }
+                          Get l2 // { arity: 1 }
     With
+      cte l2 =
+        Project (#1) // { arity: 1 }
+          Map ((#0 * 0.0001)) // { arity: 2 }
+            Union // { arity: 1 }
+              Get l1 // { arity: 1 }
+              Map (null) // { arity: 1 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l1 // { arity: 1 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l1 =
+        Reduce aggregates=[sum((#1 * integer_to_numeric(#0)))] // { arity: 1 }
+          Project (#1, #2) // { arity: 2 }
+            Get l0 // { arity: 3 }
       cte l0 =
         Project (#0, #2, #3) // { arity: 3 }
           Filter (#13 = "GERMANY") // { arity: 16 }
@@ -992,12 +1034,12 @@ Explained Query:
                       %1:customer[#0, #1, #2, #3, #4, #5, #6, #7] » %0[#0, #1, #2, #3, #4, #5, #6, #7]KKKKKKKKA
                     ArrangeBy keys=[[#0, #1, #2, #3, #4, #5, #6, #7]] // { arity: 8 }
                       Union // { arity: 8 }
+                        Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7] // { arity: 8 }
+                          Get materialize.public.customer // { arity: 8 }
                         Negate // { arity: 8 }
                           Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7] // { arity: 8 }
                             Project (#0..=#7) // { arity: 8 }
                               Get l0 // { arity: 9 }
-                        Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7] // { arity: 8 }
-                          Get materialize.public.customer // { arity: 8 }
                     ArrangeBy keys=[[#0, #1, #2, #3, #4, #5, #6, #7]] // { arity: 8 }
                       Get materialize.public.customer // { arity: 8 }
     With
@@ -1107,18 +1149,40 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#4]
     Return // { arity: 5 }
       Project (#0..=#2, #4, #8) // { arity: 5 }
-        Join on=(#0 = #7 AND #8 = #9) type=differential // { arity: 10 }
+        Join on=(#0 = #7 AND #8 = #9) type=delta // { arity: 10 }
           implementation
-            %0:supplier[#0] » %1:l0[#0]UKA » %2[#0]UKA
+            %0:supplier » %1:l0[#0]UKA » %2[#0]KA
+            %1:l0 » %0:supplier[#0]KA » %2[#0]KA
+            %2 » %1:l0[#1]KA » %0:supplier[#0]KA
           ArrangeBy keys=[[#0]] // { arity: 7 }
             Get materialize.public.supplier // { arity: 7 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
+          ArrangeBy keys=[[#0], [#1]] // { arity: 2 }
             Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Reduce aggregates=[max(#0)] // { arity: 1 }
-              Project (#1) // { arity: 1 }
-                Get l0 // { arity: 2 }
+            Union // { arity: 1 }
+              Map (error("more than one record produced in subquery")) // { arity: 1 }
+                Project () // { arity: 0 }
+                  Filter error("more than one record produced in subquery") AND (#0 > 1) // { arity: 1 }
+                    Reduce aggregates=[count(*)] // { arity: 1 }
+                      Project () // { arity: 0 }
+                        Get l2 // { arity: 1 }
+              Filter (#0) IS NOT NULL // { arity: 1 }
+                Get l2 // { arity: 1 }
     With
+      cte l2 =
+        Union // { arity: 1 }
+          Get l1 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l1 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+      cte l1 =
+        Reduce aggregates=[max(#0)] // { arity: 1 }
+          Project (#1) // { arity: 1 }
+            Get l0 // { arity: 2 }
       cte l0 =
         Reduce group_by=[#0] aggregates=[sum((#1 * (1 - #2)))] // { arity: 2 }
           Project (#2, #5, #6) // { arity: 3 }
@@ -1180,6 +1244,7 @@ Explained Query:
               Get l0 // { arity: 4 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Union // { arity: 1 }
+                Get l1 // { arity: 1 }
                 Negate // { arity: 1 }
                   Distinct group_by=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
@@ -1193,7 +1258,6 @@ Explained Query:
                             Project (#0) // { arity: 1 }
                               Filter "%Customer%Complaints%" ~~(varchar_to_text(#6)) // { arity: 7 }
                                 Get materialize.public.supplier // { arity: 7 }
-                Get l1 // { arity: 1 }
     With
       cte l1 =
         Distinct group_by=[#0] // { arity: 1 }
@@ -1243,35 +1307,57 @@ Explained Query:
     Project (#1) // { arity: 1 }
       Map ((#0 / 7)) // { arity: 2 }
         Union // { arity: 1 }
-          Get l2 // { arity: 1 }
+          Get l5 // { arity: 1 }
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
                 Project () // { arity: 0 }
-                  Get l2 // { arity: 1 }
+                  Get l5 // { arity: 1 }
               Constant // { arity: 0 }
                 - ()
   With
-    cte l2 =
+    cte l5 =
       Reduce aggregates=[sum(#0)] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (numeric_to_double(#1) < (0.2 * (numeric_to_double(#4) / bigint_to_double(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(#0 = #3) type=differential // { arity: 6 }
+          Filter (numeric_to_double(#1) < #4) // { arity: 5 }
+            Join on=(#0 = #3) type=differential // { arity: 5 }
               implementation
-                %0:l1[#0] » %1[#0]UKA
+                %1[#0] » %0:l1[#0]KA
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[sum(#1), count(*)] // { arity: 3 }
-                  Project (#0, #5) // { arity: 2 }
-                    Join on=(#0 = #2) type=differential // { arity: 17 }
-                      implementation
-                        %1:l0[#1] » %0[#0]UKA
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Get l4 // { arity: 2 }
+                  Map (error("more than one record produced in subquery")) // { arity: 2 }
+                    Project (#0) // { arity: 1 }
+                      Filter (#1 > 1) // { arity: 2 }
+                        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
                           Project (#0) // { arity: 1 }
-                            Get l1 // { arity: 3 }
-                      Get l0 // { arity: 16 }
+                            Get l4 // { arity: 2 }
+    cte l4 =
+      Project (#0, #3) // { arity: 2 }
+        Map ((0.2 * (numeric_to_double(#1) / bigint_to_double(case when (#2 = 0) then null else #2 end)))) // { arity: 4 }
+          Union // { arity: 3 }
+            Get l3 // { arity: 3 }
+            Map (null, 0) // { arity: 3 }
+              Union // { arity: 1 }
+                Get l2 // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Get l3 // { arity: 3 }
+    cte l3 =
+      Reduce group_by=[#0] aggregates=[sum(#1), count(*)] // { arity: 3 }
+        Project (#0, #5) // { arity: 2 }
+          Join on=(#0 = #2) type=differential // { arity: 17 }
+            implementation
+              %1:l0[#1] » %0:l2[#0]UKA
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Get l2 // { arity: 1 }
+            Get l0 // { arity: 16 }
+    cte l2 =
+      Distinct group_by=[#0] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l1 // { arity: 3 }
     cte l1 =
       Project (#1, #4, #5) // { arity: 3 }
         Filter (#19 = "Brand#23") AND (#22 = "MED BOX") // { arity: 25 }
@@ -1497,28 +1583,50 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Distinct group_by=[#0] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (integer_to_numeric(#2) > (0.5 * #5)) // { arity: 6 }
+                Filter (integer_to_numeric(#2) > #5) // { arity: 6 }
                   Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
                     implementation
-                      %0:l1[#1, #0] » %1[#0, #1]UKKAf
-                    ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                      %1[#1, #0] » %0:l1[#0, #1]KKAf
+                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
                         Filter (#0 = #2) // { arity: 4 }
                           Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
-                      Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
-                        Project (#0, #1, #6) // { arity: 3 }
-                          Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
-                            Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 18 }
-                              implementation
-                                %1:lineitem[#1, #2] » %0[#0, #1]UKKAiif
-                              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                                Distinct group_by=[#0, #1] // { arity: 2 }
-                                  Project (#1, #2) // { arity: 2 }
-                                    Get l1 // { arity: 4 }
-                              ArrangeBy keys=[[#1, #2]] // { arity: 16 }
-                                Get materialize.public.lineitem // { arity: 16 }
+                    ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l4 // { arity: 3 }
+                        Map (error("more than one record produced in subquery")) // { arity: 3 }
+                          Project (#0, #1) // { arity: 2 }
+                            Filter (#2 > 1) // { arity: 3 }
+                              Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+                                Project (#0, #1) // { arity: 2 }
+                                  Get l4 // { arity: 3 }
     With
+      cte l4 =
+        Project (#0, #1, #3) // { arity: 3 }
+          Map ((0.5 * #2)) // { arity: 4 }
+            Union // { arity: 3 }
+              Get l3 // { arity: 3 }
+              Map (null) // { arity: 3 }
+                Union // { arity: 2 }
+                  Get l2 // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Get l3 // { arity: 3 }
+      cte l3 =
+        Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+          Project (#0, #1, #6) // { arity: 3 }
+            Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
+              Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 18 }
+                implementation
+                  %1:lineitem[#1, #2] » %0:l2[#0, #1]UKKAiif
+                ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                  Get l2 // { arity: 2 }
+                ArrangeBy keys=[[#1, #2]] // { arity: 16 }
+                  Get materialize.public.lineitem // { arity: 16 }
+      cte l2 =
+        Distinct group_by=[#0, #1] // { arity: 2 }
+          Project (#1, #2) // { arity: 2 }
+            Get l1 // { arity: 4 }
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
           Join on=(#1 = #6) type=differential // { arity: 7 }
@@ -1610,6 +1718,7 @@ Explained Query:
               Get l2 // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 2 }
               Union // { arity: 2 }
+                Get l3 // { arity: 2 }
                 Negate // { arity: 2 }
                   Distinct group_by=[#0, #1] // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
@@ -1620,7 +1729,6 @@ Explained Query:
                           ArrangeBy keys=[[#0]] // { arity: 2 }
                             Get l3 // { arity: 2 }
                           Get l1 // { arity: 16 }
-                Get l3 // { arity: 2 }
     With
       cte l3 =
         Distinct group_by=[#1, #0] // { arity: 2 }
@@ -1734,43 +1842,64 @@ Explained Query:
         Project (#1, #2) // { arity: 2 }
           Join on=(#0 = #3) type=differential // { arity: 4 }
             implementation
-              %1[#0] » %0:l1[#0]KA
+              %1[#0] » %0:l3[#0]KA
             ArrangeBy keys=[[#0]] // { arity: 3 }
-              Get l1 // { arity: 3 }
+              Get l3 // { arity: 3 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Union // { arity: 1 }
+                Get l4 // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
                     Join on=(#0 = #1) type=differential // { arity: 2 }
                       implementation
-                        %1[#0] » %0:l2[#0]UKA
+                        %1[#0] » %0:l4[#0]UKA
                       ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Get l2 // { arity: 1 }
+                        Get l4 // { arity: 1 }
                       ArrangeBy keys=[[#0]] // { arity: 1 }
                         Distinct group_by=[#0] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             Get materialize.public.orders // { arity: 9 }
-                Get l2 // { arity: 1 }
     With
-      cte l2 =
+      cte l4 =
         Distinct group_by=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
-            Get l1 // { arity: 3 }
-      cte l1 =
+            Get l3 // { arity: 3 }
+      cte l3 =
         Project (#0..=#2) // { arity: 3 }
-          Filter (numeric_to_double(#2) > (numeric_to_double(#3) / bigint_to_double(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
-            CrossJoin type=differential // { arity: 5 }
+          Filter (numeric_to_double(#2) > #3) // { arity: 4 }
+            CrossJoin type=differential // { arity: 4 }
               implementation
-                %0:l0[×] » %1[×]UAef
+                %1[×] » %0:l0[×]Aef
               ArrangeBy keys=[[]] // { arity: 3 }
                 Project (#0, #4, #5) // { arity: 3 }
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
-              ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
-                  Project (#5) // { arity: 1 }
-                    Filter (#5 > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
-                      Get l0 // { arity: 9 }
+              ArrangeBy keys=[[]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Get l2 // { arity: 1 }
+                  Map (error("more than one record produced in subquery")) // { arity: 1 }
+                    Project () // { arity: 0 }
+                      Filter (#0 > 1) // { arity: 1 }
+                        Reduce aggregates=[count(*)] // { arity: 1 }
+                          Project () // { arity: 0 }
+                            Get l2 // { arity: 1 }
+      cte l2 =
+        Project (#2) // { arity: 1 }
+          Map ((numeric_to_double(#0) / bigint_to_double(case when (#1 = 0) then null else #1 end))) // { arity: 3 }
+            Union // { arity: 2 }
+              Get l1 // { arity: 2 }
+              Map (null, 0) // { arity: 2 }
+                Union // { arity: 0 }
+                  Negate // { arity: 0 }
+                    Project () // { arity: 0 }
+                      Get l1 // { arity: 2 }
+                  Constant // { arity: 0 }
+                    - ()
+      cte l1 =
+        Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
+          Project (#5) // { arity: 1 }
+            Filter (#5 > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+              Get l0 // { arity: 9 }
       cte l0 =
         Map (substr(char_to_text(#4), 1, 2)) // { arity: 9 }
           Get materialize.public.customer // { arity: 8 }


### PR DESCRIPTION
WIP PR intending to see the fallout of sorting the inputs to `MirRelationExpr::Union`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
