### PR TITLE
testdrive: allow deprecating statements based on version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4875,6 +4875,7 @@ dependencies = [
  "rdkafka",
  "regex",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "similar",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -56,6 +56,7 @@ rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["native-tls-vendored"] }
+semver = "1.0.14"
 serde = "1.0.152"
 serde_json = { version = "1.0.89", features = ["raw_value"] }
 similar = "2.2.1"

--- a/src/testdrive/src/action/deprecate.rs
+++ b/src/testdrive/src/action/deprecate.rs
@@ -1,0 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+pub fn deprecate(mut cmd: BuiltinCommand, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
+    let deprecate = cmd.args.string("from-version")?;
+    cmd.args.done()?;
+    state.deprecate = Some(deprecate);
+    Ok(ControlFlow::Continue)
+}


### PR DESCRIPTION
Attempting to atomize #15813 into more independently mergeable bits; #15813 has the commits in situ and I am glad to explain each commit in more detail.

@benesch just pinging you for a backward compatibility sign off or if you have a more elegant suggestion for the API.

### Motivation

  * This PR adds a known-desirable feature, which will form the basis of queryable remap shards.

ec41bbb0e629efeb19c48e34a31e865b9ad5096b is necessary because we changing the output of the output of `SHOW CREATE...`; we can retain the tests' output from the "current" version during upgrade tests, but then test that the output changes at some specified version. With the current way the tests are structured, there is no means to permit the output to change version-by-version.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
