### PR TITLE
persist: reduce S3 read timeout

### DIFF
--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -100,9 +100,9 @@ impl S3BlobConfig {
                 // maximum time allowed for a single network call
                 .operation_attempt_timeout(Duration::from_secs(90))
                 // maximum time until a connection succeeds
-                .connect_timeout(Duration::from_secs(30))
+                .connect_timeout(Duration::from_secs(2))
                 // maximum time to read the first byte of a response
-                .read_timeout(Duration::from_secs(60))
+                .read_timeout(Duration::from_secs(4))
                 .build(),
         );
 


### PR DESCRIPTION
It appears to be a common occurrence that reads from S3 time out the on the first try but immediately succeed on the second try. The previous S3 read timeout was 60 seconds, which lead to cases where reads from persist sometimes took a minute longer than usual, which in turn would become very noticable in one-off queries reading from a storage source.

This PR attempts to reduce the impact to query times by aggressively reducing the S3 read timeout. The new timeout is 4s, which would still introduce a noticable delay, especially to otherwise fast queries, but much less than the previous timeout.

4s seems like a safe timeout, since our persist clients are expected to be located physically close to the S3 endpoints. We might even be able to go lower than that after some testing.

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

Fixes #17227.

### Tips for reviewer

I understand that the persist teams plans a rethink of how our S3 timeouts work. This PR is not meant to be that. It is just a short-term fix for #17227.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
