### PR TITLE
doc/developer: remove outdated text from architecture-db.md

### DIFF
--- a/doc/developer/platform/architecture-db.md
+++ b/doc/developer/platform/architecture-db.md
@@ -58,7 +58,7 @@ This moves the onus of some behaviors on to higher layers. STORAGE is not expect
 
 The STORAGE layer is tasked with creating and maintaining definite collections.
 
-It relies on no other layers of the stack, and has great lattitude in defining what it requires of others.
+It relies on no other layers of the stack, and has great latitude in defining what it requires of others.
 
 Its primary requirements include
 1. define and respond to `CreateSource` commands (likely from ADAPTER) with the identifier of definite collections.
@@ -69,8 +69,6 @@ The layer gets to determine how it exposes these commands and what information m
 For example, STORAGE may reasonably conclude that it cannot rely on determinism of ADAPTER or COMPUTE, and therefore require `Subscribe` commands must come with a "rendition" identifier, where STORAGE is then allowed to reconcile the renditions of a collection (perhaps taking the most recent information).
 
 There are any number of secondary requirements and additional commands that can be exposed (for example, to drop sources, manage timeouts of subscriptions, advance compaction of collections, set and modify rendition reconciliation policies, etc).
-
-STORAGE can be sharded into STORAGE INSTANCEs.
 
 ### COMPUTE
 
@@ -87,7 +85,6 @@ Its primary requirements include (all from ADAPTER)
 Each COMPUTE INSTANCE is by design stateless, and should be explicitly instructed in what is required of it.
 
 COMPUTE can be sharded into COMPUTE INSTANCEs.
-Each COMPUTE INSTANCE is bound to one STORAGE INSTANCE.
 Views installed in one COMPUTE INSTANCE can be used in that same COMPUTE INSTANCE, but cannot be used by others without a round-trip through STORAGE.
 
 ### ADAPTER


### PR DESCRIPTION
From an in-person conversation with @frankmcsherry. The removed text is the result of a s/REGION/STORAGE INSTANCE/ long ago, and it appears the rewritten text does not have the intended meaning. 

### Motivation

   * This PR refactors existing documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
