### PR TITLE
plan: Generate deterministic plan for table funcs

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -29,7 +29,7 @@ use crate::ast::{AstInfo, Ident, OrderByExpr, Query, UnresolvedObjectName, Value
 /// The parser does not distinguish between expressions of different types
 /// (e.g. boolean vs string), so the caller must handle expressions of
 /// inappropriate type, like `WHERE 1` or `SELECT 1=1`, as necessary.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Expr<T: AstInfo> {
     /// Identifier e.g. table name or column name
     Identifier(Vec<Ident>),
@@ -602,7 +602,7 @@ impl<T: AstInfo> Expr<T> {
 }
 
 /// A reference to an operator.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Op {
     /// Any namespaces that preceded the operator.
     pub namespace: Vec<Ident>,
@@ -640,7 +640,7 @@ impl Op {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum HomogenizingFunction {
     Coalesce,
     Greatest,
@@ -658,7 +658,7 @@ impl AstDisplay for HomogenizingFunction {
 }
 impl_display!(HomogenizingFunction);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SubscriptPosition<T: AstInfo> {
     pub start: Option<Expr<T>>,
     pub end: Option<Expr<T>>,
@@ -682,7 +682,7 @@ impl<T: AstInfo> AstDisplay for SubscriptPosition<T> {
 impl_display_t!(SubscriptPosition);
 
 /// A window specification (i.e. `OVER (PARTITION BY .. ORDER BY .. etc.)`)
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct WindowSpec<T: AstInfo> {
     pub partition_by: Vec<Expr<T>>,
     pub order_by: Vec<OrderByExpr<T>>,
@@ -727,7 +727,7 @@ impl_display_t!(WindowSpec);
 ///
 /// Note: The parser does not validate the specified bounds; the caller should
 /// reject invalid bounds like `ROWS UNBOUNDED FOLLOWING` before execution.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct WindowFrame {
     pub units: WindowFrameUnits,
     pub start_bound: WindowFrameBound,
@@ -738,7 +738,7 @@ pub struct WindowFrame {
     // TBD: EXCLUDE
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WindowFrameUnits {
     Rows,
     Range,
@@ -757,7 +757,7 @@ impl AstDisplay for WindowFrameUnits {
 impl_display!(WindowFrameUnits);
 
 /// Specifies [WindowFrame]'s `start_bound` and `end_bound`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WindowFrameBound {
     /// `CURRENT ROW`
     CurrentRow,
@@ -787,7 +787,7 @@ impl AstDisplay for WindowFrameBound {
 impl_display!(WindowFrameBound);
 
 /// A function call
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Function<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub args: FunctionArgs<T>,
@@ -822,7 +822,7 @@ impl<T: AstInfo> AstDisplay for Function<T> {
 impl_display_t!(Function);
 
 /// Arguments for a function call.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum FunctionArgs<T: AstInfo> {
     /// The special star argument, as in `count(*)`.
     Star,
@@ -858,7 +858,7 @@ impl<T: AstInfo> AstDisplay for FunctionArgs<T> {
 }
 impl_display_t!(FunctionArgs);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum IsExprConstruct {
     Null,
     True,

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -25,7 +25,7 @@ use crate::ast::AstInfo;
 use crate::keywords::Keyword;
 
 /// An identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ident(pub(crate) String);
 
 impl Ident {
@@ -103,7 +103,7 @@ impl AstDisplay for Ident {
 impl_display!(Ident);
 
 /// A name of a table, view, custom type, etc., possibly multi-part, i.e. db.schema.obj
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct UnresolvedObjectName(pub Vec<Ident>);
 
 pub enum CatalogName {
@@ -142,7 +142,7 @@ impl AstDisplay for &UnresolvedObjectName {
 }
 
 /// A name of a schema
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct UnresolvedSchemaName(pub Vec<Ident>);
 
 impl AstDisplay for UnresolvedSchemaName {
@@ -153,7 +153,7 @@ impl AstDisplay for UnresolvedSchemaName {
 impl_display!(UnresolvedSchemaName);
 
 /// A name of a database
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct UnresolvedDatabaseName(pub Ident);
 
 impl AstDisplay for UnresolvedDatabaseName {

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -29,7 +29,7 @@ use crate::ast::{
 
 /// The most complete variant of a `SELECT` query expression, optionally
 /// including `WITH`, `UNION` / other set operations, and `ORDER BY`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Query<T: AstInfo> {
     /// WITH (common table expressions, or CTEs)
     pub ctes: CteBlock<T>,
@@ -115,7 +115,7 @@ impl<T: AstInfo> Query<T> {
 
 /// A node in a tree, representing a "query body" expression, roughly:
 /// `SELECT ... [ {UNION|EXCEPT|INTERSECT} SELECT ...]`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SetExpr<T: AstInfo> {
     /// Restricted SELECT .. FROM .. HAVING (no ORDER BY or set operations)
     Select(Box<Select<T>>),
@@ -165,7 +165,7 @@ impl<T: AstInfo> AstDisplay for SetExpr<T> {
 }
 impl_display_t!(SetExpr);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SetOperator {
     Union,
     Except,
@@ -183,7 +183,7 @@ impl AstDisplay for SetOperator {
 }
 impl_display!(SetOperator);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SelectOptionName {
     ExpectedGroupSize,
 }
@@ -197,7 +197,7 @@ impl AstDisplay for SelectOptionName {
 }
 impl_display!(SelectOptionName);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SelectOption<T: AstInfo> {
     pub name: SelectOptionName,
     pub value: Option<WithOptionValue<T>>,
@@ -216,7 +216,7 @@ impl<T: AstInfo> AstDisplay for SelectOption<T> {
 /// A restricted variant of `SELECT` (without CTEs/`ORDER BY`), which may
 /// appear either as the only body item of an `SQLQuery`, or as an operand
 /// to a set operation like `UNION`.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Select<T: AstInfo> {
     pub distinct: Option<Distinct<T>>,
     /// projection expressions
@@ -286,7 +286,7 @@ impl<T: AstInfo> Select<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Distinct<T: AstInfo> {
     EntireRow,
     On(Vec<Expr<T>>),
@@ -311,7 +311,7 @@ impl<T: AstInfo> AstDisplay for Distinct<T> {
 /// The block can either be entirely "simple" (traditional SQL `WITH` block),
 /// or "mutually recursive", which introduce their bindings before the block
 /// and may result in mutually recursive definitions.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum CteBlock<T: AstInfo> {
     Simple(Vec<Cte<T>>),
     MutuallyRecursive(Vec<CteMutRec<T>>),
@@ -370,7 +370,7 @@ impl<T: AstInfo> AstDisplay for CteBlock<T> {
 /// The names in the column list before `AS`, when specified, replace the names
 /// of the columns returned by the query. The parser does not validate that the
 /// number of columns in the query matches the number of columns in the query.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Cte<T: AstInfo> {
     pub alias: TableAlias,
     pub id: T::CteId,
@@ -387,7 +387,7 @@ impl<T: AstInfo> AstDisplay for Cte<T> {
 }
 impl_display_t!(Cte);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CteMutRec<T: AstInfo> {
     pub name: Ident,
     pub columns: Vec<CteMutRecColumnDef<T>>,
@@ -411,7 +411,7 @@ impl<T: AstInfo> AstDisplay for CteMutRec<T> {
 impl_display_t!(CteMutRec);
 
 /// A column definition in a [`CteMutRec`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CteMutRecColumnDef<T: AstInfo> {
     pub name: Ident,
     pub data_type: T::DataType,
@@ -427,7 +427,7 @@ impl<T: AstInfo> AstDisplay for CteMutRecColumnDef<T> {
 impl_display_t!(CteMutRecColumnDef);
 
 /// One item of the comma-separated list following `SELECT`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SelectItem<T: AstInfo> {
     /// An expression, optionally followed by `[ AS ] alias`.
     Expr { expr: Expr<T>, alias: Option<Ident> },
@@ -451,7 +451,7 @@ impl<T: AstInfo> AstDisplay for SelectItem<T> {
 }
 impl_display_t!(SelectItem);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TableWithJoins<T: AstInfo> {
     pub relation: TableFactor<T>,
     pub joins: Vec<Join<T>>,
@@ -481,7 +481,7 @@ impl<T: AstInfo> TableWithJoins<T> {
 }
 
 /// A table name or a parenthesized subquery with an optional alias
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TableFactor<T: AstInfo> {
     Table {
         name: T::ObjectName,
@@ -582,7 +582,7 @@ impl<T: AstInfo> AstDisplay for TableFactor<T> {
 }
 impl_display_t!(TableFactor);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TableFunction<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub args: FunctionArgs<T>,
@@ -597,7 +597,7 @@ impl<T: AstInfo> AstDisplay for TableFunction<T> {
 }
 impl_display_t!(TableFunction);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TableAlias {
     pub name: Ident,
     pub columns: Vec<Ident>,
@@ -621,7 +621,7 @@ impl AstDisplay for TableAlias {
 }
 impl_display!(TableAlias);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Join<T: AstInfo> {
     pub relation: TableFactor<T>,
     pub join_operator: JoinOperator<T>,
@@ -696,7 +696,7 @@ impl<T: AstInfo> AstDisplay for Join<T> {
 }
 impl_display_t!(Join);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum JoinOperator<T: AstInfo> {
     Inner(JoinConstraint<T>),
     LeftOuter(JoinConstraint<T>),
@@ -705,7 +705,7 @@ pub enum JoinOperator<T: AstInfo> {
     CrossJoin,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum JoinConstraint<T: AstInfo> {
     On(Expr<T>),
     Using(Vec<Ident>),
@@ -713,7 +713,7 @@ pub enum JoinConstraint<T: AstInfo> {
 }
 
 /// SQL ORDER BY expression
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OrderByExpr<T: AstInfo> {
     pub expr: Expr<T>,
     pub asc: Option<bool>,
@@ -737,13 +737,13 @@ impl<T: AstInfo> AstDisplay for OrderByExpr<T> {
 }
 impl_display_t!(OrderByExpr);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Limit<T: AstInfo> {
     pub with_ties: bool,
     pub quantity: Expr<T>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Values<T: AstInfo>(pub Vec<Vec<Expr<T>>>);
 
 impl<T: AstInfo> AstDisplay for Values<T> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -430,7 +430,7 @@ impl AstDisplay for CreateSchemaStatement {
 }
 impl_display!(CreateSchemaStatement);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct KafkaBroker<T: AstInfo> {
     pub address: String,
     pub tunnel: KafkaBrokerTunnel<T>,
@@ -447,7 +447,7 @@ impl<T: AstInfo> AstDisplay for KafkaBroker<T> {
 
 impl_display_t!(KafkaBroker);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum KafkaBrokerTunnel<T: AstInfo> {
     Direct,
     AwsPrivatelink(KafkaBrokerAwsPrivatelink<T>),
@@ -473,7 +473,7 @@ impl<T: AstInfo> AstDisplay for KafkaBrokerTunnel<T> {
 
 impl_display_t!(KafkaBrokerTunnel);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum KafkaBrokerAwsPrivatelinkOptionName {
     AvailabilityZone,
     Port,
@@ -489,7 +489,7 @@ impl AstDisplay for KafkaBrokerAwsPrivatelinkOptionName {
 }
 impl_display!(KafkaBrokerAwsPrivatelinkOptionName);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct KafkaBrokerAwsPrivatelinkOption<T: AstInfo> {
     pub name: KafkaBrokerAwsPrivatelinkOptionName,
     pub value: Option<WithOptionValue<T>>,
@@ -506,7 +506,7 @@ impl<T: AstInfo> AstDisplay for KafkaBrokerAwsPrivatelinkOption<T> {
 }
 impl_display_t!(KafkaBrokerAwsPrivatelinkOption);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct KafkaBrokerAwsPrivatelink<T: AstInfo> {
     pub connection: T::ObjectName,
     pub options: Vec<KafkaBrokerAwsPrivatelinkOption<T>>,
@@ -1145,7 +1145,7 @@ impl<T: AstInfo> AstDisplay for CreateClusterStatement<T> {
 }
 impl_display_t!(CreateClusterStatement);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ReplicaDefinition<T: AstInfo> {
     /// Name of the created replica.
     pub name: Ident,
@@ -1186,7 +1186,7 @@ impl<T: AstInfo> AstDisplay for CreateClusterReplicaStatement<T> {
 }
 impl_display_t!(CreateClusterReplicaStatement);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ReplicaOptionName {
     /// The `SIZE [[=] <size>]` option.
     Size,
@@ -1226,7 +1226,7 @@ impl AstDisplay for ReplicaOptionName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// An option in a `CREATE CLUSTER REPLICA` statement.
 pub struct ReplicaOption<T: AstInfo> {
     pub name: ReplicaOptionName,
@@ -1736,7 +1736,7 @@ impl AstDisplay for ResetVariableStatement {
 impl_display!(ResetVariableStatement);
 
 /// `SHOW <variable>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowVariableStatement {
     pub variable: Ident,
 }
@@ -1750,7 +1750,7 @@ impl AstDisplay for ShowVariableStatement {
 impl_display!(ShowVariableStatement);
 
 /// `SHOW DATABASES`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowDatabasesStatement<T: AstInfo> {
     pub filter: Option<ShowStatementFilter<T>>,
 }
@@ -1767,7 +1767,7 @@ impl<T: AstInfo> AstDisplay for ShowDatabasesStatement<T> {
 impl_display_t!(ShowDatabasesStatement);
 
 /// `SHOW SCHEMAS`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowSchemasStatement<T: AstInfo> {
     pub from: Option<T::DatabaseName>,
     pub filter: Option<ShowStatementFilter<T>>,
@@ -1789,7 +1789,7 @@ impl<T: AstInfo> AstDisplay for ShowSchemasStatement<T> {
 }
 impl_display_t!(ShowSchemasStatement);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ShowObjectType<T: AstInfo> {
     MaterializedView {
         in_cluster: Option<T::ClusterName>,
@@ -1818,7 +1818,7 @@ pub enum ShowObjectType<T: AstInfo> {
 /// SHOW VIEWS;
 /// SHOW SINKS;
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowObjectsStatement<T: AstInfo> {
     pub object_type: ShowObjectType<T>,
     pub from: Option<T::SchemaName>,
@@ -1879,7 +1879,7 @@ impl_display_t!(ShowObjectsStatement);
 /// `SHOW COLUMNS`
 ///
 /// Note: this is a MySQL-specific statement.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowColumnsStatement<T: AstInfo> {
     pub table_name: T::ObjectName,
     pub filter: Option<ShowStatementFilter<T>>,
@@ -1899,7 +1899,7 @@ impl<T: AstInfo> AstDisplay for ShowColumnsStatement<T> {
 impl_display_t!(ShowColumnsStatement);
 
 /// `SHOW CREATE VIEW <view>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateViewStatement<T: AstInfo> {
     pub view_name: T::ObjectName,
 }
@@ -1913,7 +1913,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateViewStatement<T> {
 impl_display_t!(ShowCreateViewStatement);
 
 /// `SHOW CREATE MATERIALIZED VIEW <name>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateMaterializedViewStatement<T: AstInfo> {
     pub materialized_view_name: T::ObjectName,
 }
@@ -1927,7 +1927,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateMaterializedViewStatement<T> {
 impl_display_t!(ShowCreateMaterializedViewStatement);
 
 /// `SHOW CREATE SOURCE <source>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateSourceStatement<T: AstInfo> {
     pub source_name: T::ObjectName,
 }
@@ -1941,7 +1941,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateSourceStatement<T> {
 impl_display_t!(ShowCreateSourceStatement);
 
 /// `SHOW CREATE TABLE <table>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateTableStatement<T: AstInfo> {
     pub table_name: T::ObjectName,
 }
@@ -1955,7 +1955,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateTableStatement<T> {
 impl_display_t!(ShowCreateTableStatement);
 
 /// `SHOW CREATE SINK <sink>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateSinkStatement<T: AstInfo> {
     pub sink_name: T::ObjectName,
 }
@@ -1969,7 +1969,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateSinkStatement<T> {
 impl_display_t!(ShowCreateSinkStatement);
 
 /// `SHOW CREATE INDEX <index>`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateIndexStatement<T: AstInfo> {
     pub index_name: T::ObjectName,
 }
@@ -1982,7 +1982,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateIndexStatement<T> {
 }
 impl_display_t!(ShowCreateIndexStatement);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ShowCreateConnectionStatement<T: AstInfo> {
     pub connection_name: T::ObjectName,
 }
@@ -1995,7 +1995,7 @@ impl<T: AstInfo> AstDisplay for ShowCreateConnectionStatement<T> {
 }
 
 /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StartTransactionStatement {
     pub modes: Vec<TransactionMode>,
 }
@@ -2012,7 +2012,7 @@ impl AstDisplay for StartTransactionStatement {
 impl_display!(StartTransactionStatement);
 
 /// `SET TRANSACTION ...`
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SetTransactionStatement {
     pub modes: Vec<TransactionMode>,
 }
@@ -2222,7 +2222,7 @@ impl AstDisplay for ObjectType {
 }
 impl_display!(ObjectType);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ShowStatementFilter<T: AstInfo> {
     Like(String),
     Where(Expr<T>),
@@ -2246,7 +2246,7 @@ impl<T: AstInfo> AstDisplay for ShowStatementFilter<T> {
 }
 impl_display_t!(ShowStatementFilter);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
     Ident(Ident),
@@ -2290,7 +2290,7 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
 }
 impl_display_t!(WithOptionValue);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TransactionMode {
     AccessMode(TransactionAccessMode),
     IsolationLevel(TransactionIsolationLevel),
@@ -2310,7 +2310,7 @@ impl AstDisplay for TransactionMode {
 }
 impl_display!(TransactionMode);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TransactionAccessMode {
     ReadOnly,
     ReadWrite,
@@ -2327,7 +2327,7 @@ impl AstDisplay for TransactionAccessMode {
 }
 impl_display!(TransactionAccessMode);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TransactionIsolationLevel {
     ReadUncommitted,
     ReadCommitted,
@@ -2743,7 +2743,7 @@ impl<T: AstInfo> AstDisplay for AsOf<T> {
 }
 impl_display_t!(AsOf);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ShowStatement<T: AstInfo> {
     ShowDatabases(ShowDatabasesStatement<T>),
     ShowSchemas(ShowSchemasStatement<T>),

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -38,7 +38,7 @@ impl fmt::Display for ValueError {
 }
 
 /// Primitive SQL values.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Value {
     /// Numeric value.
     Number(String),
@@ -194,7 +194,7 @@ impl FromStr for DateTimeField {
 
 /// An intermediate value for Intervals, which tracks all data from
 /// the user, as well as the computed ParsedDateTime.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct IntervalValue {
     /// The raw `[value]` that was present in `INTERVAL '[value]'`
     pub value: String,

--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -41,17 +41,17 @@ pub trait AstInfo: Clone {
     /// The type used for nested statements.
     type NestedStatement: AstDisplay + Clone + Hash + Debug + Eq;
     /// The type used for table references.
-    type ObjectName: AstDisplay + Clone + Hash + Debug + Eq;
+    type ObjectName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for schema names.
-    type SchemaName: AstDisplay + Clone + Hash + Debug + Eq;
+    type SchemaName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for database names.
-    type DatabaseName: AstDisplay + Clone + Hash + Debug + Eq;
+    type DatabaseName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for cluster names.
-    type ClusterName: AstDisplay + Clone + Hash + Debug + Eq;
+    type ClusterName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for data types.
-    type DataType: AstDisplay + Clone + Hash + Debug + Eq;
+    type DataType: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type stored next to CTEs for their assigned ID.
-    type CteId: Clone + Hash + Debug + Eq;
+    type CteId: Clone + Hash + Debug + Eq + Ord;
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Default)]
@@ -67,7 +67,7 @@ impl AstInfo for Raw {
     type CteId = ();
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 pub enum RawObjectName {
     Name(UnresolvedObjectName),
     Id(String, UnresolvedObjectName),
@@ -117,7 +117,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 pub enum RawClusterName {
     Unresolved(Ident),
     Resolved(String),
@@ -150,7 +150,7 @@ where
 }
 
 /// SQL data types
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum RawDataType {
     /// Array
     Array(Box<RawDataType>),

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -154,7 +154,7 @@ impl From<String> for PartialObjectName {
 }
 
 /// A fully-qualified human readable name of a schema in the catalog.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct FullSchemaName {
     /// The database name
     pub database: RawDatabaseSpecifier,
@@ -235,7 +235,7 @@ impl From<Option<String>> for RawDatabaseSpecifier {
 }
 
 /// An id of a database.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum ResolvedDatabaseSpecifier {
     /// The "ambient" database, which is always present and is not named
     /// explicitly, but by omission.
@@ -272,7 +272,7 @@ impl From<u64> for ResolvedDatabaseSpecifier {
  * their Id.
  */
 /// An id of a schema.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SchemaSpecifier {
     /// A temporary schema
     Temporary,
@@ -342,16 +342,16 @@ impl From<SchemaSpecifier> for u64 {
 // Aug is the type variable assigned to an AST that has already been
 // name-resolved. An AST in this state has global IDs populated next to table
 // names, and local IDs assigned to CTE definitions and references.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone, Default)]
 pub struct Aug;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ObjectQualifiers {
     pub database_spec: ResolvedDatabaseSpecifier,
     pub schema_spec: SchemaSpecifier,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ResolvedObjectName {
     Object {
         id: GlobalId,
@@ -414,7 +414,7 @@ impl std::fmt::Display for ResolvedObjectName {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ResolvedSchemaName {
     Schema {
         database_spec: ResolvedDatabaseSpecifier,
@@ -451,7 +451,7 @@ impl AstDisplay for ResolvedSchemaName {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ResolvedDatabaseName {
     Database { id: DatabaseId, name: String },
     Error,
@@ -466,7 +466,7 @@ impl AstDisplay for ResolvedDatabaseName {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ResolvedClusterName {
     pub id: ClusterId,
     /// If set, a name to print in the `AstDisplay` implementation instead of
@@ -488,7 +488,7 @@ impl AstDisplay for ResolvedClusterName {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ResolvedDataType {
     AnonymousList(Box<ResolvedDataType>),
     AnonymousMap {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2055,7 +2055,7 @@ fn plan_view_select(
 
 fn plan_scalar_table_funcs(
     qcx: &QueryContext,
-    table_funcs: HashMap<TableFunction<Aug>, String>,
+    table_funcs: Vec<(TableFunction<Aug>, String)>,
     table_func_names: &mut HashMap<String, Ident>,
     relation_expr: &HirRelationExpr,
     from_scope: &Scope,
@@ -2086,12 +2086,12 @@ fn plan_scalar_table_funcs(
         return Ok((expr, scope));
     }
     // Otherwise, plan as usual, emulating the ROWS FROM behavior
-    let (expr, mut scope, num_cols) =
-        plan_rows_from_internal(&rows_from_qcx, table_funcs.keys(), None)?;
+    let (keys, values): (Vec<_>, Vec<_>) = table_funcs.into_iter().unzip();
+    let (expr, mut scope, num_cols) = plan_rows_from_internal(&rows_from_qcx, keys.iter(), None)?;
 
     // Munge the scope so table names match with the generated ids.
     let mut i = 0;
-    for (id, num_cols) in table_funcs.values().zip(num_cols) {
+    for (id, num_cols) in values.iter().zip(num_cols) {
         for _ in 0..num_cols {
             scope.items[i].table_name = Some(PartialObjectName {
                 database: None,
@@ -4964,7 +4964,9 @@ struct AggregateTableFuncVisitor<'a> {
     scx: &'a StatementContext<'a>,
     aggs: Vec<Function<Aug>>,
     within_aggregate: bool,
-    tables: HashMap<TableFunction<Aug>, String>,
+    // We maintain the `Vec` for deterministic ordering and the `HashMap` for fast lookups.
+    tables: Vec<(TableFunction<Aug>, String)>,
+    tables_map: HashMap<TableFunction<Aug>, String>,
     table_disallowed_context: Vec<&'static str>,
     in_select_item: bool,
     err: Option<PlanError>,
@@ -4976,7 +4978,8 @@ impl<'a> AggregateTableFuncVisitor<'a> {
             scx,
             aggs: Vec::new(),
             within_aggregate: false,
-            tables: HashMap::new(),
+            tables: Vec::new(),
+            tables_map: HashMap::new(),
             table_disallowed_context: Vec::new(),
             in_select_item: false,
             err: None,
@@ -4985,7 +4988,7 @@ impl<'a> AggregateTableFuncVisitor<'a> {
 
     fn into_result(
         self,
-    ) -> Result<(Vec<Function<Aug>>, HashMap<TableFunction<Aug>, String>), PlanError> {
+    ) -> Result<(Vec<Function<Aug>>, Vec<(TableFunction<Aug>, String)>), PlanError> {
         match self.err {
             Some(err) => Err(err),
             None => {
@@ -5092,11 +5095,16 @@ impl<'a> VisitMut<'_, Aug> for AggregateTableFuncVisitor<'a> {
             {
                 let func = TableFunction { name, args };
                 // Identical table functions can be de-duplicated.
-                let id = self
-                    .tables
-                    .entry(func)
-                    .or_insert_with(|| format!("table_func_{}", Uuid::new_v4()));
-                *expr = Expr::Identifier(vec![Ident::from(id.clone())]);
+                let id = match self.tables_map.get(&func) {
+                    Some(id) => id.clone(),
+                    None => {
+                        let id = format!("table_func_{}", Uuid::new_v4());
+                        self.tables_map.insert(func.clone(), id.clone());
+                        self.tables.push((func, id.clone()));
+                        id
+                    }
+                };
+                *expr = Expr::Identifier(vec![Ident::from(id)]);
             }
         }
         if let Some(context) = disallowed_context {

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -351,7 +351,7 @@ impl Desugarer {
         } = expr
         {
             if *negated {
-                *expr = e.clone().lt(low.take()).or(e.take().gt(high.take()));
+                *expr = Expr::lt(*e.clone(), low.take()).or(e.take().gt(high.take()));
             } else {
                 *expr = e.clone().gt_eq(low.take()).and(e.take().lt_eq(high.take()));
             }

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1372,3 +1372,27 @@ Explained Query:
       Get materialize.public.y // { arity: 1 }
 
 EOF
+
+# Test that table functions should produce deterministic plans
+query T multiline
+EXPLAIN RAW PLAN FOR SELECT jsonb_object_keys('{"1":2}'::JSONB), jsonb_object_keys('{"1":2}'::JSONB);
+----
+Project (#0, #0)
+  CallTable jsonb_object_keys(text_to_jsonb("{\"1\":2}"))
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN FOR SELECT jsonb_object_keys('{"1":2}'::JSONB), jsonb_object_keys('{"3":4}'::JSONB);
+----
+Project (#5, #6)
+  Map (case when (#1) IS NULL then null else #0 end, case when (#3) IS NULL then null else #2 end)
+    Project (#0, #1, #3..=#5)
+      Map (coalesce(#2, #4))
+        FullOuterJoin (#2 = #4)
+          Map (row_number() over (), #1)
+            CallTable jsonb_object_keys(text_to_jsonb("{\"1\":2}"))
+          Map (row_number() over ())
+            CallTable jsonb_object_keys(text_to_jsonb("{\"3\":4}"))
+
+EOF


### PR DESCRIPTION
Previously, table functions in a SELECT clauses were all joined together. The order of these joins were determined by iterating over a HashMap, which meant the order was random. The end result was always correct result, but the plans created were partially random.

This commit removes the HashMap and instead uses a Vec, which creates deterministic plans with table functions. This makes testing easier and query performance less variable.

### Motivation
This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
