### PR TITLE
doc/user: explain timestamp

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -246,7 +246,7 @@ Operator | Meaning | Example
 
 ### Timestamps
 
-`EXPLAIN TIMESTAMP` displays the timestamps used for a `SELECT` statement, view, or materialized view--a valuable statement to understand why a query is lagging.
+`EXPLAIN TIMESTAMP` displays the timestamps used for a `SELECT` statement, view, or materialized view -- valuable information to acknowledge query delays.
 
 The explanation divides in two parts:
 1. Determinations for a timestamp
@@ -254,13 +254,16 @@ The explanation divides in two parts:
 
 #### Determinations for a timestamp
 
-Queries in Materialize have a logical timestamp, known as a _query timestamp_. It helps to return a correct result at a particular time. Returning a correct result implies retrieving the right data, at an exact time, from each source present in the query. A source, in this case, will be objects providing data: materialized views, views, indexes, tables, and sources.
+Queries in Materialize have a logical timestamp, known as _query timestamp_. It plays a critical role to retun a correct result. Returning a correct result implies retrieving data with the same logical time from each source present in a query. In this case, sources are objects providing data: a materialized view, view, index, table, or source. Each source will have a pair of logical timestamps, denoted as _frontiers_.
 
 #### Sources frontiers
 
-Sources have two important timestamps, the read frontier (_since_) and the write frontier (_upper_). Both represent logical timestamps limits. The read frontier indicates the minimum logical timestamp to read correct data (known as _compaction_). The write frontier represents the maximum timestamp to build the correct data at a particular point.
+Sources frontiers are the _read frontier_ and the _write frontier_. They stand for a source’s limits to return a correct result immediately:
 
-A _query timestamp_ outside the frontiers indicates chances of lag.
+* Read frontier: Indicates the minimum logical timestamp to return a correct result (known as _compaction_)
+* Write frontier: Represents the maximum timestamp to build a correct result without waiting unprocessed data.
+
+Having a _query timestamp_ outside the limits of the frontiers can explain the presence of delays. While in the middle, the space of processed but not yet compacted data, allows building and returning a correct result immediately.
 
 #### Example
 
@@ -307,14 +310,9 @@ Field | Meaning | Example
 
 Field | Meaning | Example
 ---------|---------|---------
-**read frontier** | Minimum read point. |`[1673612423000 (2023-01-13 12:20:23.000)]`
-**write frontier** | Highest available read point. | `[1673612424152 (2023-01-13 12:20:24.152)]`
-
-
-Identifying a source is done through the following properties:
-  * Database, schema, and name
-  * Dataflow ID
-  * Section (storage or compute)
+**source** | Source’s identifiers | `source materialize.public.raw_users (u2014, storage)`
+**read frontier** | Minimum logical timestamp. |`[1673612423000 (2023-01-13 12:20:23.000)]`
+**write frontier** | Maximum logical timestamp. | `[1673612424152 (2023-01-13 12:20:24.152)]`
 
 <!-- We think of `since` as the "read frontier": times not later than or equal to
 `since` cannot be correctly read. We think of `upper` as the "write frontier":

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -254,16 +254,18 @@ The explanation divides in two parts:
 
 #### Determinations for a timestamp
 
-Queries in Materialize have a logical timestamp, known as _query timestamp_. It plays a critical role to retun a correct result. Returning a correct result implies retrieving data with the same logical time from each source present in a query. In this case, sources are objects providing data: a materialized view, view, index, table, or source. Each source will have a pair of logical timestamps, denoted as _frontiers_.
+Queries in Materialize have a logical timestamp, known as _query timestamp_. It plays a critical role to return a correct result. Returning a correct result implies retrieving data with the same logical time from each source present in a query.
+
+In this case, sources are objects providing data: materialized views, views, indexes, tables, or sources. Each will have a pair of logical timestamps frontiers, denoted as _sources frontiers_.
 
 #### Sources frontiers
 
-Sources frontiers are the _read frontier_ and the _write frontier_. They stand for a source’s limits to return a correct result immediately:
+Every source has a beginning _read frontier_ and an ending _write frontier_. They stand for a source’s limits to return a correct result immediately:
 
 * Read frontier: Indicates the minimum logical timestamp to return a correct result (known as _compaction_)
-* Write frontier: Represents the maximum timestamp to build a correct result without waiting unprocessed data.
+* Write frontier: Indicates the maximum timestamp to build a correct result without waiting unprocessed data.
 
-Having a _query timestamp_ outside the limits of the frontiers can explain the presence of delays. While in the middle, the space of processed but not yet compacted data, allows building and returning a correct result immediately.
+Having a _query timestamp_ outside the values of the frontiers can explain the presence of delays. While in the middle, the space of processed but not yet compacted data, allows building and returning a correct result immediately.
 
 #### Example
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Documentation for `EXPLAIN TIMESTAMP`. In-depth technical details have been avoided. Troubleshooting answers too.
The idea is to explain the command and the meaning of the critical details. 

[Link](https://preview.materialize.com/materialize/17242/sql/explain/#timestamps)

Closes #15731.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

1. It is at the end of the section. (The section is huge)
2. The table for `Timeline values` gives me some, egh.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
