### PR TITLE
Add `sum` field to `mz_raw_peek_durations` and `mz_raw_worker_compute_delays`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -283,6 +283,7 @@ Field         | Type       | Meaning
 `worker_id`   | [`bigint`] | The ID of the worker thread servicing the peek.
 `duration_ns` | [`bigint`] | The upper bound of the bucket in nanoseconds.
 `count`       | [`bigint`] | The (noncumulative) count of peeks in this bucket.
+`sum  `       | [`bigint`] | The (noncumulative) sum of peek durations in this bucket, or `NULL` in the unlikely event it has overflowed.
 
 ### `mz_peek_durations`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -283,7 +283,7 @@ Field         | Type       | Meaning
 `worker_id`   | [`bigint`] | The ID of the worker thread servicing the peek.
 `duration_ns` | [`bigint`] | The upper bound of the bucket in nanoseconds.
 `count`       | [`bigint`] | The (noncumulative) count of peeks in this bucket.
-`sum  `       | [`bigint`] | The (noncumulative) sum of peek durations in this bucket, or `NULL` in the unlikely event it has overflowed.
+`sum`         | [`bigint`] | The (noncumulative) sum of peek durations in this bucket, or `NULL` in the unlikely event it has overflowed.
 
 ### `mz_peek_durations`
 
@@ -409,6 +409,7 @@ Field       | Type       | Meaning
 `worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
 `delay_ns`  | [`bigint`] | The upper bound of the bucket in nanoseconds.
 `count`     | [`bigint`] | The (noncumulative) count of delay measurements in this bucket.
+`sum`       | [`bigint`] | The (noncumulative) sum of delay measurements in this bucket, or `NULL` in the unlikely event it has overflowed.
 
 ### `mz_worker_compute_delays`
 

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -766,6 +766,7 @@ impl LogVariant {
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("duration_ns", ScalarType::UInt64.nullable(false))
                 .with_column("count", ScalarType::UInt64.nullable(false))
+                .with_column("sum", ScalarType::UInt64.nullable(true))
                 .with_key(vec![0, 1]),
         }
     }

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -753,6 +753,7 @@ impl LogVariant {
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("delay_ns", ScalarType::UInt64.nullable(false))
                 .with_column("count", ScalarType::Int64.nullable(false))
+                .with_column("sum", ScalarType::UInt64.nullable(true))
                 .with_key(vec![0, 1, 2, 3]),
 
             LogVariant::Compute(ComputeLog::PeekCurrent) => RelationDesc::empty()

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -192,11 +192,13 @@ pub fn construct<A: Allocate>(
                                                 let delay_pow = delay_ns.next_power_of_two();
                                                 let delay_ns: i128 =
                                                     delay_ns.try_into().expect("delay too big");
-                                                let delay_count: i128 = delay_count.into();
                                                 frontier_delay_session.give((
                                                     (id, source_id, worker, delay_pow),
                                                     time_ms,
-                                                    (-(delay_ns * delay_count), -delay_count),
+                                                    (
+                                                        -(delay_ns * i128::from(delay_count)),
+                                                        -delay_count,
+                                                    ),
                                                 ));
                                             }
                                         }
@@ -316,7 +318,7 @@ pub fn construct<A: Allocate>(
                                         peek_duration_session.give((
                                             (key.0, elapsed_pow),
                                             time_ms,
-                                            (elapsed_ns, 1),
+                                            (elapsed_ns, 1u64),
                                         ));
                                     } else {
                                         error!(
@@ -367,7 +369,7 @@ pub fn construct<A: Allocate>(
                         Datum::String(&source_id.to_string()),
                         Datum::UInt64(u64::cast_from(worker)),
                         Datum::UInt64(delay_pow.try_into().expect("pow too big")),
-                        Datum::Int64(count.try_into().expect("count too big")),
+                        Datum::Int64(count.into()),
                         u64::try_from(sum).ok().into(),
                     ])
                 }
@@ -393,7 +395,7 @@ pub fn construct<A: Allocate>(
                 Row::pack_slice(&[
                     Datum::UInt64(u64::cast_from(worker)),
                     Datum::UInt64(bucket.try_into().expect("pow too big")),
-                    Datum::UInt64(count.try_into().expect("count too big")),
+                    Datum::UInt64(count),
                     u64::try_from(sum).ok().into(),
                 ])
             });

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -370,6 +370,13 @@ pub fn construct<A: Allocate>(
                         Datum::UInt64(u64::cast_from(worker)),
                         Datum::UInt64(delay_pow.try_into().expect("pow too big")),
                         Datum::Int64(count.into()),
+                        // [btv] This is nullable so that we can fill
+                        // in `NULL` if it overflows. That would be a
+                        // bit far-fetched, but not impossible to
+                        // imagine. See discussion
+                        // [here](https://github.com/MaterializeInc/materialize/pull/17302#discussion_r1086373740)
+                        // for more details, and think about this
+                        // again if we ever decide to stabilize it.
                         u64::try_from(sum).ok().into(),
                     ])
                 }
@@ -396,6 +403,13 @@ pub fn construct<A: Allocate>(
                     Datum::UInt64(u64::cast_from(worker)),
                     Datum::UInt64(bucket.try_into().expect("pow too big")),
                     Datum::UInt64(count),
+                    // [btv] This is nullable so that we can fill
+                    // in `NULL` if it overflows. That would be a
+                    // bit far-fetched, but not impossible to
+                    // imagine. See discussion
+                    // [here](https://github.com/MaterializeInc/materialize/pull/17302#discussion_r1086373740)
+                    // for more details, and think about this
+                    // again if we ever decide to stabilize it.
                     u64::try_from(sum).ok().into(),
                 ])
             });

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -303,7 +303,7 @@ pub fn construct<A: Allocate>(
                                     if let Some(start) = peek_stash.remove(&key) {
                                         let elapsed_ns = time.as_nanos() - start;
                                         peek_duration_session.give((
-                                            (key.0, elapsed_ns.next_power_of_two(), elapsed_ns),
+                                            (key.0, elapsed_ns),
                                             time_ms,
                                             1,
                                         ));
@@ -375,7 +375,7 @@ pub fn construct<A: Allocate>(
         // Duration statistics derive from the non-rounded event times.
         let peek_duration = peek_duration
             .as_collection()
-            .explode(|(worker, bucket, val)| Some(((worker, bucket), (val, 1))))
+            .explode(|(worker, val)| Some(((worker, val.next_power_of_two()), (val, 1))))
             .count_total_core::<i64>()
             .map(|((worker, bucket), (sum, count))| {
                 Row::pack_slice(&[

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -376,7 +376,8 @@ pub fn construct<A: Allocate>(
         let peek_duration = peek_duration
             .as_collection()
             .explode(|(worker, val)| Some(((worker, val.next_power_of_two()), (val, 1))))
-            .count_total_core::<i64>()
+            // TODO(#16549): Use explicit arrangement
+            .count_total_core()
             .map(|((worker, bucket), (sum, count))| {
                 Row::pack_slice(&[
                     Datum::UInt64(u64::cast_from(worker)),

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -149,6 +149,7 @@ SID   import_id   2           text
 SID   worker_id   3           uint8
 SID   delay_ns    4           uint8
 SID   count       5           bigint
+SID   sum	  6	      uint8
 
 > SELECT mz_columns.id, mz_columns.name, position, mz_columns.type
   FROM mz_sources JOIN mz_columns USING (id)


### PR DESCRIPTION
Putting up this as a draft to check whether people think it's crazy. If not, I'll fix the tests, and do a similar thing for the other histogram relations. Cc @frankmcsherry who I believe is the original author of all the logging stuff.

### Motivation

This allows computing the sum of peek durations, which can be useful e.g. for exporting a histogram prometheus metric, or computing means.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
