### PR TITLE
storage: fix creation of storage-worker-internal control flow

### DIFF
--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -55,11 +55,20 @@ pub enum InternalStorageCommand {
 pub trait InternalCommandSender {
     /// Broadcasts the given command to all workers.
     fn broadcast(&mut self, internal_cmd: InternalStorageCommand);
+
+    /// Returns the next available command, if any. This returns `None` when
+    /// there are currently no commands but there might be commands again in the
+    /// future.
+    fn next(&mut self) -> Option<InternalStorageCommand>;
 }
 
 impl InternalCommandSender for Sequencer<InternalStorageCommand> {
     fn broadcast(&mut self, internal_cmd: InternalStorageCommand) {
         self.push(internal_cmd);
+    }
+
+    fn next(&mut self) -> Option<InternalStorageCommand> {
+        Iterator::next(self)
     }
 }
 

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -107,8 +107,6 @@ pub fn serve(
                 dropped_ids: Vec::new(),
                 source_statistics: HashMap::new(),
                 sink_statistics: HashMap::new(),
-                // TODO(aljoscha): We can refactor when `StorageState` is being
-                // created, to get around this being an `Option`.
                 internal_cmd_tx: None,
             },
         }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -380,4 +380,8 @@ impl InternalCommandSender for HaltingInternalCommandSender {
     fn broadcast(&mut self, internal_cmd: mz_storage::internal_control::InternalStorageCommand) {
         halt!("got unexpected {:?} during testing", internal_cmd);
     }
+
+    fn next(&mut self) -> Option<InternalStorageCommand> {
+        halt!("got unexpected call to next() during testing");
+    }
 }


### PR DESCRIPTION
### Motivation

Fixes a previously unreported bug.

### Tips for reviewer

I left a big comment that explains the situation and fix.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
