### PR TITLE
[persist] Perform expiry directly instead of passing it as maintenance

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -1179,31 +1179,6 @@ where
         ret
     }
 
-    pub fn handles_needing_expiration(
-        &self,
-        now_ms: EpochMillis,
-    ) -> (Vec<LeasedReaderId>, Vec<WriterId>) {
-        let mut readers = Vec::new();
-        for (reader, state) in self.collections.leased_readers.iter() {
-            let time_since_last_heartbeat_ms =
-                now_ms.saturating_sub(state.last_heartbeat_timestamp_ms);
-            if time_since_last_heartbeat_ms > state.lease_duration_ms {
-                readers.push(reader.clone());
-            }
-        }
-        // critical_readers don't need forced expiration (in fact, that's the
-        // point)
-        let mut writers = Vec::new();
-        for (writer, state) in self.collections.writers.iter() {
-            let time_since_last_heartbeat_ms =
-                now_ms.saturating_sub(state.last_heartbeat_timestamp_ms);
-            if time_since_last_heartbeat_ms > state.lease_duration_ms {
-                writers.push(writer.clone());
-            }
-        }
-        (readers, writers)
-    }
-
     pub fn need_rollup(&self) -> Option<SeqNo> {
         let (latest_rollup_seqno, _) = self.latest_rollup();
         if self.seqno.0.saturating_sub(latest_rollup_seqno.0) > PersistConfig::NEED_ROLLUP_THRESHOLD


### PR DESCRIPTION
### Motivation

When discussing #17150, we discovered that our current approach to expiry can result in **O(n^2)** command applications, where **n** is the number of handles expiring for a single shard at once. (The call to `apply_unbatched_cmd` will re-discover and relaunch expiry for the remaining **n-1** expiring handles, etc.)

Expiry is cheap -- we already scan through the list of handles once per command, so we can just drop the expired ones immediately instead of routing them through our maintenance machinery. This means expiry no longer places additional load on the state machine. (It also avoids any races where a lease is renewed after we've already decided to expire it; I think those are harmless but it's nice to have less to think about.)

### Tips for reviewer

Originally, I was hoping to expire handles based on the walltime of the state. However! This could lead to bad behaviour when clocks skew... if one clock is ahead for, say, an hour, it can advance the walltime to an hour ahead of the current time, and then any leases that are registered within the next 45 minutes will be expired immediately. I have ideas about how to avoid this - choosing the lease start time based on the walltime, etc. - but that seems like a larger change with much smaller marginal value, so I went with this simpler thing that keeps semantics closer to the existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
