### PR TITLE
adapter,storage: add envelope_type column to mz_sinks

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -307,6 +307,7 @@ Field            | Type        | Meaning
 `type`           | [`text`]    | The type of the sink: `kafka`.
 `connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any.
 `size`           | [`text`]    | The size of the sink.
+`envelope_type`  | [`text`]    | The [envelope](/sql/create-sink/#envelopes) of the sink: `upsert`, or `debezium`.
 
 ### `mz_sources`
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1557,6 +1557,14 @@ impl Sink {
         }
     }
 
+    /// Envelope of the sink.
+    pub fn envelope(&self) -> Option<&str> {
+        match &self.envelope {
+            SinkEnvelope::Debezium => Some("debezium"),
+            SinkEnvelope::Upsert => Some("upsert"),
+        }
+    }
+
     pub fn connection_id(&self) -> Option<GlobalId> {
         match &self.connection {
             StorageSinkConnectionState::Pending(pending) => pending.connection_id(),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1416,6 +1416,7 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("type", ScalarType::String.nullable(false))
         .with_column("connection_id", ScalarType::String.nullable(true))
         .with_column("size", ScalarType::String.nullable(true))
+        .with_column("envelope_type", ScalarType::String.nullable(true))
         .with_column("cluster_id", ScalarType::String.nullable(false)),
     is_retained_metrics_relation: true,
 });

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -604,6 +604,9 @@ impl CatalogState {
                     });
                 }
             };
+
+            let envelope = sink.envelope();
+
             updates.push(BuiltinTableUpdate {
                 id: self.resolve_builtin_table(&MZ_SINKS),
                 row: Row::pack_slice(&[
@@ -614,6 +617,7 @@ impl CatalogState {
                     Datum::String(connection.name()),
                     Datum::from(sink.connection_id().map(|id| id.to_string()).as_deref()),
                     Datum::from(self.get_storage_object_size(id)),
+                    Datum::from(envelope),
                     Datum::String(&sink.cluster_id.to_string()),
                 ]),
                 diff,

--- a/test/testdrive/mz-sinks.td
+++ b/test/testdrive/mz-sinks.td
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify that envelope types are correctly reported in mz_sinks
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}');
+
+> CREATE CONNECTION csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+> CREATE TABLE mz_sinks_table (name string);
+
+> CREATE SINK mz_sinks_debezium FROM mz_sinks_table
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-mz-sinks-debezium-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM;
+
+> CREATE MATERIALIZED VIEW mz_sinks_table_keyed AS
+    SELECT name, count(name) from mz_sinks_table
+    GROUP BY name;
+
+> CREATE SINK mz_sinks_upsert FROM mz_sinks_table_keyed
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-mz-upsert-debezium-${testdrive.seed}')
+  KEY (name)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT;
+
+> SELECT envelope_type FROM mz_sinks WHERE name = 'mz_sinks_debezium'
+debezium
+
+> SELECT envelope_type FROM mz_sinks WHERE name = 'mz_sinks_upsert'
+upsert


### PR DESCRIPTION
Known-desired feature: https://github.com/MaterializeInc/cloud/issues/4245

Analog to https://github.com/MaterializeInc/materialize/pull/16591 for `mz_sinks`.

In that previous PR we had concerns about changing the schema of `mz_sources`, however https://github.com/MaterializeInc/materialize/pull/17256 is already changing the schema of `mz_sinks` so we might want to eagerly merge this one as well, because it will change `mz_sinks` again.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
