### PR TITLE
parser: Impose size limit on statement batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,6 +4562,7 @@ name = "mz-sql-parser"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytesize",
  "datadriven",
  "enum-kinds",
  "itertools",

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+bytesize = "1.1.0"
 enum-kinds = "0.5.1"
 itertools = "0.10.5"
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -91,7 +91,6 @@ use std::iter;
 use itertools::Itertools;
 use unicode_width::UnicodeWidthStr;
 
-use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::fmt::FormatBuffer;
 use mz_sql_parser::ast::display::AstDisplay;
@@ -357,7 +356,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
 fn test_max_statement_batch_size() {
     let statement = "SELECT 1;";
     let size = statement.bytes().count();
-    let max_statement_count = usize::cast_from(MAX_STATEMENT_BATCH_SIZE.as_u64()) / size;
+    let max_statement_count = MAX_STATEMENT_BATCH_SIZE / size;
     let statements = iter::repeat(statement).take(max_statement_count).join("");
 
     assert!(parse_statements(&statements).is_ok());

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -86,16 +86,19 @@
 // END LINT CONFIG
 
 use std::error::Error;
+use std::iter;
 
+use itertools::Itertools;
 use unicode_width::UnicodeWidthStr;
 
+use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::fmt::FormatBuffer;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit::Visit;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{AstInfo, Expr, Ident, Raw, RawDataType, RawObjectName};
-use mz_sql_parser::parser::{self, ParserError};
+use mz_sql_parser::parser::{self, parse_statements, ParserError, MAX_STATEMENT_BATCH_SIZE};
 
 #[test]
 fn datadriven() {
@@ -348,4 +351,17 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
     assert_eq!(visitor.seen_idents, expected);
 
     Ok(())
+}
+
+#[test]
+fn test_max_statement_batch_size() {
+    let statement = "SELECT 1;";
+    let size = statement.bytes().count();
+    let max_statement_count = usize::cast_from(MAX_STATEMENT_BATCH_SIZE.as_u64()) / size;
+    let statements = iter::repeat(statement).take(max_statement_count).join("");
+
+    assert!(parse_statements(&statements).is_ok());
+    let statements = format!("{statements}{statement}");
+    let err = parse_statements(&statements).expect_err("statements should be too big");
+    assert!(err.message.contains("statement batch size cannot exceed "));
 }


### PR DESCRIPTION
This commit imposes a limit of 1MB on any batch of statements received by Materialize.

Works towards resolving #17218

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
