### PR TITLE
adapter: Add deterministic audit event timestamps

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1225,7 +1225,7 @@ impl CatalogState {
             self.unsafe_mode(),
             self.system_configuration.mock_audit_event_timestamp(),
         ) {
-            (true, Some(ts)) => ts,
+            (true, Some(ts)) => ts.into(),
             _ => oracle_write_ts.into(),
         };
         let id = tx.get_and_increment_id(storage::AUDIT_LOG_ID_ALLOC_KEY.to_string())?;

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -50,6 +50,7 @@ const APPLICATION_NAME: ServerVar<str> = ServerVar {
     value: "",
     description: "Sets the application name to be reported in statistics and logs (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const CLIENT_ENCODING: ServerVar<str> = ServerVar {
@@ -57,6 +58,7 @@ const CLIENT_ENCODING: ServerVar<str> = ServerVar {
     value: "UTF8",
     description: "Sets the client's character set encoding (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
@@ -64,6 +66,7 @@ const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
     value: &ClientSeverity::Notice,
     description: "Sets the message levels that are sent to the client (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 pub const CLUSTER_VAR_NAME: &UncasedStr = UncasedStr::new("cluster");
 
@@ -72,6 +75,7 @@ const CLUSTER: ServerVar<str> = ServerVar {
     value: "default",
     description: "Sets the current cluster (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const CLUSTER_REPLICA: ServerVar<Option<String>> = ServerVar {
@@ -79,6 +83,7 @@ const CLUSTER_REPLICA: ServerVar<Option<String>> = ServerVar {
     value: &None,
     description: "Sets a target cluster replica for SELECT queries (Materialize).",
     internal: false,
+    safe: true,
 };
 
 pub const DATABASE_VAR_NAME: &UncasedStr = UncasedStr::new("database");
@@ -88,6 +93,7 @@ const DATABASE: ServerVar<str> = ServerVar {
     value: DEFAULT_DATABASE_NAME,
     description: "Sets the current database (CockroachDB).",
     internal: false,
+    safe: true,
 };
 
 const DATE_STYLE: ServerVar<str> = ServerVar {
@@ -96,6 +102,7 @@ const DATE_STYLE: ServerVar<str> = ServerVar {
     value: "ISO, MDY",
     description: "Sets the display format for date and time values (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
@@ -103,6 +110,7 @@ const EXTRA_FLOAT_DIGITS: ServerVar<i32> = ServerVar {
     value: &3,
     description: "Adjusts the number of digits displayed for floating-point values (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const FAILPOINTS: ServerVar<str> = ServerVar {
@@ -110,6 +118,7 @@ const FAILPOINTS: ServerVar<str> = ServerVar {
     value: "",
     description: "Allows failpoints to be dynamically activated.",
     internal: false,
+    safe: true,
 };
 
 const INTEGER_DATETIMES: ServerVar<bool> = ServerVar {
@@ -117,6 +126,7 @@ const INTEGER_DATETIMES: ServerVar<bool> = ServerVar {
     value: &true,
     description: "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const INTERVAL_STYLE: ServerVar<str> = ServerVar {
@@ -125,6 +135,7 @@ const INTERVAL_STYLE: ServerVar<str> = ServerVar {
     value: "postgres",
     description: "Sets the display format for interval values (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const MZ_VERSION_NAME: &UncasedStr = UncasedStr::new("mz_version");
@@ -136,6 +147,7 @@ static SEARCH_PATH: Lazy<ServerVar<[String]>> = Lazy::new(|| ServerVar {
     description:
         "Sets the schema search order for names that are not schema-qualified (PostgreSQL).",
     internal: false,
+    safe: true,
 });
 
 const STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
@@ -144,6 +156,7 @@ const STATEMENT_TIMEOUT: ServerVar<Duration> = ServerVar {
     description:
         "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations.",
     internal: false,
+    safe: true,
 };
 
 const IDLE_IN_TRANSACTION_SESSION_TIMEOUT: ServerVar<Duration> = ServerVar {
@@ -153,6 +166,7 @@ const IDLE_IN_TRANSACTION_SESSION_TIMEOUT: ServerVar<Duration> = ServerVar {
         "Sets the maximum allowed duration that a session can sit idle in a transaction before \
          being terminated. A value of zero disables the timeout (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const SERVER_VERSION: ServerVar<str> = ServerVar {
@@ -166,6 +180,7 @@ const SERVER_VERSION: ServerVar<str> = ServerVar {
     ),
     description: "Shows the server version (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const SERVER_VERSION_NUM: ServerVar<i32> = ServerVar {
@@ -175,6 +190,7 @@ const SERVER_VERSION_NUM: ServerVar<i32> = ServerVar {
         + cast::u8_to_i32(SERVER_PATCH_VERSION)),
     description: "Shows the server version as an integer (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const SQL_SAFE_UPDATES: ServerVar<bool> = ServerVar {
@@ -182,6 +198,7 @@ const SQL_SAFE_UPDATES: ServerVar<bool> = ServerVar {
     value: &false,
     description: "Prohibits SQL statements that may be overly destructive (CockroachDB).",
     internal: false,
+    safe: true,
 };
 
 const STANDARD_CONFORMING_STRINGS: ServerVar<bool> = ServerVar {
@@ -189,6 +206,7 @@ const STANDARD_CONFORMING_STRINGS: ServerVar<bool> = ServerVar {
     value: &true,
     description: "Causes '...' strings to treat backslashes literally (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const TIMEZONE: ServerVar<TimeZone> = ServerVar {
@@ -197,6 +215,7 @@ const TIMEZONE: ServerVar<TimeZone> = ServerVar {
     value: &TimeZone::UTC,
     description: "Sets the time zone for displaying and interpreting time stamps (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 pub const TRANSACTION_ISOLATION_VAR_NAME: &UncasedStr = UncasedStr::new("transaction_isolation");
@@ -205,6 +224,7 @@ const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
     value: &IsolationLevel::StrictSerializable,
     description: "Sets the current transaction's isolation level (PostgreSQL).",
     internal: false,
+    safe: true,
 };
 
 const MAX_AWS_PRIVATELINK_CONNECTIONS: ServerVar<u32> = ServerVar {
@@ -212,6 +232,7 @@ const MAX_AWS_PRIVATELINK_CONNECTIONS: ServerVar<u32> = ServerVar {
     value: &0,
     description: "The maximum number of AWS PrivateLink connections in the region, across all schemas (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_TABLES: ServerVar<u32> = ServerVar {
@@ -219,6 +240,7 @@ const MAX_TABLES: ServerVar<u32> = ServerVar {
     value: &25,
     description: "The maximum number of tables in the region, across all schemas (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_SOURCES: ServerVar<u32> = ServerVar {
@@ -226,6 +248,7 @@ const MAX_SOURCES: ServerVar<u32> = ServerVar {
     value: &25,
     description: "The maximum number of sources in the region, across all schemas (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_SINKS: ServerVar<u32> = ServerVar {
@@ -233,6 +256,7 @@ const MAX_SINKS: ServerVar<u32> = ServerVar {
     value: &25,
     description: "The maximum number of sinks in the region, across all schemas (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_MATERIALIZED_VIEWS: ServerVar<u32> = ServerVar {
@@ -241,6 +265,7 @@ const MAX_MATERIALIZED_VIEWS: ServerVar<u32> = ServerVar {
     description:
         "The maximum number of materialized views in the region, across all schemas (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_CLUSTERS: ServerVar<u32> = ServerVar {
@@ -248,6 +273,7 @@ const MAX_CLUSTERS: ServerVar<u32> = ServerVar {
     value: &10,
     description: "The maximum number of clusters in the region (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
@@ -255,6 +281,7 @@ const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
     value: &5,
     description: "The maximum number of replicas of a single cluster (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_DATABASES: ServerVar<u32> = ServerVar {
@@ -262,6 +289,7 @@ const MAX_DATABASES: ServerVar<u32> = ServerVar {
     value: &1000,
     description: "The maximum number of databases in the region (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_SCHEMAS_PER_DATABASE: ServerVar<u32> = ServerVar {
@@ -269,6 +297,7 @@ const MAX_SCHEMAS_PER_DATABASE: ServerVar<u32> = ServerVar {
     value: &1000,
     description: "The maximum number of schemas in a database (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_OBJECTS_PER_SCHEMA: ServerVar<u32> = ServerVar {
@@ -276,6 +305,7 @@ const MAX_OBJECTS_PER_SCHEMA: ServerVar<u32> = ServerVar {
     value: &1000,
     description: "The maximum number of objects in a schema (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_SECRETS: ServerVar<u32> = ServerVar {
@@ -283,6 +313,7 @@ const MAX_SECRETS: ServerVar<u32> = ServerVar {
     value: &100,
     description: "The maximum number of secrets in the region, across all schemas (Materialize).",
     internal: false,
+    safe: true,
 };
 
 const MAX_ROLES: ServerVar<u32> = ServerVar {
@@ -290,6 +321,7 @@ const MAX_ROLES: ServerVar<u32> = ServerVar {
     value: &1000,
     description: "The maximum number of roles in the region (Materialize).",
     internal: false,
+    safe: true,
 };
 
 // Cloud environmentd is configured with 4 GiB of RAM, so 1 GiB is a good heuristic for a single
@@ -301,6 +333,7 @@ pub const MAX_RESULT_SIZE: ServerVar<u32> = ServerVar {
     value: &1_073_741_824,
     description: "The maximum size in bytes for a single query's result (Materialize).",
     internal: false,
+    safe: true,
 };
 
 /// The logical compaction window for builtin tables and sources that have the
@@ -314,6 +347,7 @@ pub const METRICS_RETENTION: ServerVar<Duration> = ServerVar {
     value: &Duration::from_secs(30 * 24 * 60 * 60),
     description: "The time to retain cluster utilization metrics (Materialize).",
     internal: true,
+    safe: true,
 };
 
 static DEFAULT_ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<Vec<String>> = Lazy::new(Vec::new);
@@ -322,6 +356,7 @@ static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<String>>> = Lazy::new(|
     value: &DEFAULT_ALLOWED_CLUSTER_REPLICA_SIZES,
     description: "The allowed sizes when creating a new cluster replica (Materialize).",
     internal: false,
+    safe: true,
 });
 
 /// Controls [`PersistConfig::blob_target_size`].
@@ -330,6 +365,7 @@ const PERSIST_BLOB_TARGET_SIZE: ServerVar<usize> = ServerVar {
     value: &PersistConfig::DEFAULT_BLOB_TARGET_SIZE,
     description: "A target maximum size of persist blob payloads in bytes (Materialize).",
     internal: true,
+    safe: true,
 };
 
 /// Controls [`PersistConfig::compaction_minimum_timeout`].
@@ -339,6 +375,7 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     description: "The minimum amount of time to allow a persist compaction request to run before \
                   timing it out (Materialize).",
     internal: true,
+    safe: true,
 };
 
 /// Boolean flag indicating that the remote configuration was synchronized at
@@ -348,15 +385,16 @@ pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
     value: &false,
     description: "Boolean flag indicating that the remote configuration was synchronized at least once (Materialize).",
     internal: true,
+    safe: true,
 };
 
-pub const REAL_TIME_RECENCY_VAR_NAME: &UncasedStr = UncasedStr::new("real_time_recency");
 /// Feature flag indicating whether real time recency is enabled.
 static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
-    name: REAL_TIME_RECENCY_VAR_NAME,
+    name: UncasedStr::new("real_time_recency"),
     value: &false,
     description: "Feature flag indicating whether real time recency is enabled (Materialize).",
     internal: true,
+    safe: false,
 };
 
 static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
@@ -365,6 +403,7 @@ static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
     description:
         "Boolean flag indicating whether to send a NOTICE specifying query timestamps (Materialize).",
     internal: false,
+    safe: true,
 };
 
 static EMIT_TRACE_ID_NOTICE: ServerVar<bool> = ServerVar {
@@ -373,6 +412,15 @@ static EMIT_TRACE_ID_NOTICE: ServerVar<bool> = ServerVar {
     description:
         "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize).",
     internal: false,
+    safe: true,
+};
+
+static MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<u64>> = ServerVar {
+    name: UncasedStr::new("mock_audit_event_timestamp"),
+    value: &None,
+    description: "Mocked timestamp to use for audit events for testing purposes",
+    internal: true,
+    safe: false,
 };
 
 /// Session variables.
@@ -996,6 +1044,9 @@ pub struct SystemVars {
 
     // misc
     metrics_retention: SystemVar<Duration>,
+
+    // testing
+    mock_audit_event_timestamp: SystemVar<Option<u64>>,
 }
 
 impl Default for SystemVars {
@@ -1019,6 +1070,7 @@ impl Default for SystemVars {
             persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
             persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
+            mock_audit_event_timestamp: SystemVar::new(&MOCK_AUDIT_EVENT_TIMESTAMP),
         }
     }
 }
@@ -1027,7 +1079,7 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        let vars: [&dyn Var; 18] = [
+        let vars: [&dyn Var; 19] = [
             &self.config_has_synced_once,
             &self.max_aws_privatelink_connections,
             &self.max_tables,
@@ -1046,6 +1098,7 @@ impl SystemVars {
             &self.persist_blob_target_size,
             &self.persist_compaction_minimum_timeout,
             &self.metrics_retention,
+            &self.mock_audit_event_timestamp,
         ];
         vars.into_iter()
     }
@@ -1110,6 +1163,8 @@ impl SystemVars {
             Ok(&self.persist_compaction_minimum_timeout)
         } else if name == METRICS_RETENTION.name {
             Ok(&self.metrics_retention)
+        } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
+            Ok(&self.mock_audit_event_timestamp)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1161,6 +1216,8 @@ impl SystemVars {
             self.persist_compaction_minimum_timeout.is_default(value)
         } else if name == METRICS_RETENTION.name {
             self.metrics_retention.is_default(value)
+        } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
+            self.mock_audit_event_timestamp.is_default(value)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1221,6 +1278,8 @@ impl SystemVars {
             self.persist_compaction_minimum_timeout.set(value)
         } else if name == METRICS_RETENTION.name {
             self.metrics_retention.set(value)
+        } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
+            self.mock_audit_event_timestamp.set(value)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1276,6 +1335,8 @@ impl SystemVars {
             Ok(self.persist_compaction_minimum_timeout.reset())
         } else if name == METRICS_RETENTION.name {
             Ok(self.metrics_retention.reset())
+        } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
+            Ok(self.mock_audit_event_timestamp.reset())
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1370,6 +1431,11 @@ impl SystemVars {
     pub fn metrics_retention(&self) -> Duration {
         *self.metrics_retention.value()
     }
+
+    /// Returns the `mock_audit_event_timestamp` configuration parameter.
+    pub fn mock_audit_event_timestamp(&self) -> Option<u64> {
+        *self.mock_audit_event_timestamp.value()
+    }
 }
 
 /// A `Var` represents a configuration parameter of an arbitrary type.
@@ -1394,6 +1460,11 @@ pub trait Var: fmt::Debug {
     /// [`crate::catalog::SYSTEM_USER`] user.
     fn visible(&self, user: &User) -> bool;
 
+    /// Indicates wither the [`Var`] is only visible in unsafe mode.
+    ///
+    /// Variables marked as `safe` are visible outside of unsafe mode.
+    fn safe(&self) -> bool;
+
     /// Indicates wither the [`Var`] is experimental.
     ///
     /// The default implementation determines this from the [`Var`] name, as
@@ -1413,6 +1484,7 @@ where
     value: &'static V,
     description: &'static str,
     internal: bool,
+    safe: bool,
 }
 
 impl<V> Var for ServerVar<V>
@@ -1437,6 +1509,10 @@ where
 
     fn visible(&self, user: &User) -> bool {
         !self.internal || user == &*SYSTEM_USER
+    }
+
+    fn safe(&self) -> bool {
+        self.safe
     }
 }
 
@@ -1525,6 +1601,10 @@ where
 
     fn visible(&self, user: &User) -> bool {
         self.parent.visible(user)
+    }
+
+    fn safe(&self) -> bool {
+        self.parent.safe()
     }
 }
 
@@ -1625,6 +1705,10 @@ where
     fn visible(&self, user: &User) -> bool {
         self.parent.visible(user)
     }
+
+    fn safe(&self) -> bool {
+        self.parent.safe()
+    }
 }
 
 impl Var for BuildInfo {
@@ -1645,6 +1729,10 @@ impl Var for BuildInfo {
     }
 
     fn visible(&self, _: &User) -> bool {
+        true
+    }
+
+    fn safe(&self) -> bool {
         true
     }
 }
@@ -1694,6 +1782,18 @@ impl Value for u32 {
     const TYPE_NAME: &'static str = "unsigned integer";
 
     fn parse(s: &str) -> Result<u32, ()> {
+        s.parse().map_err(|_| ())
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for u64 {
+    const TYPE_NAME: &'static str = "unsigned integer";
+
+    fn parse(s: &str) -> Result<u64, ()> {
         s.parse().map_err(|_| ())
     }
 
@@ -1919,6 +2019,24 @@ impl Value for Option<String> {
         match s {
             "" => Ok(None),
             _ => <str as Value>::parse(s).map(Some),
+        }
+    }
+
+    fn format(&self) -> String {
+        match self {
+            Some(s) => s.format(),
+            None => "".into(),
+        }
+    }
+}
+
+impl Value for Option<u64> {
+    const TYPE_NAME: &'static str = "optional unsigned integer";
+
+    fn parse(s: &str) -> Result<Option<u64>, ()> {
+        match s {
+            "" => Ok(None),
+            _ => <u64 as Value>::parse(s).map(Some),
         }
     }
 

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -415,7 +415,7 @@ static EMIT_TRACE_ID_NOTICE: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
-static MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<u64>> = ServerVar {
+static MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<mz_repr::Timestamp>> = ServerVar {
     name: UncasedStr::new("mock_audit_event_timestamp"),
     value: &None,
     description: "Mocked timestamp to use for audit events for testing purposes",
@@ -1046,7 +1046,7 @@ pub struct SystemVars {
     metrics_retention: SystemVar<Duration>,
 
     // testing
-    mock_audit_event_timestamp: SystemVar<Option<u64>>,
+    mock_audit_event_timestamp: SystemVar<Option<mz_repr::Timestamp>>,
 }
 
 impl Default for SystemVars {
@@ -1433,7 +1433,7 @@ impl SystemVars {
     }
 
     /// Returns the `mock_audit_event_timestamp` configuration parameter.
-    pub fn mock_audit_event_timestamp(&self) -> Option<u64> {
+    pub fn mock_audit_event_timestamp(&self) -> Option<mz_repr::Timestamp> {
         *self.mock_audit_event_timestamp.value()
     }
 }
@@ -1790,10 +1790,10 @@ impl Value for u32 {
     }
 }
 
-impl Value for u64 {
-    const TYPE_NAME: &'static str = "unsigned integer";
+impl Value for mz_repr::Timestamp {
+    const TYPE_NAME: &'static str = "mz-timestamp";
 
-    fn parse(s: &str) -> Result<u64, ()> {
+    fn parse(s: &str) -> Result<mz_repr::Timestamp, ()> {
         s.parse().map_err(|_| ())
     }
 
@@ -2030,13 +2030,13 @@ impl Value for Option<String> {
     }
 }
 
-impl Value for Option<u64> {
+impl Value for Option<mz_repr::Timestamp> {
     const TYPE_NAME: &'static str = "optional unsigned integer";
 
-    fn parse(s: &str) -> Result<Option<u64>, ()> {
+    fn parse(s: &str) -> Result<Option<mz_repr::Timestamp>, ()> {
         match s {
             "" => Ok(None),
-            _ => <u64 as Value>::parse(s).map(Some),
+            _ => <mz_repr::Timestamp as Value>::parse(s).map(Some),
         }
     }
 

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -129,3 +129,29 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 44  create  source  {"database":"materialize","id":"u13","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
 45  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","replica_id":"4","replica_name":"r"}  materialize
 46  drop  cluster  {"id":"u2","name":"foo"}  materialize
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET mock_audit_event_timestamp = 666
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE tt ()
+
+query ITTTTT
+SELECT id, event_type, object_type, details, user, occurred_at FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+47  create  table  {"database":"materialize","id":"u14","item":"tt","schema":"public"}  materialize  1970-01-01␠00:00:00.666+00
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET mock_audit_event_timestamp
+----
+COMPLETE 0
+
+statement ok
+DROP TABLE tt
+
+query B
+SELECT occurred_at::text = '1970-01-01 00:00:00.666+00' FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+false


### PR DESCRIPTION
This commit adds a toggle that allows users specify what timestamp will be used for audit events. When the toggle is off, the system will choose timestamps normally. This toggle is only available in unsafe mode and is meant for testing purposes.

This commit also adds a toggle for all system variables that will make them only available in unsafe mode.

Resolves #17331

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
 This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
