### PR TITLE
adapter: even more tracing

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -435,6 +435,7 @@ impl CatalogState {
     }
 
     /// Create and insert the per replica log sources and log views.
+    #[tracing::instrument(level = "info", skip_all)]
     fn insert_replica_introspection_items(&mut self, logging: &ReplicaLogging, replica_id: u64) {
         for (variant, source_id) in &logging.sources {
             let oid = self
@@ -509,6 +510,7 @@ impl CatalogState {
 
     /// Parse a SQL string into a catalog view item with only a limited
     /// context.
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn parse_view_item(&self, create_sql: String) -> Result<CatalogItem, anyhow::Error> {
         let session_catalog = ConnCatalog {
             state: Cow::Borrowed(self),
@@ -2277,53 +2279,56 @@ impl Catalog {
 
         let mut mz_object_dependencies_updates = vec![];
 
-        for (builtin, id) in builtin_non_indexes {
-            let schema_id = catalog.state.ambient_schemas_by_name[builtin.schema()];
-            let name = QualifiedObjectName {
-                qualifiers: ObjectQualifiers {
-                    database_spec: ResolvedDatabaseSpecifier::Ambient,
-                    schema_spec: SchemaSpecifier::Id(schema_id),
-                },
-                item: builtin.name().into(),
-            };
-            match builtin {
-                Builtin::Log(log) => {
-                    let oid = catalog.allocate_oid()?;
-                    catalog.state.insert_item(
-                        id,
-                        oid,
-                        name.clone(),
-                        CatalogItem::Log(Log {
-                            variant: log.variant.clone(),
-                            has_storage_collection: false,
-                        }),
-                    );
-                }
+        {
+            let span = tracing::span!(tracing::Level::DEBUG, "builtin_non_indexes");
+            let _enter = span.enter();
+            for (builtin, id) in builtin_non_indexes {
+                let schema_id = catalog.state.ambient_schemas_by_name[builtin.schema()];
+                let name = QualifiedObjectName {
+                    qualifiers: ObjectQualifiers {
+                        database_spec: ResolvedDatabaseSpecifier::Ambient,
+                        schema_spec: SchemaSpecifier::Id(schema_id),
+                    },
+                    item: builtin.name().into(),
+                };
+                match builtin {
+                    Builtin::Log(log) => {
+                        let oid = catalog.allocate_oid()?;
+                        catalog.state.insert_item(
+                            id,
+                            oid,
+                            name.clone(),
+                            CatalogItem::Log(Log {
+                                variant: log.variant.clone(),
+                                has_storage_collection: false,
+                            }),
+                        );
+                    }
 
-                Builtin::Table(table) => {
-                    let oid = catalog.allocate_oid()?;
-                    catalog.state.insert_item(
-                        id,
-                        oid,
-                        name.clone(),
-                        CatalogItem::Table(Table {
-                            create_sql: CREATE_SQL_TODO.to_string(),
-                            desc: table.desc.clone(),
-                            defaults: vec![Expr::null(); table.desc.arity()],
-                            conn_id: None,
-                            depends_on: vec![],
-                            custom_logical_compaction_window: table
-                                .is_retained_metrics_relation
-                                .then(|| catalog.state.system_config().metrics_retention()),
-                            is_retained_metrics_relation: table.is_retained_metrics_relation,
-                        }),
-                    );
-                }
-                Builtin::Index(_) => {
-                    unreachable!("handled later once clusters have been created")
-                }
-                Builtin::View(view) => {
-                    let item = catalog
+                    Builtin::Table(table) => {
+                        let oid = catalog.allocate_oid()?;
+                        catalog.state.insert_item(
+                            id,
+                            oid,
+                            name.clone(),
+                            CatalogItem::Table(Table {
+                                create_sql: CREATE_SQL_TODO.to_string(),
+                                desc: table.desc.clone(),
+                                defaults: vec![Expr::null(); table.desc.arity()],
+                                conn_id: None,
+                                depends_on: vec![],
+                                custom_logical_compaction_window: table
+                                    .is_retained_metrics_relation
+                                    .then(|| catalog.state.system_config().metrics_retention()),
+                                is_retained_metrics_relation: table.is_retained_metrics_relation,
+                            }),
+                        );
+                    }
+                    Builtin::Index(_) => {
+                        unreachable!("handled later once clusters have been created")
+                    }
+                    Builtin::View(view) => {
+                        let item = catalog
                         .parse_item(
                             id,
                             view.sql.into(),
@@ -2339,46 +2344,47 @@ impl Catalog {
                                 view.name, e
                             )
                         });
-                    let oid = catalog.allocate_oid()?;
-                    mz_object_dependencies_updates.push((id, item.uses().to_owned()));
-                    catalog.state.insert_item(id, oid, name, item);
-                }
+                        let oid = catalog.allocate_oid()?;
+                        mz_object_dependencies_updates.push((id, item.uses().to_owned()));
+                        catalog.state.insert_item(id, oid, name, item);
+                    }
 
-                Builtin::Type(_) => unreachable!("loaded separately"),
+                    Builtin::Type(_) => unreachable!("loaded separately"),
 
-                Builtin::Func(func) => {
-                    let oid = catalog.allocate_oid()?;
-                    catalog.state.insert_item(
-                        id,
-                        oid,
-                        name.clone(),
-                        CatalogItem::Func(Func { inner: func.inner }),
-                    );
-                }
+                    Builtin::Func(func) => {
+                        let oid = catalog.allocate_oid()?;
+                        catalog.state.insert_item(
+                            id,
+                            oid,
+                            name.clone(),
+                            CatalogItem::Func(Func { inner: func.inner }),
+                        );
+                    }
 
-                Builtin::Source(coll) => {
-                    let introspection_type = match &coll.data_source {
-                        Some(i) => i.clone(),
-                        None => continue,
-                    };
+                    Builtin::Source(coll) => {
+                        let introspection_type = match &coll.data_source {
+                            Some(i) => i.clone(),
+                            None => continue,
+                        };
 
-                    let oid = catalog.allocate_oid()?;
-                    catalog.state.insert_item(
-                        id,
-                        oid,
-                        name.clone(),
-                        CatalogItem::Source(Source {
-                            create_sql: CREATE_SQL_TODO.to_string(),
-                            data_source: DataSourceDesc::Introspection(introspection_type),
-                            desc: coll.desc.clone(),
-                            timeline: Timeline::EpochMilliseconds,
-                            depends_on: vec![],
-                            custom_logical_compaction_window: coll
-                                .is_retained_metrics_relation
-                                .then(|| catalog.state.system_config().metrics_retention()),
-                            is_retained_metrics_relation: coll.is_retained_metrics_relation,
-                        }),
-                    );
+                        let oid = catalog.allocate_oid()?;
+                        catalog.state.insert_item(
+                            id,
+                            oid,
+                            name.clone(),
+                            CatalogItem::Source(Source {
+                                create_sql: CREATE_SQL_TODO.to_string(),
+                                data_source: DataSourceDesc::Introspection(introspection_type),
+                                desc: coll.desc.clone(),
+                                timeline: Timeline::EpochMilliseconds,
+                                depends_on: vec![],
+                                custom_logical_compaction_window: coll
+                                    .is_retained_metrics_relation
+                                    .then(|| catalog.state.system_config().metrics_retention()),
+                                is_retained_metrics_relation: coll.is_retained_metrics_relation,
+                            }),
+                        );
+                    }
                 }
             }
         }
@@ -2673,6 +2679,7 @@ impl Catalog {
     ///    `system_parameter_frontend` (if present).
     ///
     /// # Errors
+    #[tracing::instrument(level = "info", skip_all)]
     async fn load_system_configuration(
         &mut self,
         bootstrap_system_parameters: BTreeMap<String, String>,
@@ -2779,6 +2786,7 @@ impl Catalog {
     /// references are circular. This makes loading built-in types more complicated than other
     /// built-in objects, and requires us to make multiple passes over the types to correctly
     /// resolve all references.
+    #[tracing::instrument(level = "info", skip_all)]
     async fn load_builtin_types(&mut self) -> Result<(), Error> {
         let persisted_builtin_ids = self.storage().await.load_system_gids().await?;
 
@@ -3133,6 +3141,7 @@ impl Catalog {
         Ok(())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn apply_persisted_builtin_migration(
         &mut self,
         migration_metadata: &mut BuiltinMigrationMetadata,
@@ -3186,6 +3195,7 @@ impl Catalog {
     /// objects, which is necessary for at least one catalog migration.
     ///
     /// TODO(justin): it might be nice if these were two different types.
+    #[tracing::instrument(level = "info", skip_all)]
     pub fn load_catalog_items<'a>(
         tx: &mut storage::Transaction<'a>,
         c: &Catalog,
@@ -5446,6 +5456,7 @@ impl Catalog {
     }
 
     // Parses the given SQL string into a `CatalogItem`.
+    #[tracing::instrument(level = "info", skip(self, pcx))]
     fn parse_item(
         &self,
         id: GlobalId,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -638,6 +638,7 @@ impl Connection {
             .await
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_databases(&mut self) -> Result<Vec<(DatabaseId, String)>, Error> {
         Ok(COLLECTION_DATABASE
             .peek_one(&mut self.stash)
@@ -647,6 +648,7 @@ impl Connection {
             .collect())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_schemas(
         &mut self,
     ) -> Result<Vec<(SchemaId, String, Option<DatabaseId>)>, Error> {
@@ -664,6 +666,7 @@ impl Connection {
             .collect())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_roles(&mut self) -> Result<Vec<(RoleId, String)>, Error> {
         Ok(COLLECTION_ROLE
             .peek_one(&mut self.stash)
@@ -673,6 +676,7 @@ impl Connection {
             .collect())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_clusters(
         &mut self,
     ) -> Result<Vec<(ClusterId, String, Option<GlobalId>)>, Error> {
@@ -684,6 +688,7 @@ impl Connection {
             .collect())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_cluster_replicas(
         &mut self,
     ) -> Result<Vec<(ClusterId, ReplicaId, String, SerializedReplicaConfig)>, Error> {
@@ -695,6 +700,7 @@ impl Connection {
             .collect())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_audit_log(&mut self) -> Result<impl Iterator<Item = VersionedEvent>, Error> {
         Ok(COLLECTION_AUDIT_LOG
             .peek_one(&mut self.stash)
@@ -703,6 +709,7 @@ impl Connection {
             .map(|ev| ev.event))
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn storage_usage(
         &mut self,
     ) -> Result<impl Iterator<Item = VersionedStorageUsage>, Error> {
@@ -714,6 +721,7 @@ impl Connection {
     }
 
     /// Load the persisted mapping of system object to global ID. Key is (schema-name, object-name).
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_system_gids(
         &mut self,
     ) -> Result<BTreeMap<(String, CatalogItemType, String), (GlobalId, String)>, Error> {
@@ -730,6 +738,7 @@ impl Connection {
             .collect())
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_introspection_source_index_gids(
         &mut self,
         cluster_id: ClusterId,
@@ -749,6 +758,7 @@ impl Connection {
     }
 
     /// Load the persisted server configurations.
+    #[tracing::instrument(level = "info", skip_all)]
     pub async fn load_system_configuration(&mut self) -> Result<BTreeMap<String, String>, Error> {
         COLLECTION_SYSTEM_CONFIGURATION
             .peek_one(&mut self.stash)

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -224,6 +224,7 @@ pub fn describe(
 /// The returned plan is tied to the state of the provided catalog. If the state
 /// of the catalog changes after planning, the validity of the plan is not
 /// guaranteed.
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn plan(
     pcx: Option<&PlanContext>,
     catalog: &dyn SessionCatalog,


### PR DESCRIPTION
This was all super necessary for improving envd startup.

See #16531

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a