### PR TITLE
Cluster unification follow ups

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -262,7 +262,7 @@ where
 
         self.instances.insert(
             id,
-            Instance::new(id, self.build_info, arranged_logs, self.envd_epoch),
+            Instance::new(self.build_info, arranged_logs, self.envd_epoch),
         );
 
         let instance = self.instances.get_mut(&id).expect("instance just added");

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -37,7 +37,7 @@ use crate::types::sources::SourceInstanceDesc;
 
 use super::error::CollectionMissing;
 use super::replica::{Replica, ReplicaConfig};
-use super::{CollectionState, ComputeControllerResponse, ComputeInstanceId, ReplicaId};
+use super::{CollectionState, ComputeControllerResponse, ReplicaId};
 
 #[derive(Error, Debug)]
 #[error("replica exists already: {0}")]
@@ -92,8 +92,6 @@ pub(super) enum SubscribeTargetError {
 /// The state we keep for a compute instance.
 #[derive(Debug)]
 pub(super) struct Instance<T> {
-    /// ID of this instance
-    _instance_id: ComputeInstanceId,
     /// Build info for spawning replicas
     build_info: &'static BuildInfo,
     /// The replicas of this compute instance.
@@ -180,7 +178,6 @@ where
     ComputeGrpcClient: ComputeClient<T>,
 {
     pub fn new(
-        instance_id: ComputeInstanceId,
         build_info: &'static BuildInfo,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
         envd_epoch: NonZeroI64,
@@ -194,7 +191,6 @@ where
             .collect();
 
         let mut instance = Self {
-            _instance_id: instance_id,
             build_info,
             replicas: Default::default(),
             collections,

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -396,19 +396,13 @@ where
 
     /// Remove an existing instance replica, by ID.
     pub fn remove_replica(&mut self, id: ReplicaId) -> Result<(), ReplicaMissing> {
-        if !self.compute.replicas.contains_key(&id) {
-            return Err(ReplicaMissing(id));
-        }
-        self.remove_replica_state(id);
-        Ok(())
-    }
+        self.compute
+            .replicas
+            .remove(&id)
+            .ok_or(ReplicaMissing(id))?;
 
-    /// Remove all state related to a replica.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the specified replica does not exist in the compute state.
-    fn remove_replica_state(&mut self, id: ReplicaId) {
+        self.compute.failed_replicas.remove(&id);
+
         // Remove frontier tracking for this replica.
         self.remove_write_frontiers(id);
 
@@ -439,20 +433,17 @@ where
             self.compute.ready_responses.push_back(response);
         }
 
-        self.compute
-            .replicas
-            .remove(&id)
-            .expect("replica not found");
-
-        // In case the replica crashes and we receive a drop replica request
-        // at the same time, the cleanup request will race with the rehydration.
-        // Hence we also have to stop a pending rehydration request.
-        self.compute.failed_replicas.remove(&id);
+        Ok(())
     }
 
+    /// Rehydrate the given instance replica.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the specified replica does not exist.
     fn rehydrate_replica(&mut self, id: ReplicaId) {
         let config = self.compute.replicas[&id].config.clone();
-        self.remove_replica_state(id);
+        self.remove_replica(id).expect("replica must exist");
         let result = self.add_replica(id, config);
 
         match result {


### PR DESCRIPTION
WIP

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
