### PR TITLE
adapter: factor out replica creation method

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -74,6 +74,8 @@ mod persist_handles;
 mod rehydration;
 mod statistics;
 
+pub use crate::controller::clusters::StorageClusterId;
+
 include!(concat!(env!("OUT_DIR"), "/mz_storage_client.controller.rs"));
 
 pub static METADATA_COLLECTION: TypedCollection<GlobalId, DurableCollectionMetadata> =


### PR DESCRIPTION
Part of the cluster unification epic (MaterializeInc/cloud#4929).

This commit factors out a replica creation method, so that it's not duplicated for both `CREATE CLUSTER` and `CREATE CLUSTER REPLICA`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR works towards a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
