### PR TITLE
Shrink `correction` buffer when appropriate

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -745,6 +745,9 @@ where
                     // spend a lot of time "consolidating" the same updates
                     // over and over again, with no changes.
                     consolidate_updates(&mut correction);
+                    if correction.len() < correction.capacity() / 4 {
+                        correction.shrink_to_fit();
+                    }
                 }
 
                 for batch_description in ready_batches.into_iter() {

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -745,6 +745,17 @@ where
                     // spend a lot of time "consolidating" the same updates
                     // over and over again, with no changes.
                     consolidate_updates(&mut correction);
+
+                    // `correction` starts large as it diffs the initial snapshots,
+                    // but in steady state contains substantially fewer updates.
+                    // We should regularly shrink it to an appropriate size.
+                    // We use a 4x threshold here to ensure that we cannot enter
+                    // a resizing cycle without a linear-in-`correction.len()`
+                    // number of updates. E.g. a 2x threshold could result in
+                    // an allocation that must soon after be re-doubled back to
+                    // the current size, then halved, then doubled. We want that
+                    // pattern to require a linear number of updates rather than
+                    // a constant number.
                     if correction.len() < correction.capacity() / 4 {
                         correction.shrink_to_fit();
                     }


### PR DESCRIPTION
The `correction` buffer in `persist_sink` starts large as it diffs the initial snapshots, but in steady state contains substantially fewer updates. However, we never shrink it from its peak size. This PR introduces a `shrink_to_fit` call when the capacity is more than 4x the actual length of the corrections, which we do to ensure that the allocation does not then immediately double if a single correction is added.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
