### PR TITLE
doc/user: adjust documentation for cluster unification

### DIFF
--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -166,8 +166,8 @@ For a deeper dive into how indexes work, see [Arrangements](/overview/arrangemen
 Clusters are logical components that let you describe how to allocate compute
 resources for a group of dataflow-powered objects, i.e., sources, sinks,
 indexes, and materialized views. When creating dataflow-powered objects, you
-must specify which cluster you want to use. (Not explicitly naming a cluster
-uses your session's default cluster.)
+must specify which cluster you want to use. Not explicitly naming a cluster
+uses your session's default cluster.
 
 Importantly, clusters are strictly a logical component; they rely on [cluster
 replicas](#cluster-replicas) to run dataflows. Said a slightly different way, a

--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -20,14 +20,15 @@ Materialize and how its components differ from traditional databases.
 
 Materialize offers the following components through its SQL API:
 
-Component              | Use
------------------------|-----
-**[Sources]**          | Sources describe an external system you want Materialize to read data from (e.g. Kafka).
-**[Views]**            | Views represent queries of sources and other views that you want to save for repeated execution.
-**[Indexes]**          | Indexes represent query results stored in memory.
-**[Sinks]**            | Sinks represent output streams or files that Materialize sends data to.
-**[Clusters]**         | Clusters represent a logical set of indexes that share physical resources.
-**[Cluster replicas]** | Cluster replicas provide physical resources for a cluster's indexes.
+Component                | Use
+-------------------------|-----
+**[Sources]**            | Sources describe an external system you want Materialize to read data from (e.g. Kafka).
+**[Views]**              | Views represent queries of sources and other views that you want to save for repeated execution.
+**[Indexes]**            | Indexes represent query results stored in memory.
+**[Materialized views]** | Materialized views represent query results stored durably.
+**[Sinks]**              | Sinks represent output streams or files that Materialize sends data to.
+**[Clusters]**           | Clusters describe logical compute resources that can be used by sources, sinks, indexes, and materialized views.
+**[Cluster replicas]**   | Cluster replicas allocate physical compute resources for a cluster.
 
 ## Sources
 
@@ -162,10 +163,11 @@ For a deeper dive into how indexes work, see [Arrangements](/overview/arrangemen
 
 ## Clusters
 
-Clusters are logical components that let you express resource isolation for all
-dataflow-powered objects, e.g. indexes. When creating dataflow-powered
-objects, you must specify which cluster you want to use. (Not explicitly naming
-a cluster uses your session's default cluster.)
+Clusters are logical components that let you describe how to allocate compute
+resources for a group of dataflow-powered objects, i.e., sources, sinks,
+indexes, and materialized views. When creating dataflow-powered objects, you
+must specify which cluster you want to use. (Not explicitly naming a cluster
+uses your session's default cluster.)
 
 Importantly, clusters are strictly a logical component; they rely on [cluster
 replicas](#cluster-replicas) to run dataflows. Said a slightly different way, a
@@ -234,6 +236,7 @@ Add replicas to a cluster | Greater tolerance to replica failure
 [Clusters]: #clusters
 [Cluster replicas]: #cluster-replicas
 [Indexes]: #indexes
+[Materialized views]: #materialized-views
 [Debezium]: http://debezium.io
 [Sinks]: #sinks
 [Sources]: #sources

--- a/doc/user/content/releases/v0.37.md
+++ b/doc/user/content/releases/v0.37.md
@@ -32,12 +32,12 @@ patch: 3
   time, and you should not rely on them for tasks like capacity planning for the
   time being.
 
-* Add [`mz_internal.mz_storage_host_metrics`](/sql/system-catalog/mz_internal/#mz_storage_host_metrics)
-  and [`mz_internal.mz_storage_host_sizes`](/sql/system-catalog/mz_internal/#mz_storage_host_sizes)
-  to the system catalog. These objects respectively expose the last known CPU
-  and RAM utilization statistics for all processes of all extant storage hosts,
-  and a mapping of logical sizes(e.g. `xlarge`) to the number of processes, as well
-  as CPU and memory allocations for each process.
+* Add `mz_internal.mz_storage_host_metrics` and
+  `mz_internal.mz_storage_host_sizes` to the system catalog. These objects
+  respectively expose the last known CPU and RAM utilization statistics for all
+  processes of all extant storage hosts, and a mapping of logical sizes
+  (e.g. `xlarge`) to the number of processes, as well as CPU and memory
+  allocations for each process.
 
   The concept of a storage host is not user-facing, and is intentionally
   undocumented. It refers to the physical resource allocation on which

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -28,6 +28,12 @@ complex materialized views on the same cluster, you choose some other
 distribution, or you replace all replicas in a cluster with more powerful
 machines.
 
+{{< warning >}}
+Clusters containing sources and sinks can have at most one replica.
+
+We plan to remove this restriction in a future version of Materialize.
+{{< /warning >}}
+
 ## Syntax
 
 {{< diagram "create-cluster-replica.svg" >}}

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -8,8 +8,8 @@ menu:
 ---
 
 `CREATE CLUSTER` creates a logical [cluster](/overview/key-concepts#clusters),
-which contains indexes. By default, a cluster named `default` with a single
-cluster replica will exist in every environment.
+which contains dataflow-powered objects. By default, a cluster named `default`
+with a single cluster replica will exist in every environment.
 
 To switch your active cluster, use the `SET` command:
 
@@ -20,9 +20,20 @@ SET cluster = other_cluster;
 ## Conceptual framework
 
 Clusters are logical components that let you express resource isolation for all
-dataflow-powered objects, e.g. indexes. When creating dataflow-powered
-objects, you must specify which cluster you want to use. (Not explicitly naming
-a cluster uses your session's default cluster.)
+dataflow-powered objects: sources, sinks, indexes, and materialized views. When
+creating dataflow-powered objects, you must specify which cluster you want to
+use.
+
+For indexes and materialized views, not explicitly naming a cluster uses your
+session's default cluster.
+
+{{< warning >}}
+A given cluster may contain any number of indexes and materialized views *or*
+any number of sources and sinks, but not both types of objects. For example,
+you may not create a cluster with a source and an index.
+
+We plan to remove this restriction in a future version of Materialize.
+{{< /warning >}}
 
 Importantly, clusters are strictly a logical component; they rely on [cluster
 replicas](/overview/key-concepts#cluster-replicas) to run dataflows. Said a
@@ -37,6 +48,12 @@ cluster replicas. Each object in a cluster gets instantiated on every replica,
 meaning that on a given physical replica, objects in the cluster are in
 contention for the same physical resources. To achieve the performance you need,
 this might require setting up more than one cluster.
+
+{{< warning >}}
+Clusters containing sources and sinks can have at most one replica.
+
+We plan to remove this restriction in a future version of Materialize.
+{{< /warning >}}
 
 ## Syntax
 

--- a/doc/user/content/sql/create-sink/_index.md
+++ b/doc/user/content/sql/create-sink/_index.md
@@ -106,7 +106,17 @@ others are high traffic and require hefty resource allocations. You choose the
 amount of CPU and memory available to a sink using the `SIZE` option, and
 adjust the provisioned size after sink creation using the [`ALTER SINK`](/sql/alter-sink) command.
 
-By default, Materialize provisions sinks using the smallest size (`3xsmall`).
+Sinks that specify the `SIZE` option are linked to a single-purpose cluster
+dedicated to maintaining that sink.
+
+You can also choose to place a sink in an existing
+[cluster](/overview/key-concepts/#clusters) by using the `IN CLUSTER` option.
+Sinks in a cluster share the resource allocation of the cluster with all other
+objects in the cluster.
+
+Colocating multiple sinks onto the same cluster can be more resource efficient
+when you have many low-traffic sinks that occasionally need some burst
+capacity.
 
 [//]: # "TODO(morsapaes) Add best practices for sizing sinks."
 

--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -42,6 +42,7 @@ Field | Use
 ------|-----
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a sink of the same name already exists. <br/><br/>If _not_ specified, throw an error if a sink of the same name already exists. _(Default)_
 _sink&lowbar;name_ | A name for the sink. This name is only used within Materialize.
+**IN CLUSTER** _cluster_name_ | The [cluster](/sql/create-cluster) to maintain this sink. If not specified, the `SIZE` option must be specified.
 _item&lowbar;name_ | The name of the source, table or materialized view you want to send to the sink.
 **CONNECTION** _connection_name_ | The name of the connection to use in the sink. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection) documentation page.
 **KEY (** _key&lowbar;column_ **)** | An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
@@ -66,7 +67,7 @@ Field                | Value  | Description
 Field                | Value  | Description
 ---------------------|--------|------------
 `SNAPSHOT`           | `bool` | Default: `true`. Whether to emit the consolidated results of the query before the sink was created at the start of the sink. To see only results after the sink is created, specify `WITH (SNAPSHOT = false)`.
-`SIZE`               | `text`    | **Required.** The [size](#sizing-a-sink) for the sink. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
+`SIZE`               | `text`    | The [size](#sizing-a-sink) for the sink. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`. Required if the `IN CLUSTER` option is not specified.
 
 ## Supported formats
 

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -234,6 +234,18 @@ It's a good idea to size up a source when:
     of unique keys in the upstream external system. Larger sizes can store more
     unique keys.
 
+Sources that specify the `SIZE` option are linked to a single-purpose cluster
+dedicated to maintaining that source.
+
+You can also choose to place a source in an existing
+[cluster](/overview/key-concepts/#clusters) by using the `IN CLUSTER` option.
+Sources in a cluster share the resource allocation of the cluster with all other
+objects in the cluster.
+
+Colocating multiple sources onto the same cluster can be more resource efficient
+when you have many low-traffic sources that occasionally need some burst
+capacity.
+
 ## Related pages
 
 - [Key Concepts](../../overview/key-concepts/)

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -58,7 +58,7 @@ Field                                | Value     | Description
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
+`SIZE`                               | `text`    | The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`. Required if the `IN CLUSTER` option is not specified.
 
 ## Supported formats
 

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -26,6 +26,7 @@ tests.
 Field | Use
 ------|-----
 _src_name_  | The name for the source.
+**IN CLUSTER** _cluster_name_ | The [cluster](/sql/create-cluster) to maintain this source. If not specified, the `SIZE` option must be specified.
 **COUNTER** | Use the [counter](#counter) load generator.
 **AUCTION** | Use the [auction](#auction) load generator.
 **TPCH**    | Use the [tpch](#tpch) load generator.
@@ -39,7 +40,7 @@ _src_name_  | The name for the source.
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
+`SIZE`                               | `text`    | The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`. Required if the `IN CLUSTER` option is not specified.
 
 ## Description
 

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -28,6 +28,7 @@ Field | Use
 ------|-----
 _src_name_  | The name for the source.
 **IF NOT EXISTS**  | Do nothing (except issuing a notice) if a source with the same name already exists. _Default._
+**IN CLUSTER** _cluster_name_ | The [cluster](/sql/create-cluster) to maintain this source. If not specified, the `SIZE` option must be specified.
 **CONNECTION** _connection_name_ | The name of the PostgreSQL connection to use in the source. For details on creating connections, check the [`CREATE CONNECTION`](/sql/create-connection/#postgres) documentation page.
 **FOR ALL TABLES** | Create subsources for all tables in the publication.
 **FOR TABLES (** _table_list_ **)** | Create subsources for specific tables in the publication.
@@ -43,7 +44,7 @@ Field                                | Value     | Description
 
 Field                                | Value     | Description
 -------------------------------------|-----------|-------------------------------------
-`SIZE`                               | `text`    | **Required.** The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`.
+`SIZE`                               | `text`    | The [size](../#sizing-a-source) for the source. Accepts values: `3xsmall`, `2xsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`. Required if the `IN CLUSTER` option is not specified.
 
 ## Features
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -308,6 +308,7 @@ Field            | Type        | Meaning
 `connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any.
 `size`           | [`text`]    | The size of the sink.
 `envelope_type`  | [`text`]    | The [envelope](/sql/create-sink/#envelopes) of the sink: `upsert`, or `debezium`.
+`cluster_id`     | [`text`]    | The ID of the cluster maintaining the sink
 
 ### `mz_sources`
 
@@ -323,6 +324,7 @@ Field            | Type       | Meaning
 `connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
 `size`           | [`text`]   | The [size](/sql/create-source/#sizing-a-source) of the source.
 `envelope_type`  | [`text`]   | The [envelope](/sql/create-source/#envelopes) of the source: `none`, `upsert`, or `debezium`.
+`cluster_id`     | [`text`]   | The ID of the cluster maintaining the source.
 
 ### `mz_storage_usage`
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -60,7 +60,7 @@ Field               | Type      | Meaning
 --------------------|-----------|--------
 `id`                | [`uint8`] | Materialize's unique ID for the cluster replica.
 `name`              | [`text`]  | The name of the cluster replica.
-`cluster_id`        | [`text`]  | The ID of the cluster to which the replica belongs.
+`cluster_id`        | [`text`]  | The ID of the cluster to which the replica belongs. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `size`              | [`text`]  | The cluster replica's size, selected during creation.
 `availability_zone` | [`text`]  | The availability zone in which the cluster is running.
 
@@ -96,7 +96,7 @@ Field            | Type        | Meaning
 -----------------|-------------|--------
 `id`             | [`text`]    | The unique ID of the connection.
 `oid`            | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the connection.
-`schema_id`      | [`uint8`]   | The ID of the schema to which the connection belongs.
+`schema_id`      | [`uint8`]   | The ID of the schema to which the connection belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`           | [`text`]    | The name of the connection.
 `type`           | [`text`]    | The type of the connection: `confluent-schema-registry`, `kafka`, `postgres`, or `ssh-tunnel`.
 
@@ -127,7 +127,7 @@ Field                       | Type              | Meaning
 ----------------------------|-------------------|--------
 `id`                        | [`text`]          | Materialize's unique ID for the function.
 `oid`                       | [`oid`]           | A [PostgreSQL-compatible OID][oid] for the function.
-`schema_id`                 | [`uint8`]         | The ID of the schema to which the function belongs.
+`schema_id`                 | [`uint8`]         | The ID of the schema to which the function belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`                      | [`text`]          | The name of the function.
 `argument_type_ids`         | [`text array`]    | The ID of each argument's type. Each entry refers to `mz_types.id`.
 `variadic_argument_type_id` | [`text`]          | The ID of the variadic argument's type, or `NULL` if the function does not have a variadic argument. Refers to `mz_types.id`.
@@ -156,7 +156,7 @@ vice-versa.
 
 Field            | Type        | Meaning
 -----------------|-------------|--------
-`index_id`       | [`text`]    | The ID of the index which contains this column.
+`index_id`       | [`text`]    | The ID of the index which contains this column. Corresponds to [`mz_indexes.id`](/sql/system-catalog/mz_catalog/#mz_indexes).
 `index_position` | [`uint8`]   | The 1-indexed position of this column within the index. (The order of columns in an index does not necessarily match the order of columns in the relation on which the index is built.)
 `on_position`    | [`uint8`]   | If not `NULL`, specifies the 1-indexed position of a column in the relation on which this index is built that determines the value of this index column.
 `on_expression`  | [`text`]    | If not `NULL`, specifies a SQL expression that is evaluated to compute the value of this index column. The expression may contain references to any of the columns of the relation.
@@ -209,9 +209,9 @@ Field          | Type      | Meaning
 ---------------|-----------|----------
 `id`           | [`text`]  | Materialize's unique ID for the materialized view.
 `oid`          | [`oid`]   | A [PostgreSQL-compatible OID][oid] for the materialized view.
-`schema_id`    | [`uint8`] | The ID of the schema to which the materialized view belongs.
+`schema_id`    | [`uint8`] | The ID of the schema to which the materialized view belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`         | [`text`]  | The name of the materialized view.
-`cluster_id`   | [`text`]  | The ID of the cluster maintaining the materialized view.
+`cluster_id`   | [`text`]  | The ID of the cluster maintaining the materialized view. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 `definition`   | [`text`]  | The materialized view definition (a `SELECT` query).
 
 ### `mz_objects`
@@ -227,7 +227,7 @@ Field       | Type       | Meaning
 ------------|------------|--------
 `id`        | [`text`]   | Materialize's unique ID for the object.
 `oid`       | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the object.
-`schema_id` | [`uint8`]  | The ID of the schema to which the object belongs.
+`schema_id` | [`uint8`]  | The ID of the schema to which the object belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`      | [`text`]   | The name of the object.
 `type`      | [`text`]   | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`.
 
@@ -248,7 +248,7 @@ Field       | Type       | Meaning
 ------------|------------|--------
 `id`        | [`text`]   | Materialize's unique ID for the relation.
 `oid`       | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the relation.
-`schema_id` | [`uint8`]  | The ID of the schema to which the relation belongs.
+`schema_id` | [`uint8`]  | The ID of the schema to which the relation belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`      | [`text`]   | The name of the relation.
 `type`      | [`text`]   | The type of the relation: either `table`, `source`, `view`, or `materialized view`.
 
@@ -270,7 +270,7 @@ Field         | Type       | Meaning
 --------------|------------|--------
 `id`          | [`uint8`]  | Materialize's unique ID for the schema.
 `oid`         | [`oid`]    | A [PostgreSQL-compatible oid][oid] for the schema.
-`database_id` | [`uint8`]  | The ID of the database containing the schema.
+`database_id` | [`uint8`]  | The ID of the database containing the schema. Corresponds to [`mz_databases.id`](/sql/system-catalog/mz_catalog/#mz_databases).
 `name`        | [`text`]   | The name of the schema.
 
 ### `mz_secrets`
@@ -280,7 +280,7 @@ The `mz_secrets` table contains a row for each connection in the system.
 Field            | Type        | Meaning
 -----------------|-------------|--------
 `id`             | [`text`]    | The unique ID of the secret.
-`schema_id`      | [`uint8`]   | The ID of the schema to which the secret belongs.
+`schema_id`      | [`uint8`]   | The ID of the schema to which the secret belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`           | [`text`]    | The name of the secret.
 
 ### `mz_ssh_tunnel_connections`
@@ -302,13 +302,13 @@ Field            | Type        | Meaning
 -----------------|-------------|--------
 `id`             | [`text`]    | Materialize's unique ID for the sink.
 `oid`            | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the sink.
-`schema_id`      | [`uint8`]   | The ID of the schema to which the sink belongs.
+`schema_id`      | [`uint8`]   | The ID of the schema to which the sink belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`           | [`text`]    | The name of the sink.
 `type`           | [`text`]    | The type of the sink: `kafka`.
-`connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any.
+`connection_id`  | [`text`]    | The ID of the connection associated with the sink, if any. Corresponds to [`mz_connections.id`](/sql/system-catalog/mz_catalog/#mz_connections).
 `size`           | [`text`]    | The size of the sink.
 `envelope_type`  | [`text`]    | The [envelope](/sql/create-sink/#envelopes) of the sink: `upsert`, or `debezium`.
-`cluster_id`     | [`text`]    | The ID of the cluster maintaining the sink
+`cluster_id`     | [`text`]    | The ID of the cluster maintaining the sink. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 
 ### `mz_sources`
 
@@ -318,13 +318,13 @@ Field            | Type       | Meaning
 -----------------|------------|----------
 `id`             | [`text`]   | Materialize's unique ID for the source.
 `oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the source.
-`schema_id`      | [`uint8`]  | The ID of the schema to which the source belongs.
+`schema_id`      | [`uint8`]  | The ID of the schema to which the source belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`           | [`text`]   | The name of the source.
 `type`           | [`text`]   | The type of the source: `kafka`, `postgres`, `load-generator`, or `subsource`.
-`connection_id`  | [`text`]   | The ID of the connection associated with the source, if any.
+`connection_id`  | [`text`]   | The ID of the connection associated with the source, if any. Corresponds to [`mz_connections.id`](/sql/system-catalog/mz_catalog/#mz_connections).
 `size`           | [`text`]   | The [size](/sql/create-source/#sizing-a-source) of the source.
 `envelope_type`  | [`text`]   | The [envelope](/sql/create-source/#envelopes) of the source: `none`, `upsert`, or `debezium`.
-`cluster_id`     | [`text`]   | The ID of the cluster maintaining the source.
+`cluster_id`     | [`text`]   | The ID of the cluster maintaining the source. Corresponds to [`mz_clusters.id`](/sql/system-catalog/mz_catalog/#mz_clusters).
 
 ### `mz_storage_usage`
 
@@ -346,7 +346,7 @@ Field            | Type       | Meaning
 -----------------|------------|----------
 `id`             | [`text`]   | Materialize's unique ID for the table.
 `oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the table.
-`schema_id`      | [`uint8`]  | The ID of the schema to which the table belongs.
+`schema_id`      | [`uint8`]  | The ID of the schema to which the table belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`           | [`text`]   | The name of the table.
 
 ### `mz_types`
@@ -357,7 +357,7 @@ Field          | Type       | Meaning
 ---------------|------------|----------
 `id`           | [`text`]   | Materialize's unique ID for the type.
 `oid`          | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the type.
-`schema_id`    | [`uint8`]  | The ID of the schema to which the type belongs.
+`schema_id`    | [`uint8`]  | The ID of the schema to which the type belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`         | [`text`]   | The name of the type.
 
 ### `mz_views`
@@ -368,7 +368,7 @@ Field          | Type        | Meaning
 ---------------|-------------|----------
 `id`           | [`text`]    | Materialize's unique ID for the view.
 `oid`          | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the view.
-`schema_id`    | [`uint8`]   | The ID of the schema to which the view belongs.
+`schema_id`    | [`uint8`]   | The ID of the schema to which the view belongs. Corresponds to [`mz_schemas.id`](/sql/system-catalog/mz_catalog/#mz_schemas).
 `name`         | [`text`]    | The name of the view.
 `definition`   | [`text`]    | The view definition (a `SELECT` query).
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -78,7 +78,11 @@ them for any kind of capacity planning.
 
 ### `mz_cluster_links`
 
-The `mz_cluster_links` table exposes the mappings between sources/sinks and their linked cluster.
+The `mz_cluster_links` table contains a row for each cluster that is linked to a
+source or sink. When present, the lifetime of the specified cluster is tied to
+the lifetime of the specified source or sink: the cluster cannot be dropped
+without dropping the linked source or sink, and dropping the linked source or
+sink will also drop the cluster. There is at most one row per cluster.
 
 {{< note >}}
 The concept of a linked cluster is not user-facing, and is intentionally undocumented. Linked clusters are meant to preserve the soon-to-be legacy interface for sizing sources and sinks.
@@ -465,48 +469,6 @@ Field       | Type       | Meaning
 `worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
 `time`      | [`mz_timestamp`] | The next timestamp at which the dataflow may change.
 
-### `mz_source_utilization`
-
-The `mz_source_utilization` table gives the last known CPU and RAM utilization
-statistics for all extant sources, as a percentage of the total allocation.
-
-At this time, we do not make any guarantees about the exactness or freshness of these numbers.
-
-| Field            | Type      | Meaning                                                    |
-|------------------|-----------|------------------------------------------------------------|
-| `source_id`      | [`uint8`] | The ID of a source.                                        |
-| `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
-| `cpu_percent_normalized`    | [`uint8`] | Approximate CPU usage, in percent of the total number of timely workers. Can exceed 100, as threads other than timely workers may be scheduled. |
-| `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
-
-### `mz_sink_utilization`
-
-The `mz_sink_utilization` table gives the last known CPU and RAM utilization
-statistics for all extant sinks, as a percentage of the total allocation.
-
-Materialize does not make any guarantees about the exactness or freshness of these numbers.
-
-| Field            | Type      | Meaning                                                    |
-|------------------|-----------|------------------------------------------------------------|
-| `sink_id`        | [`uint8`] | The ID of a sink.                                          |
-| `cpu_percent`    | [`uint8`] | Approximate CPU usage, in percent of the total allocation. |
-| `cpu_percent_normalized`    | [`uint8`] | Approximate CPU usage, in percent of the total number of timely workers. Can exceed 100, as threads other than timely workers may be scheduled. |
-| `memory_percent` | [`uint8`] | Approximate RAM usage, in percent of the total allocation. |
-
-### `mz_storage_host_metrics`
-
-The `mz_storage_host_metrics` table gives the last known CPU and RAM utilization statistics
-for all processes of all extant storage hosts.
-
-At this time, we do not make any guarantees about the exactness or freshness of these numbers.
-
-Field              | Type       | Meaning
--------------------|------------|--------
-`id`               | [`text`]   | The ID of the storage object (source or sink).
-`process_id`       | [`bigint`] | An identifier of a process within a host.
-`cpu_nano_cores`   | [`bigint`] | Approximate CPU usage, in billionths of a vCPU core.
-`memory_bytes`     | [`bigint`] | Approximate RAM usage, in bytes.
-
 ### `mz_source_statistics`
 
 The `mz_source_statistics` table contains statistics for each worker thread of
@@ -543,23 +505,6 @@ Field                 | Type         | Meaning
 `messaged_commited`   | [`bigint`]   | The number of messages committed to the sink.
 `bytes_staged`        | [`bigint`]   | The number of bytes staged but possibly not committed to the sink. This counts both keys and values, if applicable.
 `bytes_committed`     | [`bigint`]   | The number of bytes committed to the sink. This counts both keys and values, if applicable.
-
-### `mz_storage_host_sizes`
-
-The `mz_storage_host_sizes` table contains a mapping of logical sizes
-(e.g. "xlarge") to physical sizes (number of workers, and CPU and memory allocations per process).
-
-{{< warning >}}
-The values in this table may change at any time, and users should not rely on
-them for any kind of capacity planning.
-{{< /warning >}}
-
-| Field            | Type      | Meaning                                                       |
-|------------------|-----------|---------------------------------------------------------------|
-| `size`           | [`text`]  | The human-readable size.                                      |
-| `workers`        | [`uint8`] | The number of Timely Dataflow workers per process.            |
-| `cpu_nano_cores` | [`uint8`] | The CPU allocation per process, in billionths of a vCPU core. |
-| `memory_bytes`   | [`uint8`] | The RAM allocation per process, in billionths of a vCPU core. |
 
 ### `mz_source_statuses`
 

--- a/doc/user/layouts/partials/sql-grammar/create-sink-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="587" height="457">
+<svg xmlns="http://www.w3.org/2000/svg" width="587" height="489">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="114" height="32" rx="10"/>
@@ -20,111 +20,122 @@
    <rect x="345" y="3" width="88" height="32"/>
    <rect x="343" y="1" width="88" height="32" class="nonterminal"/>
    <text class="nonterminal" x="353" y="21">sink_name</text>
-   <rect x="453" y="3" width="60" height="32" rx="10"/>
-   <rect x="451"
-         y="1"
+   <rect x="47" y="133" width="104" height="32" rx="10"/>
+   <rect x="45"
+         y="131"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="55" y="151">IN CLUSTER</text>
+   <rect x="171" y="133" width="108" height="32"/>
+   <rect x="169" y="131" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="179" y="151">cluster_name</text>
+   <rect x="319" y="101" width="60" height="32" rx="10"/>
+   <rect x="317"
+         y="99"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="21">FROM</text>
-   <rect x="119" y="101" width="90" height="32"/>
-   <rect x="117" y="99" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="127" y="119">item_name</text>
-   <rect x="229" y="101" width="54" height="32" rx="10"/>
-   <rect x="227"
+   <text class="terminal" x="327" y="119">FROM</text>
+   <rect x="399" y="101" width="90" height="32"/>
+   <rect x="397" y="99" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="119">item_name</text>
+   <rect x="509" y="101" width="54" height="32" rx="10"/>
+   <rect x="507"
          y="99"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="119">INTO</text>
-   <rect x="303" y="101" width="168" height="32"/>
-   <rect x="301" y="99" width="168" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="311" y="119">kafka_sink_connection</text>
-   <rect x="146" y="211" width="48" height="32" rx="10"/>
-   <rect x="144"
-         y="209"
+   <text class="terminal" x="517" y="119">INTO</text>
+   <rect x="32" y="243" width="168" height="32"/>
+   <rect x="30" y="241" width="168" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="40" y="261">kafka_sink_connection</text>
+   <rect x="240" y="243" width="48" height="32" rx="10"/>
+   <rect x="238"
+         y="241"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="154" y="229">KEY</text>
-   <rect x="214" y="211" width="26" height="32" rx="10"/>
-   <rect x="212"
-         y="209"
+   <text class="terminal" x="248" y="261">KEY</text>
+   <rect x="308" y="243" width="26" height="32" rx="10"/>
+   <rect x="306"
+         y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="222" y="229">(</text>
-   <rect x="280" y="211" width="98" height="32"/>
-   <rect x="278" y="209" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="288" y="229">key_column</text>
-   <rect x="280" y="167" width="24" height="32" rx="10"/>
-   <rect x="278"
-         y="165"
+   <text class="terminal" x="316" y="261">(</text>
+   <rect x="374" y="243" width="98" height="32"/>
+   <rect x="372" y="241" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="382" y="261">key_column</text>
+   <rect x="374" y="199" width="24" height="32" rx="10"/>
+   <rect x="372"
+         y="197"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="288" y="185">,</text>
-   <rect x="418" y="211" width="26" height="32" rx="10"/>
-   <rect x="416"
-         y="209"
+   <text class="terminal" x="382" y="217">,</text>
+   <rect x="512" y="243" width="26" height="32" rx="10"/>
+   <rect x="510"
+         y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="426" y="229">)</text>
-   <rect x="45" y="325" width="80" height="32" rx="10"/>
+   <text class="terminal" x="520" y="261">)</text>
+   <rect x="45" y="357" width="80" height="32" rx="10"/>
    <rect x="43"
-         y="323"
+         y="355"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="343">FORMAT</text>
-   <rect x="145" y="325" width="134" height="32"/>
-   <rect x="143" y="323" width="134" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="153" y="343">sink_format_spec</text>
-   <rect x="319" y="293" width="94" height="32" rx="10"/>
+   <text class="terminal" x="53" y="375">FORMAT</text>
+   <rect x="145" y="357" width="134" height="32"/>
+   <rect x="143" y="355" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="153" y="375">sink_format_spec</text>
+   <rect x="319" y="325" width="94" height="32" rx="10"/>
    <rect x="317"
-         y="291"
+         y="323"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="327" y="311">ENVELOPE</text>
-   <rect x="453" y="293" width="92" height="32" rx="10"/>
+   <text class="terminal" x="327" y="343">ENVELOPE</text>
+   <rect x="453" y="325" width="92" height="32" rx="10"/>
    <rect x="451"
-         y="291"
+         y="323"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="311">DEBEZIUM</text>
-   <rect x="453" y="337" width="76" height="32" rx="10"/>
+   <text class="terminal" x="461" y="343">DEBEZIUM</text>
+   <rect x="453" y="369" width="76" height="32" rx="10"/>
    <rect x="451"
-         y="335"
+         y="367"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="355">UPSERT</text>
-   <rect x="359" y="423" width="58" height="32" rx="10"/>
+   <text class="terminal" x="461" y="387">UPSERT</text>
+   <rect x="359" y="455" width="58" height="32" rx="10"/>
    <rect x="357"
-         y="421"
+         y="453"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="367" y="441">WITH</text>
-   <rect x="437" y="423" width="102" height="32"/>
-   <rect x="435" y="421" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="445" y="441">with_options</text>
+   <text class="terminal" x="367" y="473">WITH</text>
+   <rect x="437" y="455" width="102" height="32"/>
+   <rect x="435" y="453" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="445" y="473">with_options</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-438 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-389 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-483 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="577 405 585 401 585 409"/>
-   <polygon points="577 405 569 401 569 409"/>
+         d="m17 17 h2 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m54 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-575 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-577 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h10 m134 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m58 0 h10 m0 0 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="577 437 585 433 585 441"/>
+   <polygon points="577 437 569 433 569 441"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="1087">
+<svg xmlns="http://www.w3.org/2000/svg" width="597" height="1185">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,278 +20,289 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="45" y="145" width="26" height="32" rx="10"/>
-   <rect x="43"
+   <rect x="83" y="145" width="26" height="32" rx="10"/>
+   <rect x="81"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="163">(</text>
-   <rect x="111" y="145" width="82" height="32"/>
-   <rect x="109" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="119" y="163">col_name</text>
-   <rect x="111" y="101" width="24" height="32" rx="10"/>
-   <rect x="109"
+   <text class="terminal" x="91" y="163">(</text>
+   <rect x="149" y="145" width="82" height="32"/>
+   <rect x="147" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="157" y="163">col_name</text>
+   <rect x="149" y="101" width="24" height="32" rx="10"/>
+   <rect x="147"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="119" y="119">,</text>
-   <rect x="253" y="177" width="24" height="32" rx="10"/>
-   <rect x="251"
+   <text class="terminal" x="157" y="119">,</text>
+   <rect x="291" y="177" width="24" height="32" rx="10"/>
+   <rect x="289"
          y="175"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="261" y="195">,</text>
-   <rect x="297" y="177" width="116" height="32"/>
-   <rect x="295" y="175" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="195">key_constraint</text>
-   <rect x="453" y="145" width="26" height="32" rx="10"/>
-   <rect x="451"
+   <text class="terminal" x="299" y="195">,</text>
+   <rect x="335" y="177" width="116" height="32"/>
+   <rect x="333" y="175" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="343" y="195">key_constraint</text>
+   <rect x="491" y="145" width="26" height="32" rx="10"/>
+   <rect x="489"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="163">)</text>
-   <rect x="519" y="145" width="60" height="32" rx="10"/>
-   <rect x="517"
-         y="143"
+   <text class="terminal" x="499" y="163">)</text>
+   <rect x="100" y="291" width="104" height="32" rx="10"/>
+   <rect x="98"
+         y="289"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="108" y="309">IN CLUSTER</text>
+   <rect x="224" y="291" width="108" height="32"/>
+   <rect x="222" y="289" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="232" y="309">cluster_name</text>
+   <rect x="372" y="259" width="60" height="32" rx="10"/>
+   <rect x="370"
+         y="257"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="527" y="163">FROM</text>
-   <rect x="57" y="259" width="68" height="32" rx="10"/>
-   <rect x="55"
+   <text class="terminal" x="380" y="277">FROM</text>
+   <rect x="452" y="259" width="68" height="32" rx="10"/>
+   <rect x="450"
          y="257"
          width="68"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="65" y="277">KAFKA</text>
-   <rect x="145" y="259" width="116" height="32" rx="10"/>
-   <rect x="143"
-         y="257"
+   <text class="terminal" x="460" y="277">KAFKA</text>
+   <rect x="63" y="357" width="116" height="32" rx="10"/>
+   <rect x="61"
+         y="355"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="277">CONNECTION</text>
-   <rect x="281" y="259" width="136" height="32"/>
-   <rect x="279" y="257" width="136" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="289" y="277">connection_name</text>
-   <rect x="437" y="259" width="26" height="32" rx="10"/>
-   <rect x="435"
-         y="257"
+   <text class="terminal" x="71" y="375">CONNECTION</text>
+   <rect x="199" y="357" width="136" height="32"/>
+   <rect x="197" y="355" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="207" y="375">connection_name</text>
+   <rect x="355" y="357" width="26" height="32" rx="10"/>
+   <rect x="353"
+         y="355"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="445" y="277">(</text>
-   <rect x="483" y="259" width="64" height="32" rx="10"/>
-   <rect x="481"
-         y="257"
+   <text class="terminal" x="363" y="375">(</text>
+   <rect x="401" y="357" width="64" height="32" rx="10"/>
+   <rect x="399"
+         y="355"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="491" y="277">TOPIC</text>
-   <rect x="131" y="325" width="52" height="32"/>
-   <rect x="129" y="323" width="52" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="139" y="343">topic</text>
-   <rect x="223" y="357" width="24" height="32" rx="10"/>
-   <rect x="221"
-         y="355"
+   <text class="terminal" x="409" y="375">TOPIC</text>
+   <rect x="485" y="357" width="52" height="32"/>
+   <rect x="483" y="355" width="52" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="493" y="375">topic</text>
+   <rect x="185" y="455" width="24" height="32" rx="10"/>
+   <rect x="183"
+         y="453"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="231" y="375">,</text>
-   <rect x="267" y="357" width="140" height="32"/>
-   <rect x="265" y="355" width="140" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="275" y="375">connection_option</text>
-   <rect x="447" y="325" width="26" height="32" rx="10"/>
-   <rect x="445"
-         y="323"
+   <text class="terminal" x="193" y="473">,</text>
+   <rect x="229" y="455" width="140" height="32"/>
+   <rect x="227" y="453" width="140" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="237" y="473">connection_option</text>
+   <rect x="409" y="423" width="26" height="32" rx="10"/>
+   <rect x="407"
+         y="421"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="455" y="343">)</text>
-   <rect x="47" y="423" width="114" height="32" rx="10"/>
-   <rect x="45"
-         y="421"
+   <text class="terminal" x="417" y="441">)</text>
+   <rect x="45" y="521" width="114" height="32" rx="10"/>
+   <rect x="43"
+         y="519"
          width="114"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="55" y="441">KEY FORMAT</text>
-   <rect x="181" y="423" width="102" height="32"/>
-   <rect x="179" y="421" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="189" y="441">format_spec</text>
-   <rect x="303" y="423" width="132" height="32" rx="10"/>
-   <rect x="301"
-         y="421"
+   <text class="terminal" x="53" y="539">KEY FORMAT</text>
+   <rect x="179" y="521" width="102" height="32"/>
+   <rect x="177" y="519" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="187" y="539">format_spec</text>
+   <rect x="301" y="521" width="132" height="32" rx="10"/>
+   <rect x="299"
+         y="519"
          width="132"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="311" y="441">VALUE FORMAT</text>
-   <rect x="47" y="467" width="80" height="32" rx="10"/>
-   <rect x="45"
-         y="465"
+   <text class="terminal" x="309" y="539">VALUE FORMAT</text>
+   <rect x="45" y="565" width="80" height="32" rx="10"/>
+   <rect x="43"
+         y="563"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="55" y="485">FORMAT</text>
-   <rect x="475" y="423" width="102" height="32"/>
-   <rect x="473" y="421" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="483" y="441">format_spec</text>
-   <rect x="50" y="549" width="82" height="32" rx="10"/>
-   <rect x="48"
-         y="547"
+   <text class="terminal" x="53" y="583">FORMAT</text>
+   <rect x="473" y="521" width="102" height="32"/>
+   <rect x="471" y="519" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="481" y="539">format_spec</text>
+   <rect x="48" y="647" width="82" height="32" rx="10"/>
+   <rect x="46"
+         y="645"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="58" y="567">INCLUDE</text>
-   <rect x="212" y="549" width="48" height="32" rx="10"/>
-   <rect x="210"
-         y="547"
+   <text class="terminal" x="56" y="665">INCLUDE</text>
+   <rect x="210" y="647" width="48" height="32" rx="10"/>
+   <rect x="208"
+         y="645"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="220" y="567">KEY</text>
-   <rect x="212" y="593" width="96" height="32" rx="10"/>
-   <rect x="210"
-         y="591"
+   <text class="terminal" x="218" y="665">KEY</text>
+   <rect x="210" y="691" width="96" height="32" rx="10"/>
+   <rect x="208"
+         y="689"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="220" y="611">PARTITION</text>
-   <rect x="212" y="637" width="74" height="32" rx="10"/>
-   <rect x="210"
-         y="635"
+   <text class="terminal" x="218" y="709">PARTITION</text>
+   <rect x="210" y="735" width="74" height="32" rx="10"/>
+   <rect x="208"
+         y="733"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="220" y="655">OFFSET</text>
-   <rect x="212" y="681" width="106" height="32" rx="10"/>
-   <rect x="210"
-         y="679"
+   <text class="terminal" x="218" y="753">OFFSET</text>
+   <rect x="210" y="779" width="106" height="32" rx="10"/>
+   <rect x="208"
+         y="777"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="220" y="699">TIMESTAMP</text>
-   <rect x="212" y="725" width="86" height="32" rx="10"/>
-   <rect x="210"
-         y="723"
+   <text class="terminal" x="218" y="797">TIMESTAMP</text>
+   <rect x="210" y="823" width="86" height="32" rx="10"/>
+   <rect x="208"
+         y="821"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="220" y="743">HEADERS</text>
-   <rect x="378" y="581" width="40" height="32" rx="10"/>
-   <rect x="376"
-         y="579"
+   <text class="terminal" x="218" y="841">HEADERS</text>
+   <rect x="376" y="679" width="40" height="32" rx="10"/>
+   <rect x="374"
+         y="677"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="386" y="599">AS</text>
-   <rect x="438" y="581" width="56" height="32"/>
-   <rect x="436" y="579" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="446" y="599">name</text>
-   <rect x="179" y="839" width="94" height="32" rx="10"/>
-   <rect x="177"
-         y="837"
+   <text class="terminal" x="384" y="697">AS</text>
+   <rect x="436" y="679" width="56" height="32"/>
+   <rect x="434" y="677" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="444" y="697">name</text>
+   <rect x="177" y="937" width="94" height="32" rx="10"/>
+   <rect x="175"
+         y="935"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="187" y="857">ENVELOPE</text>
-   <rect x="313" y="839" width="60" height="32" rx="10"/>
-   <rect x="311"
-         y="837"
+   <text class="terminal" x="185" y="955">ENVELOPE</text>
+   <rect x="311" y="937" width="60" height="32" rx="10"/>
+   <rect x="309"
+         y="935"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="857">NONE</text>
-   <rect x="313" y="883" width="92" height="32" rx="10"/>
-   <rect x="311"
-         y="881"
+   <text class="terminal" x="319" y="955">NONE</text>
+   <rect x="311" y="981" width="92" height="32" rx="10"/>
+   <rect x="309"
+         y="979"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="901">DEBEZIUM</text>
-   <rect x="313" y="927" width="76" height="32" rx="10"/>
-   <rect x="311"
-         y="925"
+   <text class="terminal" x="319" y="999">DEBEZIUM</text>
+   <rect x="311" y="1025" width="76" height="32" rx="10"/>
+   <rect x="309"
+         y="1023"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="945">UPSERT</text>
-   <rect x="189" y="1037" width="58" height="32" rx="10"/>
-   <rect x="187"
-         y="1035"
+   <text class="terminal" x="319" y="1043">UPSERT</text>
+   <rect x="185" y="1135" width="58" height="32" rx="10"/>
+   <rect x="183"
+         y="1133"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="197" y="1055">WITH</text>
-   <rect x="267" y="1037" width="26" height="32" rx="10"/>
-   <rect x="265"
-         y="1035"
+   <text class="terminal" x="193" y="1153">WITH</text>
+   <rect x="263" y="1135" width="26" height="32" rx="10"/>
+   <rect x="261"
+         y="1133"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="275" y="1055">(</text>
-   <rect x="333" y="1037" width="48" height="32"/>
-   <rect x="331" y="1035" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="341" y="1055">field</text>
-   <rect x="401" y="1037" width="28" height="32" rx="10"/>
-   <rect x="399"
-         y="1035"
+   <text class="terminal" x="271" y="1153">(</text>
+   <rect x="329" y="1135" width="48" height="32"/>
+   <rect x="327" y="1133" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="337" y="1153">field</text>
+   <rect x="397" y="1135" width="28" height="32" rx="10"/>
+   <rect x="395"
+         y="1133"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="409" y="1055">=</text>
-   <rect x="449" y="1037" width="38" height="32"/>
-   <rect x="447" y="1035" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="457" y="1055">val</text>
-   <rect x="333" y="993" width="24" height="32" rx="10"/>
-   <rect x="331"
-         y="991"
+   <text class="terminal" x="405" y="1153">=</text>
+   <rect x="445" y="1135" width="38" height="32"/>
+   <rect x="443" y="1133" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="453" y="1153">val</text>
+   <rect x="329" y="1091" width="24" height="32" rx="10"/>
+   <rect x="327"
+         y="1089"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="1011">,</text>
-   <rect x="527" y="1037" width="26" height="32" rx="10"/>
-   <rect x="525"
-         y="1035"
+   <text class="terminal" x="337" y="1109">,</text>
+   <rect x="523" y="1135" width="26" height="32" rx="10"/>
+   <rect x="521"
+         y="1133"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="535" y="1055">)</text>
+   <text class="terminal" x="531" y="1153">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-566 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-460 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m52 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m24 0 h10 m0 0 h10 m140 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-490 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-459 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m42 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-320 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="591 1051 599 1047 599 1055"/>
-   <polygon points="591 1051 583 1047 583 1055"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-434 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-501 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m68 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-501 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-416 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m24 0 h10 m0 0 h10 m140 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-459 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m42 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-322 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="587 1149 595 1145 595 1153"/>
+   <polygon points="587 1149 579 1145 579 1153"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-kinesis.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-kinesis.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="411">
+<svg xmlns="http://www.w3.org/2000/svg" width="587" height="509">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,87 +20,98 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="45" y="145" width="26" height="32" rx="10"/>
-   <rect x="43"
+   <rect x="78" y="145" width="26" height="32" rx="10"/>
+   <rect x="76"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="163">(</text>
-   <rect x="111" y="145" width="82" height="32"/>
-   <rect x="109" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="119" y="163">col_name</text>
-   <rect x="111" y="101" width="24" height="32" rx="10"/>
-   <rect x="109"
+   <text class="terminal" x="86" y="163">(</text>
+   <rect x="144" y="145" width="82" height="32"/>
+   <rect x="142" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="152" y="163">col_name</text>
+   <rect x="144" y="101" width="24" height="32" rx="10"/>
+   <rect x="142"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="119" y="119">,</text>
-   <rect x="253" y="177" width="24" height="32" rx="10"/>
-   <rect x="251"
+   <text class="terminal" x="152" y="119">,</text>
+   <rect x="286" y="177" width="24" height="32" rx="10"/>
+   <rect x="284"
          y="175"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="261" y="195">,</text>
-   <rect x="297" y="177" width="116" height="32"/>
-   <rect x="295" y="175" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="195">key_constraint</text>
-   <rect x="453" y="145" width="26" height="32" rx="10"/>
-   <rect x="451"
+   <text class="terminal" x="294" y="195">,</text>
+   <rect x="330" y="177" width="116" height="32"/>
+   <rect x="328" y="175" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="338" y="195">key_constraint</text>
+   <rect x="486" y="145" width="26" height="32" rx="10"/>
+   <rect x="484"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="163">)</text>
-   <rect x="519" y="145" width="60" height="32" rx="10"/>
-   <rect x="517"
-         y="143"
+   <text class="terminal" x="494" y="163">)</text>
+   <rect x="45" y="291" width="104" height="32" rx="10"/>
+   <rect x="43"
+         y="289"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="309">IN CLUSTER</text>
+   <rect x="169" y="291" width="108" height="32"/>
+   <rect x="167" y="289" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="177" y="309">cluster_name</text>
+   <rect x="317" y="259" width="60" height="32" rx="10"/>
+   <rect x="315"
+         y="257"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="527" y="163">FROM</text>
-   <rect x="26" y="259" width="108" height="32" rx="10"/>
-   <rect x="24"
+   <text class="terminal" x="325" y="277">FROM</text>
+   <rect x="397" y="259" width="108" height="32" rx="10"/>
+   <rect x="395"
          y="257"
          width="108"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="34" y="277">KINESIS ARN</text>
-   <rect x="154" y="259" width="40" height="32"/>
-   <rect x="152" y="257" width="40" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="162" y="277">arn</text>
-   <rect x="234" y="291" width="102" height="32"/>
-   <rect x="232" y="289" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="242" y="309">with_options</text>
-   <rect x="376" y="259" width="80" height="32" rx="10"/>
-   <rect x="374"
-         y="257"
+   <text class="terminal" x="405" y="277">KINESIS ARN</text>
+   <rect x="525" y="259" width="40" height="32"/>
+   <rect x="523" y="257" width="40" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="533" y="277">arn</text>
+   <rect x="133" y="389" width="102" height="32"/>
+   <rect x="131" y="387" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="141" y="407">with_options</text>
+   <rect x="275" y="357" width="80" height="32" rx="10"/>
+   <rect x="273"
+         y="355"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="384" y="277">FORMAT</text>
-   <rect x="476" y="259" width="102" height="32"/>
-   <rect x="474" y="257" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="484" y="277">format_spec</text>
-   <rect x="415" y="377" width="138" height="32" rx="10"/>
-   <rect x="413"
-         y="375"
+   <text class="terminal" x="283" y="375">FORMAT</text>
+   <rect x="375" y="357" width="102" height="32"/>
+   <rect x="373" y="355" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="383" y="375">format_spec</text>
+   <rect x="401" y="475" width="138" height="32" rx="10"/>
+   <rect x="399"
+         y="473"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="423" y="395">ENVELOPE NONE</text>
+   <text class="terminal" x="409" y="493">ENVELOPE NONE</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-597 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m80 0 h10 m0 0 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-227 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m23 -32 h-3"/>
-   <polygon points="591 359 599 355 599 363"/>
-   <polygon points="591 359 583 355 583 363"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-439 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-551 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-496 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m80 0 h10 m0 0 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m23 -32 h-3"/>
+   <polygon points="577 457 585 453 585 461"/>
+   <polygon points="577 457 569 453 569 461"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="667" height="661">
+<svg xmlns="http://www.w3.org/2000/svg" width="667" height="677">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,167 +20,178 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="163" y="101" width="196" height="32" rx="10"/>
-   <rect x="161"
+   <rect x="111" y="133" width="104" height="32" rx="10"/>
+   <rect x="109"
+         y="131"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="151">IN CLUSTER</text>
+   <rect x="235" y="133" width="108" height="32"/>
+   <rect x="233" y="131" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="243" y="151">cluster_name</text>
+   <rect x="383" y="101" width="196" height="32" rx="10"/>
+   <rect x="381"
          y="99"
          width="196"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="171" y="119">FROM LOAD GENERATOR</text>
-   <rect x="399" y="101" width="86" height="32" rx="10"/>
-   <rect x="397"
-         y="99"
+   <text class="terminal" x="391" y="119">FROM LOAD GENERATOR</text>
+   <rect x="112" y="243" width="86" height="32" rx="10"/>
+   <rect x="110"
+         y="241"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="119">AUCTION</text>
-   <rect x="399" y="145" width="88" height="32" rx="10"/>
-   <rect x="397"
-         y="143"
+   <text class="terminal" x="120" y="261">AUCTION</text>
+   <rect x="112" y="287" width="88" height="32" rx="10"/>
+   <rect x="110"
+         y="285"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="163">COUNTER</text>
-   <rect x="399" y="189" width="60" height="32" rx="10"/>
-   <rect x="397"
-         y="187"
+   <text class="terminal" x="120" y="305">COUNTER</text>
+   <rect x="112" y="331" width="60" height="32" rx="10"/>
+   <rect x="110"
+         y="329"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="207">TPCH</text>
-   <rect x="186" y="299" width="26" height="32" rx="10"/>
-   <rect x="184"
-         y="297"
+   <text class="terminal" x="120" y="349">TPCH</text>
+   <rect x="260" y="243" width="26" height="32" rx="10"/>
+   <rect x="258"
+         y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="194" y="317">(</text>
-   <rect x="252" y="299" width="166" height="32"/>
-   <rect x="250" y="297" width="166" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="260" y="317">load_generator_option</text>
-   <rect x="252" y="255" width="24" height="32" rx="10"/>
-   <rect x="250"
-         y="253"
+   <text class="terminal" x="268" y="261">(</text>
+   <rect x="326" y="243" width="166" height="32"/>
+   <rect x="324" y="241" width="166" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="334" y="261">load_generator_option</text>
+   <rect x="326" y="199" width="24" height="32" rx="10"/>
+   <rect x="324"
+         y="197"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="260" y="273">,</text>
-   <rect x="458" y="299" width="26" height="32" rx="10"/>
-   <rect x="456"
-         y="297"
+   <text class="terminal" x="334" y="217">,</text>
+   <rect x="532" y="243" width="26" height="32" rx="10"/>
+   <rect x="530"
+         y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="466" y="317">)</text>
-   <rect x="45" y="381" width="138" height="32" rx="10"/>
+   <text class="terminal" x="540" y="261">)</text>
+   <rect x="45" y="397" width="138" height="32" rx="10"/>
    <rect x="43"
-         y="379"
+         y="395"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="399">FOR ALL TABLES</text>
-   <rect x="45" y="469" width="106" height="32" rx="10"/>
+   <text class="terminal" x="53" y="415">FOR ALL TABLES</text>
+   <rect x="45" y="485" width="106" height="32" rx="10"/>
    <rect x="43"
-         y="467"
+         y="483"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="487">FOR TABLES</text>
-   <rect x="171" y="469" width="26" height="32" rx="10"/>
+   <text class="terminal" x="53" y="503">FOR TABLES</text>
+   <rect x="171" y="485" width="26" height="32" rx="10"/>
    <rect x="169"
-         y="467"
+         y="483"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="487">(</text>
-   <rect x="237" y="469" width="96" height="32"/>
-   <rect x="235" y="467" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="245" y="487">table_name</text>
-   <rect x="373" y="501" width="40" height="32" rx="10"/>
+   <text class="terminal" x="179" y="503">(</text>
+   <rect x="237" y="485" width="96" height="32"/>
+   <rect x="235" y="483" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="245" y="503">table_name</text>
+   <rect x="373" y="517" width="40" height="32" rx="10"/>
    <rect x="371"
-         y="499"
+         y="515"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="381" y="519">AS</text>
-   <rect x="433" y="501" width="106" height="32"/>
-   <rect x="431" y="499" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="441" y="519">subsrc_name</text>
-   <rect x="237" y="425" width="24" height="32" rx="10"/>
+   <text class="terminal" x="381" y="535">AS</text>
+   <rect x="433" y="517" width="106" height="32"/>
+   <rect x="431" y="515" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="441" y="535">subsrc_name</text>
+   <rect x="237" y="441" width="24" height="32" rx="10"/>
    <rect x="235"
-         y="423"
+         y="439"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="245" y="443">,</text>
-   <rect x="599" y="469" width="26" height="32" rx="10"/>
+   <text class="terminal" x="245" y="459">,</text>
+   <rect x="599" y="485" width="26" height="32" rx="10"/>
    <rect x="597"
-         y="467"
+         y="483"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="607" y="487">)</text>
-   <rect x="255" y="611" width="58" height="32" rx="10"/>
+   <text class="terminal" x="607" y="503">)</text>
+   <rect x="255" y="627" width="58" height="32" rx="10"/>
    <rect x="253"
-         y="609"
+         y="625"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="629">WITH</text>
-   <rect x="333" y="611" width="26" height="32" rx="10"/>
+   <text class="terminal" x="263" y="645">WITH</text>
+   <rect x="333" y="627" width="26" height="32" rx="10"/>
    <rect x="331"
-         y="609"
+         y="625"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="629">(</text>
-   <rect x="399" y="611" width="48" height="32"/>
-   <rect x="397" y="609" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="407" y="629">field</text>
-   <rect x="467" y="611" width="28" height="32" rx="10"/>
+   <text class="terminal" x="341" y="645">(</text>
+   <rect x="399" y="627" width="48" height="32"/>
+   <rect x="397" y="625" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="645">field</text>
+   <rect x="467" y="627" width="28" height="32" rx="10"/>
    <rect x="465"
-         y="609"
+         y="625"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="475" y="629">=</text>
-   <rect x="515" y="611" width="38" height="32"/>
-   <rect x="513" y="609" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="523" y="629">val</text>
-   <rect x="399" y="567" width="24" height="32" rx="10"/>
+   <text class="terminal" x="475" y="645">=</text>
+   <rect x="515" y="627" width="38" height="32"/>
+   <rect x="513" y="625" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="523" y="645">val</text>
+   <rect x="399" y="583" width="24" height="32" rx="10"/>
    <rect x="397"
-         y="565"
+         y="581"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="585">,</text>
-   <rect x="593" y="611" width="26" height="32" rx="10"/>
+   <text class="terminal" x="407" y="601">,</text>
+   <rect x="593" y="627" width="26" height="32" rx="10"/>
    <rect x="591"
-         y="609"
+         y="625"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="601" y="629">)</text>
+   <text class="terminal" x="601" y="645">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-334 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m196 0 h10 m20 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m60 0 h10 m0 0 h28 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-385 198 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-523 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="657 625 665 621 665 629"/>
-   <polygon points="657 625 649 621 649 629"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-406 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-531 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m60 0 h10 m0 0 h28 m40 -88 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-597 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="657 641 665 637 665 645"/>
+   <polygon points="657 641 649 637 649 645"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-postgres.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="667" height="721">
+<svg xmlns="http://www.w3.org/2000/svg" width="667" height="819">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,205 +20,216 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="473" y="3" width="60" height="32" rx="10"/>
-   <rect x="471"
-         y="1"
+   <rect x="121" y="133" width="104" height="32" rx="10"/>
+   <rect x="119"
+         y="131"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="129" y="151">IN CLUSTER</text>
+   <rect x="245" y="133" width="108" height="32"/>
+   <rect x="243" y="131" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="253" y="151">cluster_name</text>
+   <rect x="393" y="101" width="60" height="32" rx="10"/>
+   <rect x="391"
+         y="99"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="21">FROM</text>
-   <rect x="118" y="101" width="96" height="32" rx="10"/>
-   <rect x="116"
+   <text class="terminal" x="401" y="119">FROM</text>
+   <rect x="473" y="101" width="96" height="32" rx="10"/>
+   <rect x="471"
          y="99"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="126" y="119">POSTGRES</text>
-   <rect x="234" y="101" width="116" height="32" rx="10"/>
-   <rect x="232"
-         y="99"
+   <text class="terminal" x="481" y="119">POSTGRES</text>
+   <rect x="108" y="199" width="116" height="32" rx="10"/>
+   <rect x="106"
+         y="197"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="242" y="119">CONNECTION</text>
-   <rect x="370" y="101" width="136" height="32"/>
-   <rect x="368" y="99" width="136" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="378" y="119">connection_name</text>
-   <rect x="526" y="101" width="26" height="32" rx="10"/>
-   <rect x="524"
-         y="99"
+   <text class="terminal" x="116" y="217">CONNECTION</text>
+   <rect x="244" y="199" width="136" height="32"/>
+   <rect x="242" y="197" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="252" y="217">connection_name</text>
+   <rect x="400" y="199" width="26" height="32" rx="10"/>
+   <rect x="398"
+         y="197"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="534" y="119">(</text>
-   <rect x="200" y="167" width="116" height="32" rx="10"/>
-   <rect x="198"
-         y="165"
+   <text class="terminal" x="408" y="217">(</text>
+   <rect x="446" y="199" width="116" height="32" rx="10"/>
+   <rect x="444"
+         y="197"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="208" y="185">PUBLICATION</text>
-   <rect x="336" y="167" width="134" height="32"/>
-   <rect x="334" y="165" width="134" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="344" y="185">publication_name</text>
-   <rect x="95" y="277" width="24" height="32" rx="10"/>
+   <text class="terminal" x="454" y="217">PUBLICATION</text>
+   <rect x="268" y="265" width="134" height="32"/>
+   <rect x="266" y="263" width="134" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="276" y="283">publication_name</text>
+   <rect x="95" y="375" width="24" height="32" rx="10"/>
    <rect x="93"
-         y="275"
+         y="373"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="103" y="295">,</text>
-   <rect x="139" y="277" width="134" height="32" rx="10"/>
+   <text class="terminal" x="103" y="393">,</text>
+   <rect x="139" y="375" width="134" height="32" rx="10"/>
    <rect x="137"
-         y="275"
+         y="373"
          width="134"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="147" y="295">TEXT COLUMNS</text>
-   <rect x="313" y="277" width="26" height="32" rx="10"/>
+   <text class="terminal" x="147" y="393">TEXT COLUMNS</text>
+   <rect x="313" y="375" width="26" height="32" rx="10"/>
    <rect x="311"
-         y="275"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="321" y="295">(</text>
-   <rect x="379" y="277" width="110" height="32"/>
-   <rect x="377" y="275" width="110" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="387" y="295">column_name</text>
-   <rect x="379" y="233" width="24" height="32" rx="10"/>
-   <rect x="377"
-         y="231"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="387" y="251">,</text>
-   <rect x="529" y="277" width="26" height="32" rx="10"/>
-   <rect x="527"
-         y="275"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="537" y="295">)</text>
-   <rect x="322" y="375" width="26" height="32" rx="10"/>
-   <rect x="320"
          y="373"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="330" y="393">)</text>
-   <rect x="45" y="441" width="138" height="32" rx="10"/>
+   <text class="terminal" x="321" y="393">(</text>
+   <rect x="379" y="375" width="110" height="32"/>
+   <rect x="377" y="373" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="387" y="393">column_name</text>
+   <rect x="379" y="331" width="24" height="32" rx="10"/>
+   <rect x="377"
+         y="329"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="387" y="349">,</text>
+   <rect x="529" y="375" width="26" height="32" rx="10"/>
+   <rect x="527"
+         y="373"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="537" y="393">)</text>
+   <rect x="322" y="473" width="26" height="32" rx="10"/>
+   <rect x="320"
+         y="471"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="330" y="491">)</text>
+   <rect x="45" y="539" width="138" height="32" rx="10"/>
    <rect x="43"
-         y="439"
+         y="537"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="459">FOR ALL TABLES</text>
-   <rect x="45" y="529" width="106" height="32" rx="10"/>
+   <text class="terminal" x="53" y="557">FOR ALL TABLES</text>
+   <rect x="45" y="627" width="106" height="32" rx="10"/>
    <rect x="43"
-         y="527"
+         y="625"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="547">FOR TABLES</text>
-   <rect x="171" y="529" width="26" height="32" rx="10"/>
+   <text class="terminal" x="53" y="645">FOR TABLES</text>
+   <rect x="171" y="627" width="26" height="32" rx="10"/>
    <rect x="169"
-         y="527"
+         y="625"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="547">(</text>
-   <rect x="237" y="529" width="96" height="32"/>
-   <rect x="235" y="527" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="245" y="547">table_name</text>
-   <rect x="373" y="561" width="40" height="32" rx="10"/>
+   <text class="terminal" x="179" y="645">(</text>
+   <rect x="237" y="627" width="96" height="32"/>
+   <rect x="235" y="625" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="245" y="645">table_name</text>
+   <rect x="373" y="659" width="40" height="32" rx="10"/>
    <rect x="371"
-         y="559"
+         y="657"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="381" y="579">AS</text>
-   <rect x="433" y="561" width="106" height="32"/>
-   <rect x="431" y="559" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="441" y="579">subsrc_name</text>
-   <rect x="237" y="485" width="24" height="32" rx="10"/>
+   <text class="terminal" x="381" y="677">AS</text>
+   <rect x="433" y="659" width="106" height="32"/>
+   <rect x="431" y="657" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="441" y="677">subsrc_name</text>
+   <rect x="237" y="583" width="24" height="32" rx="10"/>
    <rect x="235"
-         y="483"
+         y="581"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="245" y="503">,</text>
-   <rect x="599" y="529" width="26" height="32" rx="10"/>
+   <text class="terminal" x="245" y="601">,</text>
+   <rect x="599" y="627" width="26" height="32" rx="10"/>
    <rect x="597"
-         y="527"
+         y="625"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="607" y="547">)</text>
-   <rect x="255" y="671" width="58" height="32" rx="10"/>
+   <text class="terminal" x="607" y="645">)</text>
+   <rect x="255" y="769" width="58" height="32" rx="10"/>
    <rect x="253"
-         y="669"
+         y="767"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="689">WITH</text>
-   <rect x="333" y="671" width="26" height="32" rx="10"/>
+   <text class="terminal" x="263" y="787">WITH</text>
+   <rect x="333" y="769" width="26" height="32" rx="10"/>
    <rect x="331"
-         y="669"
+         y="767"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="689">(</text>
-   <rect x="399" y="671" width="48" height="32"/>
-   <rect x="397" y="669" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="407" y="689">field</text>
-   <rect x="467" y="671" width="28" height="32" rx="10"/>
+   <text class="terminal" x="341" y="787">(</text>
+   <rect x="399" y="769" width="48" height="32"/>
+   <rect x="397" y="767" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="787">field</text>
+   <rect x="467" y="769" width="28" height="32" rx="10"/>
    <rect x="465"
-         y="669"
+         y="767"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="475" y="689">=</text>
-   <rect x="515" y="671" width="38" height="32"/>
-   <rect x="513" y="669" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="523" y="689">val</text>
-   <rect x="399" y="627" width="24" height="32" rx="10"/>
+   <text class="terminal" x="475" y="787">=</text>
+   <rect x="515" y="769" width="38" height="32"/>
+   <rect x="513" y="767" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="523" y="787">val</text>
+   <rect x="399" y="725" width="24" height="32" rx="10"/>
    <rect x="397"
-         y="625"
+         y="723"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="645">,</text>
-   <rect x="593" y="671" width="26" height="32" rx="10"/>
+   <text class="terminal" x="407" y="743">,</text>
+   <rect x="593" y="769" width="26" height="32" rx="10"/>
    <rect x="591"
-         y="669"
+         y="767"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="601" y="689">)</text>
+   <text class="terminal" x="601" y="787">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-459 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-396 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m134 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-439 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m-500 -34 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v30 m520 0 v-30 m-520 30 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m0 0 h490 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-317 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-367 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="657 685 665 681 665 689"/>
-   <polygon points="657 685 649 681 649 689"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-396 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-505 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m116 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m134 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-371 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m24 0 h10 m0 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m26 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v14 m282 0 v-14 m-282 14 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m0 0 h252 m-500 -34 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v30 m520 0 v-30 m-520 30 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m0 0 h490 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-317 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-367 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 230 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="657 783 665 779 665 787"/>
+   <polygon points="657 783 649 779 649 787"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-s3.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-s3.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="601" height="719">
+<svg xmlns="http://www.w3.org/2000/svg" width="593" height="817">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,165 +20,176 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="45" y="145" width="26" height="32" rx="10"/>
-   <rect x="43"
+   <rect x="81" y="145" width="26" height="32" rx="10"/>
+   <rect x="79"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="163">(</text>
-   <rect x="111" y="145" width="82" height="32"/>
-   <rect x="109" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="119" y="163">col_name</text>
-   <rect x="111" y="101" width="24" height="32" rx="10"/>
-   <rect x="109"
+   <text class="terminal" x="89" y="163">(</text>
+   <rect x="147" y="145" width="82" height="32"/>
+   <rect x="145" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="155" y="163">col_name</text>
+   <rect x="147" y="101" width="24" height="32" rx="10"/>
+   <rect x="145"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="119" y="119">,</text>
-   <rect x="253" y="177" width="24" height="32" rx="10"/>
-   <rect x="251"
+   <text class="terminal" x="155" y="119">,</text>
+   <rect x="289" y="177" width="24" height="32" rx="10"/>
+   <rect x="287"
          y="175"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="261" y="195">,</text>
-   <rect x="297" y="177" width="116" height="32"/>
-   <rect x="295" y="175" width="116" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="195">key_constraint</text>
-   <rect x="453" y="145" width="26" height="32" rx="10"/>
-   <rect x="451"
+   <text class="terminal" x="297" y="195">,</text>
+   <rect x="333" y="177" width="116" height="32"/>
+   <rect x="331" y="175" width="116" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="341" y="195">key_constraint</text>
+   <rect x="489" y="145" width="26" height="32" rx="10"/>
+   <rect x="487"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="461" y="163">)</text>
-   <rect x="519" y="145" width="60" height="32" rx="10"/>
-   <rect x="517"
-         y="143"
+   <text class="terminal" x="497" y="163">)</text>
+   <rect x="113" y="291" width="104" height="32" rx="10"/>
+   <rect x="111"
+         y="289"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="121" y="309">IN CLUSTER</text>
+   <rect x="237" y="291" width="108" height="32"/>
+   <rect x="235" y="289" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="245" y="309">cluster_name</text>
+   <rect x="385" y="259" width="60" height="32" rx="10"/>
+   <rect x="383"
+         y="257"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="527" y="163">FROM</text>
-   <rect x="27" y="259" width="38" height="32" rx="10"/>
-   <rect x="25"
+   <text class="terminal" x="393" y="277">FROM</text>
+   <rect x="465" y="259" width="38" height="32" rx="10"/>
+   <rect x="463"
          y="257"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="35" y="277">S3</text>
-   <rect x="85" y="259" width="162" height="32" rx="10"/>
-   <rect x="83"
-         y="257"
+   <text class="terminal" x="473" y="277">S3</text>
+   <rect x="52" y="357" width="162" height="32" rx="10"/>
+   <rect x="50"
+         y="355"
          width="162"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="93" y="277">DISCOVER OBJECTS</text>
-   <rect x="287" y="291" width="98" height="32" rx="10"/>
-   <rect x="285"
-         y="289"
+   <text class="terminal" x="60" y="375">DISCOVER OBJECTS</text>
+   <rect x="254" y="389" width="98" height="32" rx="10"/>
+   <rect x="252"
+         y="387"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="295" y="309">MATCHING</text>
-   <rect x="405" y="291" width="68" height="32"/>
-   <rect x="403" y="289" width="68" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="413" y="309">pattern</text>
-   <rect x="513" y="259" width="64" height="32" rx="10"/>
-   <rect x="511"
-         y="257"
+   <text class="terminal" x="262" y="407">MATCHING</text>
+   <rect x="372" y="389" width="68" height="32"/>
+   <rect x="370" y="387" width="68" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="380" y="407">pattern</text>
+   <rect x="480" y="357" width="64" height="32" rx="10"/>
+   <rect x="478"
+         y="355"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="521" y="277">USING</text>
-   <rect x="158" y="401" width="122" height="32" rx="10"/>
-   <rect x="156"
-         y="399"
+   <text class="terminal" x="488" y="375">USING</text>
+   <rect x="154" y="499" width="122" height="32" rx="10"/>
+   <rect x="152"
+         y="497"
          width="122"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="166" y="419">BUCKET SCAN</text>
-   <rect x="300" y="401" width="108" height="32"/>
-   <rect x="298" y="399" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="308" y="419">bucket_name</text>
-   <rect x="158" y="445" width="164" height="32" rx="10"/>
-   <rect x="156"
-         y="443"
+   <text class="terminal" x="162" y="517">BUCKET SCAN</text>
+   <rect x="296" y="499" width="108" height="32"/>
+   <rect x="294" y="497" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="304" y="517">bucket_name</text>
+   <rect x="154" y="543" width="164" height="32" rx="10"/>
+   <rect x="152"
+         y="541"
          width="164"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="166" y="463">SQS NOTIFICATIONS</text>
-   <rect x="342" y="445" width="104" height="32"/>
-   <rect x="340" y="443" width="104" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="350" y="463">queue_name</text>
-   <rect x="138" y="357" width="24" height="32" rx="10"/>
-   <rect x="136"
-         y="355"
+   <text class="terminal" x="162" y="561">SQS NOTIFICATIONS</text>
+   <rect x="338" y="543" width="104" height="32"/>
+   <rect x="336" y="541" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="346" y="561">queue_name</text>
+   <rect x="134" y="455" width="24" height="32" rx="10"/>
+   <rect x="132"
+         y="453"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="146" y="375">,</text>
-   <rect x="49" y="543" width="124" height="32" rx="10"/>
-   <rect x="47"
-         y="541"
+   <text class="terminal" x="142" y="473">,</text>
+   <rect x="45" y="641" width="124" height="32" rx="10"/>
+   <rect x="43"
+         y="639"
          width="124"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="57" y="561">COMPRESSION</text>
-   <rect x="213" y="543" width="60" height="32" rx="10"/>
-   <rect x="211"
-         y="541"
+   <text class="terminal" x="53" y="659">COMPRESSION</text>
+   <rect x="209" y="641" width="60" height="32" rx="10"/>
+   <rect x="207"
+         y="639"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="221" y="561">NONE</text>
-   <rect x="213" y="587" width="52" height="32" rx="10"/>
-   <rect x="211"
-         y="585"
+   <text class="terminal" x="217" y="659">NONE</text>
+   <rect x="209" y="685" width="52" height="32" rx="10"/>
+   <rect x="207"
+         y="683"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="221" y="605">GZIP</text>
-   <rect x="353" y="543" width="102" height="32"/>
-   <rect x="351" y="541" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="361" y="561">with_options</text>
-   <rect x="495" y="511" width="80" height="32" rx="10"/>
-   <rect x="493"
-         y="509"
+   <text class="terminal" x="217" y="703">GZIP</text>
+   <rect x="349" y="641" width="102" height="32"/>
+   <rect x="347" y="639" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="357" y="659">with_options</text>
+   <rect x="491" y="609" width="80" height="32" rx="10"/>
+   <rect x="489"
+         y="607"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="503" y="529">FORMAT</text>
-   <rect x="273" y="653" width="102" height="32"/>
-   <rect x="271" y="651" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="281" y="671">format_spec</text>
-   <rect x="415" y="685" width="138" height="32" rx="10"/>
-   <rect x="413"
-         y="683"
+   <text class="terminal" x="499" y="627">FORMAT</text>
+   <rect x="265" y="751" width="102" height="32"/>
+   <rect x="263" y="749" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="273" y="769">format_spec</text>
+   <rect x="407" y="783" width="138" height="32" rx="10"/>
+   <rect x="405"
+         y="781"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="423" y="703">ENVELOPE NONE</text>
+   <text class="terminal" x="415" y="801">ENVELOPE NONE</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m20 -66 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-596 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m38 0 h10 m0 0 h10 m162 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m98 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-503 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m122 0 h10 m0 0 h10 m108 0 h10 m0 0 h38 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v24 m328 0 v-24 m-328 24 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m164 0 h10 m0 0 h10 m104 0 h10 m-348 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m348 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-348 0 h10 m24 0 h10 m0 0 h304 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-501 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m124 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m60 -76 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-346 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m102 0 h10 m20 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m23 -32 h-3"/>
-   <polygon points="591 667 599 663 599 671"/>
-   <polygon points="591 667 583 663 583 671"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-436 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m40 44 h10 m0 0 h170 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v12 m200 0 v-12 m-200 12 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m24 0 h10 m0 0 h10 m116 0 h10 m20 -32 h10 m26 0 h10 m-474 0 h20 m454 0 h20 m-494 0 q10 0 10 10 m474 0 q0 -10 10 -10 m-484 10 v46 m474 0 v-46 m-474 46 q0 10 10 10 m454 0 q10 0 10 -10 m-464 10 h10 m0 0 h444 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-486 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-495 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m162 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m98 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-474 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m122 0 h10 m0 0 h10 m108 0 h10 m0 0 h38 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v24 m328 0 v-24 m-328 24 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m164 0 h10 m0 0 h10 m104 0 h10 m-348 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m348 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-348 0 h10 m24 0 h10 m0 0 h304 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-501 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m124 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m52 0 h10 m0 0 h8 m60 -76 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m20 -32 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-350 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m102 0 h10 m20 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m23 -32 h-3"/>
+   <polygon points="583 765 591 761 591 769"/>
+   <polygon points="583 765 575 761 575 769"/>
 </svg>

--- a/doc/user/layouts/shortcodes/create-source/syntax-connector-details.html
+++ b/doc/user/layouts/shortcodes/create-source/syntax-connector-details.html
@@ -5,6 +5,7 @@ Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
 _col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
+**IN CLUSTER** _cluster_name_ | The [cluster](/sql/create-cluster) to maintain this source. If not specified, the `SIZE` option must be specified.
 {{ partial (printf "create-source/connector/%s/syntax" $connector ) . -}}
 {{ range $envelopes }}{{ partial (printf "create-source/envelope/%s/syntax" .) . }}{{ end -}}
 **WITH (** _option&lowbar;list_ **)** | Options affecting source creation. For more detail, see [`WITH` options](#with-options).

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -70,6 +70,7 @@ create_schema ::=
     'CREATE' 'SCHEMA' ('IF NOT EXISTS')? schema_name
 create_sink_kafka ::=
     'CREATE SINK' 'IF NOT EXISTS'? sink_name
+    ('IN CLUSTER' cluster_name)?
     'FROM' item_name
     'INTO' kafka_sink_connection
     ('KEY' '(' key_column ( ',' key_column )* ')')?
@@ -79,6 +80,7 @@ create_sink_kafka ::=
 create_source_kafka ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
+  ('IN CLUSTER' cluster_name)?
   'FROM' 'KAFKA' 'CONNECTION' connection_name
   '(' 'TOPIC' topic ( ( ',' connection_option )? ) ')'
   ('KEY FORMAT' format_spec 'VALUE FORMAT' format_spec | 'FORMAT' format_spec)
@@ -90,11 +92,13 @@ create_source_kafka ::=
 create_source_kinesis ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
+  ('IN CLUSTER' cluster_name)?
   'FROM' 'KINESIS ARN' arn with_options?
   'FORMAT' format_spec
   ('ENVELOPE NONE')?
 create_source_load_generator ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('IN CLUSTER' cluster_name)?
   'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER' | 'TPCH')
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
   ('FOR ALL TABLES' | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
@@ -104,6 +108,7 @@ load_generator_option ::=
     | 'SCALE FACTOR' scale_factor
 create_source_postgres ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('IN CLUSTER' cluster_name)?
   'FROM' 'POSTGRES' 'CONNECTION' connection_name
   '(' 'PUBLICATION' publication_name ( ( ',' 'TEXT COLUMNS' ('(' (column_name) ( ( ',' column_name ) )* ')')? )? ) ')'
   ('FOR ALL TABLES' | 'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
@@ -111,6 +116,7 @@ create_source_postgres ::=
 create_source_s3 ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ( ',' key_constraint )? ')')?
+  ('IN CLUSTER' cluster_name)?
   'FROM' 'S3' 'DISCOVER OBJECTS'
   ('MATCHING' pattern)?
   'USING' (


### PR DESCRIPTION
Adjust documentation for cluster unification
(MaterializeInc/cloud#4929).

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Allow placing sources and sinks in clusters via the `IN CLUSTER` clause. As a short term restriction, clusters containing sources and sinks cannot have more than one replica. Additionally, a cluster may contain either sources and sinks or indexes and materialized views, but not both types of objects.
