### PR TITLE
pgtest: teach tests to be restartable

### DIFF
--- a/test/pgtest-mz/affected.pt
+++ b/test/pgtest-mz/affected.pt
@@ -1,6 +1,20 @@
 # Test affected row counts.
 
 send
+Query {"query": "DROP TABLE IF EXISTS t"}
+Query {"query": "DROP TABLE IF EXISTS u"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
 Query {"query": "CREATE TABLE t (i int)"}
 Query {"query": "INSERT INTO t VALUES (1), (1)"}
 Query {"query": "INSERT INTO t SELECT * FROM generate_series(1, 10)"}

--- a/test/pgtest-mz/ddl-extended.pt
+++ b/test/pgtest-mz/ddl-extended.pt
@@ -1,4 +1,19 @@
 # Test that multiple DDL statements in the same extended request are supported
+
+send
+Query {"query": "DROP TABLE IF EXISTS a"}
+Query {"query": "DROP TABLE IF EXISTS b"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
 send
 Parse {"query": "CREATE TABLE a (a int)"}
 Bind

--- a/test/pgtest-mz/transactions.pt
+++ b/test/pgtest-mz/transactions.pt
@@ -2,6 +2,17 @@
 # MZ differs from PG.
 # See pgtest/transactions.pt for more details
 
+
+send
+Query {"query": "DROP TABLE IF EXISTS t"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
 # Verify implicit transactions are properly upgraded
 send
 Query {"query": "CREATE TABLE t (a INT)"}

--- a/test/pgtest/copy-from-null.pt
+++ b/test/pgtest/copy-from-null.pt
@@ -9,6 +9,16 @@ CommandComplete {"tag":"DROP TABLE"}
 ReadyForQuery {"status":"I"}
 
 send
+Query {"query": "DROP TABLE IF EXISTS t"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
+send
 Query {"query": "CREATE TABLE t (i INT8, t TEXT)"}
 ----
 

--- a/test/pgtest/ddl-extended.pt
+++ b/test/pgtest/ddl-extended.pt
@@ -1,4 +1,19 @@
 # Test that multiple DDL statements in the same extended request are supported
+
+send
+Query {"query": "DROP TABLE IF EXISTS a"}
+Query {"query": "DROP TABLE IF EXISTS b"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP TABLE"}
+ReadyForQuery {"status":"I"}
+
 send
 Parse {"query": "CREATE TABLE a (a int)"}
 Bind


### PR DESCRIPTION
This makes running them in a loop much easier.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a