### PR TITLE
persist: small cleanups from schema api addition

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -458,9 +458,6 @@ pub struct PersistClient {
 impl PersistClient {
     /// A "fake" object used to fill `schema` parameters for opening handles in tests.
     pub const TEST_SCHEMA: () = ();
-    /// Same as `TEST_SCHEMA`, but to be deleted over the course of a stack of commits, and
-    /// after some migrations are done.
-    pub const TO_REPLACE_SCHEMA: () = ();
 
     /// Returns a new client for interfacing with persist shards made durable to
     /// the given [Blob] and [Consensus].
@@ -522,7 +519,7 @@ impl PersistClient {
         ))
     }
 
-    /// [Self::open], but returning only a [/eadHandle].
+    /// [Self::open], but returning only a [ReadHandle].
     ///
     /// Use this to save latency and a bit of persist traffic if you're just
     /// going to immediately drop or expire the [WriteHandle].

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1983,7 +1983,7 @@ where
     }
 
     #[allow(dead_code)]
-    async fn truncate_shards(&mut self, shards: &[(ShardId, String)]) {
+    async fn truncate_shards(&mut self, shards: &[(ShardId, String, RelationDesc)]) {
         // Open a persist client to delete unused shards.
         let persist_client = self
             .persist
@@ -1993,14 +1993,12 @@ where
             .await
             .unwrap();
 
-        for (shard_id, shard_purpose) in shards {
+        for (shard_id, shard_purpose, desc) in shards {
             let (mut write, mut read) = persist_client
                 .open::<crate::types::sources::SourceData, (), T, Diff, _>(
                     *shard_id,
                     shard_purpose.as_str(),
-                    // We have to _read_ the shard to figure out if its been migrated or not, so we
-                    // hedge on setting a `RelationDesc`.
-                    PersistClient::TO_REPLACE_SCHEMA,
+                    desc,
                 )
                 .await
                 .expect("invalid persist usage");

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -216,7 +216,7 @@ where
                     "rehydration since",
                     // This is also `from_desc`, but this would be the _only_ usage
                     // of `from_desc` in storage, and we try to be consistent about
-                    // where we get `RelationDesc`s for perist clients
+                    // where we get `RelationDesc`s for persist clients
                     export
                         .description
                         .from_storage_metadata


### PR DESCRIPTION
Just some small cleanups!

### Motivation

  * This PR adds a known-desirable feature.
 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

