### PR TITLE
storage: only create async worker once (aka. revert the removal of not halting in storage)

### DIFF
--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -1,0 +1,80 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Types for cluster-internal control messages that can be broadcast to all
+//! workers from individual operators/workers.
+
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use timely::communication::Allocate;
+use timely::progress::Antichain;
+use timely::synchronization::Sequencer;
+
+use mz_repr::GlobalId;
+use mz_storage_client::controller::CollectionMetadata;
+use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
+use mz_storage_client::types::sources::IngestionDescription;
+
+use crate::storage_state::Worker;
+
+/// Internal commands that can be sent by individual operators/workers that will
+/// be broadcast to all workers. The worker main loop will receive those and act
+/// on them.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum InternalStorageCommand {
+    /// Suspend and restart the dataflow identified by the `GlobalId`.
+    SuspendAndRestart {
+        /// The id of the dataflow that should be restarted.
+        id: GlobalId,
+        /// The reason for the restart request.
+        reason: String,
+    },
+    /// Render an ingestion dataflow at the given resumption frontier.
+    CreateIngestionDataflow {
+        /// ID of the ingestion/sourve.
+        id: GlobalId,
+        /// The description of the ingestion/source.
+        ingestion_description: IngestionDescription<CollectionMetadata>,
+        /// The frontier at which we should (re-)start ingestion.
+        resumption_frontier: Antichain<mz_repr::Timestamp>,
+    },
+    /// Render a sink dataflow.
+    CreateSinkDataflow(
+        GlobalId,
+        StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
+    ),
+    /// Drop all state and operators for a dataflow.
+    DropDataflow(GlobalId),
+}
+
+/// Allows broadcasting [`internal commands`](InternalStorageCommand) to all
+/// workers.
+pub trait InternalCommandSender {
+    /// Broadcasts the given command to all workers.
+    fn broadcast(&mut self, internal_cmd: InternalStorageCommand);
+
+    /// Returns the next available command, if any. This returns `None` when
+    /// there are currently no commands but there might be commands again in the
+    /// future.
+    fn next(&mut self) -> Option<InternalStorageCommand>;
+}
+
+impl InternalCommandSender for Sequencer<InternalStorageCommand> {
+    fn broadcast(&mut self, internal_cmd: InternalStorageCommand) {
+        self.push(internal_cmd);
+    }
+
+    fn next(&mut self) -> Option<InternalStorageCommand> {
+        Iterator::next(self)
+    }
+}
+
+impl<'w, A: Allocate> Worker<'w, A> {
+    pub(crate) fn setup_command_sequencer(&mut self) -> Sequencer<InternalStorageCommand> {
+        // TODO(aljoscha): Use something based on `mz_ore::NowFn`?
+        Sequencer::new(self.timely_worker, Instant::now())
+    }
+}

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -12,13 +12,12 @@ use serde::{Deserialize, Serialize};
 use timely::communication::Allocate;
 use timely::progress::Antichain;
 use timely::synchronization::Sequencer;
+use timely::worker::Worker as TimelyWorker;
 
 use mz_repr::GlobalId;
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::IngestionDescription;
-
-use crate::storage_state::Worker;
 
 /// Internal commands that can be sent by individual operators/workers that will
 /// be broadcast to all workers. The worker main loop will receive those and act
@@ -72,9 +71,9 @@ impl InternalCommandSender for Sequencer<InternalStorageCommand> {
     }
 }
 
-impl<'w, A: Allocate> Worker<'w, A> {
-    pub(crate) fn setup_command_sequencer(&mut self) -> Sequencer<InternalStorageCommand> {
-        // TODO(aljoscha): Use something based on `mz_ore::NowFn`?
-        Sequencer::new(self.timely_worker, Instant::now())
-    }
+pub(crate) fn setup_command_sequencer<'w, A: Allocate>(
+    timely_worker: &'w mut TimelyWorker<A>,
+) -> Sequencer<InternalStorageCommand> {
+    // TODO(aljoscha): Use something based on `mz_ore::NowFn`?
+    Sequencer::new(timely_worker, Instant::now())
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -78,6 +78,7 @@
 //! Materialize's storage layer.
 
 pub mod decode;
+pub mod internal_control;
 pub mod render;
 pub mod server;
 pub mod sink;

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -110,6 +110,13 @@ where
     // a million fields
     let resumption_calculator = description.clone();
 
+    let internal_cmd_tx = Rc::clone(
+        storage_state
+            .internal_cmd_tx
+            .as_ref()
+            .expect("missing internal command sender"),
+    );
+
     // Build the _raw_ ok and error sources using `create_raw_source` and the
     // correct `SourceReader` implementations
     let ((ok_sources, err_source), capability) = match connection {
@@ -120,6 +127,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                internal_cmd_tx,
             );
             let oks: Vec<_> = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)
@@ -131,6 +139,7 @@ where
                 DelimitedValueSourceConnection(connection),
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                internal_cmd_tx,
             );
             let oks = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)
@@ -142,6 +151,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                internal_cmd_tx,
             );
             let oks = oks.into_iter().map(SourceType::ByteStream).collect();
             ((oks, err), cap)
@@ -153,6 +163,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                internal_cmd_tx,
             );
             let oks = oks.into_iter().map(SourceType::Row).collect();
             ((oks, err), cap)
@@ -164,6 +175,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                internal_cmd_tx,
             );
             let oks = oks.into_iter().map(SourceType::Row).collect();
             ((oks, err), cap)
@@ -175,6 +187,7 @@ where
                 connection,
                 storage_state.connection_context.clone(),
                 resumption_calculator,
+                internal_cmd_tx,
             );
             let oks: Vec<_> = oks.into_iter().map(SourceType::Delimited).collect();
             ((oks, err), cap)

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -110,12 +110,7 @@ where
     // a million fields
     let resumption_calculator = description.clone();
 
-    let internal_cmd_tx = Rc::clone(
-        storage_state
-            .internal_cmd_tx
-            .as_ref()
-            .expect("missing internal command sender"),
-    );
+    let internal_cmd_tx = Rc::clone(&storage_state.internal_cmd_tx);
 
     // Build the _raw_ ok and error sources using `create_raw_source` and the
     // correct `SourceReader` implementations

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -107,8 +107,7 @@ pub fn serve(
                 dropped_ids: Vec::new(),
                 source_statistics: HashMap::new(),
                 sink_statistics: HashMap::new(),
-                // TODO(aljoscha): We can refactor when `StorageState` is being
-                // created, to get around this being an `Option`.
+                internal_cmd_tx: None,
             },
         }
         .run()

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -108,6 +108,7 @@ pub fn serve(
                 source_statistics: HashMap::new(),
                 sink_statistics: HashMap::new(),
                 internal_cmd_tx: None,
+                async_worker: None,
             },
         }
         .run()

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -123,12 +123,7 @@ where
             Antichain::new()
         }));
 
-        let internal_cmd_tx = Rc::clone(
-            storage_state
-                .internal_cmd_tx
-                .as_ref()
-                .expect("missing internal command sender"),
-        );
+        let internal_cmd_tx = Rc::clone(&storage_state.internal_cmd_tx);
 
         let token = kafka(
             sinked_collection,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::needless_borrow)]
 
 use std::any::Any;
+use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
@@ -52,7 +53,6 @@ use tracing::{info, trace, warn};
 
 use mz_expr::PartitionId;
 use mz_ore::cast::CastFrom;
-use mz_ore::halt;
 use mz_ore::now::NowFn;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
@@ -70,7 +70,7 @@ use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuild
 use mz_timely_util::operator::StreamExt as _;
 
 use crate::healthcheck::write_to_persist;
-
+use crate::internal_control::{InternalCommandSender, InternalStorageCommand};
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::{ReclockBatch, ReclockError, ReclockFollower, ReclockOperator};
 use crate::source::types::{
@@ -169,6 +169,7 @@ pub fn create_raw_source<G, C, R>(
     source_connection: C,
     connection_context: ConnectionContext,
     calc: R,
+    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
 ) -> (
     (
         Vec<
@@ -240,7 +241,7 @@ where
         remap_stream,
     );
 
-    let health_token = health_operator(scope, config, health_stream);
+    let health_token = health_operator(scope, config, health_stream, internal_cmd_tx);
 
     let token = Rc::new((source_reader_token, remap_token, resume_token, health_token));
 
@@ -697,6 +698,7 @@ where
                             return;
                         }
                     };
+
                     let SourceReaderOperatorOutput {
                         messages,
                         status_update,
@@ -876,6 +878,7 @@ fn health_operator<G>(
     scope: &G,
     config: RawSourceCreationConfig,
     health_stream: Stream<G, (usize, HealthStatusUpdate)>,
+    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
 ) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -974,8 +977,13 @@ where
 
                     last_reported_status = new_status.clone();
                 }
+                // TODO(aljoscha): Instead of threading through the
+                // `should_halt` bit, we can give an internal command sender
+                // directly to the places where `should_halt = true` originates.
+                // We should definitely do that, but this is okay for a PoC.
                 if let Some(halt_with) = halt_with {
-                    halt!("halting with status {halt_with:?}");
+                    info!("Broadcasting suspend-and-restart command because of {:?}", halt_with);
+                    internal_cmd_tx.borrow_mut().broadcast(InternalStorageCommand::SuspendAndRestart{id: source_id, reason: format!("{:?}", halt_with)});
                 }
             }
         }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -4,12 +4,74 @@
 // included in the LICENSE file.
 
 //! Worker-local state for storage timely instances.
+//!
+//! One instance of a [`Worker`], along with its contained [`StorageState`], is
+//! part of an ensemble of storage workers that all run inside the same timely
+//! cluster. We call this worker a _storage worker_ to disambiguate it from
+//! other kinds of workers, potentially other components that might be sharing
+//! the same timely cluster.
+//!
+//! ## Controller and internal communication
+//!
+//! A worker receives _external_ [`StorageCommands`](StorageCommand) from the
+//! storage controller, via a channel. Storage workers also share an _internal_
+//! control/command fabric ([`internal_control`](crate::internal_control)).
+//! Internal commands go through a `Sequencer` dataflow that ensures that all
+//! workers receive all commands in the same consistent order.
+//!
+//! We need to make sure that commands that cause dataflows to be rendered are
+//! processed in the same consistent order across all workers because timely
+//! requires this. To achieve this, we make sure that only internal commands can
+//! cause dataflows to be rendered. External commands (from the controller)
+//! cause internal commands to be broadcast (by only one worker), to get
+//! dataflows rendered.
+//!
+//! The internal command fabric is also used to broadcast messages from a local
+//! operator/worker to all workers. For example, when we need to tear down and
+//! restart a dataflow on all workers when an error is encountered.
+//!
+//! ## Async Storage Worker
+//!
+//! The storage worker has a companion [`AsyncStorageWorker`] that must be used
+//! when running code that requires `async`. This is needed because a timely
+//! main loop cannot run `async` code.
+//!
+//! ## Example flow of commands for `CreateSources`
+//!
+//! With external commands, internal commands, and the async worker,
+//! understanding where and how commands from the controller are realized can
+//! get complicated. We will follow the complete flow for `CreateSources`, as an
+//! example:
+//!
+//! 1. Worker receives a [`StorageCommand::CreateSources`] command from the
+//!    controller.
+//! 2. This command is processed in [`StorageState::handle_storage_command`].
+//!    This step cannot render dataflows, because it does not have access to the
+//!    timely worker. It will only set up state that stays over the whole
+//!    lifetime of the source, such as the `reported_frontier`. Putting in place
+//!    this reported frontier will enable frontier reporting for that source.
+//!    We will not start reporting when we only see an internal command for
+//!    rendering a dataflow, which can "overtake" the external `CreateSources`
+//!    command.
+//! 3. During processing of that command, we call
+//!    [`AsyncStorageWorker::calculate_resume_upper`], which causes a command to
+//!    be sent to the async worker.
+//! 4. We eventually get a response from the async worker:
+//!    [`AsyncStorageWorkerResponse::IngestDescriptionWithResumeUpper`].
+//! 5. This response is handled in [`Worker::handle_async_worker_response`].
+//! 6. Handling that response causes a
+//!    [`InternalStorageCommand::CreateIngestionDataflow`] to be broadcast to
+//!    all workers via the internal command fabric.
+//! 7. This message will be processed (on each worker) in
+//!    [`Worker::handle_internal_storage_command`]. This is what will cause the
+//!    required dataflow to be rendered on all workers.
 
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
+use std::thread;
 
 use crossbeam_channel::TryRecvError;
 use differential_dataflow::lattice::Lattice;
@@ -22,6 +84,7 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration, Instant};
+use tracing::info;
 
 use mz_ore::halt;
 use mz_ore::now::NowFn;
@@ -37,9 +100,13 @@ use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::{IngestionDescription, SourceData};
 
 use crate::decode::metrics::DecodeMetrics;
+use crate::internal_control::{InternalCommandSender, InternalStorageCommand};
 use crate::sink::SinkBaseMetrics;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::statistics::{SinkStatisticsMetrics, SourceStatisticsMetrics, StorageStatistics};
+use crate::storage_state::async_storage_worker::{AsyncStorageWorker, AsyncStorageWorkerResponse};
+
+pub mod async_storage_worker;
 
 type CommandReceiver = crossbeam_channel::Receiver<StorageCommand>;
 type ResponseSender = mpsc::UnboundedSender<StorageResponse>;
@@ -110,6 +177,12 @@ pub struct StorageState {
     /// The same as `source_statistics`, but for sinks.
     pub sink_statistics:
         HashMap<GlobalId, StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>>,
+
+    /// Sender for cluster-internal storage commands. These can be sent from
+    /// within workers/operators and will be distributed to all workers. For
+    /// example, for shutting down an entire dataflow from within a
+    /// operator/worker.
+    pub internal_cmd_tx: Option<Rc<RefCell<dyn InternalCommandSender>>>,
 }
 
 /// This maintains an additional read hold on the source data for a sink, alongside
@@ -218,9 +291,53 @@ impl<'w, A: Allocate> Worker<'w, A> {
         }
     }
 
-    /// Draws commands from a single client until disconnected.
+    /// Runs this (timely) storage worker until the given `command_rx` is
+    /// disconnected.
+    ///
+    /// See the [module documentation](crate::storage_state) for this
+    /// workers responsibilities, how it communicates with the other workers and
+    /// how commands flow from the controller and through the workers.
     fn run_client(&mut self, command_rx: CommandReceiver, response_tx: ResponseSender) {
-        self.reconcile(&command_rx);
+        let command_sequencer = match self.storage_state.internal_cmd_tx.as_ref() {
+            Some(command_sequencer) => Rc::clone(command_sequencer),
+            None => {
+                // It is very important that we only create the internal control
+                // flow/command sequencer once because a) the `StorageState` is
+                // re-used when a new client connects and b) dataflows that have
+                // already been rendered into the timely worker are reused as
+                // well.
+                //
+                // If we created a new sequencer every time we get a new client
+                // (likely because the controller re-started and re-connected),
+                // dataflows that were rendered before would still hold a handle
+                // to the old sequencer but we would not read their commands
+                // anymore.
+                let command_sequencer = self.setup_command_sequencer();
+                let command_sequencer = Rc::new(RefCell::new(command_sequencer));
+
+                let command_sequencer_clone = Rc::clone(&command_sequencer);
+                self.storage_state
+                    .internal_cmd_tx
+                    .replace(command_sequencer_clone);
+
+                command_sequencer
+            }
+        };
+
+        // TODO(aljoscha): This `Activatable` business seems brittle, but that's
+        // also how the command channel works currently. We can wrap it inside a
+        // struct that holds both a channel and an `Activatable`, but I don't
+        // think that would help too much.
+        let mut async_worker = async_storage_worker::AsyncStorageWorker::new(
+            thread::current(),
+            Arc::clone(&self.storage_state.persist_clients),
+        );
+
+        // At this point, all workers are still reading from the command flow.
+        {
+            let mut command_sequencer = command_sequencer.borrow_mut();
+            self.reconcile(&mut *command_sequencer, &mut async_worker, &command_rx);
+        }
 
         let mut disconnected = false;
 
@@ -229,16 +346,17 @@ impl<'w, A: Allocate> Worker<'w, A> {
         while !disconnected {
             // Ask Timely to execute a unit of work.
             //
-            // If there are no pending commands, we ask Timely to park the
-            // thread if there's nothing to do. We rely on another thread
-            // unparking us when there's new work to be done, e.g., when sending
-            // a command or when new Kafka messages have arrived.
+            // If there are no pending commands or responses from the async
+            // worker, we ask Timely to park the thread if there's nothing to
+            // do. We rely on another thread unparking us when there's new work
+            // to be done, e.g., when sending a command or when new Kafka
+            // messages have arrived.
             //
             // It is critical that we allow Timely to park iff there are no
-            // pending commands. The command may have already been consumed by
-            // the call to `client_rx.recv`.
-            // See: https://github.com/MaterializeInc/materialize/pull/13973#issuecomment-1200312212
-            if command_rx.is_empty() {
+            // pending commands or responses. The command may have already been
+            // consumed by the call to `client_rx.recv`. See:
+            // https://github.com/MaterializeInc/materialize/pull/13973#issuecomment-1200312212
+            if command_rx.is_empty() && async_worker.is_empty() {
                 self.timely_worker.step_or_park(None);
             } else {
                 self.timely_worker.step();
@@ -282,130 +400,245 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                 }
             }
-            for cmd in cmds {
-                self.handle_storage_command(cmd);
+            {
+                let mut internal_cmd_tx = command_sequencer.borrow_mut();
+                for cmd in cmds {
+                    self.storage_state.handle_storage_command(
+                        self.timely_worker.index(),
+                        &mut *internal_cmd_tx,
+                        &mut async_worker,
+                        cmd,
+                    )
+                }
+            }
+
+            // Handle responses from the async worker.
+            let mut empty = false;
+            while !empty {
+                match async_worker.try_recv() {
+                    Ok(response) => {
+                        let mut command_sequencer = command_sequencer.borrow_mut();
+                        self.handle_async_worker_response(&mut *command_sequencer, response);
+                    }
+                    Err(TryRecvError::Empty) => empty = true,
+                    Err(TryRecvError::Disconnected) => {
+                        empty = true;
+                    }
+                }
+            }
+
+            // Handle any received commands.
+            {
+                let mut command_sequencer = command_sequencer.borrow_mut();
+                while let Some(internal_cmd) = command_sequencer.next() {
+                    self.handle_internal_storage_command(
+                        &mut *command_sequencer,
+                        &mut async_worker,
+                        internal_cmd,
+                    );
+                }
             }
         }
     }
 
-    /// Entry point for applying a storage command.
-    pub fn handle_storage_command(&mut self, cmd: StorageCommand) {
-        match cmd {
-            StorageCommand::InitializationComplete => (),
-            StorageCommand::UpdateConfiguration(params) => {
-                tracing::info!("Applying configuration update: {params:?}");
-
-                // TODO(#16753): apply config to `self.storage_state.persist_clients`
-                let _ = params.persist;
+    /// Entry point for applying a response from the async storage worker.
+    pub fn handle_async_worker_response(
+        &mut self,
+        internal_cmd_tx: &mut dyn InternalCommandSender,
+        async_response: AsyncStorageWorkerResponse<mz_repr::Timestamp>,
+    ) {
+        match async_response {
+            AsyncStorageWorkerResponse::IngestDescriptionWithResumeUpper(
+                id,
+                ingestion_description,
+                resumption_frontier,
+            ) => {
+                // NOTE: If we want to share the load of async processing we
+                // have to change `handle_storage_command` and change this
+                // assert.
+                assert!(
+                    self.timely_worker.index() == 0,
+                    "only worker #0 is doing async processing"
+                );
+                internal_cmd_tx.broadcast(InternalStorageCommand::CreateIngestionDataflow {
+                    id,
+                    ingestion_description,
+                    resumption_frontier,
+                });
             }
-            StorageCommand::CreateSources(ingestions) => {
-                for ingestion in ingestions {
-                    // Remember the ingestion description to facilitate possible
-                    // reconciliation later.
-                    self.storage_state
-                        .ingestions
-                        .insert(ingestion.id, ingestion.description.clone());
+        }
+    }
 
-                    // Initialize shared frontier tracking.
-                    for (export_id, export) in ingestion.description.source_exports.iter() {
-                        // This is a separate line cause rustfmt :(
-                        let stats = StorageStatistics::<
-                            SourceStatisticsUpdate,
-                            SourceStatisticsMetrics,
-                        >::new(
+    /// Entry point for applying an internal storage command.
+    pub fn handle_internal_storage_command(
+        &mut self,
+        internal_cmd_tx: &mut dyn InternalCommandSender,
+        async_worker: &mut AsyncStorageWorker<mz_repr::Timestamp>,
+        internal_cmd: InternalStorageCommand,
+    ) {
+        match internal_cmd {
+            InternalStorageCommand::SuspendAndRestart { id, reason } => {
+                info!(
+                    "worker {}/{} initiating suspend-and-restart for {id} because of: {reason}",
+                    self.timely_worker.index(),
+                    self.timely_worker.peers(),
+                );
+
+                let maybe_ingestion = self.storage_state.ingestions.get(&id).cloned();
+                if let Some(ingestion_description) = maybe_ingestion {
+                    // Yank the token of the previously existing source
+                    // dataflow.
+                    let maybe_token = self.storage_state.source_tokens.remove(&id);
+
+                    if maybe_token.is_none() {
+                        // Something has dropped the source. Make sure we don't
+                        // accidentally re-create it.
+                        return;
+                    }
+
+                    // This needs to be done by one worker, which will
+                    // broadcasts a `CreateIngestionDataflow` command to all
+                    // workers based on the response that contains the
+                    // resumption upper.
+                    //
+                    // Doing this separately on each worker could lead to
+                    // differing resume_uppers which might lead to all kinds of
+                    // mayhem.
+                    //
+                    // TODO(aljoscha): If we ever become worried that this is
+                    // putting undue pressure on worker 0 we can pick the
+                    // designated worker for a source/sink based on `id.hash()`.
+                    if self.timely_worker.index() == 0 {
+                        async_worker.calculate_resume_upper(id, ingestion_description);
+                    }
+
+                    // Continue with other commands.
+                    return;
+                }
+
+                let maybe_sink = self.storage_state.exports.get(&id).cloned();
+                if let Some(sink_description) = maybe_sink {
+                    // Yank the token of the previously existing sink
+                    // dataflow.
+                    let maybe_token = self.storage_state.sink_tokens.remove(&id);
+
+                    if maybe_token.is_none() {
+                        // Something has dropped the sink. Make sure we don't
+                        // accidentally re-create it.
+                        return;
+                    }
+
+                    // This needs to be broadcast by one worker and go through
+                    // the internal command fabric, to ensure consistent
+                    // ordering of dataflow rendering across all workers.
+                    if self.timely_worker.index() == 0 {
+                        internal_cmd_tx.broadcast(InternalStorageCommand::CreateSinkDataflow(
+                            id,
+                            sink_description,
+                        ));
+                    }
+
+                    // Continue with other commands.
+                    return;
+                }
+
+                panic!("got InternalStorageCommand::SuspendAndRestart for something that is not a source or sink: {id}");
+            }
+            InternalStorageCommand::CreateIngestionDataflow {
+                id: ingestion_id,
+                ingestion_description,
+                resumption_frontier,
+            } => {
+                info!(
+                    "worker {}/{} trying to (re-)start ingestion {ingestion_id} at resumption frontier {:?}",
+                    self.timely_worker.index(),
+                    self.timely_worker.peers(),
+                    resumption_frontier
+                );
+
+                for (export_id, export) in ingestion_description.source_exports.iter() {
+                    // This is a separate line cause rustfmt :(
+                    let stats =
+                        StorageStatistics::<SourceStatisticsUpdate, SourceStatisticsMetrics>::new(
                             *export_id,
                             self.storage_state.timely_worker_index,
                             &self.storage_state.source_metrics,
-                            ingestion.id,
+                            ingestion_id,
                             &export.storage_metadata.data_shard,
                         );
-                        self.storage_state
-                            .source_statistics
-                            .insert(*export_id, stats);
-
-                        self.storage_state.source_uppers.insert(
-                            *export_id,
-                            Rc::new(RefCell::new(Antichain::from_elem(
-                                mz_repr::Timestamp::minimum(),
-                            ))),
-                        );
-                        self.storage_state.reported_frontiers.insert(
-                            *export_id,
-                            Antichain::from_elem(mz_repr::Timestamp::minimum()),
-                        );
-                    }
-
-                    crate::render::build_ingestion_dataflow(
-                        self.timely_worker,
-                        &mut self.storage_state,
-                        ingestion.id,
-                        ingestion.description,
-                        ingestion.resume_upper,
-                    );
-                }
-            }
-            StorageCommand::CreateSinks(exports) => {
-                for export in exports {
                     self.storage_state
-                        .exports
-                        .insert(export.id, export.description.clone());
+                        .source_statistics
+                        .insert(*export_id, stats);
 
-                    self.storage_state.sink_write_frontiers.insert(
-                        export.id,
-                        Rc::new(RefCell::new(Antichain::from_elem(
-                            mz_repr::Timestamp::minimum(),
-                        ))),
-                    );
+                    // If there is already a shared upper, we re-use it, to make
+                    // sure that parties that are already using the shared upper
+                    // can continue doing so.
+                    let source_upper = self
+                        .storage_state
+                        .source_uppers
+                        .entry(export_id.clone())
+                        .or_insert_with(|| Rc::new(RefCell::new(Antichain::new())));
 
-                    self.storage_state.sink_handles.insert(
-                        export.id,
-                        SinkHandle::new(
-                            export.id,
-                            &export.description.from_storage_metadata,
-                            export.description.from_storage_metadata.data_shard,
-                            Arc::clone(&self.storage_state.persist_clients),
-                        ),
-                    );
-
-                    // This is a separate line cause rustfmt :(
-                    let stats =
-                        StorageStatistics::<SinkStatisticsUpdate, SinkStatisticsMetrics>::new(
-                            export.id,
-                            self.storage_state.timely_worker_index,
-                            &self.storage_state.sink_metrics,
-                        );
-                    self.storage_state.sink_statistics.insert(export.id, stats);
-
-                    crate::render::build_export_dataflow(
-                        self.timely_worker,
-                        &mut self.storage_state,
-                        export.id,
-                        export.description,
-                    );
-
-                    self.storage_state.reported_frontiers.insert(
-                        export.id,
-                        Antichain::from_elem(mz_repr::Timestamp::minimum()),
-                    );
+                    let mut source_upper = source_upper.borrow_mut();
+                    source_upper.clear();
+                    source_upper.insert(mz_repr::Timestamp::minimum());
                 }
+
+                crate::render::build_ingestion_dataflow(
+                    self.timely_worker,
+                    &mut self.storage_state,
+                    ingestion_id,
+                    ingestion_description,
+                    resumption_frontier,
+                );
             }
-            StorageCommand::AllowCompaction(list) => {
-                for (id, frontier) in list {
-                    if frontier.is_empty() {
-                        // Indicates that we may drop `id`, as there are no more valid times to read.
-                        // Clean up per-source / per-sink state.
-                        self.storage_state.source_uppers.remove(&id);
-                        self.storage_state.reported_frontiers.remove(&id);
-                        // TODO(aljoscha): I think this is wrong, we need to
-                        // remove the statistics for the sub-sources as well.
-                        self.storage_state.source_statistics.remove(&id);
-                        self.storage_state.sink_statistics.remove(&id);
-                        self.storage_state.source_tokens.remove(&id);
-                        self.storage_state.sink_tokens.remove(&id);
-                        self.storage_state.sink_handles.remove(&id);
-                        self.storage_state.dropped_ids.push(id);
-                    }
+            InternalStorageCommand::CreateSinkDataflow(sink_id, sink_description) => {
+                info!(
+                    "worker {}/{} trying to (re-)start sink {sink_id}",
+                    self.timely_worker.index(),
+                    self.timely_worker.peers(),
+                );
+
+                {
+                    // If there is already a shared write frontier, we re-use it, to
+                    // make sure that parties that are already using the shared
+                    // frontier can continue doing so.
+                    let sink_write_frontier = self
+                        .storage_state
+                        .sink_write_frontiers
+                        .entry(sink_id.clone())
+                        .or_insert_with(|| Rc::new(RefCell::new(Antichain::new())));
+
+                    let mut sink_write_frontier = sink_write_frontier.borrow_mut();
+                    sink_write_frontier.clear();
+                    sink_write_frontier.insert(mz_repr::Timestamp::minimum());
                 }
+                // This is a separate line cause rustfmt :(
+                let stats = StorageStatistics::<SinkStatisticsUpdate, SinkStatisticsMetrics>::new(
+                    sink_id,
+                    self.storage_state.timely_worker_index,
+                    &self.storage_state.sink_metrics,
+                );
+                self.storage_state.sink_statistics.insert(sink_id, stats);
+
+                crate::render::build_export_dataflow(
+                    self.timely_worker,
+                    &mut self.storage_state,
+                    sink_id,
+                    sink_description,
+                );
+            }
+            InternalStorageCommand::DropDataflow(id) => {
+                // Clean up per-source / per-sink state.
+                self.storage_state.source_uppers.remove(&id);
+                self.storage_state.source_tokens.remove(&id);
+                self.storage_state.source_statistics.remove(&id);
+
+                self.storage_state.sink_tokens.remove(&id);
+
+                // Report the dataflow as dropped once we went through the whole
+                // control flow from external command to this internal command.
+                self.storage_state.dropped_ids.push(id);
             }
         }
     }
@@ -430,11 +663,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
             .iter()
             .chain(self.storage_state.sink_write_frontiers.iter())
         {
-            let reported_frontier = self
-                .storage_state
-                .reported_frontiers
-                .get_mut(id)
-                .expect("Reported frontier missing!");
+            let Some(reported_frontier) = self.storage_state.reported_frontiers.get_mut(id) else {
+                // Frontier reporting has not yet been started for this object.
+                // Potentially because this timely worker has not yet seen the
+                // `CreateSources` command.
+                continue;
+            };
 
             let observed_frontier = frontier.borrow();
 
@@ -516,7 +750,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
     /// subscribe response buffer. We will need to be vigilant with future
     /// modifications to `StorageState` to line up changes there with clean
     /// resets here.
-    fn reconcile(&mut self, command_rx: &CommandReceiver) {
+    fn reconcile(
+        &mut self,
+        internal_cmd_tx: &mut dyn InternalCommandSender,
+        async_worker: &mut AsyncStorageWorker<mz_repr::Timestamp>,
+        command_rx: &CommandReceiver,
+    ) {
         // To initialize the connection, we want to drain all commands until we
         // receive a `StorageCommand::InitializationComplete` command to form a
         // target command state.
@@ -595,7 +834,122 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
         // Execute the modified commands.
         for command in commands {
-            self.handle_storage_command(command);
+            self.storage_state.handle_storage_command(
+                self.timely_worker.index(),
+                internal_cmd_tx,
+                async_worker,
+                command,
+            );
+        }
+    }
+}
+
+impl StorageState {
+    /// Entry point for applying a storage command.
+    ///
+    /// NOTE: This does not have access to the timely worker and therefore
+    /// cannot render dataflows. For dataflow rendering, this needs to either
+    /// send asynchronous command to the given `async_worker` or internal
+    /// commands to the given `internal_cmd_tx`.
+    pub fn handle_storage_command(
+        &mut self,
+        worker_index: usize,
+        internal_cmd_tx: &mut dyn InternalCommandSender,
+        async_worker: &mut AsyncStorageWorker<mz_repr::Timestamp>,
+        cmd: StorageCommand,
+    ) {
+        match cmd {
+            StorageCommand::InitializationComplete => (),
+            StorageCommand::UpdateConfiguration(params) => {
+                tracing::info!("Applying configuration update: {params:?}");
+
+                // TODO(#16753): apply config to `self.storage_state.persist_clients`
+                let _ = params.persist;
+            }
+            StorageCommand::CreateSources(ingestions) => {
+                for ingestion in ingestions {
+                    // Remember the ingestion description to facilitate possible
+                    // reconciliation later.
+                    self.ingestions
+                        .insert(ingestion.id, ingestion.description.clone());
+
+                    // Initialize shared frontier reporting.
+                    for (export_id, _export) in ingestion.description.source_exports.iter() {
+                        self.reported_frontiers.insert(
+                            *export_id,
+                            Antichain::from_elem(mz_repr::Timestamp::minimum()),
+                        );
+                    }
+
+                    // This needs to be done by one worker, which will
+                    // broadcasts a `CreateIngestionDataflow` command to all
+                    // workers based on the response that contains the
+                    // resumption upper.
+                    //
+                    // Doing this separately on each worker could lead to
+                    // differing resume_uppers which might lead to all kinds of
+                    // mayhem.
+                    if worker_index == 0 {
+                        async_worker.calculate_resume_upper(ingestion.id, ingestion.description);
+                    }
+                }
+            }
+            StorageCommand::CreateSinks(exports) => {
+                for export in exports {
+                    // Remember the sink description to facilitate possible
+                    // reconciliation later.
+                    self.exports.insert(export.id, export.description.clone());
+
+                    self.reported_frontiers.insert(
+                        export.id,
+                        Antichain::from_elem(mz_repr::Timestamp::minimum()),
+                    );
+
+                    self.sink_handles.insert(
+                        export.id,
+                        SinkHandle::new(
+                            export.id,
+                            &export.description.from_storage_metadata,
+                            export.description.from_storage_metadata.data_shard,
+                            Arc::clone(&self.persist_clients),
+                        ),
+                    );
+
+                    // This needs to be broadcast by one worker and go through
+                    // the internal command fabric, to ensure consistent
+                    // ordering of dataflow rendering across all workers.
+                    if worker_index == 0 {
+                        internal_cmd_tx.broadcast(InternalStorageCommand::CreateSinkDataflow(
+                            export.id,
+                            export.description,
+                        ));
+                    }
+                }
+            }
+            StorageCommand::AllowCompaction(list) => {
+                for (id, frontier) in list {
+                    if frontier.is_empty() {
+                        // Indicates that we may drop `id`, as there are no more valid times to read.
+                        //
+                        // This handler removes state that is put in place by
+                        // the handler for `CreateSources`/`CreateSinks`, while
+                        // the handler for the internal command does the same
+                        // for the state put in place by its corresponding
+                        // creation command.
+
+                        // This will stop reporting of frontiers.
+                        self.reported_frontiers.remove(&id);
+
+                        self.sink_handles.remove(&id);
+
+                        // Broadcast from one worker to make sure its sequences
+                        // with the other internal commands.
+                        if worker_index == 0 {
+                            internal_cmd_tx.broadcast(InternalStorageCommand::DropDataflow(id));
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -1,0 +1,177 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A friendly companion async worker that can be used by a timely storage
+//! worker to do work that requires async.
+//!
+//! CAUTION: This is not meant for high-throughput data processing but for
+//! one-off requests that we need to do every now and then.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use differential_dataflow::lattice::Lattice;
+use timely::progress::{Antichain, Timestamp};
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tracing::Instrument;
+
+use mz_persist_client::cache::PersistClientCache;
+use mz_persist_types::Codec64;
+use mz_repr::GlobalId;
+use mz_service::local::Activatable;
+use mz_storage_client::controller::CollectionMetadata;
+use mz_storage_client::controller::ResumptionFrontierCalculator;
+use mz_storage_client::types::sources::IngestionDescription;
+
+/// A worker that can execute commands that come in on a channel and returns
+/// responses on another channel. This is useful in places where we can't
+/// normally run async code, such as the timely main loop.
+#[derive(Debug)]
+pub struct AsyncStorageWorker<T: Timestamp + Lattice + Codec64> {
+    tx: mpsc::UnboundedSender<(tracing::Span, AsyncStorageWorkerCommand<T>)>,
+    rx: crossbeam_channel::Receiver<AsyncStorageWorkerResponse<T>>,
+}
+
+/// Commands for [AsyncStorageWorker].
+#[derive(Debug)]
+pub enum AsyncStorageWorkerCommand<T: Timestamp + Lattice + Codec64> {
+    /// Calculate a recent resumption frontier for the ingestion.
+    CalculateResumeFrontier(
+        GlobalId,
+        IngestionDescription<CollectionMetadata>,
+        PhantomData<T>,
+    ),
+}
+
+/// Responses from [AsyncStorageWorker].
+#[derive(Debug)]
+pub enum AsyncStorageWorkerResponse<T: Timestamp + Lattice + Codec64> {
+    /// An `IngestionDescription` with a calculated, recent resume upper.
+    IngestDescriptionWithResumeUpper(
+        GlobalId,
+        IngestionDescription<CollectionMetadata>,
+        Antichain<T>,
+    ),
+}
+
+impl<T: Timestamp + Lattice + Codec64> AsyncStorageWorker<T> {
+    /// Creates a new [`AsyncStorageWorker`].
+    ///
+    /// IMPORTANT: The passed in `activatable` is activated when new responses
+    /// are added the response channel. It is important to not sleep the thread
+    /// that is reading from this via [`try_recv`](Self::try_recv) when
+    /// [`is_empty`](Self::is_empty) has returned `false`.
+    pub fn new<A: Activatable + Send + 'static>(
+        activatable: A,
+        persist_clients: Arc<Mutex<PersistClientCache>>,
+    ) -> Self {
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel::<(tracing::Span, _)>();
+        let (response_tx, response_rx) = crossbeam_channel::unbounded();
+
+        let mut response_tx = ActivatingSender::new(response_tx, activatable);
+
+        mz_ore::task::spawn(|| "AsyncStorageWorker", async move {
+            while let Some((span, command)) = command_rx.recv().await {
+                match command {
+                    AsyncStorageWorkerCommand::CalculateResumeFrontier(
+                        id,
+                        ingestion_description,
+                        _phantom_data,
+                    ) => {
+                        let mut persist_clients = persist_clients.lock().await;
+                        let mut state = ingestion_description
+                            .initialize_state(&mut persist_clients)
+                            .instrument(span.clone())
+                            .await;
+                        let resume_upper: Antichain<T> = ingestion_description
+                            .calculate_resumption_frontier(&mut state)
+                            .instrument(span)
+                            .await;
+                        let res = response_tx.send(
+                            AsyncStorageWorkerResponse::IngestDescriptionWithResumeUpper(
+                                id,
+                                ingestion_description,
+                                resume_upper,
+                            ),
+                        );
+
+                        match res {
+                            Ok(_) => {
+                                // All's well!
+                            }
+                            Err(_err) => {
+                                // Receiver must have hung up.
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            tracing::trace!("shutting down async storage worker task");
+        });
+
+        Self {
+            tx: command_tx,
+            rx: response_rx,
+        }
+    }
+
+    /// Calculates a recent resume upper for the given `IngestionDescription`.
+    pub fn calculate_resume_upper(
+        &self,
+        id: GlobalId,
+        ingestion: IngestionDescription<CollectionMetadata>,
+    ) {
+        self.send(AsyncStorageWorkerCommand::CalculateResumeFrontier(
+            id,
+            ingestion,
+            PhantomData,
+        ))
+    }
+
+    fn send(&self, cmd: AsyncStorageWorkerCommand<T>) {
+        self.tx
+            .send((tracing::Span::current(), cmd))
+            .expect("persist worker exited while its handle was alive")
+    }
+
+    /// Attempts to receive a message from the worker without blocking.
+    ///
+    /// This internally does a `try_recv` on a channel.
+    pub fn try_recv(
+        &self,
+    ) -> Result<AsyncStorageWorkerResponse<T>, crossbeam_channel::TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    /// Returns `true` if there are currently no responses.
+    pub fn is_empty(&self) -> bool {
+        self.rx.is_empty()
+    }
+}
+
+/// Helper that makes sure that we always activate the target when we send a
+/// message.
+struct ActivatingSender<T, A: Activatable> {
+    tx: crossbeam_channel::Sender<T>,
+    activatable: A,
+}
+
+impl<T, A: Activatable> ActivatingSender<T, A> {
+    fn new(tx: crossbeam_channel::Sender<T>, activatable: A) -> Self {
+        Self { tx, activatable }
+    }
+
+    fn send(&mut self, message: T) -> Result<(), crossbeam_channel::SendError<T>> {
+        let res = self.tx.send(message);
+        self.activatable.activate();
+        res
+    }
+}

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -76,12 +76,17 @@
 
 //! Unit tests for sources.
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::{Send, Sync};
+use std::rc::Rc;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
+use mz_ore::halt;
 use mz_persist_types::codec_impls::UnitSchema;
+use mz_storage::internal_control::{InternalCommandSender, InternalStorageCommand};
 use timely::progress::{Antichain, Timestamp as _};
 
 use mz_build_info::DUMMY_BUILD_INFO;
@@ -93,8 +98,8 @@ use mz_repr::{Diff, GlobalId, RelationDesc, Timestamp};
 use mz_storage::sink::SinkBaseMetrics;
 use mz_storage::source::metrics::SourceBaseMetrics;
 use mz_storage::source::testscript::ScriptCommand;
+use mz_storage::storage_state::async_storage_worker::AsyncStorageWorker;
 use mz_storage::DecodeMetrics;
-use mz_storage_client::client::StorageCommand;
 use mz_storage_client::types::sources::{
     encoding::SourceDataEncoding, GenericSourceConnection, SourceData, SourceDesc, SourceEnvelope,
     TestScriptSourceConnection,
@@ -227,13 +232,14 @@ where
                     aws_external_id_prefix: None,
                     secrets_reader: Arc::new(mz_secrets::InMemorySecretsController::new()),
                 },
-                persist_clients,
+                persist_clients: Arc::clone(&persist_clients),
                 sink_tokens: HashMap::new(),
                 sink_write_frontiers: HashMap::new(),
                 sink_handles: HashMap::new(),
                 dropped_ids: Vec::new(),
                 source_statistics: HashMap::new(),
                 sink_statistics: HashMap::new(),
+                internal_cmd_tx: HaltingInternalCommandSender::new(),
             };
 
             let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);
@@ -263,22 +269,37 @@ where
 
             {
                 let _tokio_guard = tokio_runtime.enter();
-                worker.handle_storage_command(StorageCommand::CreateSources(vec![
-                    mz_storage_client::client::CreateSourceCommand {
+
+                let mut async_storage_worker =
+                    AsyncStorageWorker::new(thread::current(), Arc::clone(&persist_clients));
+                let internal_command_fabric = &mut HaltingInternalCommandSender::new();
+
+                // NOTE: We only feed internal commands into the worker,
+                // bypassing "external" StorageCommand and the async worker that
+                // also sits into the normal processing loop. If you ever
+                // encounter weird behaviour from this test, this might be the
+                // reason.
+                worker.handle_internal_storage_command(
+                    &mut *internal_command_fabric.as_mut().unwrap().borrow_mut(),
+                    &mut async_storage_worker,
+                    InternalStorageCommand::CreateIngestionDataflow {
                         id,
-                        description: mz_storage_client::types::sources::IngestionDescription {
-                            desc: desc.clone(),
-                            ingestion_metadata: collection_metadata,
-                            source_exports,
-                            // Only used for Debezium
-                            source_imports: BTreeMap::new(),
-                            instance_id:
-                                mz_storage_client::types::instances::StorageInstanceId::User(100),
-                        },
+                        ingestion_description:
+                            mz_storage_client::types::sources::IngestionDescription {
+                                desc: desc.clone(),
+                                ingestion_metadata: collection_metadata,
+                                source_exports,
+                                // Only used for Debezium
+                                source_imports: BTreeMap::new(),
+                                instance_id:
+                                    mz_storage_client::types::instances::StorageInstanceId::User(
+                                        100,
+                                    ),
+                            },
                         // TODO: test resumption as well!
-                        resume_upper: Antichain::from_elem(Timestamp::minimum()),
+                        resumption_frontier: Antichain::from_elem(Timestamp::minimum()),
                     },
-                ]));
+                );
             }
 
             // Run the assertions in a tokio task, so we can step the dataflow
@@ -345,4 +366,22 @@ where
 
     // There is always exactly one worker.
     Ok(value.unwrap())
+}
+
+struct HaltingInternalCommandSender {}
+
+impl HaltingInternalCommandSender {
+    fn new() -> Option<Rc<RefCell<dyn InternalCommandSender>>> {
+        Some(Rc::new(RefCell::new(HaltingInternalCommandSender {})))
+    }
+}
+
+impl InternalCommandSender for HaltingInternalCommandSender {
+    fn broadcast(&mut self, internal_cmd: mz_storage::internal_control::InternalStorageCommand) {
+        halt!("got unexpected {:?} during testing", internal_cmd);
+    }
+
+    fn next(&mut self) -> Option<InternalStorageCommand> {
+        halt!("got unexpected call to next() during testing");
+    }
 }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -240,6 +240,7 @@ where
                 source_statistics: HashMap::new(),
                 sink_statistics: HashMap::new(),
                 internal_cmd_tx: HaltingInternalCommandSender::new(),
+                async_worker: None,
             };
 
             let (_fake_tx, fake_rx) = crossbeam_channel::bounded(1);


### PR DESCRIPTION
### Motivation

Similar to the internal command sequencer, it is very important that we
only create the async worker once because a) the `StorageState` is
re-used when a new client connects and b) commands that have already
been sent and might yield a response will be lost if a new iteration of
`run_client` creates a new async worker.

If we created a new async worker every time we get a new client (likely
because the controller re-started and re-connected), we can get into an
inconsistent state where we think that a dataflow has been rendered, for
example because there is an entry in `StorageState::ingestions`, while
there is not yet a dataflow. This happens because the dataflow only gets
rendered once we get a response from the async worker and send off an
internal command.

The core idea is that both the sequencer and the async worker are part
of the per-worker state, and must be treated as such, meaning they must
survive between invocations of `run_client`.

Fixes https://github.com/MaterializeInc/materialize/issues/17309

### Tips for reviewer

**NOTE: I'm currently doing multiple runs of the release qualification test that surfaced the original problem. To be sure that this actually _does_ fix things.**

The first commit is a straight revert of the original revert, next commits embellish some logging, and then we have the fix. The problem and the fix are described in the commit message and added comments.

You should not look at the revert of the revert but instead look at the individual commit that fixes the bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
