### PR TITLE
adapter: disallow queries on storage clusters

### DIFF
--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -103,11 +103,11 @@ contains:cannot modify linked cluster "materialize_public_lg2"
 contains:cannot modify linked cluster "materialize_public_lg2"
 > SET cluster = materialize_public_lg2
 ! SELECT 1
-contains:cannot execute queries on linked clusters
+contains:cannot execute queries on cluster containing sources or sinks
 ! SUBSCRIBE v
-contains:cannot execute queries on linked clusters
+contains:cannot execute queries on cluster containing sources or sinks
 ! EXPLAIN SELECT 1
-contains:cannot execute queries on linked clusters
+contains:cannot execute queries on cluster containing sources or sinks
 > SET cluster = default
 
 # Test that only the default clusters and replicas remain after dropping

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -17,6 +17,11 @@
 # Create a cluster for sources and sinks.
 > CREATE CLUSTER storage REPLICAS ()
 
+# Querying a cluster with no replicas does not succeed.
+> SET cluster = storage
+! SELECT 1
+contains:CLUSTER "storage" has no replicas available to service request
+
 # Specifying `IN CLUSTER` and `SIZE` simultaneously is banned.
 ! CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER WITH (SIZE = '1')
 contains:only one of IN CLUSTER or SIZE can be set
@@ -30,6 +35,10 @@ contains:cannot create index in cluster containing sources or sinks
 ! CREATE MATERIALIZED VIEW bad IN CLUSTER storage AS SELECT 1
 contains:cannot create materialized view in cluster containing sources or sinks
 
+# Executing queries on a storage cluster is banned.
+! SELECT 1
+contains:cannot execute queries on cluster containing sources or sinks
+
 # Only one replica of a storage cluster is permitted.
 > CREATE CLUSTER REPLICA storage.r1 SIZE '1'
 ! CREATE CLUSTER REPLICA storage.r2 SIZE '1'
@@ -40,6 +49,10 @@ contains:cannot create more than one replica of a cluster containing sources or 
 > DROP SOURCE loadgen;
 > CREATE INDEX idx IN CLUSTER storage ON t (a)
 > CREATE MATERIALIZED VIEW mv IN CLUSTER storage AS SELECT 1
+
+# As is running queries.
+> SELECT 1
+1
 
 # Recreating the source is banned.
 ! CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER
@@ -63,6 +76,8 @@ contains:cannot create source in cluster with more than one replica
 ! DROP CLUSTER storage
 contains:cannot drop cluster with active objects
 > DROP CLUSTER storage CASCADE
+
+> SET cluster = default
 
 # Test that a cluster can contain multiple sources and sinks, and verify that
 # the sources and sinks produce the correct output.


### PR DESCRIPTION
Part of the cluster unification epic (MaterializeInc/cloud#4929).

See comment within for rationale.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug that @teskje noticed on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
