### PR TITLE
test: add `allowed_cluster_replica_sizes` nightly test

### DIFF
--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -9,6 +9,7 @@
 
 from itertools import chain
 from os import environ
+from textwrap import dedent
 from time import sleep
 from typing import Any, List, Optional
 from uuid import uuid1
@@ -183,12 +184,12 @@ def workflow_default(c: Composition) -> None:
         c.stop("materialized")
     except launchdarkly_api.ApiException as e:
         raise UIError(
-            "\n".join(
-                [
-                    "Error when calling the Launch Darkly API.",
-                    "- Status: %s." % e.status,
-                    "- Reason: %s." % e.reason,
-                ]
+            dedent(
+                f"""
+                Error when calling the Launch Darkly API.
+                - Status: {e.status},
+                - Reason: {e.reason},
+                """
             )
         )
     finally:


### PR DESCRIPTION
Assert that restricting the `allowed_cluster_replica_sizes` to a set that excludes the sizes of any already existing replicas survives restarts.


### Motivation

  * This PR adds a known-desirable feature.

This adds a test to the bug resolved in #17272 so we can catch regressions.

### Tips for reviewer

At the moment the test is:

1. Written as the `default` workflow of a stand-alone `mzcompose` folder.
2. Executed only as part of the `nightlies` BuildKite pipeline.

Please comment if you want me to change these aspects.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
