### PR TITLE
compute-client: remove outdated panic

### DIFF
--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -169,10 +169,9 @@ where
         )
         .await;
 
-        if let Err(error) = result {
-            tracing::warn!("replica task for {replica_id} failed: {error}");
-        } else {
-            panic!("replica message loop should never return successfully");
+        match result {
+            Ok(()) => tracing::info!("stopped replica task for {replica_id}"),
+            Err(error) => tracing::warn!("replica task for {replica_id} failed: {error}"),
         }
     }
 }


### PR DESCRIPTION
The replica task would panic when it returned successfully, because prior to #17273 it was not expected to do so. Since #17273 the replica task does return without an error if the controller disconnects, so this panic is wrong now.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
