### PR TITLE
adapter: trace various startup functions

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2115,7 +2115,7 @@ impl Catalog {
     /// schemas since last restart, a list of updates to builtin tables that
     /// describe the initial state of the catalog, and the version of the
     /// catalog before any migrations were performed.
-    #[tracing::instrument(level = "info", skip_all)]
+    #[tracing::instrument(name = "catalog::open", level = "info", skip_all)]
     pub async fn open(
         config: Config<'_>,
     ) -> Result<

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -525,6 +525,7 @@ pub struct Connection {
 }
 
 impl Connection {
+    #[tracing::instrument(name = "storage::open", level = "info", skip_all)]
     pub async fn open(
         mut stash: Stash,
         now: NowFn,
@@ -1728,6 +1729,7 @@ where
 }
 
 /// Inserts empty values into all new collections, so the collections are readable.
+#[tracing::instrument(level = "info", skip_all)]
 pub async fn initialize_stash(stash: &mut Stash) -> Result<(), Error> {
     async fn add_batch<'tx, K, V>(
         tx: &'tx mz_stash::Transaction<'tx>,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -236,6 +236,7 @@ pub enum TlsMode {
 }
 
 /// Start an `environmentd` server.
+#[tracing::instrument(name = "environmentd::serve", level = "info", skip_all)]
 pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let tls = mz_postgres_util::make_tls(&tokio_postgres::config::Config::from_str(
         &config.adapter_stash_url,


### PR DESCRIPTION
See #16531

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a