### PR TITLE
doc/user: add documentation for mz_internal.mz_postgres_sources

### DIFF
--- a/doc/user/content/integrations/cdc-postgres.md
+++ b/doc/user/content/integrations/cdc-postgres.md
@@ -161,7 +161,7 @@ Once logical replication is enabled:
 
 ### Create a source
 
-Postgres sources ingest the raw replication stream data for all tables included in a publication to avoid creating multiple replication slots and minimize the required bandwidth.
+Postgres sources ingest the raw replication stream data for all tables included in a publication to avoid creating multiple [replication slots](/sql/create-source/postgres/#postgresql-replication-slots) and minimize the required bandwidth.
 
 When you define a Postgres source, Materialize will automatically create a **subsource** for each original table in the publication (so you don't have to!):
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -291,6 +291,16 @@ Field         | Type          | Meaning
 `duration`    | [`interval`]  | The upper bound of the bucket as an interval.
 `count`       | [`bigint`]    | The (noncumulative) count of peeks in this bucket.
 
+### `mz_postgres_sources`
+
+The `mz_postgres_sources` table contains a row for each PostgreSQL source in the
+system.
+
+Field              | Type           | Meaning
+-------------------|----------------|--------
+`id`               | [`text`]       | The ID of the source.
+`replication_slot` | [`text`]       | The name of the replication slot in the PostgreSQL database that Materialize will create and stream data from.
+
 ### `mz_records_per_dataflow`
 
 The `mz_records_per_dataflow` view describes the number of records in each

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -298,7 +298,7 @@ system.
 
 Field              | Type           | Meaning
 -------------------|----------------|--------
-`id`               | [`text`]       | The ID of the source.
+`id`               | [`text`]       | The ID of the source. Corresponds to [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources).
 `replication_slot` | [`text`]       | The name of the replication slot in the PostgreSQL database that Materialize will create and stream data from.
 
 ### `mz_records_per_dataflow`


### PR DESCRIPTION
mz_internal.mz_postgres_sources is a new table that exposes replication slot information for PostgreSQL sources.

For v0.41.0.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Documents #17234.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
