### PR TITLE
adapter: expose postgres source replication slots

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1290,6 +1290,14 @@ pub static MZ_KAFKA_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable 
         .with_column("sink_progress_topic", ScalarType::String.nullable(false)),
     is_retained_metrics_relation: false,
 });
+pub static MZ_POSTGRES_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_postgres_sources",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("replication_slot", ScalarType::String.nullable(false)),
+    is_retained_metrics_relation: false,
+});
 pub static MZ_OBJECT_DEPENDENCIES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_object_dependencies",
     schema: MZ_INTERNAL_SCHEMA,
@@ -3025,6 +3033,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_INDEX_COLUMNS),
         Builtin::Table(&MZ_TABLES),
         Builtin::Table(&MZ_SOURCES),
+        Builtin::Table(&MZ_POSTGRES_SOURCES),
         Builtin::Table(&MZ_SINKS),
         Builtin::Table(&MZ_VIEWS),
         Builtin::Table(&MZ_MATERIALIZED_VIEWS),

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -253,6 +253,13 @@ types_table           subsource <null>
 utf<NUMBER>_table     subsource <null>
 таблица               subsource <null>
 
+$ set-regex match=[0-9]+|_[a-f0-9]+ replacement=<SUPPRESSED>
+
+> SELECT * FROM mz_internal.mz_postgres_sources
+id             replication_slot
+---------------------------------------
+u<SUPPRESSED>  materialize<SUPPRESSED>
+
 $ unset-regex
 
 # Cannot drop subsources independent of primary source

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -288,6 +288,10 @@ mz_peek_durations
 VIEW
 materialize
 mz_internal
+mz_postgres_sources
+BASE TABLE
+materialize
+mz_internal
 mz_raw_compute_operator_durations
 VIEW
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -535,6 +535,7 @@ mz_cluster_replica_heartbeats
 mz_cluster_replica_metrics
 mz_cluster_replica_sizes
 mz_cluster_replica_statuses
+mz_postgres_sources
 mz_storage_host_sizes
 mz_storage_usage_by_shard
 mz_view_foreign_keys
@@ -583,7 +584,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-39
+40
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
Add a new `mz_internal` table named `mz_postgres_sources` that exposes the randomly-generated replication slot associated with each PostgreSQL source.

Useful for correlating replication statistics in PostgreSQL with a particular Materialize environment.

Touches MaterializeInc/cloud#5154.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Useful for a forthcoming cloud e2e test. See: MaterializeInc/cloud#5154.

Needs a test before it's mergeable. Probably won't have time myself.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add the `mz_internal.mz_postgres_sources` system catalog table, which exposes the randomly-generated replication slot associated with each PostgreSQL source.
