### PR TITLE
Move linked cluster tests to adapter

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -992,14 +992,13 @@ impl CatalogState {
         id == self.get_mz_catalog_schema_id()
             || id == self.get_pg_catalog_schema_id()
             || id == self.get_information_schema_id()
-        || id == self.get_mz_internal_schema_id()
-        
+            || id == self.get_mz_internal_schema_id()
     }
 
     pub fn is_system_schema_specifier(&self, spec: &SchemaSpecifier) -> bool {
         match spec {
             SchemaSpecifier::Temporary => false,
-            SchemaSpecifier::Id(id) => self.is_system_schema_id(id)
+            SchemaSpecifier::Id(id) => self.is_system_schema_id(id),
         }
     }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -424,10 +424,6 @@ impl CatalogState {
             .map(|id| &self.clusters_by_id[id])
     }
 
-    fn get_linked_object(&self, cluster_id: ClusterId) -> Option<GlobalId> {
-        self.clusters_by_id[&cluster_id].linked_object_id
-    }
-
     fn get_storage_object_size(&self, object_id: GlobalId) -> Option<&str> {
         let cluster = self.get_linked_cluster(object_id)?;
         let replica_id = cluster.replica_id_by_name[LINKED_CLUSTER_REPLICA_NAME];
@@ -3905,12 +3901,6 @@ impl Catalog {
     /// exists.
     pub fn get_linked_cluster(&self, object_id: GlobalId) -> Option<&Cluster> {
         self.state.get_linked_cluster(object_id)
-    }
-
-    /// Gets the linked object associated with the provided cluster ID, if it
-    /// exists. Panics if there is no such cluster.
-    pub fn get_linked_object(&self, cluster_id: ClusterId) -> Option<GlobalId> {
-        self.state.get_linked_object(cluster_id)
     }
 
     /// Gets the size associated with the provided source or sink ID, if a

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -39,6 +39,7 @@ use mz_ore::task;
 use mz_repr::explain_new::{ExplainFormat, Explainee};
 use mz_repr::{Datum, Diff, GlobalId, RelationDesc, Row, RowArena, Timestamp};
 use mz_sql::ast::{ExplainStage, IndexOptionName, ObjectType};
+use mz_sql::catalog::CatalogItem as SqlCatalogItem;
 use mz_sql::catalog::{CatalogCluster, CatalogError, CatalogItemType, CatalogTypeDetails};
 use mz_sql::names::QualifiedObjectName;
 use mz_sql::plan::{
@@ -470,6 +471,32 @@ impl Coordinator {
             }
         }
     }
+
+    // Utilities used by `sequence` functions
+    // ---
+    fn ensure_cluster_is_not_linked(&self, cluster_id: ClusterId) -> Result<(), AdapterError> {
+        if let Some(linked_id) = self.catalog.get_linked_object(cluster_id) {
+            let cluster_name = self.catalog.get_cluster(cluster_id).name.clone();
+            let linked_object_name = self.catalog.get_entry(&linked_id).name().to_string();
+            Err(AdapterError::ModifyLinkedCluster {
+                cluster_name,
+                linked_object_name,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn is_compute_cluster(&self, id: ClusterId) -> bool {
+        let cluster = self.catalog.get_cluster(id);
+        cluster.bound_objects().iter().all(|id| {
+            matches!(
+                self.catalog.get_entry(id).item_type(),
+                CatalogItemType::Index | CatalogItemType::MaterializedView
+            )
+        })
+    }
+    // ---
 
     pub(crate) async fn sequence_create_source(
         &mut self,
@@ -954,7 +981,8 @@ impl Coordinator {
             config,
         }: CreateClusterReplicaPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        // Choose default AZ if necessary
+        self.ensure_cluster_is_not_linked(cluster_id)?;
+
         let (compute, location) = match config {
             mz_sql::plan::ReplicaConfig::Unmanaged {
                 storagectl_addr,
@@ -1459,6 +1487,18 @@ impl Coordinator {
             if_not_exists,
         } = plan;
 
+        if !self
+            .catalog
+            .state()
+            .is_system_schema_specifier(&name.qualifiers.schema_spec)
+        {
+            self.ensure_cluster_is_not_linked(cluster_id)?;
+            if !self.is_compute_cluster(cluster_id) {
+                let cluster_name = self.catalog.get_cluster(cluster_id).name.clone();
+                return Err(AdapterError::BadItemInStorageCluster { cluster_name });
+            }
+        }
+
         self.validate_timeline_context(depends_on.clone())?;
 
         // Materialized views are not allowed to depend on log sources, as replicas
@@ -1578,6 +1618,18 @@ impl Coordinator {
 
         // An index must be created on a specific cluster.
         let cluster_id = index.cluster_id;
+
+        if !self
+            .catalog
+            .state()
+            .is_system_schema_specifier(&name.qualifiers.schema_spec)
+        {
+            self.ensure_cluster_is_not_linked(cluster_id)?;
+            if !self.is_compute_cluster(cluster_id) {
+                let cluster_name = self.catalog.get_cluster(cluster_id).name.clone();
+                return Err(AdapterError::BadItemInStorageCluster { cluster_name });
+            }
+        }
 
         let id = self.catalog.allocate_user_id().await?;
         let index = catalog::Index {
@@ -1706,6 +1758,10 @@ impl Coordinator {
             .active_cluster(session)
             .ok()
             .map(|cluster| cluster.id);
+        for id in &ids {
+            self.ensure_cluster_is_not_linked(*id)?;
+        }
+
         let ops = self.catalog.drop_cluster_ops(&ids, &mut HashSet::new());
 
         self.catalog_transact(Some(session), ops).await?;
@@ -1726,6 +1782,9 @@ impl Coordinator {
         session: &Session,
         DropClusterReplicasPlan { ids }: DropClusterReplicasPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
+        for (id, _) in &ids {
+            self.ensure_cluster_is_not_linked(*id)?;
+        }
         let ops = self
             .catalog
             .drop_cluster_replica_ops(&ids, &mut HashSet::new());

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -983,6 +983,7 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         self.ensure_cluster_is_not_linked(cluster_id)?;
 
+        // Choose default AZ if necessary
         let (compute, location) = match config {
             mz_sql::plan::ReplicaConfig::Unmanaged {
                 storagectl_addr,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -370,7 +370,7 @@ impl fmt::Display for AdapterError {
                 p.type_name().quoted()
             ),
             AdapterError::BadItemInStorageCluster { .. } => f.write_str(
-                "Cannot create this kind of item in a cluster that contains sources and sinks",
+                "cannot create this kind of item in a cluster that contains sources or sinks",
             ),
             AdapterError::InvalidParameterValue {
                 parameter,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -97,6 +97,16 @@ pub enum AdapterError {
     },
     /// The selection value for a table mutation operation refers to an invalid object.
     InvalidTableMutationSelection,
+    /// An operation attempted to modify a linked cluster.
+    ModifyLinkedCluster {
+        cluster_name: String,
+        linked_object_name: String,
+    },
+    /// An operation attempted to create an illegal item in a
+    /// storage-only cluster
+    BadItemInStorageCluster {
+        cluster_name: String,
+    },
     /// Expression violated a column's constraint
     ConstraintViolation(NotNullViolation),
     /// Target cluster has no replicas to service query.
@@ -320,6 +330,9 @@ impl fmt::Display for AdapterError {
                     up_to, as_of
                 )
             }
+            AdapterError::ModifyLinkedCluster { cluster_name, .. } => {
+                write!(f, "cannot modify linked cluster {}", cluster_name.quoted())
+            }
             AdapterError::ChangedPlan => f.write_str("cached plan must not change result type"),
             AdapterError::Catalog(e) => e.fmt(f),
             AdapterError::ConstrainedParameter {
@@ -356,6 +369,7 @@ impl fmt::Display for AdapterError {
                 p.name().quoted(),
                 p.type_name().quoted()
             ),
+            AdapterError::BadItemInStorageCluster { .. } => f.write_str("Canont create this kind of item in a cluster that contains sources and sinks"),
             AdapterError::InvalidParameterValue {
                 parameter,
                 value,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -369,7 +369,9 @@ impl fmt::Display for AdapterError {
                 p.name().quoted(),
                 p.type_name().quoted()
             ),
-            AdapterError::BadItemInStorageCluster { .. } => f.write_str("Canont create this kind of item in a cluster that contains sources and sinks"),
+            AdapterError::BadItemInStorageCluster { .. } => f.write_str(
+                "Cannot create this kind of item in a cluster that contains sources and sinks",
+            ),
             AdapterError::InvalidParameterValue {
                 parameter,
                 value,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -314,9 +314,11 @@ impl ErrorResponse {
             // DATA_EXCEPTION to match what Postgres returns for degenerate
             // range bounds
             AdapterError::AbsurdSubscribeBounds { .. } => SqlState::DATA_EXCEPTION,
+            AdapterError::BadItemInStorageCluster { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Catalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::ConstrainedParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
+            AdapterError::ModifyLinkedCluster { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             AdapterError::Eval(EvalError::CharacterNotValidForEncoding(_)) => {
                 SqlState::PROGRAM_LIMIT_EXCEEDED

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -175,9 +175,6 @@ impl PlanError {
             Self::ExplainViewOnMaterializedView(_) => {
                 Some("Use EXPLAIN [...] MATERIALIZED VIEW to explain a materialized view.".into())
             }
-            // Self::CannotModifyLinkedCluster { linked_object_name, .. } => {
-            //     Some(format!("This cluster is linked to {}. Use ALTER or DROP on that object instead.", linked_object_name))
-            // }
             Self::UnacceptableTimelineName(_) => {
                 Some("The prefix \"mz_\" is reserved for system timelines.".into())
             }
@@ -320,9 +317,6 @@ impl fmt::Display for PlanError {
             | Self::AlterViewOnMaterializedView(name)
             | Self::ShowCreateViewOnMaterializedView(name)
             | Self::ExplainViewOnMaterializedView(name) => write!(f, "{name} is not a view"),
-            // Self::CannotModifyLinkedCluster { cluster_name, .. } => {
-            //     write!(f, "cannot modify linked cluster {}", cluster_name.quoted())
-            // }
             Self::UnrecognizedTypeInPostgresSource { cols } => {
                 let mut cols = cols.to_owned();
                 cols.sort();

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -90,10 +90,6 @@ pub enum PlanError {
     AlterViewOnMaterializedView(String),
     ShowCreateViewOnMaterializedView(String),
     ExplainViewOnMaterializedView(String),
-    CannotModifyLinkedCluster {
-        cluster_name: String,
-        linked_object_name: String,
-    },
     UnacceptableTimelineName(String),
     UnrecognizedTypeInPostgresSource {
         cols: Vec<(String, Oid)>,
@@ -179,9 +175,9 @@ impl PlanError {
             Self::ExplainViewOnMaterializedView(_) => {
                 Some("Use EXPLAIN [...] MATERIALIZED VIEW to explain a materialized view.".into())
             }
-            Self::CannotModifyLinkedCluster { linked_object_name, .. } => {
-                Some(format!("This cluster is linked to {}. Use ALTER or DROP on that object instead.", linked_object_name))
-            }
+            // Self::CannotModifyLinkedCluster { linked_object_name, .. } => {
+            //     Some(format!("This cluster is linked to {}. Use ALTER or DROP on that object instead.", linked_object_name))
+            // }
             Self::UnacceptableTimelineName(_) => {
                 Some("The prefix \"mz_\" is reserved for system timelines.".into())
             }
@@ -324,9 +320,9 @@ impl fmt::Display for PlanError {
             | Self::AlterViewOnMaterializedView(name)
             | Self::ShowCreateViewOnMaterializedView(name)
             | Self::ExplainViewOnMaterializedView(name) => write!(f, "{name} is not a view"),
-            Self::CannotModifyLinkedCluster { cluster_name, .. } => {
-                write!(f, "cannot modify linked cluster {}", cluster_name.quoted())
-            }
+            // Self::CannotModifyLinkedCluster { cluster_name, .. } => {
+            //     write!(f, "cannot modify linked cluster {}", cluster_name.quoted())
+            // }
             Self::UnrecognizedTypeInPostgresSource { cols } => {
                 let mut cols = cols.to_owned();
                 cols.sort();

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3360,7 +3360,6 @@ pub fn plan_drop_cluster_replica(
             Err(_) if if_exists => continue,
             Err(e) => return Err(e.into()),
         };
-        // ensure_cluster_is_not_linked(scx, cluster)?;
         let replica_name = replica.into_string();
         // Check to see if name exists
         if let Some(replica_id) = cluster.replicas().get(&replica_name) {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1704,11 +1704,6 @@ pub fn plan_create_materialized_view(
         None => scx.resolve_cluster(None)?.id(),
         Some(in_cluster) => in_cluster.id,
     };
-    let cluster = scx.catalog.get_cluster(cluster_id);
-    ensure_cluster_is_not_linked(scx, cluster)?;
-    if !is_compute_cluster(scx, cluster) {
-        sql_bail!("cannot create materialized view in cluster containing sources or sinks");
-    }
     stmt.in_cluster = Some(ResolvedClusterName {
         id: cluster_id,
         print_name: None,
@@ -2248,11 +2243,6 @@ pub fn plan_create_index(
         None => scx.resolve_cluster(None)?.id(),
         Some(in_cluster) => in_cluster.id,
     };
-    let cluster = scx.catalog.get_cluster(cluster_id);
-    ensure_cluster_is_not_linked(scx, cluster)?;
-    if !is_compute_cluster(scx, cluster) {
-        sql_bail!("cannot create index in cluster containing sources or sinks");
-    }
     *in_cluster = Some(ResolvedClusterName {
         id: cluster_id,
         print_name: None,
@@ -2606,7 +2596,6 @@ pub fn plan_create_cluster_replica(
     }: CreateClusterReplicaStatement<Aug>,
 ) -> Result<Plan, PlanError> {
     let cluster = scx.catalog.resolve_cluster(Some(&of_cluster.to_string()))?;
-    ensure_cluster_is_not_linked(scx, cluster)?;
     if is_storage_cluster(scx, cluster)
         && cluster.bound_objects().len() > 0
         && cluster.replicas().len() > 0
@@ -3329,7 +3318,6 @@ pub fn plan_drop_cluster(
         };
         match scx.catalog.resolve_cluster(Some(name.as_str())) {
             Ok(cluster) => {
-                ensure_cluster_is_not_linked(scx, cluster)?;
                 if !cascade && !cluster.bound_objects().is_empty() {
                     sql_bail!("cannot drop cluster with active objects");
                 }
@@ -3345,36 +3333,11 @@ pub fn plan_drop_cluster(
     Ok(Plan::DropClusters(DropClustersPlan { ids }))
 }
 
-fn ensure_cluster_is_not_linked(
-    scx: &StatementContext,
-    cluster: &dyn CatalogCluster,
-) -> Result<(), PlanError> {
-    if let Some(linked_object_id) = cluster.linked_object_id() {
-        let linked_item = scx.catalog.get_item(&linked_object_id);
-        let linked_item_name = scx.catalog.resolve_full_name(linked_item.name());
-        Err(PlanError::CannotModifyLinkedCluster {
-            cluster_name: cluster.name().into(),
-            linked_object_name: linked_item_name.to_string(),
-        })
-    } else {
-        Ok(())
-    }
-}
-
 fn is_storage_cluster(scx: &StatementContext, cluster: &dyn CatalogCluster) -> bool {
     cluster.bound_objects().iter().all(|id| {
         matches!(
             scx.catalog.get_item(id).item_type(),
             CatalogItemType::Source | CatalogItemType::Sink
-        )
-    })
-}
-
-fn is_compute_cluster(scx: &StatementContext, cluster: &dyn CatalogCluster) -> bool {
-    cluster.bound_objects().iter().all(|id| {
-        matches!(
-            scx.catalog.get_item(id).item_type(),
-            CatalogItemType::Index | CatalogItemType::MaterializedView
         )
     })
 }
@@ -3397,7 +3360,7 @@ pub fn plan_drop_cluster_replica(
             Err(_) if if_exists => continue,
             Err(e) => return Err(e.into()),
         };
-        ensure_cluster_is_not_linked(scx, cluster)?;
+        // ensure_cluster_is_not_linked(scx, cluster)?;
         let replica_name = replica.into_string();
         // Check to see if name exists
         if let Some(replica_id) = cluster.replicas().get(&replica_name) {

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -89,14 +89,12 @@ materialize_public_lg2  linked  ${arg.default-storage-size}
 
 # Test that linked clusters cannot be dropped, nor can their replicas be
 # dropped, nor can new replicas be created, nor can they run queries.
-! DROP CLUSTER materialize_public_lg2
-contains:cannot modify linked cluster "materialize_public_lg2"
 ! DROP CLUSTER materialize_public_lg2 CASCADE
 contains:cannot modify linked cluster "materialize_public_lg2"
 ! DROP CLUSTER REPLICA materialize_public_lg2.linked
 contains:cannot modify linked cluster "materialize_public_lg2"
 ! CREATE CLUSTER REPLICA materialize_public_lg2.new SIZE 'small'
-contains:cannot modify linked cluster "materialize_public_lg2"
+contains:cannot create more than one replica of a cluster containing sources or sinks
 ! CREATE MATERIALIZED VIEW v IN CLUSTER materialize_public_lg2 AS SELECT 1
 contains:cannot modify linked cluster "materialize_public_lg2"
 ! CREATE INDEX IN CLUSTER materialize_public_lg2 ON v (a)

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -31,9 +31,9 @@ contains:only one of IN CLUSTER or SIZE can be set
 
 # Create indexes and materialized views in a storage cluster is banned.
 ! CREATE INDEX bad IN CLUSTER storage ON t (a)
-contains:cannot create index in cluster containing sources or sinks
+contains:cannot create this kind of item in a cluster that contains sources or sinks
 ! CREATE MATERIALIZED VIEW bad IN CLUSTER storage AS SELECT 1
-contains:cannot create materialized view in cluster containing sources or sinks
+contains:cannot create this kind of item in a cluster that contains sources or sinks
 
 # Executing queries on a storage cluster is banned.
 ! SELECT 1


### PR DESCRIPTION
This allows us to avoid the check in the case where we are modifying builtin introspection sources.