### PR TITLE
Update several dependencies to variants without advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,15 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,7 +4050,6 @@ dependencies = [
 name = "mz-ore"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "async-trait",
  "atty",
@@ -4095,6 +4085,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "workspace-hack",
+ "yansi",
 ]
 
 [[package]]
@@ -5728,14 +5719,14 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
 dependencies = [
- "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
+ "yansi",
 ]
 
 [[package]]
@@ -7269,9 +7260,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -8205,6 +8196,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -57,7 +57,7 @@ semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", features = ["rt", "time"] }
+tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -21,7 +21,7 @@ hyper = { version = "0.14.23", features = ["server"] }
 once_cell = "1.16.0"
 mz-ore = { path = "../ore", features = ["async"] }
 serde_json = "1.0.89"
-tokio = { version = "1.23.0", features = ["macros"] }
+tokio = { version = "1.24.2", features = ["macros"] }
 tracing = "0.1.37"
 
 [build-dependencies]

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -29,7 +29,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = { version = "1.16.0" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-stream = "0.1.11"
 tonic = "0.8.2"
 tracing = "0.1.37"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -33,7 +33,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", features = ["fs", "rt", "sync", "net"] }
+tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1.16.0"
 regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 uuid = { version = "1.2.2" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -72,7 +72,7 @@ socket2 = "0.4.7"
 sysctl = "0.5.4"
 tempfile = "3.2.0"
 thiserror = "1.0.37"
-tokio = { version = "1.23.0", features = ["sync"] }
+tokio = { version = "1.24.2", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-stream = { version = "0.1.11", features = ["net"] }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -15,7 +15,7 @@ mz-ore = { path = "../ore", features = ["network"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"
-tokio = { version = "1.23.0", features = ["macros"] }
+tokio = { version = "1.24.2", features = ["macros"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -35,7 +35,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
-tokio = { version = "1.23.0", features = ["macros"] }
+tokio = { version = "1.24.2", features = ["macros"] }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-tokio = { version = "1.23.0", features = ["macros", "sync"] }
+tokio = { version = "1.24.2", features = ["macros", "sync"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -19,7 +19,7 @@ open = "3.2.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rpassword = "7.2.0"
 serde = { version = "1.0.152", features = ["derive"] }
-tokio = { version = "1.23.0", features = ["full"] }
+tokio = { version = "1.24.2", features = ["full"] }
 toml = "0.5.9"
 uuid = "1.2.2"
 url = "2.3.1"

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.89"
 scopeguard = "1.1.0"
 sha1 = "0.10.5"
 sysinfo = "0.27.2"
-tokio = { version = "1.23.0", features = [ "fs", "process", "time" ] }
+tokio = { version = "1.24.2", features = [ "fs", "process", "time" ] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -32,7 +32,7 @@ smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
-tokio = { version = "1.23.0", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }
+tokio = { version = "1.24.2", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up
@@ -44,7 +44,6 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
 
 
 # For the `tracing` feature
-ansi_term = { version = "0.12.1", optional = true }
 atty = { version = "0.2.14", optional = true }
 http = { version = "0.2.8", optional = true }
 tracing = { version = "0.1.37", optional = true }
@@ -58,19 +57,19 @@ opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.gi
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git", optional = true }
 console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
+yansi = { version = "0.5.1", optional = true }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 anyhow = { version = "1.0.66" }
 scopeguard = "1.1.0"
-tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 
 [features]
 async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic"]
 tracing_ = [
   "anyhow",
-  "ansi_term",
   "atty",
   "tracing",
   "tracing-subscriber",
@@ -87,6 +86,7 @@ tracing_ = [
   "tonic",
   "sentry",
   "sentry-tracing",
+  "yansi",
 ]
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing"]
 cli = ["clap"]

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -461,19 +461,11 @@ where
         match &self.prefix {
             None => self.inner.format_event(ctx, writer, event)?,
             Some(prefix) => {
-                let style = ansi_term::Style::new();
-                let target_style = if writer.has_ansi_escapes() {
-                    style.bold()
-                } else {
-                    style
-                };
-                write!(
-                    writer,
-                    "{}{}:{} ",
-                    target_style.prefix(),
-                    prefix,
-                    target_style.infix(style)
-                )?;
+                let mut prefix = yansi::Paint::new(prefix);
+                if writer.has_ansi_escapes() {
+                    prefix = prefix.bold();
+                }
+                write!(writer, "{}: ", prefix)?;
                 self.inner.format_event(ctx, writer, event)?;
             }
         }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -52,7 +52,7 @@ semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.24.2", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -45,7 +45,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.24.2", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -23,7 +23,7 @@ mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
 openssl = { version = "0.10.43", features = ["vendored"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-openssl = "0.6.3"
 tokio-util = { version = "0.7.4", features = ["codec"] }
 tracing = "0.1.37"

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -20,7 +20,7 @@ proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-fea
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"
-tokio = { version = "1.23.0", features = ["fs", "rt", "sync"] }
+tokio = { version = "1.24.2", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 tempfile = "3.2.0"
 tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"], optional = true }
 tracing = "0.1.37"
-tokio = { version = "1.23.0", features = ["time"] }
+tokio = { version = "1.24.2", features = ["time"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "3.2.20", features = ["derive"] }
 futures = "0.3.25"
 indicatif = "0.17.2"
 mz-ore = { path = "../ore", features = ["cli"] }
-tokio = { version = "1.23.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.24.2", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 mz-ore = { path = "../ore", features = ["async"] }
 segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
 serde_json = "1.0.89"
-tokio = { version = "1.23.0", features = ["sync"] }
+tokio = { version = "1.24.2", features = ["sync"] }
 tracing = "0.1.37"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -27,7 +27,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 semver = "1.0.16"
 sysinfo = "0.27.2"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-stream = "0.1.11"
 tonic = "0.8.2"
 tower = "0.4.13"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = "0.11.13"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-tokio = { version = "1.23.0", features = ["fs"] }
+tokio = { version = "1.24.2", features = ["fs"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
 tracing = "0.1.37"
 uncased = "0.9.7"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = "1.0.89"
 tempfile = "3.2.0"
 time = "0.3.17"
 tracing = "0.1.37"
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 uuid = "1.2.2"

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -19,7 +19,7 @@ mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
 once_cell = "1.16.0"
 serde_json = "1.0.89"
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.5"
 serde = "1.0.152"
 serde_json = "1.0.89"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -31,7 +31,7 @@ anyhow = "1.0.66"
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 mz-postgres-util = { path = "../postgres-util" }
 once_cell = "1.16.0"
-tokio = { version = "1.23.0", features = ["macros"] }
+tokio = { version = "1.24.2", features = ["macros"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -51,7 +51,7 @@ regex = { version = "1.7.0" }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
 tokio-stream = "0.1.11"
 tonic = "0.8.2"
@@ -67,7 +67,7 @@ tonic-build = "0.8.2"
 
 [dev-dependencies]
 itertools = "0.10.5"
-tokio = { version = "1.23.0", features = ["test-util"] }
+tokio = { version = "1.24.2", features = ["test-util"] }
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -56,7 +56,7 @@ regex = { version = "1.7.0" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.23.0", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["io"] }
@@ -74,7 +74,7 @@ tonic-build = "0.8.2"
 [dev-dependencies]
 datadriven = { version = "0.6.0", features = ["async"] }
 itertools = "0.10.5"
-tokio = { version = "1.23.0", features = ["test-util"] }
+tokio = { version = "1.24.2", features = ["test-util"] }
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -65,7 +65,7 @@ tiberius = { version = "0.11.3", default-features = false }
 time = "0.3.17"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tokio = { version = "1.23.0", features = ["process"] }
+tokio = { version = "1.24.2", features = ["process"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_"] }
 polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
-tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread", "time"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -95,7 +95,7 @@ socket2 = { version = "0.4.7", default-features = false, features = ["all"] }
 syn = { version = "1.0.107", features = ["extra-traits", "full", "visit", "visit-mut"] }
 textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
-tokio = { version = "1.23.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.24.2", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
@@ -194,7 +194,7 @@ syn = { version = "1.0.107", features = ["extra-traits", "full", "visit", "visit
 textwrap = { version = "0.15.0", default-features = false, features = ["terminal_size"] }
 time = { version = "0.3.17", features = ["macros", "quickcheck", "serde-well-known"] }
 time-macros = { version = "0.2.6", default-features = false, features = ["formatting", "parsing", "serde"] }
-tokio = { version = "1.23.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.24.2", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.66"
 itertools = "0.10.5"
 mz-metabase = { path = "../../../src/metabase" }
 mz-ore = { path = "../../../src/ore", features = ["network", "async", "test"] }
-tokio = { version = "1.23.0", features = ["macros"] }
+tokio = { version = "1.24.2", features = ["macros"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../../../src/workspace-hack" }

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -18,7 +18,7 @@ mz-kinesis-util = { path = "../../src/kinesis-util" }
 mz-ore = { path = "../../src/ore", features = ["async"] }
 mz-test-util = { path = "../test-util" }
 rand = "0.8.5"
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -13,7 +13,7 @@ mz-kafka-util = { path = "../../src/kafka-util" }
 mz-ore = { path = "../../src/ore", features = ["async"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
-tokio = "1.23.0"
+tokio = "1.24.2"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../../src/workspace-hack" }


### PR DESCRIPTION
Address some of the advisories found by our [security builds](https://buildkite.com/materialize/security/builds/859#0185ee9f-e530-4c7b-b681-0b4482e04df0).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
