### PR TITLE
storage-client: fix emission of "dropped" source/sink status

### DIFF
--- a/test/testdrive/status-history.td
+++ b/test/testdrive/status-history.td
@@ -112,3 +112,19 @@ SELECT id FROM mz_sinks WHERE name = 'kafka_sink_2'
 > select * from mz_internal.mz_source_statuses where id in ('${source_id}', '${source_id_2}') order by id;
 "${source_id}" kafka_source kafka "<TIMESTAMP> UTC" running <null> <null>
 "${source_id_2}" kafka_source_2 kafka "<TIMESTAMP> UTC" running <null> <null>
+
+
+# ensure `dropped` also shows up
+> DROP SINK kafka_sink
+
+> SELECT * FROM mz_internal.mz_sink_status_history WHERE sink_id = '${sink_id}' ORDER BY occurred_at;
+"<TIMESTAMP> UTC" ${sink_id} starting <null> <null>
+"<TIMESTAMP> UTC" ${sink_id} running <null> <null>
+"<TIMESTAMP> UTC" ${sink_id} dropped <null> <null>
+
+> DROP SOURCE kafka_source
+
+> select * from mz_internal.mz_source_status_history where source_id = '${source_id}' order by occurred_at;
+"<TIMESTAMP> UTC" ${source_id} starting <null> <null>
+"<TIMESTAMP> UTC" ${source_id} running <null> <null>
+"<TIMESTAMP> UTC" ${source_id} dropped <null> <null>


### PR DESCRIPTION
@guswynn spotted that the cluster unification work broke the emission of the final "dropped" status for a source/sink. This commit surgically extracts the bit of #17300 that corrects that, in case it makes for a less scary backport.

Co-authored-by: Gus Wynn <gus@materialize.com>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
