### PR TITLE
Use `ConsolidateBuffer` for more aggressive per-worker pre-aggregation in `explode_one`

### DIFF
--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -77,14 +77,14 @@ pub fn construct<A: Allocate>(
         let mut demux_buffer = Vec::new();
         demux.build(move |_capability| {
             move |_frontiers| {
-                let arrangement_batches = arrangement_batches_out.activate();
-                let arrangement_records = arrangement_records_out.activate();
-                let sharing = sharing_out.activate();
+                let mut arrangement_batches = arrangement_batches_out.activate();
+                let mut arrangement_records = arrangement_records_out.activate();
+                let mut sharing = sharing_out.activate();
                 let mut arrangement_batches_session =
-                    ConsolidateBuffer::new(arrangement_batches, 0);
+                    ConsolidateBuffer::new(&mut arrangement_batches, 0);
                 let mut arrangement_records_session =
-                    ConsolidateBuffer::new(arrangement_records, 1);
-                let mut sharing_session = ConsolidateBuffer::new(sharing, 2);
+                    ConsolidateBuffer::new(&mut arrangement_records, 1);
+                let mut sharing_session = ConsolidateBuffer::new(&mut sharing, 2);
 
                 input.for_each(|cap, data| {
                     data.swap(&mut demux_buffer);

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -112,8 +112,8 @@ pub fn construct<A: Allocate>(
             let mut buffer = Vec::new();
             flatten.build(move |_capability| {
                 move |_frontiers| {
-                    let updates = updates_out.activate();
-                    let mut updates_session = ConsolidateBuffer::new(updates, 0);
+                    let mut updates = updates_out.activate();
+                    let mut updates_session = ConsolidateBuffer::new(&mut updates, 0);
 
                     input.for_each(|cap, data| {
                         data.swap(&mut buffer);

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -96,24 +96,26 @@ pub fn construct<A: Allocate>(
             let mut messages_received_data: BTreeMap<_, Vec<Diff>> = BTreeMap::new();
             let mut schedules_data: BTreeMap<_, Vec<(isize, Diff)>> = BTreeMap::new();
             move |_frontiers| {
-                let operates = operates_out.activate();
-                let channels = channels_out.activate();
-                let addresses = addresses_out.activate();
-                let parks = parks_out.activate();
-                let messages_sent = messages_sent_out.activate();
-                let messages_received = messages_received_out.activate();
-                let schedules_duration = schedules_duration_out.activate();
-                let schedules_histogram = schedules_histogram_out.activate();
+                let mut operates = operates_out.activate();
+                let mut channels = channels_out.activate();
+                let mut addresses = addresses_out.activate();
+                let mut parks = parks_out.activate();
+                let mut messages_sent = messages_sent_out.activate();
+                let mut messages_received = messages_received_out.activate();
+                let mut schedules_duration = schedules_duration_out.activate();
+                let mut schedules_histogram = schedules_histogram_out.activate();
 
-                let mut operates_session = ConsolidateBuffer::new(operates, 0);
-                let mut channels_session = ConsolidateBuffer::new(channels, 1);
-                let mut addresses_session = ConsolidateBuffer::new(addresses, 2);
-                let mut parks_session = ConsolidateBuffer::new(parks, 3);
-                let mut messages_sent_session = ConsolidateBuffer::new(messages_sent, 4);
-                let mut messages_received_session = ConsolidateBuffer::new(messages_received, 5);
-                let mut schedules_duration_session = ConsolidateBuffer::new(schedules_duration, 6);
+                let mut operates_session = ConsolidateBuffer::new(&mut operates, 0);
+                let mut channels_session = ConsolidateBuffer::new(&mut channels, 1);
+                let mut addresses_session = ConsolidateBuffer::new(&mut addresses, 2);
+                let mut parks_session = ConsolidateBuffer::new(&mut parks, 3);
+                let mut messages_sent_session = ConsolidateBuffer::new(&mut messages_sent, 4);
+                let mut messages_received_session =
+                    ConsolidateBuffer::new(&mut messages_received, 5);
+                let mut schedules_duration_session =
+                    ConsolidateBuffer::new(&mut schedules_duration, 6);
                 let mut schedules_histogram_session =
-                    ConsolidateBuffer::new(schedules_histogram, 7);
+                    ConsolidateBuffer::new(&mut schedules_histogram, 7);
 
                 input.for_each(|cap, data| {
                     data.swap(&mut demux_buffer);

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -426,15 +426,14 @@ where
                     let mut out = ConsolidateBuffer::new(output, 0);
                     input.for_each(|time, data| {
                         data.swap(&mut buffer);
-                        let exploded = buffer.drain(..).map(|(x, t, d)| {
-                            let (x, d2) = logic(x);
-                            (x, t, d2.multiply(&d))
-                        });
-                        for item in exploded {
-                            out.give(&time, item);
-                        }
+                        out.give_iterator(
+                            &time,
+                            buffer.drain(..).map(|(x, t, d)| {
+                                let (x, d2) = logic(x);
+                                (x, t, d2.multiply(&d))
+                            }),
+                        );
                     });
-                    out.flush();
                 }
             })
             .as_collection()

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -12,8 +12,8 @@
 use std::future::Future;
 
 use differential_dataflow::difference::{Multiply, Semigroup};
-use differential_dataflow::AsCollection;
-use differential_dataflow::Collection;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::{AsCollection, Collection};
 use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
@@ -25,6 +25,7 @@ use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::Data;
 
+use crate::buffer::ConsolidateBuffer;
 use crate::builder_async::{AsyncInputHandle, OperatorBuilder as OperatorBuilderAsync};
 
 /// Extension methods for timely [`Stream`]s.
@@ -189,10 +190,11 @@ where
     /// and move the data into the difference component. This will allow differential dataflow to update in-place.
     fn explode_one<D2, R2, L>(&self, logic: L) -> Collection<G, D2, <R2 as Multiply<R>>::Output>
     where
-        D2: Data + Ord,
+        D2: differential_dataflow::Data,
         R2: Semigroup + Multiply<R>,
         <R2 as Multiply<R>>::Output: Data + Semigroup,
-        L: FnMut(D1) -> (D2, R2) + 'static;
+        L: FnMut(D1) -> (D2, R2) + 'static,
+        G::Timestamp: Lattice;
 }
 
 impl<G, D1> StreamExt<G, D1> for Stream<G, D1>
@@ -411,29 +413,28 @@ where
 
     fn explode_one<D2, R2, L>(&self, mut logic: L) -> Collection<G, D2, <R2 as Multiply<R>>::Output>
     where
-        D2: Data + Ord,
+        D2: differential_dataflow::Data,
         R2: Semigroup + Multiply<R>,
         <R2 as Multiply<R>>::Output: Data + Semigroup,
         L: FnMut(D1) -> (D2, R2) + 'static,
+        G::Timestamp: Lattice,
     {
-        let mut buffer = Vec::new();
-        let mut out = Vec::new();
         self.inner
             .unary(Pipeline, "ExplodeOne", move |_, _| {
+                let mut buffer = Vec::new();
                 move |input, output| {
+                    let mut out = ConsolidateBuffer::new(output, 0);
                     input.for_each(|time, data| {
                         data.swap(&mut buffer);
-                        out.extend(buffer.drain(..).map(|(x, t, d)| {
+                        let exploded = buffer.drain(..).map(|(x, t, d)| {
                             let (x, d2) = logic(x);
                             (x, t, d2.multiply(&d))
-                        }));
-                        differential_dataflow::consolidation::consolidate_updates(&mut out);
-                        if out.len() < out.capacity() / 2 {
-                            output.session(&time).give_iterator(out.drain(..));
-                        } else {
-                            output.session(&time).give_container(&mut out);
+                        });
+                        for item in exploded {
+                            out.give(&time, item);
                         }
                     });
+                    out.flush();
                 }
             })
             .as_collection()


### PR DESCRIPTION
This PR aims to improve the existing `explode_one` operator implementation in `src/timely-util/src/operator.rs` to more aggressively pre-aggregate on a per-worker basis when key domains are small. This goal is achieved by:

1. Employing a `ConsolidateBuffer` to call `consolidate_updates` across input batches as long as these input batches are of the same `time`.
2. Change the consolidation policy in `ConsolidateBuffer` to call `consolidate_updates` every time the output buffer doubles instead of only when it is filled with input tuples. In small key domains, this strategy limits as possible the lifetime of allocations and passes smaller buffers to `consolidate_updates`, attempting to mimic as much as possible in-place aggregation without introducing an additional data structure for this purpose.

### Motivation

  * This PR adds a known-desirable feature.

    Fixes #17271 

### Tips for reviewer

You can look at the individual commits for this PR. Adjustments to the `ConsolidateBuffer` typing were carried out to allow it to be employed with a `unary` operator. Note that we can instead implement the logic here with a raw Timely operator to avoid allocating a new output buffer for every new set of input batches; however, the changes to enable broader use of `ConsolidateBuffer` are probably useful in any case.

Measurements for this alternative have been collected in an [internal spreadsheet](https://docs.google.com/spreadsheets/d/1cVJEJ6ZwMG2KYpcl0TFSDJbH4iibybEE3igBEgHoosQ/edit#gid=0). The setup is referred to in PR #17281, which is a direct algorithmic change to `explode_one`. Only one of these two PRs should be merged, and I favor the present one. Note that the performance results are broadly comparable between the two PRs, indicating that (a) the better software organization here does not cost us much, if at all; (b) further going down the road of a raw Timely operator seems to be unnecessary at this point.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
N/A
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A