### PR TITLE
[persist] Lock down the diff type in Persist's API

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -307,7 +307,7 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff, _>(
+            .open_writer::<SourceData, (), Timestamp, _>(
                 shard_id,
                 &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
                 target_relation_desc,
@@ -576,7 +576,7 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff, _>(
+            .open_writer::<SourceData, (), Timestamp, _>(
                 shard_id,
                 &format!("compute::persist_sink::write_batches {}", sink_id),
                 target_relation_desc,
@@ -897,7 +897,7 @@ where
             .expect("could not open persist client");
 
         let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff,_>(
+            .open_writer::<SourceData, (), Timestamp, _>(
                 shard_id,
                 &format!("persist_sink::append_batches {}", sink_id),
                 target_relation_desc,

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -742,7 +742,7 @@ mod tests {
             .await
             .expect("client construction failed");
         let (mut write, mut read) = client
-            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .expect_open::<String, String, u64>(ShardId::new())
             .await;
 
         // A new builder has no writing or finished parts.
@@ -751,7 +751,7 @@ mod tests {
         assert_eq!(builder.parts.finished_parts.len(), 0);
 
         // We set blob_target_size to 0, so the first update gets forced out
-        // into a batch.
+        // into a batch.m
         builder
             .add(&data[0].0 .0, &data[0].0 .1, &data[0].1, &data[0].2)
             .await
@@ -807,9 +807,7 @@ mod tests {
             .await
             .expect("client construction failed");
         let shard_id = ShardId::new();
-        let (mut write, _) = client
-            .expect_open::<String, String, u64, i64>(shard_id)
-            .await;
+        let (mut write, _) = client.expect_open::<String, String, u64>(shard_id).await;
 
         let batch = write
             .expect_batch(

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -351,7 +351,7 @@ mod tests {
         let shard_id = crate::ShardId::new();
 
         let mut since = client
-            .open_critical_since::<(), (), u64, i64, i64>(shard_id, CriticalReaderId::new(), "")
+            .open_critical_since::<(), (), u64, i64>(shard_id, CriticalReaderId::new(), "")
             .await
             .expect("codec mismatch");
 
@@ -377,7 +377,7 @@ mod tests {
         let shard_id = ShardId::new();
 
         let mut since = client
-            .open_critical_since::<(), (), u64, i64, i64>(
+            .open_critical_since::<(), (), u64, i64>(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
                 "",
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(since.opaque(), &5);
 
         let since2 = client
-            .open_critical_since::<(), (), u64, i64, i64>(
+            .open_critical_since::<(), (), u64, i64>(
                 shard_id,
                 PersistClient::CONTROLLER_CRITICAL_SINCE,
                 "",

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -941,7 +941,7 @@ mod tests {
             })
             .await
             .expect("client construction failed")
-            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .expect_open::<String, String, u64>(ShardId::new())
             .await;
         let b0 = write
             .expect_batch(&data[..1], 0, 1)

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1608,7 +1608,7 @@ pub mod datadriven {
         let as_of = args.expect_antichain("as_of");
         let read = datadriven
             .client
-            .open_leased_reader::<String, (), u64, i64, _>(
+            .open_leased_reader::<String, (), u64, _>(
                 datadriven.shard_id,
                 "",
                 PersistClient::TEST_SCHEMA,
@@ -1849,7 +1849,7 @@ pub mod tests {
 
         let (mut write, _) = new_test_client()
             .await
-            .expect_open::<String, (), u64, i64>(ShardId::new())
+            .expect_open::<String, (), u64>(ShardId::new())
             .await;
 
         // Write a bunch of batches. This should result in a bounded number of
@@ -1904,7 +1904,7 @@ pub mod tests {
             intercept.clone(),
         ));
         let (_, mut read) = client
-            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .expect_open::<String, String, u64>(ShardId::new())
             .await;
 
         // Create a new SeqNo

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -154,6 +154,8 @@ mod internal {
     pub mod datadriven;
 }
 
+pub type Diff = i64;
+
 const BUILD_INFO: BuildInfo = build_info!();
 
 /// A location in s3, other cloud storage, or otherwise "durable storage" used

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -187,7 +187,7 @@ where
         };
         let read = read
             .expect("location should be valid")
-            .open_leased_reader::<K, V, G::Timestamp, Diff, _>(
+            .open_leased_reader::<K, V, G::Timestamp, _>(
                 shard_id,
                 &format!("shard_source({})", name_owned),
                 schema,
@@ -463,7 +463,7 @@ where
             std::mem::drop(clients);
 
             client
-                .create_batch_fetcher::<K, V, T, Diff, _>(shard_id, schema)
+                .create_batch_fetcher::<K, V, T, _>(shard_id, schema)
                 .await
         };
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -973,7 +973,7 @@ mod tests {
 
         let (mut write, read) = new_test_client()
             .await
-            .expect_open::<String, String, u64, i64>(crate::ShardId::new())
+            .expect_open::<String, String, u64>(crate::ShardId::new())
             .await;
 
         write.expect_compare_and_append(&data[0..1], 0, 1).await;
@@ -1002,7 +1002,7 @@ mod tests {
 
         let (mut write, read) = new_test_client()
             .await
-            .expect_open::<String, String, u64, i64>(crate::ShardId::new())
+            .expect_open::<String, String, u64>(crate::ShardId::new())
             .await;
 
         // Seed with some values
@@ -1206,7 +1206,7 @@ mod tests {
             Arc::new(CpuHeavyRuntime::new()),
         )
         .expect("client construction failed")
-        .expect_open::<String, String, u64, i64>(ShardId::new())
+        .expect_open::<String, String, u64>(ShardId::new())
         .await;
 
         write.expect_compare_and_append(&data[0..1], 0, 1).await;

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -162,20 +162,20 @@ mod tests {
 
         // write one row into shard 1
         let (mut write, _) = client
-            .expect_open::<String, String, u64, i64>(shard_id_one)
+            .expect_open::<String, String, u64>(shard_id_one)
             .await;
         write.expect_append(&data[..1], vec![0], vec![2]).await;
 
         // write two rows into shard 2 from writer 1
         let (mut write, _) = client
-            .expect_open::<String, String, u64, i64>(shard_id_two)
+            .expect_open::<String, String, u64>(shard_id_two)
             .await;
         write.expect_append(&data[1..3], vec![0], vec![4]).await;
         let writer_one = write.writer_id.clone();
 
         // write one row into shard 2 from writer 2
         let (mut write, _) = client
-            .expect_open::<String, String, u64, i64>(shard_id_two)
+            .expect_open::<String, String, u64>(shard_id_two)
             .await;
         write.expect_append(&data[4..], vec![0], vec![5]).await;
         let writer_two = write.writer_id.clone();

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -772,7 +772,7 @@ mod tests {
 
         let (mut write, _) = new_test_client()
             .await
-            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .expect_open::<String, String, u64>(ShardId::new())
             .await;
         let blob = Arc::clone(&write.blob);
 
@@ -818,7 +818,7 @@ mod tests {
 
         let (mut write, mut read) = new_test_client()
             .await
-            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .expect_open::<String, String, u64>(ShardId::new())
             .await;
 
         let mut batch0 = write.expect_batch(&data0, 0, 5).await;
@@ -882,7 +882,7 @@ mod tests {
 
         let (mut write, mut read) = new_test_client()
             .await
-            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .expect_open::<String, String, u64>(ShardId::new())
             .await;
 
         // This test is a bit more complex than it should be. It would be easier

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1405,7 +1405,7 @@ where
         // heartbeat continously. The assumption is that calls to snapshot are rare and therefore
         // worth it to always create a new handle.
         let mut read_handle = persist_client
-            .open_leased_reader::<SourceData, (), _, _, _>(
+            .open_leased_reader::<SourceData, (), _, _>(
                 metadata.data_shard,
                 &format!("snapshot {}", id),
                 metadata.relation_desc.clone(),
@@ -1995,7 +1995,7 @@ where
 
         for (shard_id, shard_purpose) in shards {
             let (mut write, mut read) = persist_client
-                .open::<crate::types::sources::SourceData, (), T, Diff, _>(
+                .open::<crate::types::sources::SourceData, (), T, _>(
                     *shard_id,
                     shard_purpose.as_str(),
                     // We have to _read_ the shard to figure out if its been migrated or not, so we

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -35,7 +35,7 @@ use mz_ore::retry::Retry;
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_types::Codec64;
-use mz_repr::{Diff, GlobalId};
+use mz_repr::GlobalId;
 use mz_service::client::GenericClient;
 
 use crate::client::{
@@ -211,7 +211,7 @@ where
                 .await
                 .expect("error creating persist client");
             let from_read_handle = persist_client
-                .open_leased_reader::<SourceData, (), T, Diff, _>(
+                .open_leased_reader::<SourceData, (), T, _>(
                     export.description.from_storage_metadata.data_shard,
                     "rehydration since",
                     // This is also `from_desc`, but this would be the _only_ usage

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -109,7 +109,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
                 .open(persist_location.clone())
                 .await
                 .expect("error creating persist client")
-                .open_writer::<SourceData, (), T, Diff, _>(
+                .open_writer::<SourceData, (), T, _>(
                     *data_shard,
                     &format!("resumption data {}", id),
                     relation_desc.clone(),
@@ -141,7 +141,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
             .await
             .expect("error creating persist client")
             // TODO: Any way to plumb the GlobalId to this?
-            .open_writer::<SourceData, (), T, Diff, _>(
+            .open_writer::<SourceData, (), T, _>(
                 *remap_shard,
                 "resumption remap",
                 remap_relation_desc,

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -110,7 +110,7 @@ where
             .open(metadata.persist_location)
             .await
             .expect("could not open persist client")
-            .open_writer::<SourceData, (), Timestamp, Diff, _>(
+            .open_writer::<SourceData, (), Timestamp, _>(
                 metadata.data_shard,
                 &format!("storage::persist_sink {}", src_id),
                 metadata.relation_desc.clone(),

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -1347,7 +1347,7 @@ mod tests {
         drop(persist_clients);
 
         let read_handle = persist_client
-            .open_leased_reader::<SourceData, (), Timestamp, Diff, _>(
+            .open_leased_reader::<SourceData, (), Timestamp, _>(
                 binding_shard,
                 "test_since_hold",
                 mz_storage_client::types::sources::KAFKA_PROGRESS_DESC.clone(),

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -306,7 +306,7 @@ where
                 (&tokio_runtime).spawn_named(|| "check_loop".to_string(), async move {
                     loop {
                         let (mut data_write_handle, data_read_handle) = persist_client
-                            .open::<SourceData, (), Timestamp, Diff, _>(
+                            .open::<SourceData, (), Timestamp, _>(
                                 data_shard.clone(),
                                 "tests::check_loop",
                                 // TODO(guswynn|danhhz): replace this with a real desc when persist requires a


### PR DESCRIPTION
Prevent constructing any persist handle (or derivative) with a non-`i64` diff type. (It does not yet start removing type parameters from structs or Persist internals, though if we end up thinking this is a good idea that would be a natural followup.)

### Motivation

Mostly working it through to see what it looked like. (Not too bad!)

Locking down the timestamp type looks like it would be moderately harder; the generics percolate further out in one or two places.

### Tips for reviewer

We haven't discussed this much yet so I've got no expectation that we'll merge this in, and anyways it's already got a merge conflict on it... but if the team thinks it looks like a good idea I'm happy to get this in proper shape.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
