### PR TITLE
CODEOWNERS: add owners for src/controller

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /src/clusterd                       @MaterializeInc/compute @MaterializeInc/storage
 /src/compute                        @MaterializeInc/compute
 /src/compute-client                 @MaterializeInc/compute
+/src/controller                     @MaterializeInc/compute @MaterializeInc/storage
 /src/environmentd                   @MaterializeInc/surfaces
 /src/expr                           @MaterializeInc/compute
 /src/expr-test-util                 @MaterializeInc/compute


### PR DESCRIPTION
This PR adds `src/controller` to the CODEOWNERS file. That crate provides an interface to the compute and storage controllers, as well as management for compute and storage cluster services, so I added both the compute and the storage team as owners.

### Motivation

  * This PR adds a missing entry in CODEOWNERS.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
