### PR TITLE
Migration to remove legacy orchestrator services

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -101,6 +101,7 @@ use mz_build_info::{build_info, BuildInfo};
 use mz_cloud_resources::CloudResourceController;
 use mz_controller::ControllerConfig;
 use mz_frontegg_auth::FronteggAuthentication;
+use mz_orchestrator::NamespacedOrchestrator;
 use mz_ore::future::OreFutureExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
@@ -344,6 +345,12 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     .await
     .context("opening storage usage client")?;
 
+    // TODO(teskje): Remove this migration in v0.42, since v0.41+ will only create orchestrator
+    // resources in the "cluster" namespace.
+    tracing::info!("SPECIAL MIGRATION: removing legacy orchestrator services");
+    remove_orchestrator_services(config.controller.orchestrator.namespace("compute")).await?;
+    remove_orchestrator_services(config.controller.orchestrator.namespace("storage")).await?;
+
     // Initialize controller.
     let controller = mz_controller::Controller::new(config.controller, envd_epoch).await;
 
@@ -503,4 +510,13 @@ impl Server {
     pub fn internal_http_local_addr(&self) -> SocketAddr {
         self.internal_http_listener.local_addr()
     }
+}
+
+async fn remove_orchestrator_services(
+    orchestrator: Arc<dyn NamespacedOrchestrator>,
+) -> Result<(), anyhow::Error> {
+    for name in orchestrator.list_services().await? {
+        orchestrator.drop_service(&name).await?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
This PR adds a special migration that removes all orchestrator services in the 'compute' and 'storage' namespaces when environmentd starts up.

In version 0.41.0, the controller only knows about the 'cluster' namespace, so services that were created in other namespaces previously leak. The purpose of this migration is to clean up those leaked services.

### Motivation

  * This PR adds a known-desirable feature.

Advances https://github.com/MaterializeInc/cloud/issues/4929.

### Tips for reviewer

This seems straightforward. I tested that this works as expected in my staging env, by performing an upgrade from materialize:latest to this branch.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
