### PR TITLE
persist: remove some short-lived allocations under Trace::push_batch

### DIFF
--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -163,6 +163,7 @@ pub fn bench_persist(c: &mut Criterion) {
         bench_compare_and_set(1, ncpus_useful);
     }
     plumbing::bench_encode_batch("plumbing/encode_batch", throughput, c, &data);
+    plumbing::bench_trace_push_batch(c);
 }
 
 fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -214,7 +214,7 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
 
 pub fn bench_trace_push_batch(c: &mut Criterion) {
     let mut g = c.benchmark_group("trace");
-    const NUM_BATCHES: usize = 5_000;
+    const NUM_BATCHES: usize = 20_000;
     g.bench_function(BenchmarkId::new("push_batch", NUM_BATCHES), |b| {
         b.iter(|| trace_push_batch_one_iter(NUM_BATCHES));
     });

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -17,6 +17,7 @@ use bytes::Bytes;
 use criterion::{Bencher, BenchmarkId, Criterion, Throughput};
 use differential_dataflow::trace::Description;
 use futures::stream::{FuturesUnordered, StreamExt};
+use mz_persist_client::internals_bench::trace_push_batch_one_iter;
 use timely::progress::Antichain;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
@@ -208,5 +209,13 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
             let mut buf = Vec::new();
             trace.encode(&mut buf);
         })
+    });
+}
+
+pub fn bench_trace_push_batch(c: &mut Criterion) {
+    let mut g = c.benchmark_group("trace");
+    const NUM_BATCHES: usize = 5_000;
+    g.bench_function(BenchmarkId::new("push_batch", NUM_BATCHES), |b| {
+        b.iter(|| trace_push_batch_one_iter(NUM_BATCHES));
     });
 }

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -202,7 +202,7 @@ pub async fn force_compaction(
             let req = CompactReq {
                 shard_id,
                 desc: req.desc,
-                inputs: req.inputs,
+                inputs: req.inputs.iter().map(|b| b.as_ref().clone()).collect(),
             };
             let parts = req.inputs.iter().map(|x| x.parts.len()).sum::<usize>();
             let bytes = req

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -423,7 +423,7 @@ where
                         let req = CompactReq {
                             shard_id: self.shard_id(),
                             desc: req.desc,
-                            inputs: req.inputs,
+                            inputs: req.inputs.iter().map(|b| b.as_ref().clone()).collect(),
                         };
                         compact_reqs.push(req);
                     }

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -48,6 +48,7 @@
 //! [Batch::Merger]: differential_dataflow::trace::Batch::Merger
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
@@ -64,7 +65,7 @@ use crate::internal::state::HollowBatch;
 #[derive(Debug, Clone, PartialEq)]
 pub struct FueledMergeReq<T> {
     pub desc: Description<T>,
-    pub inputs: Vec<HollowBatch<T>>,
+    pub inputs: Vec<Arc<HollowBatch<T>>>,
 }
 
 #[derive(Debug)]
@@ -187,7 +188,7 @@ impl<T: Timestamp + Lattice> Trace<T> {
     pub fn push_batch(&mut self, batch: HollowBatch<T>) -> Vec<FueledMergeReq<T>> {
         let mut merge_reqs = Vec::new();
         self.spine
-            .insert(SpineBatch::Merged(batch), &mut merge_reqs);
+            .insert(SpineBatch::Merged(Arc::new(batch)), &mut merge_reqs);
         // Spine::roll_up (internally used by insert) clears all batches out of
         // levels below a target by walking up from level 0 and merging each
         // level into the next (providing the necessary fuel). In practice, this
@@ -289,10 +290,10 @@ impl<T: Timestamp + Lattice> Trace<T> {
 #[derive(Debug, Clone)]
 #[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 enum SpineBatch<T> {
-    Merged(HollowBatch<T>),
+    Merged(Arc<HollowBatch<T>>),
     Fueled {
         desc: Description<T>,
-        parts: Vec<HollowBatch<T>>,
+        parts: Vec<Arc<HollowBatch<T>>>,
         // A cached version of parts.iter().map(|x| x.len).sum()
         len: usize,
     },
@@ -335,14 +336,14 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
 
     fn desc(&self) -> &Description<T> {
         match self {
-            SpineBatch::Merged(HollowBatch { desc, .. }) => desc,
+            SpineBatch::Merged(b) => &b.desc,
             SpineBatch::Fueled { desc, .. } => desc,
         }
     }
 
     pub fn len(&self) -> usize {
         match self {
-            SpineBatch::Merged(HollowBatch { len, .. }) => *len,
+            SpineBatch::Merged(b) => b.len,
             // NB: This is an upper bound on len, we won't know for sure until
             // we compact it.
             SpineBatch::Fueled { len, parts, .. } => {
@@ -359,12 +360,12 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
     }
 
     pub fn empty(lower: Antichain<T>, upper: Antichain<T>, since: Antichain<T>) -> Self {
-        SpineBatch::Merged(HollowBatch {
+        SpineBatch::Merged(Arc::new(HollowBatch {
             desc: Description::new(lower, upper, since),
             parts: vec![],
             len: 0,
             runs: vec![],
-        })
+        }))
     }
 
     pub fn begin_merge(
@@ -408,7 +409,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
             if res.output.len > self.len() {
                 return ApplyMergeResult::NotAppliedTooManyUpdates;
             }
-            *self = SpineBatch::Merged(res.output.clone());
+            *self = SpineBatch::Merged(Arc::new(res.output.clone()));
             return ApplyMergeResult::AppliedExact;
         }
 
@@ -445,7 +446,7 @@ impl<T: Timestamp + Lattice> SpineBatch<T> {
                     (Some(lower), Some(upper)) => {
                         let mut new_parts = vec![];
                         new_parts.extend_from_slice(&parts[..lower]);
-                        new_parts.push(res.output.clone());
+                        new_parts.push(Arc::new(res.output.clone()));
                         new_parts.extend_from_slice(&parts[upper + 1..]);
                         let new_spine_batch = SpineBatch::Fueled {
                             desc: desc.to_owned(),
@@ -502,14 +503,27 @@ impl<T: Timestamp + Lattice> FuelingMerge<T> {
         }
 
         let desc = Description::new(lower, upper, since);
+        let len = self.b1.len() + self.b2.len();
 
-        let mut merged_parts = Vec::new();
-        let mut append_parts = |b| match b {
-            SpineBatch::Merged(b) => merged_parts.push(b),
-            SpineBatch::Fueled { parts, .. } => merged_parts.extend_from_slice(&parts),
-        };
-        append_parts(self.b1);
-        append_parts(self.b2);
+        // Pre-size the merged_parts Vec. Benchmarking has shown that, at least
+        // in the worst case, the double iteration is absolutely worth having
+        // merged_parts pre-sized.
+        let mut merged_parts_len = 0;
+        for b in [&self.b1, &self.b2] {
+            match b {
+                SpineBatch::Merged(_) => merged_parts_len += 1,
+                SpineBatch::Fueled { parts, .. } => merged_parts_len += parts.len(),
+            }
+        }
+        let mut merged_parts = Vec::with_capacity(merged_parts_len);
+        for b in [self.b1, self.b2] {
+            match b {
+                SpineBatch::Merged(b) => merged_parts.push(b),
+                SpineBatch::Fueled { mut parts, .. } => merged_parts.append(&mut parts),
+            }
+        }
+        // Sanity check the pre-size code.
+        debug_assert_eq!(merged_parts.len(), merged_parts_len);
 
         merge_reqs.push(FueledMergeReq {
             desc: desc.clone(),
@@ -518,7 +532,7 @@ impl<T: Timestamp + Lattice> FuelingMerge<T> {
 
         SpineBatch::Fueled {
             desc,
-            len: merged_parts.iter().map(|x| x.len).sum(),
+            len,
             parts: merged_parts,
         }
     }
@@ -1235,18 +1249,13 @@ pub mod datadriven {
         let mut s = String::new();
         datadriven.trace.spine.map_batches(|b| {
             let b = match b {
-                SpineBatch::Merged(HollowBatch {
-                    desc,
-                    len,
-                    parts,
-                    runs: _runs,
-                }) => format!(
+                SpineBatch::Merged(b) => format!(
                     "{:?}{:?}{:?} {}{}\n",
-                    desc.lower().elements(),
-                    desc.upper().elements(),
-                    desc.since().elements(),
-                    len,
-                    parts
+                    b.desc.lower().elements(),
+                    b.desc.upper().elements(),
+                    b.desc.since().elements(),
+                    b.len,
+                    b.parts
                         .iter()
                         .map(|x| format!(" {}", x.key))
                         .collect::<Vec<_>>()

--- a/src/persist-client/src/internals_bench.rs
+++ b/src/persist-client/src/internals_bench.rs
@@ -1,0 +1,52 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmarks of internal code not exposed through the public API.
+
+#![allow(missing_docs)]
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use differential_dataflow::trace::Description;
+use timely::progress::Antichain;
+use tracing::info;
+
+use crate::internal::state::HollowBatch;
+use crate::internal::trace::Trace;
+
+pub fn trace_push_batch_one_iter(num_batches: usize) {
+    let mut trace = Trace::<usize>::default();
+    let mut start = Instant::now();
+    for ts in 0..num_batches {
+        if ts % 1000 == 0 {
+            info!("{} {:?}", ts, start.elapsed());
+            start = Instant::now();
+        }
+        // A single non-empty batch followed by a large number of empty batches
+        // and no compaction. This is a particularly problematic workload for
+        // our fork of Spine which came up during deserialization of State in
+        // #17214.
+        //
+        // Other, much better handled, workloads include all empty or all
+        // non-empty.
+        let len = if ts == 0 { 1 } else { 0 };
+        let _ = trace.push_batch(HollowBatch {
+            desc: Description::new(
+                Antichain::from_elem(ts),
+                Antichain::from_elem(ts + 1),
+                Antichain::from_elem(0),
+            ),
+            parts: vec![],
+            len,
+            runs: vec![],
+        });
+    }
+    black_box(trace);
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -132,6 +132,7 @@ pub mod metrics {
     pub use crate::internal::metrics::encode_ts_metric;
     pub use crate::internal::metrics::Metrics;
 }
+pub mod internals_bench;
 pub mod read;
 pub mod usage;
 pub mod write;


### PR DESCRIPTION
    trace/push_batch/5000   time:   [119.33 ms 119.44 ms 119.52 ms]
                            change: [-95.359% -95.082% -94.843%] (p = 0.00 < 0.05)
                            Performance has improved.

Specifically:
- Pre-size the Vec in FuelingMerge::done
- Wrap HollowBatch in an Arc within persist Trace. This might be a small
  pessimization for the common case in prod of a steady state shard.
  However, for the problematic case of deserializing a State with a
  single non-empty batch followed by many empty batches, the allocations
  of cloning all the Antichains transitively involved in the
  FueledMergeReqs just to throw the merge req away are extremely costly.
  Ideally, we'd do what differential_dataflow does and use Rc, but until
  https://github.com/MaterializeInc/materialize/pull/17150 these need to be Send+Sync.

These allocations were costly enough that they were the overwhelming
result of cpu profiling. Also sneak in a tweak to use the pre-computed
lens of b1 and b2 in FuelingMerge::done, which was also showing up on
cpu profiles.

Touches #17214

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

This is still quadratic, but that's going to be a much more involved fix. This was straightforward and 20x faster means that maybe we'd have avoided the issues that led to #17214, so I wanted to be sure to get it into next week's release.

(I'm still working on understanding enough of details of the quadratic behavior that I can coherently explain it. The very rough sketch is that all empty batches gets the empty-batch optimization. All non-empty batches get arranged nicely into tiers by spine. One non-empty followed by a bunch of empty means that we repeatedly generate merge requests with a linearly increasing number of inputs.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
