### PR TITLE
adapter: remove unneeded and slow delayed consolidations

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1636,7 +1636,6 @@ pub struct Connection {
 pub struct TransactionResult<R> {
     pub builtin_table_updates: Vec<BuiltinTableUpdate>,
     pub audit_events: Vec<VersionedEvent>,
-    pub collections: Vec<mz_stash::Id>,
     pub result: R,
 }
 
@@ -4011,7 +4010,7 @@ impl Catalog {
         let result = f(&state)?;
 
         // The user closure was successful, apply the updates.
-        let (_stash, collections) = tx.commit_without_consolidate().await?;
+        tx.commit().await?;
         // Dropping here keeps the mutable borrow on self, preventing us accidentally
         // mutating anything until after f is executed.
         drop(storage);
@@ -4021,7 +4020,6 @@ impl Catalog {
         Ok(TransactionResult {
             builtin_table_updates,
             audit_events,
-            collections,
             result,
         })
     }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, Mutex, MutexGuard};
+use tokio::sync::{Mutex, MutexGuard};
 use tracing::{info, trace, warn};
 use uuid::Uuid;
 
@@ -3264,9 +3264,6 @@ impl Catalog {
     /// Opens a debug catalog from a stash.
     pub async fn open_debug_stash(stash: Stash, now: NowFn) -> Result<Catalog, anyhow::Error> {
         let metrics_registry = &MetricsRegistry::new();
-        let (consolidations_tx, consolidations_rx) = mpsc::unbounded_channel();
-        // Leak the receiver so it's not dropped and send will work.
-        std::mem::forget(consolidations_rx);
         let storage = storage::Connection::open(
             stash,
             now.clone(),
@@ -3275,7 +3272,6 @@ impl Catalog {
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
             },
-            consolidations_tx.clone(),
         )
         .await?;
         let secrets_reader = Arc::new(InMemorySecretsController::new());

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -237,7 +237,6 @@ impl Coordinator {
         let TransactionResult {
             builtin_table_updates,
             audit_events,
-            collections,
             result,
         } = self
             .catalog
@@ -316,10 +315,6 @@ impl Coordinator {
             }
         }
         .await;
-
-        self.consolidations_tx
-            .send(collections)
-            .expect("sending on consolidations_tx must succeed");
 
         if let (Some(segment_client), Some(user_metadata)) = (
             &self.segment_client,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -81,9 +81,6 @@ impl Coordinator {
             Message::StorageUsageUpdate(sizes) => {
                 self.storage_usage_update(sizes).await;
             }
-            Message::Consolidate(collections) => {
-                self.consolidate(&collections).await;
-            }
             Message::RealTimeRecencyTimestamp {
                 conn_id,
                 transient_revision,
@@ -96,13 +93,6 @@ impl Coordinator {
                 )
                 .await;
             }
-        }
-    }
-
-    #[tracing::instrument(level = "debug", skip_all)]
-    async fn consolidate(&mut self, collections: &[mz_stash::Id]) {
-        if let Err(err) = self.catalog.consolidate(collections).await {
-            warn!("consolidation error: {:?}", err);
         }
     }
 

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -88,7 +88,6 @@ use std::{
 
 use clap::Parser;
 use once_cell::sync::Lazy;
-use tokio::sync::mpsc;
 
 use mz_adapter::{
     catalog::{
@@ -374,9 +373,6 @@ impl Usage {
 
         let metrics_registry = &MetricsRegistry::new();
         let now = SYSTEM_TIME.clone();
-        let (consolidations_tx, consolidations_rx) = mpsc::unbounded_channel();
-        // Leak the receiver so it's not dropped and send will work.
-        std::mem::forget(consolidations_rx);
         let storage = mz_adapter::catalog::storage::Connection::open(
             stash,
             now.clone(),
@@ -385,7 +381,6 @@ impl Usage {
                 builtin_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
             },
-            consolidations_tx.clone(),
         )
         .await?;
         let secrets_reader = Arc::new(InMemorySecretsController::new());


### PR DESCRIPTION
These are no longer needed and were makings things slower.

See #16531

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a