### PR TITLE
controller: set storage workers appropriately

### DIFF
--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -335,6 +335,7 @@ where
                     init_container_image: self.init_container_image.clone(),
                     args: &|assigned| {
                         vec![
+                            format!("--storage-workers={}", location.allocation.workers),
                             format!(
                                 "--storage-controller-listen-addr={}",
                                 assigned["storagectl"]


### PR DESCRIPTION
Part of the cluster unification epic (MaterializeInc/cloud#4929).

Fix a regression spotted by Philip in the feature benchmark, due to not correctly setting the number of storage workers in the unified cluster.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a regression noticed by Philip.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
