### PR TITLE
doc/developer: suggest use of forked Homebrew tap on macOS

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -51,9 +51,13 @@ Running Materialize locally requires a running CockroachDB server.
 On macOS, when using Homebrew, CockroachDB can be installed and started via:
 
 ```shell
-brew install cockroachdb/cockroach/cockroach
+brew install materializeinc/cockroach/cockroach
 brew services start cockroach
 ```
+
+(We recommend use of our [forked Homebrew tap][forked-cockroach-tap] because it
+runs CockroachDB using an in-memory store, which avoids slow filesystem
+operations on macOS.)
 
 On Linux, we recommend using Docker:
 
@@ -466,6 +470,7 @@ source /path/to/materialize/misc/completions/zsh/*
 [github-https]: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
 [hakari documentation]: https://docs.rs/cargo-hakari/latest/cargo_hakari/about/index.html
 [Homebrew]: https://brew.sh
+[forked-cockroach-tap]: https://github.com/materializeInc/homebrew-cockroach
 [Kubernetes]: https://kubernetes.io
 [materialize-dbt-utils]: https://github.com/MaterializeInc/materialize-dbt-utils
 [Nix]: https://nixos.org


### PR DESCRIPTION
The forked Homebrew tap avoids slow filesystem operations on macOS by configuring Cockroach to run with an in-memory store.

Touches #16963.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR partially fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
