### PR TITLE
persist: actually hook up Batch deletion to blob deletion

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -49,6 +49,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_pubsub_push_diff_enabled": "true",
     "persist_pubsub_client_enabled": "true",
     "persist_stats_audit_percent": "100",
+    "persist_batch_delete_enabled": "true",
     "enable_rbac_checks": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_dangerous_functions": "true",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -49,10 +49,17 @@ impl PersistFeatureFlag {
         default: false,
         description: "use the new streaming consolidate during snapshot_and_fetch",
     };
+    // TODO: Remove this once we're comfortable that there aren't any bugs.
+    pub(crate) const BATCH_DELETE_ENABLED: PersistFeatureFlag = PersistFeatureFlag {
+        name: "persist_batch_delete_enabled",
+        default: false,
+        description: "Whether to actually delete blobs when batch delete is called (Materialize).",
+    };
 
     pub const ALL: &'static [PersistFeatureFlag] = &[
         Self::STREAMING_COMPACTION,
         Self::STREAMING_SNAPSHOT_AND_FETCH,
+        Self::BATCH_DELETE_ENABLED,
     ];
 }
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1949,6 +1949,8 @@ pub mod datadriven {
                     .expect("unknown batch")
                     .clone();
                 Batch::new(
+                    true,
+                    Arc::clone(&datadriven.client.metrics),
                     Arc::clone(&datadriven.client.blob),
                     datadriven.shard_id,
                     datadriven.client.cfg.build_version.clone(),


### PR DESCRIPTION
This was "temporarily" commented out ~8~ 17 months ago (apparently)
because of a nemesis failure and was never re-enabled.

We now not only have s3 object versioning, but also a persistcli
`restore-blob` command, which should resolve any of these if they do pop
up, making this much less stressful than the last time we tried this in
Jan. (I still plan to let this back in staging for a while.)

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

We should definitely throw some pre-merge testing resources at this.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
