### PR TITLE
Replace MIR column runs by ranges

### DIFF
--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -31,6 +31,7 @@ use mz_ore::str::{bracketed, separated, IndentLike, StrExt};
 use mz_repr::explain_new::{fmt_text_constant_rows, separated_text, DisplayText, ExprHumanizer};
 use mz_repr::{GlobalId, Row};
 
+use super::MirIndices;
 use crate::explain_new::{Displayable, PlanRenderingContext};
 
 impl<'a> DisplayText<PlanRenderingContext<'_, MirRelationExpr>>
@@ -184,7 +185,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
             Map { scalars, input } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        let scalars = separated_text(", ", scalars.iter().map(Displayable::from));
+                        let scalars = MirIndices(scalars);
                         write!(f, "{}Map ({})", ctx.indent, scalars)?;
                         self.fmt_attributes(f, ctx)
                     },
@@ -390,8 +391,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                             write!(f, "{}Distinct", ctx.indent)?;
                         }
                         if group_key.len() > 0 {
-                            let group_key =
-                                separated_text(", ", group_key.iter().map(Displayable::from));
+                            let group_key = MirIndices(group_key);
                             write!(f, " group_by=[{}]", group_key)?;
                         }
                         if aggregates.len() > 0 {
@@ -486,11 +486,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
             ArrangeBy { input, keys } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        let keys = separated(
-                            "], [",
-                            keys.iter()
-                                .map(|key| separated_text(", ", key.iter().map(Displayable::from))),
-                        );
+                        let keys = separated("], [", keys.iter().map(|key| MirIndices(key)));
                         write!(f, "{}ArrangeBy keys=[[{}]]", ctx.indent, keys)?;
                         self.fmt_attributes(f, ctx)
                     },


### PR DESCRIPTION
Experiment in which MIR explanations for `MirScalarExpr` sequences that have runs of column references are replaced by `#x .. #y` notation. This as a result of seeing a whole lot of outputs that had 15-long sequences of all the same columns.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
