### PR TITLE
sql: complex range functions, pt 0

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -589,7 +589,13 @@ message ProtoBinaryFunc {
         google.protobuf.Empty mod_uint32 = 170;
         google.protobuf.Empty mod_uint64 = 171;
         ProtoRangeContainsInner range_contains_elem = 172;
-        ProtoRangeContainsInner range_contains_range = 173;
+        bool range_contains_range = 173;
+        google.protobuf.Empty range_overlaps = 174;
+        google.protobuf.Empty range_after = 175;
+        google.protobuf.Empty range_before = 176;
+        google.protobuf.Empty range_overleft = 177;
+        google.protobuf.Empty range_overright = 178;
+        google.protobuf.Empty range_adjacent = 179;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -414,7 +414,7 @@ message ProtoUnaryFunc {
 }
 
 message ProtoBinaryFunc {
-    message ProtoRangeContainsElemInner {
+    message ProtoRangeContainsInner {
         mz_repr.relation_and_scalar.ProtoScalarType elem_type = 1;
         bool rev = 2;
     }
@@ -588,7 +588,8 @@ message ProtoBinaryFunc {
         google.protobuf.Empty mod_uint16 = 169;
         google.protobuf.Empty mod_uint32 = 170;
         google.protobuf.Empty mod_uint64 = 171;
-        ProtoRangeContainsElemInner range_contains_elem = 172;
+        ProtoRangeContainsInner range_contains_elem = 172;
+        ProtoRangeContainsInner range_contains_range = 173;
     }
 }
 

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -206,17 +206,28 @@ impl<D> Range<D> {
 }
 
 /// Range implementations meant to work with `Range<Datum>` and `Range<DatumNested>`.
-impl<'a, B: Copy> Range<B>
+impl<'a, B: Copy + Ord + PartialOrd> Range<B>
 where
     Datum<'a>: From<B>,
 {
-    pub fn contains<T: RangeOps<'a>>(&self, elem: &T) -> bool
+    pub fn contains_elem<T: RangeOps<'a>>(&self, elem: &T) -> bool
     where
         <T as TryFrom<Datum<'a>>>::Error: std::fmt::Debug,
     {
         match self.inner {
             None => false,
             Some(inner) => inner.lower.satisfied_by(elem) && inner.upper.satisfied_by(elem),
+        }
+    }
+
+    pub fn contains_range<T: RangeOps<'a>>(&self, other: &Range<B>) -> bool
+    where
+        <T as TryFrom<Datum<'a>>>::Error: std::fmt::Debug,
+    {
+        match (self.inner, other.inner) {
+            (None, None) | (Some(_), None) => return true,
+            (None, Some(_)) => return false,
+            (Some(i), Some(j)) => i.lower <= j.lower && j.upper <= i.upper,
         }
     }
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3569,6 +3569,10 @@ static OP_IMPLS: Lazy<HashMap<&'static str, Func>> = Lazy::new(|| {
                 let elem_type = ecx.scalar_type(&lhs).unwrap_range_element_type().clone();
                 Ok(lhs.call_binary(rhs, BinaryFunc::RangeContainsElem { elem_type, rev: false }))
             }) => Bool, 3889;
+            params!(RangeAny, RangeAny) => Operation::binary(|ecx, lhs, rhs| {
+                let elem_type = ecx.scalar_type(&lhs).unwrap_range_element_type().clone();
+                Ok(lhs.call_binary(rhs, BinaryFunc::RangeContainsRange { elem_type, rev: false }))
+            }) => Bool, 3890;
         },
         "<@" => Scalar {
             params!(Jsonb, Jsonb) => Operation::binary(|_ecx, lhs, rhs| {
@@ -3594,6 +3598,10 @@ static OP_IMPLS: Lazy<HashMap<&'static str, Func>> = Lazy::new(|| {
                 let elem_type = ecx.scalar_type(&rhs).unwrap_range_element_type().clone();
                 Ok(rhs.call_binary(lhs, BinaryFunc::RangeContainsElem { elem_type, rev: true }))
             }) => Bool, 3891;
+            params!(RangeAny, RangeAny) => Operation::binary(|ecx, lhs, rhs| {
+                let elem_type = ecx.scalar_type(&rhs).unwrap_range_element_type().clone();
+                Ok(rhs.call_binary(lhs, BinaryFunc::RangeContainsRange { elem_type, rev: true }))
+            }) => Bool, 3892;
         },
         "?" => Scalar {
             params!(Jsonb, String) => JsonbContainsString, 3247;

--- a/test/pgtest/range.pt
+++ b/test/pgtest/range.pt
@@ -1,0 +1,299 @@
+# test that our range types' binary functions have the same implementation/results as PG
+
+send
+Parse {"query": "CREATE TABLE int4range_values (a int4range)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO int4range_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
+Bind
+Execute
+Parse {"query": "CREATE TABLE int4range_test_values (v int4range)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO int4range_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
+Bind
+Execute
+Parse {"query": "CREATE TABLE numrange_values (a numrange)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO numrange_values VALUES ('[,1)'), ('[,1]'), ('[,)'), ('[,]'), ('(,1)'), ('(,1]'), ('(,)'), ('(,]'), ('[-1,1)'), ('[-1,1]'), ('(-1,1)'), ('(-1,1]'), ('[0,0)'), ('[0,0]'), ('(0,0)'), ('(0,0]'), ('[1,)'), ('[1,]'), ('(1,)'), ('(1,]')"}
+Bind
+Execute
+Parse {"query": "CREATE TABLE numrange_test_values (v numrange)"}
+Bind
+Execute
+Parse {"query": "INSERT INTO numrange_test_values VALUES ('empty'), ('(,)'), ('(,1)'), ('(-1,)'), ('[-1,1)'), ('[-99,-50)'), ('[50,99)')"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 20"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 7"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 20"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 7"}
+ReadyForQuery {"status":"I"}
+
+send
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL) int4range_values(a), int4range_test_values WHERE a @> v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a <@ v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a && v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a << v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a >> v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a &< v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a &> v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL ) int4range_values(a), int4range_test_values WHERE a -|- v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","{empty}"]}
+DataRow {"fields":["(,1)","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,2)","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,)","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{empty,\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,2)","{empty,\"[-1,1)\"}"]}
+DataRow {"fields":["[0,1)","{empty}"]}
+DataRow {"fields":["[0,2)","{empty}"]}
+DataRow {"fields":["[1,)","{empty,\"[50,99)\"}"]}
+DataRow {"fields":["[2,)","{empty,\"[50,99)\"}"]}
+CommandComplete {"tag":"SELECT 10"}
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,2)","{\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[2,)","{\"(,)\",\"[0,)\"}"]}
+CommandComplete {"tag":"SELECT 10"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["(,2)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[2,)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+CommandComplete {"tag":"SELECT 9"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["(,2)","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,2)","{\"[50,99)\"}"]}
+DataRow {"fields":["[0,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["[0,2)","{\"[50,99)\"}"]}
+CommandComplete {"tag":"SELECT 6"}
+ParseComplete
+BindComplete
+DataRow {"fields":["[-1,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[-1,2)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[0,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[0,2)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[2,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+CommandComplete {"tag":"SELECT 6"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,2)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,)\",\"[0,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"[0,)\"}"]}
+DataRow {"fields":["[2,)","{\"(,)\",\"[0,)\"}"]}
+CommandComplete {"tag":"SELECT 9"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,2)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,2)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[0,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[0,2)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+DataRow {"fields":["[2,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"[0,)\"}"]}
+CommandComplete {"tag":"SELECT 9"}
+ParseComplete
+BindComplete
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-1,1)\"}"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+send
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a @> v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a <@ v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a && v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a << v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a >> v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a &< v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a &> v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Parse {"query": "SELECT a::text t, array_agg(v::text ORDER BY v) FROM ( SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL ) numrange_values(a), numrange_test_values WHERE a -|- v GROUP BY a ORDER BY a;"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","{empty}"]}
+DataRow {"fields":["(,1)","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,1]","{empty,\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(,)","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{empty,\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,1]","{empty,\"[-1,1)\"}"]}
+DataRow {"fields":["(-1,1)","{empty}"]}
+DataRow {"fields":["(-1,1]","{empty}"]}
+DataRow {"fields":["[0,0]","{empty}"]}
+DataRow {"fields":["[1,)","{empty,\"[50,99)\"}"]}
+DataRow {"fields":["(1,)","{empty,\"[50,99)\"}"]}
+CommandComplete {"tag":"SELECT 11"}
+ParseComplete
+BindComplete
+DataRow {"fields":["empty","{empty,\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,1]","{\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["(1,)","{\"(,)\",\"(-1,)\"}"]}
+CommandComplete {"tag":"SELECT 11"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(,1]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(1,)","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+CommandComplete {"tag":"SELECT 10"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["(,1]","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1]","{\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1)","{\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1]","{\"[50,99)\"}"]}
+DataRow {"fields":["[0,0]","{\"[50,99)\"}"]}
+CommandComplete {"tag":"SELECT 7"}
+ParseComplete
+BindComplete
+DataRow {"fields":["[-1,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[-1,1]","{\"[-99,-50)\"}"]}
+DataRow {"fields":["(-1,1)","{\"[-99,-50)\"}"]}
+DataRow {"fields":["(-1,1]","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[0,0]","{\"[-99,-50)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(1,)","{\"(,1)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+CommandComplete {"tag":"SELECT 7"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,1]","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(,)","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-1,1)\",\"(-1,)\",\"[50,99)\"}"]}
+DataRow {"fields":["[1,)","{\"(,)\",\"(-1,)\"}"]}
+DataRow {"fields":["(1,)","{\"(,)\",\"(-1,)\"}"]}
+CommandComplete {"tag":"SELECT 10"}
+ParseComplete
+BindComplete
+DataRow {"fields":["(,1)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,1]","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["(,)","{\"(,1)\",\"(,)\"}"]}
+DataRow {"fields":["[-1,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["[-1,1]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\"}"]}
+DataRow {"fields":["(-1,1)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(-1,1]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[0,0]","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["[1,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+DataRow {"fields":["(1,)","{\"(,1)\",\"(,)\",\"[-99,-50)\",\"[-1,1)\",\"(-1,)\"}"]}
+CommandComplete {"tag":"SELECT 10"}
+ParseComplete
+BindComplete
+DataRow {"fields":["[1,)","{\"(,1)\",\"[-1,1)\"}"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -643,155 +643,202 @@ select '(,)'::int4range <= 'empty'::int4range;
 ----
 false
 
-# Results from PG
-# (,) true true true
-# [0,1) false true false
-# [0,2) false true true
-# (,1) true true false
-# [1,) false false true
-# [-1,1) true true false
-# [-1,2) true true true
-# (,2) true true true
-# [2,) false false false
-# empty false false false
-# Note that the predicate also ensures equality between @> and <@
-query TTTT
-SELECT
-	DISTINCT
-	a::STRING,
-	a @> -1 AS contains_neg_1,
-	a @> 0 AS contains_0,
-	a @> 1 AS contains_1
-FROM
-	int4range_values
-WHERE
-	(a @> -1 = -1 <@ a)
-	AND (a @> 0 = 0 <@ a)
-	AND (a @> 1 = 1 <@ a)
-ORDER BY
-	a;
-----
-(,)
-true
-true
-true
-(,1)
-true
-true
-false
-(,2)
-true
-true
-true
-[-1,1)
-true
-true
-false
-[-1,2)
-true
-true
-true
-[0,1)
-false
-true
-false
-[0,2)
-false
-true
-true
-[1,)
-false
-false
-true
-[2,)
-false
-false
-false
-empty
-false
-false
-false
+statement ok
+CREATE TABLE int4range_test_values (v int4range);
 
-query TTTTTT
-SELECT
-        DISTINCT
-        a::text,
-        a @> 'empty'::int4range AS contains_empty,
-        a @> '(,)'::int4range AS contains_all,
-        a @> '(,1)'::int4range AS contains_neg_inf_1,
-        a @> '(-1,)'::int4range AS contains_neg_1_inf,
-        a @> '[-1,1)'::int4range AS contains_neg_1_1
-FROM
-        int4range_values
-WHERE
-        (a @> 'empty'::int4range = 'empty'::int4range <@ a)
-        AND (a @> '(,)'::int4range = '(,)'::int4range <@ a)
-        AND (a @> '(,1)'::int4range = '(,1)'::int4range <@ a)
-        AND (a @> '(-1,)'::int4range = '(-1,)'::int4range <@ a)
-        AND (a @> '[-1,1)'::int4range = '[-1,1)'::int4range <@ a)
-ORDER BY
-        a;
+statement ok
+INSERT INTO int4range_test_values VALUES ('empty'),
+('(,)'),
+('(,1)'),
+('(-1,)'),
+('[-1,1)'),
+('[-99,-50)'),
+('[50,99)');
+
+#
+# int4range contains
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a @> v GROUP BY a ORDER BY a;
 ----
-(,)
-true
-true
-true
-true
-true
-(,1)
-true
-false
-true
-false
-true
-(,2)
-true
-false
-true
-false
-true
-[-1,1)
-true
-false
-false
-false
-true
-[-1,2)
-true
-false
-false
-false
-true
-[0,1)
-true
-false
-false
-false
-false
-[0,2)
-true
-false
-false
-false
-false
-[1,)
-true
-false
-false
-false
-false
-[2,)
-true
-false
-false
-false
-false
 empty
-true
-false
-false
-false
-false
+{empty}
+(,1)
+{empty,"(,1)","[-99,-50)","[-1,1)"}
+(,2)
+{empty,"(,1)","[-99,-50)","[-1,1)"}
+(,)
+{empty,"(,1)","(,)","[-99,-50)","[-1,1)","[0,)","[50,99)"}
+[-1,1)
+{empty,"[-1,1)"}
+[-1,2)
+{empty,"[-1,1)"}
+[0,1)
+{empty}
+[0,2)
+{empty}
+[1,)
+{empty,"[50,99)"}
+[2,)
+{empty,"[50,99)"}
+
+#
+# int4range contained by
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a <@ v GROUP BY a ORDER BY a;
+----
+empty
+{empty,"(,1)","(,)","[-99,-50)","[-1,1)","[0,)","[50,99)"}
+(,1)
+{"(,1)","(,)"}
+(,2)
+{"(,)"}
+(,)
+{"(,)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)"}
+[-1,2)
+{"(,)"}
+[0,1)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[0,2)
+{"(,)","[0,)"}
+[1,)
+{"(,)","[0,)"}
+[2,)
+{"(,)","[0,)"}
+
+#
+# int4range contained overlaps
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a && v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+(,2)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+(,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)","[50,99)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[-1,2)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[0,1)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[0,2)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[1,)
+{"(,)","[0,)","[50,99)"}
+[2,)
+{"(,)","[0,)","[50,99)"}
+
+#
+# int4range before
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a << v GROUP BY a ORDER BY a;
+----
+(,1)
+{"[50,99)"}
+(,2)
+{"[50,99)"}
+[-1,1)
+{"[50,99)"}
+[-1,2)
+{"[50,99)"}
+[0,1)
+{"[50,99)"}
+[0,2)
+{"[50,99)"}
+
+#
+# int4range after
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a >> v GROUP BY a ORDER BY a;
+----
+[-1,1)
+{"[-99,-50)"}
+[-1,2)
+{"[-99,-50)"}
+[0,1)
+{"[-99,-50)"}
+[0,2)
+{"[-99,-50)"}
+[1,)
+{"(,1)","[-99,-50)","[-1,1)"}
+[2,)
+{"(,1)","[-99,-50)","[-1,1)"}
+
+#
+# int4range overleft
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a &< v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)","[-1,1)","[0,)","[50,99)"}
+(,2)
+{"(,)","[0,)","[50,99)"}
+(,)
+{"(,)","[0,)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)","[0,)","[50,99)"}
+[-1,2)
+{"(,)","[0,)","[50,99)"}
+[0,1)
+{"(,1)","(,)","[-1,1)","[0,)","[50,99)"}
+[0,2)
+{"(,)","[0,)","[50,99)"}
+[1,)
+{"(,)","[0,)"}
+[2,)
+{"(,)","[0,)"}
+
+#
+# int4range overright
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a &> v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)"}
+(,2)
+{"(,1)","(,)"}
+(,)
+{"(,1)","(,)"}
+[-1,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)"}
+[-1,2)
+{"(,1)","(,)","[-99,-50)","[-1,1)"}
+[0,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+[0,2)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+[1,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+[2,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+
+#
+# int4range adjacent
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int4range_values WHERE a IS NOT NULL
+) int4range_values(a), int4range_test_values WHERE a -|- v GROUP BY a ORDER BY a;
+----
+[1,)
+{"(,1)","[-1,1)"}
+
 
 #
 # int8range
@@ -1364,155 +1411,202 @@ select '(,)'::int8range <= 'empty'::int8range;
 ----
 false
 
-# Results from PG
-# (,) true true true
-# [0,1) false true false
-# [0,2) false true true
-# (,1) true true false
-# [1,) false false true
-# [-1,1) true true false
-# [-1,2) true true true
-# (,2) true true true
-# [2,) false false false
-# empty false false false
-# Note that the predicate also ensures equality between @> and <@
-query TTTT
-SELECT
-	DISTINCT
-	a::STRING,
-	-1 <@ a AS contains_neg_1,
-	a @> 0 AS contains_0,
-	a @> 1 AS contains_1
-FROM
-	int8range_values
-WHERE
-	(a @> -1 = -1 <@ a)
-	AND (a @> 0 = 0 <@ a)
-	AND (a @> 1 = 1 <@ a)
-ORDER BY
-	a;
-----
-(,)
-true
-true
-true
-(,1)
-true
-true
-false
-(,2)
-true
-true
-true
-[-1,1)
-true
-true
-false
-[-1,2)
-true
-true
-true
-[0,1)
-false
-true
-false
-[0,2)
-false
-true
-true
-[1,)
-false
-false
-true
-[2,)
-false
-false
-false
-empty
-false
-false
-false
+statement ok
+CREATE TABLE int8range_test_values (v int8range);
 
-query TTTTTT
-SELECT
-        DISTINCT
-        a::text,
-        a @> 'empty'::int8range AS contains_empty,
-        a @> '(,)'::int8range AS contains_all,
-        a @> '(,1)'::int8range AS contains_neg_inf_1,
-        a @> '(-1,)'::int8range AS contains_neg_1_inf,
-        a @> '[-1,1)'::int8range AS contains_neg_1_1
-FROM
-        int8range_values
-WHERE
-        (a @> 'empty'::int8range = 'empty'::int8range <@ a)
-        AND (a @> '(,)'::int8range = '(,)'::int8range <@ a)
-        AND (a @> '(,1)'::int8range = '(,1)'::int8range <@ a)
-        AND (a @> '(-1,)'::int8range = '(-1,)'::int8range <@ a)
-        AND (a @> '[-1,1)'::int8range = '[-1,1)'::int8range <@ a)
-ORDER BY
-        a;
+statement ok
+INSERT INTO int8range_test_values VALUES ('empty'),
+('(,)'),
+('(,1)'),
+('(-1,)'),
+('[-1,1)'),
+('[-99,-50)'),
+('[50,99)');
+
+#
+# int8range contains
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a @> v GROUP BY a ORDER BY a;
 ----
-(,)
-true
-true
-true
-true
-true
-(,1)
-true
-false
-true
-false
-true
-(,2)
-true
-false
-true
-false
-true
-[-1,1)
-true
-false
-false
-false
-true
-[-1,2)
-true
-false
-false
-false
-true
-[0,1)
-true
-false
-false
-false
-false
-[0,2)
-true
-false
-false
-false
-false
-[1,)
-true
-false
-false
-false
-false
-[2,)
-true
-false
-false
-false
-false
 empty
-true
-false
-false
-false
-false
+{empty}
+(,1)
+{empty,"(,1)","[-99,-50)","[-1,1)"}
+(,2)
+{empty,"(,1)","[-99,-50)","[-1,1)"}
+(,)
+{empty,"(,1)","(,)","[-99,-50)","[-1,1)","[0,)","[50,99)"}
+[-1,1)
+{empty,"[-1,1)"}
+[-1,2)
+{empty,"[-1,1)"}
+[0,1)
+{empty}
+[0,2)
+{empty}
+[1,)
+{empty,"[50,99)"}
+[2,)
+{empty,"[50,99)"}
+
+#
+# int8range contained by
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a <@ v GROUP BY a ORDER BY a;
+----
+empty
+{empty,"(,1)","(,)","[-99,-50)","[-1,1)","[0,)","[50,99)"}
+(,1)
+{"(,1)","(,)"}
+(,2)
+{"(,)"}
+(,)
+{"(,)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)"}
+[-1,2)
+{"(,)"}
+[0,1)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[0,2)
+{"(,)","[0,)"}
+[1,)
+{"(,)","[0,)"}
+[2,)
+{"(,)","[0,)"}
+
+#
+# int8range overlaps
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a && v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+(,2)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+(,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)","[50,99)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[-1,2)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[0,1)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[0,2)
+{"(,1)","(,)","[-1,1)","[0,)"}
+[1,)
+{"(,)","[0,)","[50,99)"}
+[2,)
+{"(,)","[0,)","[50,99)"}
+
+#
+# int8range before
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a << v GROUP BY a ORDER BY a;
+----
+(,1)
+{"[50,99)"}
+(,2)
+{"[50,99)"}
+[-1,1)
+{"[50,99)"}
+[-1,2)
+{"[50,99)"}
+[0,1)
+{"[50,99)"}
+[0,2)
+{"[50,99)"}
+
+#
+# int8range after
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a >> v GROUP BY a ORDER BY a;
+----
+[-1,1)
+{"[-99,-50)"}
+[-1,2)
+{"[-99,-50)"}
+[0,1)
+{"[-99,-50)"}
+[0,2)
+{"[-99,-50)"}
+[1,)
+{"(,1)","[-99,-50)","[-1,1)"}
+[2,)
+{"(,1)","[-99,-50)","[-1,1)"}
+
+#
+# int8range overleft
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a &< v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)","[-1,1)","[0,)","[50,99)"}
+(,2)
+{"(,)","[0,)","[50,99)"}
+(,)
+{"(,)","[0,)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)","[0,)","[50,99)"}
+[-1,2)
+{"(,)","[0,)","[50,99)"}
+[0,1)
+{"(,1)","(,)","[-1,1)","[0,)","[50,99)"}
+[0,2)
+{"(,)","[0,)","[50,99)"}
+[1,)
+{"(,)","[0,)"}
+[2,)
+{"(,)","[0,)"}
+
+#
+# int8range overright
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a &> v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)"}
+(,2)
+{"(,1)","(,)"}
+(,)
+{"(,1)","(,)"}
+[-1,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)"}
+[-1,2)
+{"(,1)","(,)","[-99,-50)","[-1,1)"}
+[0,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+[0,2)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+[1,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+[2,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","[0,)"}
+
+#
+# int8range adjacent
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM int8range_values WHERE a IS NOT NULL
+) int8range_values(a), int8range_test_values WHERE a -|- v GROUP BY a ORDER BY a;
+----
+[1,)
+{"(,1)","[-1,1)"}
+
 
 #
 # daterange
@@ -2029,144 +2123,192 @@ select '(,)'::daterange <= 'empty'::daterange;
 ----
 false
 
-# Results from PG
-# (,)|t|t|t
-# [1969-12-31,1970-01-01)|t|f|f
-# [1969-12-31,1970-01-02)|t|t|f
-# (,1970-01-01)|t|f|f
-# [1970-01-01,)|f|t|t
-# [1970-01-01,1970-01-02)|f|t|f
-# (,1970-01-02)|t|t|f
-# [1970-01-02,)|f|f|t
-# empty|f|f|f
-# Note that the predicate also ensures equality between @> and <@
-query TTTT
-SELECT
-	DISTINCT
-	a::text,
-	a @> DATE '1969-12-31' AS contains_neg_1,
-	a @> DATE '1970-01-01' AS contains_0,
-	a @> DATE '1970-01-02' AS contains_1
-FROM
-	daterange_values
-WHERE
-	(a @> DATE '1969-12-31' = DATE '1969-12-31' <@ a)
-	AND (a @> DATE '1970-01-01' = DATE '1970-01-01' <@ a)
-	AND (a @> DATE '1970-01-02' = DATE '1970-01-02' <@ a)
-ORDER BY
-	a;
-----
-(,)
-true
-true
-true
-(,1970-01-01)
-true
-false
-false
-(,1970-01-02)
-true
-true
-false
-[1969-12-31,1970-01-01)
-true
-false
-false
-[1969-12-31,1970-01-02)
-true
-true
-false
-[1970-01-01,)
-false
-true
-true
-[1970-01-01,1970-01-02)
-false
-true
-false
-[1970-01-02,)
-false
-false
-true
-empty
-false
-false
-false
+statement ok
+CREATE TABLE daterange_test_values (v daterange);
 
-query TTTTTT
-SELECT
-        DISTINCT
-        a::text,
-        a @> 'empty'::daterange AS contains_empty,
-        a @> '(,)'::daterange AS contains_all,
-        a @> '(,1970-01-02)'::daterange AS contains_neg_inf_1,
-        a @> '(1969-12-31,)'::daterange AS contains_neg_1_inf,
-        a @> '[1969-12-31,1970-01-02)'::daterange AS contains_neg_1_1
-FROM
-        daterange_values
-WHERE
-        (a @> 'empty'::daterange = 'empty'::daterange <@ a)
-        AND (a @> '(,)'::daterange = '(,)'::daterange <@ a)
-        AND (a @> '(,1970-01-02)'::daterange = '(,1970-01-02)'::daterange <@ a)
-        AND (a @> '(1969-12-31,)'::daterange = '(1969-12-31,)'::daterange <@ a)
-        AND (a @> '[1969-12-31,1970-01-02)'::daterange = '[1969-12-31,1970-01-02)'::daterange <@ a)
-ORDER BY
-        a;
+statement ok
+INSERT INTO daterange_test_values VALUES ('empty'),
+('(,)'),
+('(,1970-01-02)'),
+('(1969-12-31,)'),
+('[1969-12-31,1970-01-02)'),
+('[1969-01-01,1969-01-02)'),
+('[1971-01-01,1971-01-02)');
+
+#
+# daterange contains
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a @> v GROUP BY a ORDER BY a;
 ----
-(,)
-true
-true
-true
-true
-true
-(,1970-01-01)
-true
-false
-false
-false
-false
-(,1970-01-02)
-true
-false
-true
-false
-true
-[1969-12-31,1970-01-01)
-true
-false
-false
-false
-false
-[1969-12-31,1970-01-02)
-true
-false
-false
-false
-true
-[1970-01-01,)
-true
-false
-false
-true
-false
-[1970-01-01,1970-01-02)
-true
-false
-false
-false
-false
-[1970-01-02,)
-true
-false
-false
-false
-false
 empty
-true
-false
-false
-false
-false
+{empty}
+(,1970-01-01)
+{empty,"[1969-01-01,1969-01-02)"}
+(,1970-01-02)
+{empty,"(,1970-01-02)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)"}
+(,)
+{empty,"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1969-12-31,1970-01-01)
+{empty}
+[1969-12-31,1970-01-02)
+{empty,"[1969-12-31,1970-01-02)"}
+[1970-01-01,1970-01-02)
+{empty}
+[1970-01-01,)
+{empty,"[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1970-01-02,)
+{empty,"[1971-01-01,1971-01-02)"}
+
+#
+# daterange contained by
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a <@ v GROUP BY a ORDER BY a;
+----
+empty
+{empty,"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+(,1970-01-01)
+{"(,1970-01-02)","(,)"}
+(,1970-01-02)
+{"(,1970-01-02)","(,)"}
+(,)
+{"(,)"}
+[1969-12-31,1970-01-01)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)"}
+[1969-12-31,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)"}
+[1970-01-01,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+[1970-01-01,)
+{"(,)","[1970-01-01,)"}
+[1970-01-02,)
+{"(,)","[1970-01-01,)"}
+
+#
+# daterange overlaps
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a && v GROUP BY a ORDER BY a;
+----
+(,1970-01-01)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)"}
+(,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+(,)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1969-12-31,1970-01-01)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)"}
+[1969-12-31,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+[1970-01-01,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+[1970-01-01,)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1970-01-02,)
+{"(,)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+
+#
+# daterange before
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a << v GROUP BY a ORDER BY a;
+----
+(,1970-01-01)
+{"[1970-01-01,)","[1971-01-01,1971-01-02)"}
+(,1970-01-02)
+{"[1971-01-01,1971-01-02)"}
+[1969-12-31,1970-01-01)
+{"[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1969-12-31,1970-01-02)
+{"[1971-01-01,1971-01-02)"}
+[1970-01-01,1970-01-02)
+{"[1971-01-01,1971-01-02)"}
+
+#
+# daterange after
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a >> v GROUP BY a ORDER BY a;
+----
+[1969-12-31,1970-01-01)
+{"[1969-01-01,1969-01-02)"}
+[1969-12-31,1970-01-02)
+{"[1969-01-01,1969-01-02)"}
+[1970-01-01,1970-01-02)
+{"[1969-01-01,1969-01-02)"}
+[1970-01-01,)
+{"[1969-01-01,1969-01-02)"}
+[1970-01-02,)
+{"(,1970-01-02)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)"}
+
+#
+# daterange overleft
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a &< v GROUP BY a ORDER BY a;
+----
+(,1970-01-01)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+(,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+(,)
+{"(,)","[1970-01-01,)"}
+[1969-12-31,1970-01-01)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1969-12-31,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1970-01-01,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-12-31,1970-01-02)","[1970-01-01,)","[1971-01-01,1971-01-02)"}
+[1970-01-01,)
+{"(,)","[1970-01-01,)"}
+[1970-01-02,)
+{"(,)","[1970-01-01,)"}
+
+#
+# daterange overright
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a &> v GROUP BY a ORDER BY a;
+----
+(,1970-01-01)
+{"(,1970-01-02)","(,)"}
+(,1970-01-02)
+{"(,1970-01-02)","(,)"}
+(,)
+{"(,1970-01-02)","(,)"}
+[1969-12-31,1970-01-01)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)"}
+[1969-12-31,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)"}
+[1970-01-01,1970-01-02)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+[1970-01-01,)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+[1970-01-02,)
+{"(,1970-01-02)","(,)","[1969-01-01,1969-01-02)","[1969-12-31,1970-01-02)","[1970-01-01,)"}
+
+#
+# daterange adjacent
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM daterange_values WHERE a IS NOT NULL
+) daterange_values(a), daterange_test_values WHERE a -|- v GROUP BY a ORDER BY a;
+----
+(,1970-01-01)
+{"[1970-01-01,)"}
+[1969-12-31,1970-01-01)
+{"[1970-01-01,)"}
+[1970-01-02,)
+{"(,1970-01-02)","[1969-12-31,1970-01-02)"}
+
 
 #
 # numrange
@@ -2788,166 +2930,217 @@ select '(,)'::numrange <= 'empty'::numrange;
 ----
 false
 
-# Results from PG
-# (,)|t|t|t
-# [0,0]|f|t|f
-# (,1)|t|t|f
-# (,1]|t|t|t
-# (1,)|f|f|f
-# [1,)|f|f|t
-# (-1,1)|f|t|f
-# (-1,1]|f|t|t
-# [-1,1)|t|t|f
-# [-1,1]|t|t|t
-# empty|f|f|f
-# Note that the predicate also ensures equality between @> and <@
-query TTTT
-SELECT
-	DISTINCT
-	a::TEXT,
-	a @> -1::numeric AS contains_neg_1,
-	a @> 0::numeric AS contains_0,
-	a @> 1::numeric AS contains_1
-FROM
-	numrange_values
-WHERE
-	(a @> -1::numeric = -1::numeric <@ a)
-	AND (a @> 0::numeric = 0::numeric <@ a)
-	AND (a @> 1::numeric = 1::numeric <@ a)
-ORDER BY
-	a;
-----
-(,)
-true
-true
-true
-(,1)
-true
-true
-false
-(,1]
-true
-true
-true
-(-1,1)
-false
-true
-false
-(-1,1]
-false
-true
-true
-(1,)
-false
-false
-false
-[-1,1)
-true
-true
-false
-[-1,1]
-true
-true
-true
-[0,0]
-false
-true
-false
-[1,)
-false
-false
-true
-empty
-false
-false
-false
+statement ok
+CREATE TABLE numrange_test_values (v numrange);
 
-query TTTTTT
-SELECT
-        DISTINCT
-        a::text,
-        a @> 'empty'::numrange AS contains_empty,
-        a @> '(,)'::numrange AS contains_all,
-        a @> '(,1)'::numrange AS contains_neg_inf_1,
-        a @> '(-1,)'::numrange AS contains_neg_1_inf,
-        a @> '[-1,1)'::numrange AS contains_neg_1_1
-FROM
-        numrange_values
-WHERE
-        (a @> 'empty'::numrange = 'empty'::numrange <@ a)
-        AND (a @> '(,)'::numrange = '(,)'::numrange <@ a)
-        AND (a @> '(,1)'::numrange = '(,1)'::numrange <@ a)
-        AND (a @> '(-1,)'::numrange = '(-1,)'::numrange <@ a)
-        AND (a @> '[-1,1)'::numrange = '[-1,1)'::numrange <@ a)
-ORDER BY
-        a;
+statement ok
+INSERT INTO numrange_test_values VALUES
+('empty'),
+('(,)'),
+('(,1)'),
+('(-1,)'),
+('[-1,1)'),
+('[-99,-50)'),
+('[50,99)');
+
+#
+# numrange contains
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a @> v GROUP BY a ORDER BY a;
 ----
-(,)
-true
-true
-true
-true
-true
-(,1)
-true
-false
-true
-false
-true
-(,1]
-true
-false
-true
-false
-true
-(-1,1)
-true
-false
-false
-false
-false
-(-1,1]
-true
-false
-false
-false
-false
-(1,)
-true
-false
-false
-false
-false
-[-1,1)
-true
-false
-false
-false
-true
-[-1,1]
-true
-false
-false
-false
-true
-[0,0]
-true
-false
-false
-false
-false
-[1,)
-true
-false
-false
-false
-false
 empty
-true
-false
-false
-false
-false
+{empty}
+(,1)
+{empty,"(,1)","[-99,-50)","[-1,1)"}
+(,1]
+{empty,"(,1)","[-99,-50)","[-1,1)"}
+(,)
+{empty,"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)","[50,99)"}
+[-1,1)
+{empty,"[-1,1)"}
+[-1,1]
+{empty,"[-1,1)"}
+(-1,1)
+{empty}
+(-1,1]
+{empty}
+[0,0]
+{empty}
+[1,)
+{empty,"[50,99)"}
+(1,)
+{empty,"[50,99)"}
+
+#
+# numrange contained by
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a <@ v GROUP BY a ORDER BY a;
+----
+empty
+{empty,"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)","[50,99)"}
+(,1)
+{"(,1)","(,)"}
+(,1]
+{"(,)"}
+(,)
+{"(,)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)"}
+[-1,1]
+{"(,)"}
+(-1,1)
+{"(,1)","(,)","[-1,1)","(-1,)"}
+(-1,1]
+{"(,)","(-1,)"}
+[0,0]
+{"(,1)","(,)","[-1,1)","(-1,)"}
+[1,)
+{"(,)","(-1,)"}
+(1,)
+{"(,)","(-1,)"}
+
+#
+# numrange overlaps
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a && v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+(,1]
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+(,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)","[50,99)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)","(-1,)"}
+[-1,1]
+{"(,1)","(,)","[-1,1)","(-1,)"}
+(-1,1)
+{"(,1)","(,)","[-1,1)","(-1,)"}
+(-1,1]
+{"(,1)","(,)","[-1,1)","(-1,)"}
+[0,0]
+{"(,1)","(,)","[-1,1)","(-1,)"}
+[1,)
+{"(,)","(-1,)","[50,99)"}
+(1,)
+{"(,)","(-1,)","[50,99)"}
+
+#
+# numrange before
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a << v GROUP BY a ORDER BY a;
+----
+(,1)
+{"[50,99)"}
+(,1]
+{"[50,99)"}
+[-1,1)
+{"[50,99)"}
+[-1,1]
+{"[50,99)"}
+(-1,1)
+{"[50,99)"}
+(-1,1]
+{"[50,99)"}
+[0,0]
+{"[50,99)"}
+
+#
+# numrange after
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a >> v GROUP BY a ORDER BY a;
+----
+[-1,1)
+{"[-99,-50)"}
+[-1,1]
+{"[-99,-50)"}
+(-1,1)
+{"[-99,-50)"}
+(-1,1]
+{"[-99,-50)"}
+[0,0]
+{"[-99,-50)"}
+[1,)
+{"(,1)","[-99,-50)","[-1,1)"}
+(1,)
+{"(,1)","[-99,-50)","[-1,1)"}
+
+#
+# numrange overleft
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a &< v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)","[-1,1)","(-1,)","[50,99)"}
+(,1]
+{"(,)","(-1,)","[50,99)"}
+(,)
+{"(,)","(-1,)"}
+[-1,1)
+{"(,1)","(,)","[-1,1)","(-1,)","[50,99)"}
+[-1,1]
+{"(,)","(-1,)","[50,99)"}
+(-1,1)
+{"(,1)","(,)","[-1,1)","(-1,)","[50,99)"}
+(-1,1]
+{"(,)","(-1,)","[50,99)"}
+[0,0]
+{"(,1)","(,)","[-1,1)","(-1,)","[50,99)"}
+[1,)
+{"(,)","(-1,)"}
+(1,)
+{"(,)","(-1,)"}
+
+#
+# numrange overright
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a &> v GROUP BY a ORDER BY a;
+----
+(,1)
+{"(,1)","(,)"}
+(,1]
+{"(,1)","(,)"}
+(,)
+{"(,1)","(,)"}
+[-1,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)"}
+[-1,1]
+{"(,1)","(,)","[-99,-50)","[-1,1)"}
+(-1,1)
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+(-1,1]
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+[0,0]
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+[1,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+(1,)
+{"(,1)","(,)","[-99,-50)","[-1,1)","(-1,)"}
+
+#
+# numrange adjacent
+query TT
+SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
+    SELECT DISTINCT a FROM numrange_values WHERE a IS NOT NULL
+) numrange_values(a), numrange_test_values WHERE a -|- v GROUP BY a ORDER BY a;
+----
+[1,)
+{"(,1)","[-1,1)"}
+
 
 query T
 SELECT '[1.1,1.1]'::numrange::text;

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -712,6 +712,87 @@ false
 false
 false
 
+query TTTTTT
+SELECT
+        DISTINCT
+        a::text,
+        a @> 'empty'::int4range AS contains_empty,
+        a @> '(,)'::int4range AS contains_all,
+        a @> '(,1)'::int4range AS contains_neg_inf_1,
+        a @> '(-1,)'::int4range AS contains_neg_1_inf,
+        a @> '[-1,1)'::int4range AS contains_neg_1_1
+FROM
+        int4range_values
+WHERE
+        (a @> 'empty'::int4range = 'empty'::int4range <@ a)
+        AND (a @> '(,)'::int4range = '(,)'::int4range <@ a)
+        AND (a @> '(,1)'::int4range = '(,1)'::int4range <@ a)
+        AND (a @> '(-1,)'::int4range = '(-1,)'::int4range <@ a)
+        AND (a @> '[-1,1)'::int4range = '[-1,1)'::int4range <@ a)
+ORDER BY
+        a;
+----
+(,)
+true
+true
+true
+true
+true
+(,1)
+true
+false
+true
+false
+true
+(,2)
+true
+false
+true
+false
+true
+[-1,1)
+true
+false
+false
+false
+true
+[-1,2)
+true
+false
+false
+false
+true
+[0,1)
+true
+false
+false
+false
+false
+[0,2)
+true
+false
+false
+false
+false
+[1,)
+true
+false
+false
+false
+false
+[2,)
+true
+false
+false
+false
+false
+empty
+true
+false
+false
+false
+false
+
 #
 # int8range
 
@@ -1352,6 +1433,87 @@ false
 false
 false
 
+query TTTTTT
+SELECT
+        DISTINCT
+        a::text,
+        a @> 'empty'::int8range AS contains_empty,
+        a @> '(,)'::int8range AS contains_all,
+        a @> '(,1)'::int8range AS contains_neg_inf_1,
+        a @> '(-1,)'::int8range AS contains_neg_1_inf,
+        a @> '[-1,1)'::int8range AS contains_neg_1_1
+FROM
+        int8range_values
+WHERE
+        (a @> 'empty'::int8range = 'empty'::int8range <@ a)
+        AND (a @> '(,)'::int8range = '(,)'::int8range <@ a)
+        AND (a @> '(,1)'::int8range = '(,1)'::int8range <@ a)
+        AND (a @> '(-1,)'::int8range = '(-1,)'::int8range <@ a)
+        AND (a @> '[-1,1)'::int8range = '[-1,1)'::int8range <@ a)
+ORDER BY
+        a;
+----
+(,)
+true
+true
+true
+true
+true
+(,1)
+true
+false
+true
+false
+true
+(,2)
+true
+false
+true
+false
+true
+[-1,1)
+true
+false
+false
+false
+true
+[-1,2)
+true
+false
+false
+false
+true
+[0,1)
+true
+false
+false
+false
+false
+[0,2)
+true
+false
+false
+false
+false
+[1,)
+true
+false
+false
+false
+false
+[2,)
+true
+false
+false
+false
+false
+empty
+true
+false
+false
+false
+false
+
 #
 # daterange
 
@@ -1927,6 +2089,81 @@ false
 false
 true
 empty
+false
+false
+false
+
+query TTTTTT
+SELECT
+        DISTINCT
+        a::text,
+        a @> 'empty'::daterange AS contains_empty,
+        a @> '(,)'::daterange AS contains_all,
+        a @> '(,1970-01-02)'::daterange AS contains_neg_inf_1,
+        a @> '(1969-12-31,)'::daterange AS contains_neg_1_inf,
+        a @> '[1969-12-31,1970-01-02)'::daterange AS contains_neg_1_1
+FROM
+        daterange_values
+WHERE
+        (a @> 'empty'::daterange = 'empty'::daterange <@ a)
+        AND (a @> '(,)'::daterange = '(,)'::daterange <@ a)
+        AND (a @> '(,1970-01-02)'::daterange = '(,1970-01-02)'::daterange <@ a)
+        AND (a @> '(1969-12-31,)'::daterange = '(1969-12-31,)'::daterange <@ a)
+        AND (a @> '[1969-12-31,1970-01-02)'::daterange = '[1969-12-31,1970-01-02)'::daterange <@ a)
+ORDER BY
+        a;
+----
+(,)
+true
+true
+true
+true
+true
+(,1970-01-01)
+true
+false
+false
+false
+false
+(,1970-01-02)
+true
+false
+true
+false
+true
+[1969-12-31,1970-01-01)
+true
+false
+false
+false
+false
+[1969-12-31,1970-01-02)
+true
+false
+false
+false
+true
+[1970-01-01,)
+true
+false
+false
+true
+false
+[1970-01-01,1970-01-02)
+true
+false
+false
+false
+false
+[1970-01-02,)
+true
+false
+false
+false
+false
+empty
+true
+false
 false
 false
 false
@@ -2621,6 +2858,93 @@ false
 false
 true
 empty
+false
+false
+false
+
+query TTTTTT
+SELECT
+        DISTINCT
+        a::text,
+        a @> 'empty'::numrange AS contains_empty,
+        a @> '(,)'::numrange AS contains_all,
+        a @> '(,1)'::numrange AS contains_neg_inf_1,
+        a @> '(-1,)'::numrange AS contains_neg_1_inf,
+        a @> '[-1,1)'::numrange AS contains_neg_1_1
+FROM
+        numrange_values
+WHERE
+        (a @> 'empty'::numrange = 'empty'::numrange <@ a)
+        AND (a @> '(,)'::numrange = '(,)'::numrange <@ a)
+        AND (a @> '(,1)'::numrange = '(,1)'::numrange <@ a)
+        AND (a @> '(-1,)'::numrange = '(-1,)'::numrange <@ a)
+        AND (a @> '[-1,1)'::numrange = '[-1,1)'::numrange <@ a)
+ORDER BY
+        a;
+----
+(,)
+true
+true
+true
+true
+true
+(,1)
+true
+false
+true
+false
+true
+(,1]
+true
+false
+true
+false
+true
+(-1,1)
+true
+false
+false
+false
+false
+(-1,1]
+true
+false
+false
+false
+false
+(1,)
+true
+false
+false
+false
+false
+[-1,1)
+true
+false
+false
+false
+true
+[-1,1]
+true
+false
+false
+false
+true
+[0,0]
+true
+false
+false
+false
+false
+[1,)
+true
+false
+false
+false
+false
+empty
+true
+false
 false
 false
 false


### PR DESCRIPTION
Implements a set of binary functions for range types.

Note that there are no docs for the `range` type yet (#17340), so not including a release note is intentional.

### Motivation

This PR adds a known-desirable feature.

### Tips for reviewer

@mjibson I added PG tests here because these tests' output is hard for a human to parse; this is meant to ensure that our implementation lines up with PG but that seems like an uncommon/unexpected use of these tests. Is that something you're OK with?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
