### PR TITLE
Cluster unification followups

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -3846,7 +3846,7 @@ impl Coordinator {
     /// source or sink with the given name.
     ///
     /// The operations are written to the provided `ops` vector. The ID
-    /// allocated for the TODO TODO
+    /// allocated for the linked cluster is returned.
     pub(crate) async fn create_linked_cluster_ops(
         &mut self,
         linked_object_id: GlobalId,


### PR DESCRIPTION
*Part of the cluster unification epic (https://github.com/MaterializeInc/cloud/issues/4929).*

Address followups from the review of #17256.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
