### PR TITLE
adapter: allow all replica sizes in `Catalog::open`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2431,7 +2431,8 @@ impl Catalog {
                 views: log_views,
             };
             let config = ReplicaConfig {
-                location: catalog.concretize_replica_location(serialized_config.location)?,
+                location: catalog
+                    .concretize_replica_location(serialized_config.location, &vec![])?,
                 compute: ComputeReplicaConfig {
                     logging,
                     idle_arrangement_merge_effort: serialized_config.idle_arrangement_merge_effort,
@@ -3872,6 +3873,7 @@ impl Catalog {
     pub fn concretize_replica_location(
         &self,
         location: SerializedReplicaLocation,
+        allowed_sizes: &Vec<String>,
     ) -> Result<ReplicaLocation, AdapterError> {
         let location = match location {
             SerializedReplicaLocation::Unmanaged {
@@ -3891,7 +3893,6 @@ impl Catalog {
                 az_user_specified,
             } => {
                 let cluster_replica_sizes = &self.state.cluster_replica_sizes;
-                let allowed_sizes = self.state.system_config().allowed_cluster_replica_sizes();
 
                 if !cluster_replica_sizes.0.contains_key(&size)
                     || (!allowed_sizes.is_empty() && !allowed_sizes.contains(&size))

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -890,7 +890,10 @@ impl Coordinator {
             };
 
             let config = ReplicaConfig {
-                location: self.catalog.concretize_replica_location(location)?,
+                location: self.catalog.concretize_replica_location(
+                    location,
+                    self.catalog.system_config().allowed_cluster_replica_sizes(),
+                )?,
                 compute: ComputeReplicaConfig {
                     logging,
                     idle_arrangement_merge_effort: compute.idle_arrangement_merge_effort,
@@ -1030,7 +1033,10 @@ impl Coordinator {
         };
 
         let config = ReplicaConfig {
-            location: self.catalog.concretize_replica_location(location)?,
+            location: self.catalog.concretize_replica_location(
+                location,
+                self.catalog.system_config().allowed_cluster_replica_sizes(),
+            )?,
             compute: ComputeReplicaConfig {
                 logging,
                 idle_arrangement_merge_effort: compute.idle_arrangement_merge_effort,
@@ -3877,7 +3883,10 @@ impl Coordinator {
             availability_zone,
             az_user_specified: false,
         };
-        let location = self.catalog.concretize_replica_location(location)?;
+        let location = self.catalog.concretize_replica_location(
+            location,
+            self.catalog.system_config().allowed_cluster_replica_sizes(),
+        )?;
         let logging = {
             ReplicaLogging {
                 log_logging: false,


### PR DESCRIPTION
Fixes #17194 by allowing all replica sizes in `Catalog::open`.

### Motivation

* This PR fixes a recognized bug.

Fixes #17194.

### Tips for reviewer

Fixes #17194 by making the following changes:

- Promote `allowed_sizes` as a `Catalog::concretize_replica_location` parameter.
- Bind an empty vector as an argument for the above in `Catalog::open`.
- Bind the `allowed_cluster_replica_sizes` sytem variable in the remaining `concretize_replica_location` call sites (all of those are methods on the `Coordinator` implementation).

I'm marking this as ready for review as we might want to land this before cutting the next release.

I'll try to add a `*.td` test (or extend an existing test) before we merge this. So far I've only tested this manually on my local environment as follows:

1. `CREATE CLUSTER REPLICA default.r2 SIZE = '2';`
1. `ALTER SYSTEM SET allowed_cluster_replica_sizes = 1;`
1. Restart he cluster without `--reset`.

With the changes proposed in this PR I am able to restart the cluster.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
