### PR TITLE
adapter: separate cluster [replica] ID allocation from creation

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -598,7 +598,7 @@ impl Coordinator {
 
         // It is possible that we receive a status update for a replica that has
         // already been dropped from the catalog. Just ignore these events.
-        let Some(instance) = self.catalog.try_get_compute_instance(event.instance_id) else {
+        let Some(instance) = self.catalog.try_get_cluster(event.instance_id) else {
             return;
         };
         let Some(replica) = instance.replicas_by_id.get(&event.replica_id) else {
@@ -617,10 +617,7 @@ impl Coordinator {
             .await
             .unwrap_or_terminate("updating compute instance status cannot fail");
 
-            let instance = self
-                .catalog
-                .try_get_compute_instance(event.instance_id)
-                .expect("instance known to exist");
+            let instance = self.catalog.get_cluster(event.instance_id);
             let replica = &instance.replicas_by_id[&event.replica_id];
             let new_status = replica.status();
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -291,9 +291,8 @@ pub trait CatalogComputeInstance<'a> {
     /// any.
     fn linked_object_id(&self) -> Option<GlobalId>;
 
-    /// Returns the set of non-transient exports (indexes, materialized views)
-    /// of this cluster.
-    fn exports(&self) -> &HashSet<GlobalId>;
+    /// Returns the objects that are bound to this cluster.
+    fn bound_objects(&self) -> &HashSet<GlobalId>;
 
     /// Returns the replicas of the cluster as a map from replica name to
     /// replica ID.

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
-use mz_compute_client::controller::ComputeInstanceId;
+use mz_compute_client::controller::{ComputeInstanceId, ReplicaId};
 use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
@@ -293,10 +293,11 @@ pub trait CatalogComputeInstance<'a> {
 
     /// Returns the set of non-transient exports (indexes, materialized views)
     /// of this cluster.
-    fn exports(&self) -> &std::collections::HashSet<GlobalId>;
+    fn exports(&self) -> &HashSet<GlobalId>;
 
-    /// Returns the set of replicas of this cluster.
-    fn replica_names(&self) -> HashSet<&String>;
+    /// Returns the replicas of the cluster as a map from replica name to
+    /// replica ID.
+    fn replicas(&self) -> &HashMap<String, ReplicaId>;
 }
 
 /// An item in a [`SessionCatalog`].

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -38,7 +38,7 @@ use chrono::{DateTime, Utc};
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
-use mz_compute_client::controller::ComputeInstanceId;
+use mz_compute_client::controller::{ComputeInstanceId, ReplicaId};
 use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_pgcopy::CopyFormatParams;
@@ -256,8 +256,8 @@ pub struct CreateComputeInstancePlan {
 
 #[derive(Debug)]
 pub struct CreateComputeReplicaPlan {
+    pub cluster_id: ComputeInstanceId,
     pub name: String,
-    pub of_cluster: String,
     pub config: ComputeReplicaConfig,
 }
 
@@ -432,12 +432,12 @@ pub struct DropRolesPlan {
 
 #[derive(Debug)]
 pub struct DropComputeInstancesPlan {
-    pub names: Vec<String>,
+    pub ids: Vec<ComputeInstanceId>,
 }
 
 #[derive(Debug)]
 pub struct DropComputeReplicasPlan {
-    pub names: Vec<(String, String)>,
+    pub ids: Vec<(ComputeInstanceId, ReplicaId)>,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3308,7 +3308,7 @@ pub fn plan_drop_cluster(
         match scx.catalog.resolve_compute_instance(Some(name.as_str())) {
             Ok(instance) => {
                 ensure_cluster_is_not_linked(scx, instance)?;
-                if !cascade && !instance.exports().is_empty() {
+                if !cascade && !instance.bound_objects().is_empty() {
                     sql_bail!("cannot drop cluster with active indexes or materialized views");
                 }
                 ids.push(instance.id());

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -53,7 +53,7 @@ s1  mz_system
 s2  mz_introspection
 u1  default
 u3  foo
-u4  bar
+u6  bar
 
 query T rowsort
 SHOW CLUSTERS
@@ -151,57 +151,57 @@ FROM
 WHERE clusters.name = 'bar'
 ORDER BY on_name, seq_in_index ASC;
 ----
-bar  mz_active_peeks  mz_active_peeks_u4_primary_idx  1  id  NULL  false
-bar  mz_active_peeks  mz_active_peeks_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_u4_primary_idx  1  operator_id  NULL  false
-bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_arrangement_records_internal  mz_arrangement_records_internal_u4_primary_idx  1  operator_id  NULL  false
-bar  mz_arrangement_records_internal  mz_arrangement_records_internal_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_u4_primary_idx  1  operator_id  NULL  false
-bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_compute_exports  mz_compute_exports_u4_primary_idx  1  export_id  NULL  false
-bar  mz_compute_exports  mz_compute_exports_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_dataflow_addresses  mz_dataflow_addresses_u4_primary_idx  1  id  NULL  false
-bar  mz_dataflow_addresses  mz_dataflow_addresses_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_dataflow_channels  mz_dataflow_channels_u4_primary_idx  1  id  NULL  false
-bar  mz_dataflow_channels  mz_dataflow_channels_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  1  address  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  2  port  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  3  worker_id  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  4  update_type  NULL  false
-bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u4_primary_idx  5  time  NULL  true
-bar  mz_dataflow_operators  mz_dataflow_operators_u4_primary_idx  1  id  NULL  false
-bar  mz_dataflow_operators  mz_dataflow_operators_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u4_primary_idx  1  channel_id  NULL  false
-bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u4_primary_idx  2  from_worker_id  NULL  false
-bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u4_primary_idx  3  to_worker_id  NULL  false
-bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u4_primary_idx  1  channel_id  NULL  false
-bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u4_primary_idx  2  from_worker_id  NULL  false
-bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u4_primary_idx  3  to_worker_id  NULL  false
-bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u4_primary_idx  1  id  NULL  false
-bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u4_primary_idx  3  duration_ns  NULL  false
-bar  mz_raw_peek_durations  mz_raw_peek_durations_u4_primary_idx  1  worker_id  NULL  false
-bar  mz_raw_peek_durations  mz_raw_peek_durations_u4_primary_idx  2  duration_ns  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  1  export_id  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  2  import_id  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  3  worker_id  NULL  false
-bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u4_primary_idx  4  delay_ns  NULL  false
-bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_u4_primary_idx  1  id  NULL  false
-bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u4_primary_idx  1  worker_id  NULL  false
-bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u4_primary_idx  2  slept_for  NULL  false
-bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u4_primary_idx  3  requested  NULL  false
-bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u4_primary_idx  1  export_id  NULL  false
-bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u4_primary_idx  2  import_id  NULL  false
-bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u4_primary_idx  3  worker_id  NULL  false
-bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u4_primary_idx  1  export_id  NULL  false
-bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u4_primary_idx  2  worker_id  NULL  false
-bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u4_primary_idx  3  time  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  1  export_id  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  2  import_id  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  3  worker_id  NULL  false
-bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u4_primary_idx  4  time  NULL  false
+bar  mz_active_peeks  mz_active_peeks_u6_primary_idx  1  id  NULL  false
+bar  mz_active_peeks  mz_active_peeks_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_u6_primary_idx  1  operator_id  NULL  false
+bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_arrangement_records_internal  mz_arrangement_records_internal_u6_primary_idx  1  operator_id  NULL  false
+bar  mz_arrangement_records_internal  mz_arrangement_records_internal_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_u6_primary_idx  1  operator_id  NULL  false
+bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_compute_exports  mz_compute_exports_u6_primary_idx  1  export_id  NULL  false
+bar  mz_compute_exports  mz_compute_exports_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_dataflow_addresses  mz_dataflow_addresses_u6_primary_idx  1  id  NULL  false
+bar  mz_dataflow_addresses  mz_dataflow_addresses_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_dataflow_channels  mz_dataflow_channels_u6_primary_idx  1  id  NULL  false
+bar  mz_dataflow_channels  mz_dataflow_channels_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u6_primary_idx  1  address  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u6_primary_idx  2  port  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u6_primary_idx  3  worker_id  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u6_primary_idx  4  update_type  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_u6_primary_idx  5  time  NULL  true
+bar  mz_dataflow_operators  mz_dataflow_operators_u6_primary_idx  1  id  NULL  false
+bar  mz_dataflow_operators  mz_dataflow_operators_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u6_primary_idx  1  channel_id  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u6_primary_idx  2  from_worker_id  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_u6_primary_idx  3  to_worker_id  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u6_primary_idx  1  channel_id  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u6_primary_idx  2  from_worker_id  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_u6_primary_idx  3  to_worker_id  NULL  false
+bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u6_primary_idx  1  id  NULL  false
+bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_raw_compute_operator_durations_internal  mz_raw_compute_operator_durations_internal_u6_primary_idx  3  duration_ns  NULL  false
+bar  mz_raw_peek_durations  mz_raw_peek_durations_u6_primary_idx  1  worker_id  NULL  false
+bar  mz_raw_peek_durations  mz_raw_peek_durations_u6_primary_idx  2  duration_ns  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u6_primary_idx  1  export_id  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u6_primary_idx  2  import_id  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u6_primary_idx  3  worker_id  NULL  false
+bar  mz_raw_worker_compute_delays  mz_raw_worker_compute_delays_u6_primary_idx  4  delay_ns  NULL  false
+bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_u6_primary_idx  1  id  NULL  false
+bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u6_primary_idx  1  worker_id  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u6_primary_idx  2  slept_for  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_u6_primary_idx  3  requested  NULL  false
+bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u6_primary_idx  1  export_id  NULL  false
+bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u6_primary_idx  2  import_id  NULL  false
+bar  mz_worker_compute_dependencies  mz_worker_compute_dependencies_u6_primary_idx  3  worker_id  NULL  false
+bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u6_primary_idx  1  export_id  NULL  false
+bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u6_primary_idx  2  worker_id  NULL  false
+bar  mz_worker_compute_frontiers  mz_worker_compute_frontiers_u6_primary_idx  3  time  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u6_primary_idx  1  export_id  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u6_primary_idx  2  import_id  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u6_primary_idx  3  worker_id  NULL  false
+bar  mz_worker_compute_import_frontiers  mz_worker_compute_import_frontiers_u6_primary_idx  4  time  NULL  false
 bar  v  v_primary_idx  1  ?column?  NULL  false
 
 query TTTT


### PR DESCRIPTION
Part of the cluster unification epic (MaterializeInc/cloud#4929).

Adjust the API for creating clusters and cluster replicas to allow allocating the ID for the to-be-created cluster or cluster replica outside of the transaction that creates the cluster or cluster replica. This matches what we do for other catalog entities.

A future commit will use this ability to create sources and sinks that refer to their linked cluster in single transaction.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

No (intentional) behavioral changes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
