### PR TITLE
stash: dynamically prepare all update statements

### DIFF
--- a/src/stash/src/transaction.rs
+++ b/src/stash/src/transaction.rs
@@ -590,8 +590,8 @@ impl<'a> Transaction<'a> {
             args.push(time);
             args.push(diff);
         }
-        let stmt = self.stmts.update(entries.len());
-        let insert_fut = self.client.execute(&*stmt, &args).map_err(|err| err.into());
+        let stmt = self.stmts.update(self.client, entries.len()).await?;
+        let insert_fut = self.client.execute(&stmt, &args).map_err(|err| err.into());
         try_join(upper_fut, insert_fut).await?;
         Ok(())
     }


### PR DESCRIPTION
Overall speed increase because any repeated update statement will already be prepared.

See #16531

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a