### PR TITLE
Cluster unification, part 3.4

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -175,16 +175,7 @@ impl Coordinator {
                 log_sources_to_drop.extend(replica_logs);
 
                 // Drop the cluster itself.
-                //
-                // Linked clusters are presently a fiction maintained by the
-                // catalog. They do not yet result in the creation of actual
-                // compute instances, and so we must suppress their drop.
-                //
-                // TODO(benesch): turn linked clusters into real clusters.
-                // See MaterializeInc/cloud#4929.
-                if instance.linked_object_id.is_none() {
-                    clusters_to_drop.push(id);
-                }
+                clusters_to_drop.push(id);
 
                 // Drop timelines
                 timelines_to_drop.extend(self.remove_compute_instance_from_timeline(id));
@@ -202,16 +193,7 @@ impl Coordinator {
                 log_sources_to_drop.extend(replica_logs);
 
                 // Drop the cluster replica itself.
-                //
-                // Linked clusters are presently a fiction maintained by the
-                // catalog. They do not yet result in the creation of actual
-                // compute instances, and so we must suppress their drop.
-                //
-                // TODO(benesch): turn linked clusters into real clusters.
-                // See MaterializeInc/cloud#4929.
-                if compute_instance.linked_object_id.is_none() {
-                    cluster_replicas_to_drop.push((compute_instance.id, replica_id));
-                }
+                cluster_replicas_to_drop.push((compute_instance.id, replica_id));
             }
         }
 


### PR DESCRIPTION
Part of the cluster unification epic (MaterializeInc/cloud#4929).

This commit creates and drops compute instances for linked clusters. Previously they were just a fiction maintained by the catalog.

This results in *twice* the physical resources being used for each source/sink. The storage controller is not yet smart enough to actually *use* the cluster created by the compute instance. So it provisions its own cluster, and the compute-managed instance goes unused.

A future commit will further the unification and ensure only one physical cluster is turned on. ~**NOTE:** This PR will not be merged until this commit exists.~ I changed my mind. I'm merging this now. We're committed to unification now.


### Motivation

  * This PR works towards a known-desirable feature.

### Tips for reviewer

~The compute instance associated with each linked cluster will be leaked after this commit, until #17244 merges (separately).~ #17244 merged.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
