### PR TITLE
controller: minor cleanup

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -69,8 +69,6 @@ mod replica;
 
 pub mod error;
 
-pub use mz_orchestrator::ServiceStatus as ComputeInstanceStatus;
-
 /// Identifer of a compute instance.
 pub type ComputeInstanceId = StorageInstanceId;
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -25,8 +25,7 @@ use timely::progress::Timestamp;
 use tracing::{error, warn};
 
 use mz_compute_client::controller::{
-    ComputeInstanceId, ComputeInstanceStatus, ComputeReplicaConfig, ComputeReplicaLocation,
-    ComputeReplicaLogging,
+    ComputeInstanceId, ComputeReplicaConfig, ComputeReplicaLocation, ComputeReplicaLogging,
 };
 use mz_compute_client::logging::LogVariant;
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
@@ -54,7 +53,7 @@ pub struct ClusterConfig {
 }
 
 /// The status of a cluster.
-pub type ClusterStatus = ComputeInstanceStatus;
+pub type ClusterStatus = mz_orchestrator::ServiceStatus;
 
 /// Identifies a cluster replica.
 pub type ReplicaId = mz_compute_client::controller::ReplicaId;
@@ -95,7 +94,7 @@ impl ReplicaLocation {
     /// any.
     pub fn availability_zone(&self) -> Option<&str> {
         match self {
-            ReplicaLocation::Unmanaged { .. } => None,
+            ReplicaLocation::Unmanaged(_) => None,
             ReplicaLocation::Managed(m) => Some(&m.availability_zone),
         }
     }
@@ -155,7 +154,7 @@ pub struct ClusterEvent {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
     pub process_id: ProcessId,
-    pub status: ComputeInstanceStatus,
+    pub status: ClusterStatus,
     pub time: DateTime<Utc>,
 }
 


### PR DESCRIPTION
This PR does two minor cleanups to the controller code:

 * Removes the `ComputeInstanceStatus` type, which is not needed anymore.
 * Replace a confusing pattern match on a tuple enum variant.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
