### PR TITLE
adapter: align `EXPLAIN AS TEXT` for `With` clauses in HIR/MIR/LIR

### DIFF
--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -111,7 +111,7 @@ impl<'a> Displayable<'a, HirRelationExpr> {
 
                 writeln!(f, "{}Return", ctx.indent)?;
                 ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
-                writeln!(f, "{}Where", ctx.indent)?;
+                writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
                     for (id, value) in bindings.iter().rev() {
                         // TODO: print the name and not the id
@@ -124,7 +124,7 @@ impl<'a> Displayable<'a, HirRelationExpr> {
             LetRec { bindings, body } => {
                 writeln!(f, "{}Return", ctx.indent)?;
                 ctx.indented(|ctx| Displayable::from(body.as_ref()).fmt_text(f, ctx))?;
-                writeln!(f, "{}Where Recursive", ctx.indent)?;
+                writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
                 ctx.indented(|ctx| {
                     for (_name, id, value, _type) in bindings.iter().rev() {
                         // TODO: print the name and not the id

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -117,7 +117,7 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, Plan> {
 
                 writeln!(f, "{}Return", ctx.indent)?;
                 ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
-                writeln!(f, "{}Where", ctx.indent)?;
+                writeln!(f, "{}With", ctx.indent)?;
                 ctx.indented(|ctx| {
                     for (id, value) in bindings.iter().rev() {
                         writeln!(f, "{}cte {} =", ctx.indent, *id)?;
@@ -132,7 +132,7 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, Plan> {
 
                 writeln!(f, "{}Return", ctx.indent)?;
                 ctx.indented(|ctx| Displayable::from(head).fmt_text(f, ctx))?;
-                writeln!(f, "{}Where Mutually Recursive", ctx.indent)?;
+                writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
                 ctx.indented(|ctx| {
                     for (id, value) in bindings.iter().rev() {
                         writeln!(f, "{}cte {} =", ctx.indent, *id)?;

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -34,7 +34,7 @@ Project (#0)
     InnerJoin (true AND (#0 = #1))
       Get l0
       Get l0
-  Where
+  With
     cte l0 =
       Filter (#0 < 3)
         Get materialize.public.y
@@ -50,7 +50,7 @@ WITH t AS (SELECT * FROM y WHERE a < 3)
 Return
   Filter (select(Get l0) < #0)
     Get materialize.public.y
-Where
+With
   cte l0 =
     Filter (#0 < 3)
       Get materialize.public.y
@@ -524,12 +524,12 @@ Project (#1)
       Return
         Filter (select(Get l6) < select(Get l7))
           Get l3
-      Where
+      With
         cte l6 =
           Return
             Reduce aggregates=[min(#0)]
               Get l4
-          Where
+          With
             cte l4 =
               Get l3
         cte l7 =
@@ -537,17 +537,17 @@ Project (#1)
             Get l2
         cte l3 =
           Get l1
-  Where
+  With
     cte l8 =
       Return
         Filter (select(Get l5) > 1)
           Get l3
-      Where
+      With
         cte l5 =
           Return
             Reduce aggregates=[max(#0)]
               Get l4
-          Where
+          With
             cte l4 =
               Get l3
         cte l3 =
@@ -568,7 +568,7 @@ WITH a(a) AS (SELECT a FROM y) SELECT * FROM (WITH a(a) AS (SELECT a FROM a) SEL
 ----
 Return
   Get l1
-Where
+With
   cte l1 =
     Get l0
   cte l0 =

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -193,7 +193,7 @@ Explained Query:
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-  Where
+  With
     cte l0 =
       Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
         ArrangeBy
@@ -347,7 +347,7 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  Where
+  With
     cte l0 =
       Reduce::Accumulable
         simple_aggrs[0]=(0, 0, sum(#0))
@@ -425,7 +425,7 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  Where
+  With
     cte l0 =
       Reduce::Hierarchical
         aggr_funcs=[min, max]
@@ -504,7 +504,7 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0, #1) }
           Constant
             - ()
-  Where
+  With
     cte l0 =
       Reduce::Basic
         aggrs[0]=(0, string_agg(row(row((integer_to_text(#0) || "1"), ","))))
@@ -600,7 +600,7 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0..=#5) }
           Constant
             - ()
-  Where
+  With
     cte l0 =
       Reduce::Collation
         aggregate_types=[a, b, h, h, a, b]

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -147,7 +147,7 @@ SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELEC
 Return
   Filter (exists(Get l1) AND exists(Get l2))
     Get materialize.public.t
-Where
+With
   cte l1 =
     Filter (#^0 < #0)
       Get materialize.public.mv
@@ -166,7 +166,7 @@ Project (#2, #3)
   Return
     Map (select(Get l1), select(Get l2))
       Get materialize.public.t
-  Where
+  With
     cte l1 =
       Project (#0)
         TopK limit=1
@@ -267,7 +267,7 @@ Project (#1)
   Return
     Map ((#0 + 5))
       Get l0
-  Where
+  With
     cte l0 =
       Project (#2)
         Map ((#0 * #1))
@@ -284,7 +284,7 @@ Return
   CrossJoin
     Get l0
     Get l1
-Where
+With
   cte l1 =
     Filter (#0 > 0)
       Get l0
@@ -324,14 +324,14 @@ CrossJoin
     Return
       Filter (#0 != #^0)
         Get l0
-    Where
+    With
       cte l0 =
         Reduce aggregates=[max((#^0 * #0))]
           Get materialize.public.t
   Return
     Filter ((#0 != #^0) OR ((#0) IS NOT NULL AND (#^0) IS NULL))
       Get l0
-  Where
+  With
     cte l0 =
       Reduce aggregates=[max((#^0 * #0))]
         Get materialize.public.t
@@ -374,11 +374,11 @@ CrossJoin
         Return
           Filter ((#^^0 = #^0) AND (#0 > 5))
             Get l1
-        Where
+        With
           cte l1 =
             Reduce aggregates=[max((#^^0 * #0))]
               Get materialize.public.t
-  Where
+  With
     cte l0 =
       Reduce aggregates=[max((#^0 * #0))]
         Get materialize.public.t

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -109,7 +109,7 @@ Explained Query:
             Get::Collection materialize.public.orders
               filter=((#0) IS NOT NULL)
               raw=true
-  Where
+  With
     cte l0 =
       Join::Linear
         linear_stage[0]

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -162,7 +162,7 @@ Explained Query:
               arrangements[0]={ key=[], permutation=id, thinning=(#0) }
           Constant
             - ()
-  Where
+  With
     cte l0 =
       Reduce::Accumulable
         simple_aggrs[0]=(0, 0, count(*))

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -840,7 +840,7 @@ Return
   Map (case when (select(Get l1) = 1) then 0 else 2 end, "TEXT")
     Constant
       - ()
-Where
+With
   cte l1 =
     Map (1)
       Constant

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1832,14 +1832,14 @@ Finish order_by=[#0 asc nulls_last] output=[#0, #1]
         CrossJoin
           Get materialize.public.supplier
           Get materialize.public.nation
-    Where
+    With
       cte l3 =
         Reduce aggregates=[any((#^0 = #0))]
           Project (#1)
             Return
               Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
                 Get materialize.public.partsupp
-            Where
+            With
               cte l1 =
                 Reduce aggregates=[any((#^0 = #0))]
                   Project (#0)

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -115,7 +115,7 @@ Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0, #1]
     Return
       Map (row_number() over (#0) order by (#0))
         Get l0
-    Where
+    With
       cte l0 =
         CallTable wrap2("a", 1, "b", 2, "c", 1)
 


### PR DESCRIPTION
Fix `EXPLAIN AS TEXT` output across the board so we always print `With Mutually Recursive` / `With` instead of `Where` / `Where Recursive`.

### Motivation

  * This PR adds a known-desirable feature.

    [Requested in internal discussion](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1671543608629039) by @frankmcsherry.

### Tips for reviewer

N/A

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `EXPLAIN AS TEXT` output for CTEs now uses the `With` keyword (which is closer to the SQL syntax) as opposed to `Where`.
