### PR TITLE
adapter,stash: reduce total stash statement count

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -130,12 +130,18 @@ pub struct StashCollection<K, V> {
     _kv: PhantomData<(K, V)>,
 }
 
-impl<K, V> Clone for StashCollection<K, V> {
-    fn clone(&self) -> Self {
+impl<K, V> StashCollection<K, V> {
+    fn new(id: Id) -> Self {
         Self {
-            id: self.id,
+            id,
             _kv: PhantomData,
         }
+    }
+}
+
+impl<K, V> Clone for StashCollection<K, V> {
+    fn clone(&self) -> Self {
+        Self::new(self.id)
     }
 }
 

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -315,7 +315,7 @@ where
         .with_transaction(move |tx| {
             Box::pin(async move {
                 // Seal so we can invalidate the upper below.
-                tx.seal(other.id, &Antichain::from_elem(1), None)
+                tx.seal(other.id, Antichain::from_elem(1), None)
                     .await
                     .unwrap();
                 let mut orders_batch = orders.make_batch_tx(&tx).await.unwrap();
@@ -410,7 +410,7 @@ where
                 tx.update_savepoint(orders.id, &[(("k3".into(), "v3".into()), 1, 1)], None)
                     .await
                     .unwrap();
-                tx.seal(orders.id, &Antichain::from_elem(2), None)
+                tx.seal(orders.id, Antichain::from_elem(2), None)
                     .await
                     .unwrap();
 
@@ -557,7 +557,7 @@ where
                 )
                 .await
                 .unwrap();
-                tx.seal(orders.id, &Antichain::from_elem(3), None)
+                tx.seal(orders.id, Antichain::from_elem(3), None)
                     .await
                     .unwrap();
                 // Peek should not observe widgets from timestamps 3 or 4.
@@ -593,7 +593,7 @@ where
 
                 // Test invalid seals, compactions, and updates.
                 assert_eq!(
-                    tx.seal(orders.id, &Antichain::from_elem(2), None)
+                    tx.seal(orders.id, Antichain::from_elem(2), None)
                         .await
                         .unwrap_err()
                         .to_string(),
@@ -622,7 +622,7 @@ where
                 );
 
                 // Test advancing since and upper to the empty frontier.
-                tx.seal(orders.id, &Antichain::new(), None).await.unwrap();
+                tx.seal(orders.id, Antichain::new(), None).await.unwrap();
                 tx.compact(orders.id, &Antichain::new(), None)
                     .await
                     .unwrap();
@@ -657,7 +657,7 @@ where
                 );
 
                 // Test peek_one.
-                tx.seal(other.id, &Antichain::from_elem(2), None)
+                tx.seal(other.id, Antichain::from_elem(2), None)
                     .await
                     .unwrap();
                 assert_eq!(


### PR DESCRIPTION
Various improvements to the stash and adapter catalog to perform fewer cockroach statement executions. This is done by using the new transaction API in the catalog and caching collections, sinces, and uppers in the stash, which was the major benefit of the cache stash that was recently removed.

See #16531

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a