### PR TITLE
Add "role" labels to cluster replicas

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -152,6 +152,14 @@ class MaterializeApplication(Application):
         super().create()
         wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
 
+    def wait_replicas(self) -> None:
+        # NOTE[btv] - This will need to change if the order of
+        # creating clusters/replicas changes, but it seemed fine to
+        # assume this order, since we already assume it in `create`.
+        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-2-0")
+        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-3-0")
+
     def wait_for_sql(self) -> None:
         """Wait until environmentd pod is ready and can accept SQL connections"""
         wait(condition="condition=Ready", resource="pod/environmentd-0")

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -19,6 +19,7 @@ use anyhow::bail;
 use chrono::{DateTime, Utc};
 use futures::Future;
 use itertools::Itertools;
+use mz_controller::clusters::ReplicaRole;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -1363,6 +1364,15 @@ pub struct ClusterReplica {
 }
 
 impl ClusterReplica {
+    pub fn role(&self) -> ReplicaRole {
+        // NOTE - These roles power monitoring systems. Do not change
+        // them without talking to the cloud or observability groups.
+        match self.name.as_str() {
+            "mz_system" => ReplicaRole::SystemCritical,
+            "mz_introspection" => ReplicaRole::System,
+            _ => ReplicaRole::User,
+        }
+    }
     /// Computes the status of the cluster replica as a whole.
     pub fn status(&self) -> ClusterStatus {
         self.process_status

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -590,8 +590,9 @@ impl Coordinator {
                     .storage_ids
                     .extend(replica.config.compute.logging.source_ids());
 
+                let replica_role = replica.role();
                 self.controller
-                    .create_replica(instance.id, replica_id, replica.config)
+                    .create_replica(instance.id, replica_id, replica_role, replica.config)
                     .await?;
             }
         }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -590,9 +590,9 @@ impl Coordinator {
                     .storage_ids
                     .extend(replica.config.compute.logging.source_ids());
 
-                let replica_role = replica.role();
+                let role = instance.role();
                 self.controller
-                    .create_replica(instance.id, replica_id, replica_role, replica.config)
+                    .create_replica(instance.id, replica_id, role, replica.config)
                     .await?;
             }
         }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1061,7 +1061,7 @@ impl Coordinator {
     async fn create_cluster_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
         let cluster = self.catalog.get_cluster(cluster_id);
         let replica_config = cluster.replicas_by_id[&replica_id].config.clone();
-        let replica_role = cluster.replicas_by_id[&replica_id].role();
+        let role = cluster.role();
 
         let log_source_ids: Vec<_> = replica_config.compute.logging.source_ids().collect();
         let log_source_collections = replica_config
@@ -1078,7 +1078,7 @@ impl Coordinator {
             .unwrap();
 
         self.controller
-            .create_replica(cluster.id, replica_id, replica_role, replica_config)
+            .create_replica(cluster.id, replica_id, role, replica_config)
             .await
             .expect("creating replica must not fail");
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1061,6 +1061,7 @@ impl Coordinator {
     async fn create_cluster_replica(&mut self, cluster_id: ClusterId, replica_id: ReplicaId) {
         let cluster = self.catalog.get_cluster(cluster_id);
         let replica_config = cluster.replicas_by_id[&replica_id].config.clone();
+        let replica_role = cluster.replicas_by_id[&replica_id].role();
 
         let log_source_ids: Vec<_> = replica_config.compute.logging.source_ids().collect();
         let log_source_collections = replica_config
@@ -1077,7 +1078,7 @@ impl Coordinator {
             .unwrap();
 
         self.controller
-            .create_replica(cluster.id, replica_id, replica_config)
+            .create_replica(cluster.id, replica_id, replica_role, replica_config)
             .await
             .expect("creating replica must not fail");
 

--- a/test/cloudtest/test_labels.py
+++ b/test/cloudtest/test_labels.py
@@ -23,9 +23,9 @@ def test_roles(mz: MaterializeApplication) -> None:
     names_roles = (
         (
             item["metadata"]["name"],
-            item["metadata"]["labels"].get(
-                "cluster.environmentd.materialize.cloud/replica-role"
-            ),
+            item["metadata"]
+            .get("labels", {})
+            .get("cluster.environmentd.materialize.cloud/replica-role"),
         )
         for item in pods["items"]
     )

--- a/test/cloudtest/test_labels.py
+++ b/test/cloudtest/test_labels.py
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import json
+from textwrap import dedent
+
+from materialize.cloudtest.application import MaterializeApplication
+
+
+# NOTE [btv] - Quick and dirty hack: assume s1 is always mz_system and
+# s2 is always mz_introspection.
+#
+# This will need to be done properly (i.e., by actually looking up
+# the cluster id->name mapping in SQL) if that assumption ever changes.
+def test_roles(mz: MaterializeApplication) -> None:
+    pods = json.loads(mz.kubectl("get", "pods", "-o", "json"))
+    names_roles = (
+        (
+            item.metadata.name,
+            item.metadata.labels.get(
+                "cluster.environmentd.materialize.cloud/replica-role"
+            ),
+        )
+        for item in pods["items"]
+    )
+    for (name, role) in names_roles:
+        if name.startswith("cluster-s1"):
+            assert role == "system-critical"
+        elif name.startswith("cluster-s2"):
+            assert role == "system"
+        else:
+            assert role == "user"

--- a/test/cloudtest/test_labels.py
+++ b/test/cloudtest/test_labels.py
@@ -19,11 +19,12 @@ from materialize.cloudtest.application import MaterializeApplication
 # This will need to be done properly (i.e., by actually looking up
 # the cluster id->name mapping in SQL) if that assumption ever changes.
 def test_roles(mz: MaterializeApplication) -> None:
+    mz.wait_replicas()
     pods = json.loads(mz.kubectl("get", "pods", "-o", "json"))
     names_roles = (
         (
-            item.metadata.name,
-            item.metadata.labels.get(
+            item["metadata"]["name"],
+            item["metadata"]["labels"].get(
                 "cluster.environmentd.materialize.cloud/replica-role"
             ),
         )

--- a/test/cloudtest/test_labels.py
+++ b/test/cloudtest/test_labels.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 import json
-from textwrap import dedent
 
 from materialize.cloudtest.application import MaterializeApplication
 

--- a/test/cloudtest/test_labels.py
+++ b/test/cloudtest/test_labels.py
@@ -29,10 +29,15 @@ def test_roles(mz: MaterializeApplication) -> None:
         )
         for item in pods["items"]
     )
+    n_replica_pods = 0
     for (name, role) in names_roles:
         if name.startswith("cluster-s1"):
             assert role == "system-critical"
+            n_replica_pods += 1
         elif name.startswith("cluster-s2"):
             assert role == "system"
-        else:
+            n_replica_pods += 1
+        elif name.startswith("cluster-u"):
             assert role == "user"
+            n_replica_pods += 1
+    assert n_replica_pods >= 3


### PR DESCRIPTION
This causes Kubernetes labels to be applied to the pods in replicas, allowing us to distinguish system-managed clusters from others. The labels are `system-critical` for `mz_system`, `system` for `mz_introspection`, and `user` for everything else.