### PR TITLE
storage,compute: clarify `create_instance`/`drop_instance` naming

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -250,8 +250,12 @@ where
     T: Timestamp + Lattice,
     ComputeGrpcClient: ComputeClient<T>,
 {
-    /// Create a compute instance.
-    pub fn create_instance(
+    /// Notifies the controller about a newly created instance with the
+    /// specified `id`.
+    ///
+    /// Returns an error if the controller was previously notified about a
+    /// storage instance with the given `id`.
+    pub fn notify_create_instance(
         &mut self,
         id: ComputeInstanceId,
         arranged_logs: BTreeMap<LogVariant, GlobalId>,
@@ -276,12 +280,13 @@ where
         Ok(())
     }
 
-    /// Remove a compute instance.
+    /// Notifies the controller that the instance with the given `id` has just
+    /// been dropped.
     ///
     /// # Panics
     ///
-    /// Panics if the identified `instance` still has active replicas.
-    pub fn drop_instance(&mut self, id: ComputeInstanceId) {
+    /// Panics if the identified instance still has active replicas.
+    pub fn notify_drop_instance(&mut self, id: ComputeInstanceId) {
         if let Some(compute_state) = self.instances.remove(&id) {
             compute_state.drop();
         }

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -174,8 +174,9 @@ where
         id: ClusterId,
         config: ClusterConfig,
     ) -> Result<(), anyhow::Error> {
-        self.storage.create_instance(id);
-        self.compute.create_instance(id, config.arranged_logs)?;
+        self.storage.notify_create_instance(id);
+        self.compute
+            .notify_create_instance(id, config.arranged_logs)?;
         Ok(())
     }
 
@@ -185,8 +186,8 @@ where
     ///
     /// Panics if the cluster still has replicas.
     pub fn drop_cluster(&mut self, id: ClusterId) {
-        self.storage.drop_instance(id);
-        self.compute.drop_instance(id);
+        self.storage.notify_drop_instance(id);
+        self.compute.notify_drop_instance(id);
     }
 
     /// Creates a replica of the specified cluster with the specified identifier


### PR DESCRIPTION
Before, the name was implying that the callee was doing the actual work while in fact it is just being notified of things that already happened.

Now, prefix these methods with `notify_` to convey that fact.

NOTE: I can thread this all the way to `controller/clusters.rs` if we like the change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
