### PR TITLE
explain: replace column runs with ranges in `~ScalarExpr` sequences

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -36,7 +36,7 @@ use mz_repr::{Diff, GlobalId, RelationType, Row};
 
 use crate::client::ConnectionId;
 use crate::coord::timestamp_selection::TimestampContext;
-use crate::explain_new::Displayable;
+use crate::explain_new::{CompactScalarSeq, Displayable};
 use crate::util::send_immediate_rows;
 use crate::{AdapterError, AdapterNotice};
 
@@ -118,7 +118,7 @@ where
                     *ctx.as_mut() += 1;
                 }
                 if !map.is_empty() {
-                    let scalars = separated_text(", ", map.iter().map(Displayable::from));
+                    let scalars = CompactScalarSeq(&map);
                     writeln!(f, "{}Map ({})", ctx.as_mut(), scalars)?;
                     *ctx.as_mut() += 1;
                 }

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -27,7 +27,7 @@ use mz_ore::str::{separated, IndentLike};
 use mz_repr::explain_new::{fmt_text_constant_rows, separated_text, DisplayText};
 use mz_sql::plan::{AggregateExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
 
-use crate::explain_new::{Displayable, PlanRenderingContext};
+use crate::explain_new::{CompactScalarSeq, Displayable, PlanRenderingContext};
 
 impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
     for Displayable<'a, HirRelationExpr>
@@ -150,12 +150,12 @@ impl<'a> Displayable<'a, HirRelationExpr> {
                 ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
             }
             Map { scalars, input } => {
-                let scalars = separated_text(", ", scalars.iter().map(Displayable::from));
+                let scalars = CompactScalarSeq(scalars);
                 writeln!(f, "{}Map ({})", ctx.indent, scalars)?;
                 ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
             }
             CallTable { func, exprs } => {
-                let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                let exprs = CompactScalarSeq(exprs);
                 writeln!(f, "{}CallTable {}({})", ctx.indent, func, exprs)?;
             }
             Filter { predicates, input } => {

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -31,7 +31,7 @@ use mz_ore::str::{bracketed, separated, IndentLike, StrExt};
 use mz_repr::explain_new::{fmt_text_constant_rows, separated_text, DisplayText, ExprHumanizer};
 use mz_repr::{GlobalId, Row};
 
-use crate::explain_new::{Displayable, PlanRenderingContext};
+use crate::explain_new::{CompactScalarSeq, Displayable, PlanRenderingContext};
 
 impl<'a> DisplayText<PlanRenderingContext<'_, MirRelationExpr>>
     for Displayable<'a, MirRelationExpr>
@@ -184,7 +184,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
             Map { scalars, input } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        let scalars = separated_text(", ", scalars.iter().map(Displayable::from));
+                        let scalars = CompactScalarSeq(scalars);
                         write!(f, "{}Map ({})", ctx.indent, scalars)?;
                         self.fmt_attributes(f, ctx)
                     },
@@ -198,7 +198,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
             FlatMap { input, func, exprs } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                        let exprs = CompactScalarSeq(exprs);
                         write!(f, "{}FlatMap {}({})", ctx.indent, func, exprs)?;
                         self.fmt_attributes(f, ctx)
                     },
@@ -288,7 +288,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                         if key.is_empty() {
                             "×".to_owned()
                         } else {
-                            separated_text(", ", key.iter().map(Displayable::from)).to_string()
+                            CompactScalarSeq(key).to_string()
                         }
                     };
                     let join_order = |start_idx: usize,
@@ -390,8 +390,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
                             write!(f, "{}Distinct", ctx.indent)?;
                         }
                         if group_key.len() > 0 {
-                            let group_key =
-                                separated_text(", ", group_key.iter().map(Displayable::from));
+                            let group_key = CompactScalarSeq(group_key);
                             write!(f, " group_by=[{}]", group_key)?;
                         }
                         if aggregates.len() > 0 {
@@ -486,11 +485,7 @@ impl<'a> Displayable<'a, MirRelationExpr> {
             ArrangeBy { input, keys } => {
                 FmtNode {
                     fmt_root: |f, ctx| {
-                        let keys = separated(
-                            "], [",
-                            keys.iter()
-                                .map(|key| separated_text(", ", key.iter().map(Displayable::from))),
-                        );
+                        let keys = separated("], [", keys.iter().map(|key| CompactScalarSeq(key)));
                         write!(f, "{}ArrangeBy keys=[[{}]]", ctx.indent, keys)?;
                         self.fmt_attributes(f, ctx)
                     },

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -47,7 +47,7 @@ Explained Query:
     Threshold // { arity: 4 }
       Union // { arity: 4 }
         Negate // { arity: 4 }
-          Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
+          Distinct group_by=[#0..=#3] // { arity: 4 }
             TopK order_by=[#1 asc nulls_last] limit=10 offset=1 monotonic=false // { arity: 4 }
               Project (#0..=#2, #4) // { arity: 4 }
                 Map ((#3 + 1)) // { arity: 5 }

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -381,18 +381,18 @@ Explained Query:
         Project (#1..=#3, #10, #14) // { arity: 5 }
           Join on=(#0 = #9 AND eq(#1, #4, #7, #12) AND eq(#2, #5, #8, #13) AND eq(#3, #6, #11)) type=differential // { arity: 15 }
             implementation
-              %3:orderline[#0, #1, #2] » %2:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAlif » %1:neworder[#0, #1, #2]UKKKAlif
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+              %3:orderline[#0..=#2] » %2:order[#0..=#2]UKKKAif » %0:customer[#0..=#2]UKKKAlif » %1:neworder[#0..=#2]UKKKAlif
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Filter "A%" ~~(padchar(#9)) // { arity: 22 }
                   Get materialize.public.customer // { arity: 22 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Get materialize.public.neworder // { arity: 3 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
               Project (#0..=#4) // { arity: 5 }
                 Filter (#3) IS NOT NULL AND (date_to_timestamp(#4) > 2007-01-02 00:00:00) // { arity: 8 }
                   Get materialize.public.order // { arity: 8 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
               Project (#0..=#2, #8) // { arity: 4 }
                 Get materialize.public.orderline // { arity: 10 }
 
@@ -428,21 +428,21 @@ Explained Query:
         Project (#4) // { arity: 1 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7 AND #3 = #8) type=differential // { arity: 9 }
             implementation
-              %1[#0, #1, #2, #3] » %0:l0[#0, #1, #2, #3]UKKKKAiif
-            ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 5 }
+              %1[#0..=#3] » %0:l0[#0..=#3]UKKKKAiif
+            ArrangeBy keys=[[#0..=#3]] // { arity: 5 }
               Project (#0..=#2, #4, #6) // { arity: 5 }
                 Get l0 // { arity: 9 }
-            ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 4 }
-              Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
+            ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
+              Distinct group_by=[#0..=#3] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
                   Filter (#7 >= #3) // { arity: 8 }
                     Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 8 }
                       implementation
-                        %1:orderline[#0, #1, #2] » %0:l0[#0, #1, #2]UKKKAiif
-                      ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+                        %1:orderline[#0..=#2] » %0:l0[#0..=#2]UKKKAiif
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                         Project (#0..=#2, #4) // { arity: 4 }
                           Get l0 // { arity: 9 }
-                      ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                         Project (#0..=#2, #6) // { arity: 4 }
                           Get materialize.public.orderline // { arity: 10 }
     With
@@ -487,16 +487,16 @@ Explained Query:
       Project (#12, #19) // { arity: 2 }
         Join on=(#0 = #7 AND eq(#1, #5, #9) AND eq(#2, #6, #10, #14) AND eq(#3, #17, #18) AND #4 = #8 AND #11 = #13 AND #15 = #16 AND #20 = #21) type=differential // { arity: 22 }
           implementation
-            %2:orderline[#0, #1, #2] » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:stock[#0, #1]UKKAif » %4:supplier[#0, #1]UKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+            %2:orderline[#0..=#2] » %1:order[#0..=#2]UKKKAif » %0:customer[#0..=#2]UKKKAif » %3:stock[#0, #1]UKKAif » %4:supplier[#0, #1]UKKAif » %5:nation[#0]UKAif » %6:region[#0]UKAeif
+          ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
             Project (#0..=#2, #21) // { arity: 4 }
               Filter (#21) IS NOT NULL // { arity: 22 }
                 Get materialize.public.customer // { arity: 22 }
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
             Project (#0..=#3) // { arity: 4 }
               Filter (#3) IS NOT NULL AND (date_to_timestamp(#4) >= 2007-01-02 00:00:00) // { arity: 8 }
                 Get materialize.public.order // { arity: 8 }
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
             Project (#0..=#2, #4, #8) // { arity: 5 }
               Filter (#4) IS NOT NULL // { arity: 10 }
                 Get materialize.public.orderline // { arity: 10 }
@@ -597,23 +597,23 @@ Explained Query:
           Filter (((#22 = "GERMANY") AND (#24 = "CAMBODIA")) OR ((#22 = "CAMBODIA") AND (#24 = "GERMANY"))) // { arity: 25 }
             Join on=(#0 = #4 AND #1 = #21 AND #2 = #8 AND #3 = #9 AND #5 = #11 AND eq(#6, #12, #17) AND eq(#7, #13, #18) AND #14 = #16 AND #20 = #23) type=differential // { arity: 25 }
               implementation
-                %2:orderline[#0, #1, #2] » %3:order[#0, #1, #2]UKKKAiif » %4:customer[#0, #1, #2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
+                %2:orderline[#0..=#2] » %3:order[#0..=#2]UKKKAiif » %4:customer[#0..=#2]UKKKAiif » %1:stock[#0, #1]UKKAiif » %6:l0[#0]UKAeiif » %0:supplier[#0]UKAeiif » %5:l0[#0]UKAeiif
               ArrangeBy keys=[[#0]] // { arity: 2 }
                 Project (#0, #3) // { arity: 2 }
                   Get materialize.public.supplier // { arity: 7 }
               ArrangeBy keys=[[#0, #1]] // { arity: 3 }
                 Project (#0, #1, #17) // { arity: 3 }
                   Get materialize.public.stock // { arity: 18 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
                 Project (#0..=#2, #4, #5, #8) // { arity: 6 }
                   Filter (#10 <= 2012-01-02 00:00:00) AND (#10 >= 2007-01-02 00:00:00) AND (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 11 }
                     Map (date_to_timestamp(#6)) // { arity: 11 }
                       Get materialize.public.orderline // { arity: 10 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                 Project (#0..=#4) // { arity: 5 }
                   Filter (#3) IS NOT NULL // { arity: 8 }
                     Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                 Project (#0..=#2, #9, #21) // { arity: 5 }
                   Filter (#21) IS NOT NULL // { arity: 22 }
                     Get materialize.public.customer // { arity: 22 }
@@ -672,7 +672,7 @@ Explained Query:
           Project (#11, #16, #24) // { arity: 3 }
             Join on=(eq(#0, #3, #9) AND #1 = #5 AND #2 = #23 AND #4 = #10 AND #6 = #12 AND eq(#7, #13, #18) AND eq(#8, #14, #19) AND #15 = #17 AND #20 = #21 AND #22 = #25) type=differential // { arity: 26 }
               implementation
-                %3:orderline[#0, #1, #2] » %4:order[#0, #1, #2]UKKKAiiif » %5:customer[#0, #1, #2]UKKKAiiif » %2:stock[#0, #1]UKKAiiiif » %0:item[#0]UKAliiiiif » %1:supplier[#0]UKAliiiiif » %6:nation[#0]UKAliiiiif » %8:region[#0]UKAeliiiiif » %7:nation[#0]UKAeliiiiif
+                %3:orderline[#0..=#2] » %4:order[#0..=#2]UKKKAiiif » %5:customer[#0..=#2]UKKKAiiif » %2:stock[#0, #1]UKKAiiiif » %0:item[#0]UKAliiiiif » %1:supplier[#0]UKAliiiiif » %6:nation[#0]UKAliiiiif » %8:region[#0]UKAeliiiiif » %7:nation[#0]UKAeliiiiif
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (#0 < 1000) AND "%b" ~~(padchar(#4)) // { arity: 5 }
@@ -684,16 +684,16 @@ Explained Query:
                 Project (#0, #1, #17) // { arity: 3 }
                   Filter (#0 < 1000) // { arity: 18 }
                     Get materialize.public.stock // { arity: 18 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
                 Project (#0..=#2, #4, #5, #8) // { arity: 6 }
                   Filter (#4 < 1000) AND (#5) IS NOT NULL // { arity: 10 }
                     Get materialize.public.orderline // { arity: 10 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                 Project (#0..=#4) // { arity: 5 }
                   Filter (#8 <= 2012-01-02 00:00:00) AND (#8 >= 2007-01-02 00:00:00) AND (#3) IS NOT NULL // { arity: 9 }
                     Map (date_to_timestamp(#4)) // { arity: 9 }
                       Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                 Project (#0..=#2, #21) // { arity: 4 }
                   Filter (#21) IS NOT NULL // { arity: 22 }
                     Get materialize.public.customer // { arity: 22 }
@@ -748,7 +748,7 @@ Explained Query:
       Project (#11, #15, #17) // { arity: 3 }
         Join on=(eq(#0, #1, #9) AND #2 = #10 AND #3 = #4 AND #5 = #16 AND #6 = #12 AND #7 = #13 AND #8 = #14) type=differential // { arity: 18 }
           implementation
-            %3:orderline[#0, #1, #2] » %4:order[#0, #1, #2]UKKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
+            %3:orderline[#0..=#2] » %4:order[#0..=#2]UKKKA » %1:stock[#0, #1]UKKA » %0:item[#0]UKAlf » %2:supplier[#0]UKAlf » %5:nation[#0]UKAlf
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter "%BB" ~~(padchar(#4)) // { arity: 5 }
@@ -759,11 +759,11 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Project (#0, #3) // { arity: 2 }
               Get materialize.public.supplier // { arity: 7 }
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
             Project (#0..=#2, #4, #5, #8) // { arity: 6 }
               Filter (#4) IS NOT NULL AND (#5) IS NOT NULL // { arity: 10 }
                 Get materialize.public.orderline // { arity: 10 }
-          ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+          ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
             Project (#0..=#2, #4) // { arity: 4 }
               Get materialize.public.order // { arity: 8 }
           ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -803,21 +803,21 @@ ORDER BY revenue DESC
 Explained Query:
   Finish order_by=[#2 desc nulls_first] output=[#0..=#5]
     Project (#0, #1, #5, #2..=#4) // { arity: 6 }
-      Reduce group_by=[#0, #1, #2, #3, #5] aggregates=[sum(#4)] // { arity: 6 }
+      Reduce group_by=[#0..=#3, #5] aggregates=[sum(#4)] // { arity: 6 }
         Project (#0, #3..=#5, #16, #18) // { arity: 6 }
           Filter (#11 <= #15) // { arity: 19 }
             Join on=(#0 = #10 AND eq(#1, #8, #13) AND eq(#2, #9, #14) AND #6 = #17 AND #7 = #12) type=differential // { arity: 19 }
               implementation
-                %2:orderline[#0, #1, #2] » %1:order[#0, #1, #2]UKKKAif » %0:customer[#0, #1, #2]UKKKAif » %3:nation[#0]UKAif
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 7 }
+                %2:orderline[#0..=#2] » %1:order[#0..=#2]UKKKAif » %0:customer[#0..=#2]UKKKAif » %3:nation[#0]UKAif
+              ArrangeBy keys=[[#0..=#2]] // { arity: 7 }
                 Project (#0..=#2, #5, #8, #11, #21) // { arity: 7 }
                   Filter (#21) IS NOT NULL // { arity: 22 }
                     Get materialize.public.customer // { arity: 22 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                 Project (#0..=#4) // { arity: 5 }
                   Filter (#3) IS NOT NULL AND (date_to_timestamp(#4) >= 2007-01-02 00:00:00) // { arity: 8 }
                     Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                 Project (#0..=#2, #6, #8) // { arity: 5 }
                   Get materialize.public.orderline // { arity: 10 }
               ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -912,11 +912,11 @@ Explained Query:
         Filter (#3 <= #9) // { arity: 10 }
           Join on=(#0 = #6 AND #1 = #7 AND #2 = #8) type=differential // { arity: 10 }
             implementation
-              %1:orderline[#0, #1, #2] » %0:order[#0, #1, #2]UKKKAif
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
+              %1:orderline[#0..=#2] » %0:order[#0..=#2]UKKKAif
+            ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
               Project (#0..=#2, #4..=#6) // { arity: 6 }
                 Get materialize.public.order // { arity: 8 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
               Project (#0..=#2, #6) // { arity: 4 }
                 Filter (date_to_timestamp(#6) < 2020-01-01 00:00:00) // { arity: 10 }
                   Get materialize.public.orderline // { arity: 10 }
@@ -956,7 +956,7 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21] // { arity: 22 }
+                      Distinct group_by=[#0..=#21] // { arity: 22 }
                         Project (#0..=#21) // { arity: 22 }
                           Get l0 // { arity: 23 }
                   Project (#0) // { arity: 1 }
@@ -966,8 +966,8 @@ Explained Query:
         Project (#0..=#22) // { arity: 23 }
           Join on=(#0 = #25 AND #1 = #23 AND #2 = #24) type=differential // { arity: 26 }
             implementation
-              %1:order[#3, #1, #2] » %0:customer[#0, #1, #2]UKKKAif
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 22 }
+              %1:order[#3, #1, #2] » %0:customer[#0..=#2]UKKKAif
+            ArrangeBy keys=[[#0..=#2]] // { arity: 22 }
               Get materialize.public.customer // { arity: 22 }
             ArrangeBy keys=[[#3, #1, #2]] // { arity: 4 }
               Project (#0..=#3) // { arity: 4 }
@@ -1245,15 +1245,15 @@ Explained Query:
           Project (#0..=#4, #8, #9, #13) // { arity: 8 }
             Join on=(#0 = #7 AND eq(#1, #5, #11) AND eq(#2, #6, #12) AND #4 = #10) type=differential // { arity: 14 }
               implementation
-                %2:orderline[#0, #1, #2] » %1:order[#0, #1, #2]UKKKA » %0:customer[#0, #1, #2]UKKKA
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+                %2:orderline[#0..=#2] » %1:order[#0..=#2]UKKKA » %0:customer[#0..=#2]UKKKA
+              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                 Project (#0..=#2, #5) // { arity: 4 }
                   Get materialize.public.customer // { arity: 22 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 6 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 6 }
                 Project (#0..=#4, #6) // { arity: 6 }
                   Filter (#3) IS NOT NULL // { arity: 8 }
                     Get materialize.public.order // { arity: 8 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                 Project (#0..=#2, #8) // { arity: 4 }
                   Get materialize.public.orderline // { arity: 10 }
 
@@ -1361,7 +1361,7 @@ Explained Query:
             Distinct group_by=[#0] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (integer_to_bigint((2 * #3)) > #4) AND (#0 = ((#1 * #2) % 10000)) // { arity: 5 }
-                  Reduce group_by=[#0, #1, #2, #3] aggregates=[sum(#4)] // { arity: 5 }
+                  Reduce group_by=[#0..=#3] aggregates=[sum(#4)] // { arity: 5 }
                     Project (#0..=#3, #26) // { arity: 5 }
                       Filter (date_to_timestamp(#25) > 2010-05-23 12:00:00) // { arity: 30 }
                         Join on=(eq(#1, #23, #29)) type=differential // { arity: 30 }
@@ -1436,13 +1436,13 @@ Explained Query:
         Project (#0) // { arity: 1 }
           Join on=(#1 = #5 AND #2 = #6 AND #3 = #7 AND #4 = #8) type=differential // { arity: 9 }
             implementation
-              %1[#0, #1, #2, #3] » %0:l0[#1, #2, #3, #4]KKKKA
-            ArrangeBy keys=[[#1, #2, #3, #4]] // { arity: 5 }
+              %1[#0..=#3] » %0:l0[#1..=#4]KKKKA
+            ArrangeBy keys=[[#1..=#4]] // { arity: 5 }
               Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0, #1, #2, #3]] // { arity: 4 }
+            ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
-                  Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
+                  Distinct group_by=[#0..=#3] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
                       Filter (#10 > #3) // { arity: 14 }
                         Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
@@ -1455,7 +1455,7 @@ Explained Query:
                 Get l1 // { arity: 4 }
     With
       cte l1 =
-        Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
+        Distinct group_by=[#0..=#3] // { arity: 4 }
           Project (#1..=#4) // { arity: 4 }
             Get l0 // { arity: 5 }
       cte l0 =
@@ -1463,15 +1463,15 @@ Explained Query:
           Filter (#7 > #11) // { arity: 16 }
             Join on=(#0 = #14 AND #2 = #15 AND #3 = #8 AND #4 = #9 AND eq(#5, #10, #13) AND #6 = #12) type=differential // { arity: 16 }
               implementation
-                %1:orderline[#0, #1, #2] » %2:order[#0, #1, #2]UKKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
+                %1:orderline[#0..=#2] » %2:order[#0..=#2]UKKKA » %3:stock[#0, #1]UKKA » %0:supplier[#0]UKA » %4:nation[#0]UKAef
               ArrangeBy keys=[[#0]] // { arity: 3 }
                 Project (#0, #1, #3) // { arity: 3 }
                   Get materialize.public.supplier // { arity: 7 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
                 Project (#0..=#2, #4, #6) // { arity: 5 }
                   Filter (#4) IS NOT NULL // { arity: 10 }
                     Get materialize.public.orderline // { arity: 10 }
-              ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
+              ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
                 Project (#0..=#2, #4) // { arity: 4 }
                   Get materialize.public.order // { arity: 8 }
               ArrangeBy keys=[[#0, #1]] // { arity: 3 }
@@ -1521,19 +1521,19 @@ Explained Query:
         Project (#3, #4) // { arity: 2 }
           Join on=(#0 = #5 AND #1 = #6 AND #2 = #7) type=differential // { arity: 8 }
             implementation
-              %1[#0, #1, #2] » %0:l1[#0, #1, #2]UKKKA
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 5 }
+              %1[#0..=#2] » %0:l1[#0..=#2]UKKKA
+            ArrangeBy keys=[[#0..=#2]] // { arity: 5 }
               Get l1 // { arity: 5 }
-            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
               Union // { arity: 3 }
                 Negate // { arity: 3 }
                   Project (#0..=#2) // { arity: 3 }
                     Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                       implementation
-                        %1[#0, #1, #2] » %0:l2[#0, #1, #2]UKKKA
-                      ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                        %1[#0..=#2] » %0:l2[#0..=#2]UKKKA
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                         Get l2 // { arity: 3 }
-                      ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                         Distinct group_by=[#2, #0, #1] // { arity: 3 }
                           Project (#1..=#3) // { arity: 3 }
                             Filter (#3) IS NOT NULL // { arity: 8 }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -782,3 +782,42 @@ With
         - ()
 
 EOF
+
+# Test #17348.
+
+statement ok
+CREATE TABLE r(f0 INT, f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT, f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT);
+
+query T multiline
+EXPLAIN SELECT *
+FROM r AS r0, r AS r1
+WHERE
+  r0.f0=r1.f0 AND
+  r0.f2=r1.f2 AND
+  r0.f3=r1.f3 AND
+  r0.f4=r1.f4 AND
+  r0.f6=r1.f6 AND
+  r0.f8=r1.f8 AND
+  r0.f9=r1.f9 AND
+  r0.f11=r1.f11 AND
+  r0.f12=r1.f12 AND
+  r0.f13=r1.f13 AND
+  r0.f15=r1.f15 AND
+  r0.f16=r1.f16;
+----
+Explained Query:
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
+        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
+          Get materialize.public.r
+
+Source materialize.public.r
+  filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
+
+EOF

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -712,3 +712,42 @@ Used Indexes:
   - materialize.public.t_a_b_idx
 
 EOF
+
+# Test #17348.
+
+statement ok
+CREATE TABLE r(f0 INT, f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT, f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT);
+
+query T multiline
+EXPLAIN SELECT *
+FROM r AS r0, r AS r1
+WHERE
+  r0.f0=r1.f0 AND
+  r0.f2=r1.f2 AND
+  r0.f3=r1.f3 AND
+  r0.f4=r1.f4 AND
+  r0.f6=r1.f6 AND
+  r0.f8=r1.f8 AND
+  r0.f9=r1.f9 AND
+  r0.f11=r1.f11 AND
+  r0.f12=r1.f12 AND
+  r0.f13=r1.f13 AND
+  r0.f15=r1.f15 AND
+  r0.f16=r1.f16;
+----
+Explained Query:
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
+        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
+          Get materialize.public.r
+
+Source materialize.public.r
+  filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
+
+EOF

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -806,3 +806,42 @@ Used Indexes:
   - materialize.public.v_e_idx
 
 EOF
+
+# Test #17348.
+
+statement ok
+CREATE TABLE r(f0 INT, f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT, f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT);
+
+query T multiline
+EXPLAIN SELECT *
+FROM r AS r0, r AS r1
+WHERE
+  r0.f0=r1.f0 AND
+  r0.f2=r1.f2 AND
+  r0.f3=r1.f3 AND
+  r0.f4=r1.f4 AND
+  r0.f6=r1.f6 AND
+  r0.f8=r1.f8 AND
+  r0.f9=r1.f9 AND
+  r0.f11=r1.f11 AND
+  r0.f12=r1.f12 AND
+  r0.f13=r1.f13 AND
+  r0.f15=r1.f15 AND
+  r0.f16=r1.f16;
+----
+Explained Query:
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
+        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
+          Get materialize.public.r
+
+Source materialize.public.r
+  filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
+
+EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -393,3 +393,42 @@ Reduce aggregates=[count(*)]
     - ()
 
 EOF
+
+# Test #17348.
+
+statement ok
+CREATE TABLE r(f0 INT, f1 INT, f2 INT, f3 INT, f4 INT, f5 INT, f6 INT, f7 INT, f8 INT, f9 INT, f10 INT, f11 INT, f12 INT, f13 INT, f14 INT, f15 INT, f16 INT);
+
+query T multiline
+EXPLAIN SELECT *
+FROM r AS r0, r AS r1
+WHERE
+  r0.f0=r1.f0 AND
+  r0.f2=r1.f2 AND
+  r0.f3=r1.f3 AND
+  r0.f4=r1.f4 AND
+  r0.f6=r1.f6 AND
+  r0.f8=r1.f8 AND
+  r0.f9=r1.f9 AND
+  r0.f11=r1.f11 AND
+  r0.f12=r1.f12 AND
+  r0.f13=r1.f13 AND
+  r0.f15=r1.f15 AND
+  r0.f16=r1.f16;
+----
+Explained Query:
+  Return
+    Project (#0..=#16, #0, #18, #2..=#4, #22, #6, #24, #8, #9, #27, #11..=#13, #31, #15, #16)
+      Join on=(#0 = #17 AND #2 = #19 AND #3 = #20 AND #4 = #21 AND #6 = #23 AND #8 = #25 AND #9 = #26 AND #11 = #28 AND #12 = #29 AND #13 = #30 AND #15 = #32 AND #16 = #33) type=differential
+        Get l0
+        Get l0
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0, #2..=#4, #6, #8, #9, #11..=#13, #15, #16]]
+        Filter (#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL
+          Get materialize.public.r
+
+Source materialize.public.r
+  filter=((#0) IS NOT NULL AND (#2) IS NOT NULL AND (#3) IS NOT NULL AND (#4) IS NOT NULL AND (#6) IS NOT NULL AND (#8) IS NOT NULL AND (#9) IS NOT NULL AND (#11) IS NOT NULL AND (#12) IS NOT NULL AND (#13) IS NOT NULL AND (#15) IS NOT NULL AND (#16) IS NOT NULL)
+
+EOF

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -336,7 +336,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #2 asc nulls_last] output=[#0..=#3]
     Project (#0, #3, #1, #2) // { arity: 4 }
-      Reduce group_by=[#0, #1, #2] aggregates=[sum((#3 * (1 - #4)))] // { arity: 4 }
+      Reduce group_by=[#0..=#2] aggregates=[sum((#3 * (1 - #4)))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
           Filter (#6 = "BUILDING") AND (#12 < 1995-03-15) AND (#27 > 1995-03-15) // { arity: 33 }
             Join on=(#0 = #9 AND #8 = #17) type=delta // { arity: 33 }
@@ -989,16 +989,16 @@ Explained Query:
                 Map (null) // { arity: 17 }
                   Join on=(#0 = #8 AND #1 = #9 AND #2 = #10 AND #3 = #11 AND #4 = #12 AND #5 = #13 AND #6 = #14 AND #7 = #15) type=differential // { arity: 16 }
                     implementation
-                      %1:customer[#0, #1, #2, #3, #4, #5, #6, #7] » %0[#0, #1, #2, #3, #4, #5, #6, #7]KKKKKKKKA
-                    ArrangeBy keys=[[#0, #1, #2, #3, #4, #5, #6, #7]] // { arity: 8 }
+                      %1:customer[#0..=#7] » %0[#0..=#7]KKKKKKKKA
+                    ArrangeBy keys=[[#0..=#7]] // { arity: 8 }
                       Union // { arity: 8 }
                         Negate // { arity: 8 }
-                          Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7] // { arity: 8 }
+                          Distinct group_by=[#0..=#7] // { arity: 8 }
                             Project (#0..=#7) // { arity: 8 }
                               Get l0 // { arity: 9 }
-                        Distinct group_by=[#0, #1, #2, #3, #4, #5, #6, #7] // { arity: 8 }
+                        Distinct group_by=[#0..=#7] // { arity: 8 }
                           Get materialize.public.customer // { arity: 8 }
-                    ArrangeBy keys=[[#0, #1, #2, #3, #4, #5, #6, #7]] // { arity: 8 }
+                    ArrangeBy keys=[[#0..=#7]] // { arity: 8 }
                       Get materialize.public.customer // { arity: 8 }
     With
       cte l0 =
@@ -1171,7 +1171,7 @@ ORDER BY
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
-      Reduce group_by=[#1, #2, #3] aggregates=[count(distinct #0)] // { arity: 4 }
+      Reduce group_by=[#1..=#3] aggregates=[count(distinct #0)] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
           Join on=(#0 = #4) type=differential // { arity: 5 }
             implementation

--- a/test/sqllogictest/transform/reduce_fusion.slt
+++ b/test/sqllogictest/transform/reduce_fusion.slt
@@ -14,7 +14,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT * FROM t GROUP BY f1, f2, f0
 ----
 Explained Query:
-  Distinct group_by=[#0, #1, #2] // { arity: 3 }
+  Distinct group_by=[#0..=#2] // { arity: 3 }
     Get materialize.public.t // { arity: 3 }
 
 EOF

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -323,7 +323,7 @@ Explained Query:
           Get l0
   With
     cte l0 =
-      Distinct group_by=[#0, #1, #2, #3]
+      Distinct group_by=[#0..=#3]
         Union
           Get materialize.public.people
           Negate


### PR DESCRIPTION
This is a more general version of the noise reduction in `EXPLAIN AS TEXT` proposed in #17324.

### Motivation

  * This PR adds a known-desirable feature.

 Replaces #17324. Some of our `*.slt` plans are affected in a positive way.

### Tips for reviewer

Having revisited this code after a while, I can definitely see how the various `Display*` and  `Explain*` types/traits can be confusing. I'll revisit the code and try to come up with some simplifications.

1. The `CompactScalarSeq` type is a generic version of `MirIndices` from the original PR.
2. I've implemented `std::fmt::Display` instead of `DisplayText` for `CompactScalarSeq`. This is OK because:
    1. This is a helper struct used only for `EXPLAIN AS TEXT` rendering, so we'll probably never need more than one `Display` implementation.
    2. The default rendering context type in `DisplayText` is the empty context (`&mut ()`), and all `~ScalarExpr` nodes implement `DisplayText` with this rendering context type.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Long runs of column references in `EXPlAIN AS TEXT` are now represented in a more compact way.
