### PR TITLE
[persist] Timing metrics and delete-rollup parallelism for GC

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -115,7 +115,7 @@ pub struct PersistConfig {
     /// compaction requests to queue.
     pub compaction_queue_size: usize,
     /// The maximum number of concurrent blob deletes during garbage collection.
-    pub gc_batch_part_delete_concurrency_limit: usize,
+    pub gc_blob_delete_concurrency_limit: usize,
     /// In Compactor::compact_and_apply_background, the minimum amount of time to
     /// allow a compaction request to run before timing it out. A request may be
     /// given a timeout greater than this value depending on the inputs' size
@@ -174,7 +174,7 @@ impl PersistConfig {
             compaction_heuristic_min_updates: 1024,
             compaction_concurrency_limit: 5,
             compaction_queue_size: 20,
-            gc_batch_part_delete_concurrency_limit: 32,
+            gc_blob_delete_concurrency_limit: 32,
             compaction_minimum_timeout: Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT,
             consensus_connection_pool_max_size: 50,
             consensus_connection_pool_ttl: Duration::from_secs(300),


### PR DESCRIPTION
Minor improvements to GC:
- Parallelize rollup deletes.
- Add metrics that track the overall timing of individual GC steps. The names and structure follow very closely the compaction metrics; the actual metric calculation is a pretty vanilla walltime diff.

### Motivation

Desired enhancement: #17290

### Tips for reviewer

I appreciate this is two distinct changes; let me know if you'd like me to break this up.

Here's the output of the `force-gc` tool running against a local persist install, if you want a sense of what the prometheus output looks like:

```
2023-01-25T23:22:22.631294Z  INFO persistcli: mz_persist_client::cli::admin: mz_persist_gc_step_seconds{step:apply_diff} 0.000166666
2023-01-25T23:22:22.631309Z  INFO persistcli: mz_persist_client::cli::admin: mz_persist_gc_step_seconds{step:delete_batch_part} 0.000042916
2023-01-25T23:22:22.631325Z  INFO persistcli: mz_persist_client::cli::admin: mz_persist_gc_step_seconds{step:delete_rollup} 0.00028
2023-01-25T23:22:22.631341Z  INFO persistcli: mz_persist_client::cli::admin: mz_persist_gc_step_seconds{step:fetch} 0.002433166
2023-01-25T23:22:22.631357Z  INFO persistcli: mz_persist_client::cli::admin: mz_persist_gc_step_seconds{step:truncate_diff} 0.000056041
2023-01-25T23:22:22.631372Z  INFO persistcli: mz_persist_client::cli::admin: mz_persist_gc_step_seconds{step:write_rollup} 0.001036291
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
