### PR TITLE
mzcompose: use native Docker Compose healthchecks

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -40,9 +40,7 @@ SERVICES = [
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("args", nargs="*")
     args = parser.parse_args()
-    c.start_and_wait_for_tcp(
-        ["zookeeper", "kafka", "schema-registry", "postgres", "cockroach"]
-    )
+    c.up("zookeeper", "kafka", "schema-registry", "postgres", "cockroach")
     # Heads up: this intentionally runs on the host rather than in a Docker
     # image. See #13010.
     postgres_url = (

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -67,9 +67,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             with c.test_case(test_case.name):
                 with c.override(materialized):
                     c.down()
-                    c.start_and_wait_for_tcp(services=["redpanda"])
+                    c.up("redpanda")
                     c.up("materialized")
-                    c.wait_for_tcp(host="materialized", port=6875)
                     c.run(
                         "dbt-test",
                         "pytest",

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -47,8 +47,6 @@ class StartMz(MzcomposeAction):
         with c.override(mz):
             c.up("materialized")
 
-        c.wait_for_materialized()
-
         for config_param in ["max_tables", "max_sources"]:
             c.sql(
                 f"ALTER SYSTEM SET {config_param} TO 1000",
@@ -115,7 +113,7 @@ class StartClusterdCompute(MzcomposeAction):
         print(f"Starting Compute using image {clusterd.config.get('image')}")
 
         with c.override(clusterd):
-            c.start_and_wait_for_tcp(services=["clusterd_compute_1"])
+            c.up("clusterd_compute_1")
 
 
 class RestartRedpandaDebezium(MzcomposeAction):
@@ -126,7 +124,7 @@ class RestartRedpandaDebezium(MzcomposeAction):
 
         for service in ["redpanda", "debezium"]:
             c.kill(service)
-            c.start_and_wait_for_tcp(services=[service])
+            c.up(service)
 
 
 class RestartCockroach(MzcomposeAction):
@@ -143,7 +141,6 @@ class RestartSourcePostgres(MzcomposeAction):
 
         c.kill("postgres")
         c.up("postgres")
-        c.wait_for_postgres(service="postgres")
 
 
 class KillClusterdStorage(MzcomposeAction):

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -441,14 +441,6 @@ class Composition:
             cursor.execute(sql)
             return cursor.fetchall()
 
-    def start_and_wait_for_tcp(self, services: List[str]) -> None:
-        """Sequentially start the named services, waiting for eaach to become
-        available via TCP before moving on to the next."""
-        for service in services:
-            self.up(service)
-            for port in self.compose["services"][service].get("ports", []):
-                self.wait_for_tcp(host=service, port=port)
-
     def run(
         self,
         service: str,
@@ -674,119 +666,6 @@ class Composition:
         """Sleep for the specified duration in seconds."""
         print(f"Sleeping for {duration} seconds...")
         time.sleep(duration)
-
-    # TODO(benesch): replace with Docker health checks.
-    def wait_for_tcp(
-        self,
-        *,
-        host: str = "localhost",
-        port: Union[int, str],
-        timeout_secs: int = 240,
-    ) -> None:
-        if isinstance(port, str):
-            port = int(port.split(":")[0])
-        ui.progress(f"waiting for {host}:{port}", "C")
-        cmd = f"docker run --rm -t --network {self.name}_default ubuntu:focal-20210723".split()
-        try:
-            _check_tcp(cmd[:], host, port, timeout_secs)
-        except subprocess.CalledProcessError:
-            ui.progress(" error!", finish=True)
-            raise UIError(f"unable to connect to {host}:{port}")
-        else:
-            ui.progress(" success!", finish=True)
-
-    # TODO(benesch): replace with Docker health checks.
-    def wait_for_postgres(
-        self,
-        *,
-        dbname: str = "postgres",
-        port: Optional[int] = None,
-        host: str = "localhost",
-        timeout_secs: int = 120,
-        query: str = "SELECT 1",
-        user: str = "postgres",
-        password: str = "postgres",
-        expected: Union[Iterable[Any], Literal["any"]] = [[1]],
-        print_result: bool = False,
-        service: str = "postgres",
-    ) -> None:
-        """Wait for a PostgreSQL service to start.
-
-        Args:
-            dbname: the name of the database to wait for
-            host: the host postgres is listening on
-            port: the port postgres is listening on
-            timeout_secs: How long to wait for postgres to be up before failing (Default: 30)
-            query: The query to execute to ensure that it is running (Default: "Select 1")
-            user: The chosen user (this is only relevant for postgres)
-            service: The service that postgres is running as (Default: postgres)
-        """
-        _wait_for_pg(
-            dbname=dbname,
-            host=host,
-            port=self.port(service, port) if port else self.default_port(service),
-            timeout_secs=timeout_secs,
-            query=query,
-            user=user,
-            password=password,
-            expected=expected,
-            print_result=print_result,
-        )
-
-    # TODO(benesch): replace with Docker health checks.
-    def wait_for_cockroach(
-        self,
-        *,
-        dbname: str = "defaultdb",
-        port: Optional[int] = None,
-        host: str = "localhost",
-        timeout_secs: int = 120,
-        query: str = "SELECT 1",
-        user: str = "root",
-        password: Optional[str] = None,
-        expected: Union[Iterable[Any], Literal["any"]] = [[1]],
-        print_result: bool = False,
-        service: str = "cockroach",
-    ) -> None:
-        """Wait for a CockroachDB service to start."""
-        _wait_for_pg(
-            dbname=dbname,
-            host=host,
-            port=self.port(service, port) if port else self.default_port(service),
-            timeout_secs=timeout_secs,
-            query=query,
-            user=user,
-            password=password,
-            expected=expected,
-            print_result=print_result,
-        )
-
-    # TODO(benesch): replace with Docker health checks.
-    def wait_for_materialized(
-        self,
-        service: str = "materialized",
-        *,
-        user: str = "materialize",
-        dbname: str = "materialize",
-        host: str = "localhost",
-        port: Optional[int] = None,
-        timeout_secs: int = 60,
-        query: str = "SELECT 1",
-        expected: Union[Iterable[Any], Literal["any"]] = [[1]],
-        print_result: bool = False,
-    ) -> None:
-        """Like `Workflow.wait_for_postgres`, but with Materialize defaults."""
-        self.wait_for_postgres(
-            user=user,
-            dbname=dbname,
-            host=host,
-            port=port,
-            timeout_secs=timeout_secs,
-            query=query,
-            expected=expected,
-            print_result=print_result,
-            service=service,
-        )
 
     def testdrive(
         self,

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -31,7 +31,7 @@ class DebeziumStart(Action):
         return [DebeziumRunning()]
 
     def run(self, c: Composition) -> None:
-        c.start_and_wait_for_tcp(services=["debezium"])
+        c.up("debezium")
 
 
 class DebeziumStop(Action):

--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -43,7 +43,7 @@ class KafkaStart(Action):
         return [KafkaRunning()]
 
     def run(self, c: Composition) -> None:
-        c.start_and_wait_for_tcp(services=["kafka"])
+        c.up("kafka")
 
 
 class KafkaStop(Action):

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -26,8 +26,6 @@ class MzStart(Action):
 
     def run(self, c: Composition) -> None:
         c.up("materialized")
-        # Loaded Mz environments take a while to start up
-        c.wait_for_materialized(timeout_secs=600)
 
         for config_param in [
             "max_tables",
@@ -71,7 +69,6 @@ class MzRestart(Action):
     def run(self, c: Composition) -> None:
         c.kill("materialized")
         c.up("materialized")
-        c.wait_for_materialized(timeout_secs=300)
 
 
 class KillClusterd(Action):

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -24,8 +24,7 @@ class PostgresStart(Action):
         return [PostgresRunning()]
 
     def run(self, c: Composition) -> None:
-        c.start_and_wait_for_tcp(services=["postgres"])
-        c.wait_for_postgres()
+        c.up("postgres")
 
 
 class PostgresStop(Action):
@@ -47,8 +46,7 @@ class PostgresRestart(Action):
 
     def run(self, c: Composition) -> None:
         c.kill("postgres")
-        c.start_and_wait_for_tcp(services=["postgres"])
-        c.wait_for_postgres()
+        c.up("postgres")
 
 
 class CreatePostgresTable(Action):

--- a/misc/python/materialize/zippy/storaged_actions.py
+++ b/misc/python/materialize/zippy/storaged_actions.py
@@ -25,7 +25,7 @@ class StoragedStart(Action):
         return {CockroachIsRunning, MinioIsRunning}
 
     def run(self, c: Composition) -> None:
-        c.start_and_wait_for_tcp(services=["storaged"])
+        c.up("storaged")
 
     def provides(self) -> List[Capability]:
         return [StoragedRunning()]
@@ -40,7 +40,7 @@ class StoragedRestart(Action):
 
     def run(self, c: Composition) -> None:
         c.kill("storaged")
-        c.start_and_wait_for_tcp(services=["storaged"])
+        c.up("storaged")
 
 
 class StoragedKill(Action):

--- a/misc/rqg/mzcompose.py
+++ b/misc/rqg/mzcompose.py
@@ -68,4 +68,3 @@ def workflow_start_two_mzs(c: Composition, parser: WorkflowArgumentParser) -> No
     ):
         for mz in ["mz_this", "mz_other"]:
             c.up(mz)
-            c.wait_for_materialized(service=mz)

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -363,10 +363,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.down(destroy_volumes=True)
 
-        c.start_and_wait_for_tcp(
-            services=["redpanda", "materialized", "postgres", "clusterd"]
-        )
-        c.wait_for_materialized()
+        c.up("redpanda", "materialized", "postgres", "clusterd")
 
         c.sql(
             """
@@ -383,7 +380,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         # Restart Mz to confirm that re-hydration is also bounded memory
         c.kill("materialized", "clusterd")
-        c.start_and_wait_for_tcp(services=["materialized", "clusterd"])
-        c.wait_for_materialized()
+        c.up("materialized", "clusterd")
 
         c.testdrive(scenario.post_restart)

--- a/test/catalog-compat/mzcompose.py
+++ b/test/catalog-compat/mzcompose.py
@@ -23,5 +23,5 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka"])
+    c.up("zookeeper", "kafka")
     c.run("catcompatck")

--- a/test/chbench/mzcompose.py
+++ b/test/chbench/mzcompose.py
@@ -25,7 +25,7 @@ SERVICES = [
     Kafka(auto_create_topics=True),
     SchemaRegistry(),
     Debezium(),
-    MySql(mysql_root_password="rootpw"),
+    MySql(root_password="rootpw"),
     Materialized(),
     Metabase(),
     Service(
@@ -50,12 +50,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     # Start Materialize.
     c.up("materialized")
-    c.wait_for_materialized()
 
     # Start MySQL and Debezium.
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "mysql", "debezium"]
-    )
+    c.up("zookeeper", "kafka", "schema-registry", "mysql", "debezium")
 
     # Generate initial data.
     c.run(

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -40,8 +40,7 @@ def workflow_default(c: Composition) -> None:
     """Deploy the current source to the cloud and run a smoke test."""
 
     print("Obtaining mz_version() string from local instance ...")
-    c.start_and_wait_for_tcp(services=["materialized"])
-    c.wait_for_materialized()
+    c.up("materialized")
     local_version = c.sql_query("SELECT mz_version();")[0][0]
 
     print(f"Shutting down region {REGION} ...")

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -91,7 +91,7 @@ def workflow_default(c: Composition) -> None:
     and then making sure that cluster2 continues to operate properly
     """
 
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
     for id, disruption in enumerate(disruptions):
         run_test(c, disruption, id)
 
@@ -216,7 +216,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
     c.up("testdrive", persistent=True)
     c.up("materialized")
-    c.wait_for_materialized()
 
     nodes = [
         Clusterd(name="clusterd_1_1"),

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import random
-import string
-
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Debezium,
@@ -25,10 +22,6 @@ from materialize.mzcompose.services import (
 
 prerequisites = ["zookeeper", "kafka", "schema-registry", "debezium", "materialized"]
 
-password = "AAbb!@" + "".join(
-    random.choices(string.ascii_uppercase + string.digits, k=10)
-)
-
 SERVICES = [
     Zookeeper(),
     Kafka(auto_create_topics=True),
@@ -36,32 +29,34 @@ SERVICES = [
     Debezium(),
     Materialized(),
     Postgres(),
-    SqlServer(sa_password=password),
-    MySql(mysql_root_password=password),
+    SqlServer(),
+    MySql(),
     Testdrive(no_reset=True, default_timeout="300s"),
 ]
 
 
 def workflow_postgres(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=prerequisites)
-    c.start_and_wait_for_tcp(services=["postgres"])
-
-    c.wait_for_postgres(service="postgres")
-    c.wait_for_materialized("materialized")
+    c.up(*prerequisites, "postgres")
 
     c.run("testdrive", "postgres/debezium-postgres.td.initialize")
     c.run("testdrive", "postgres/*.td")
 
 
 def workflow_sql_server(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=prerequisites)
-    c.start_and_wait_for_tcp(services=["sql-server"])
+    c.up(*prerequisites, "sql-server")
 
-    c.run("testdrive", f"--var=sa-password={password}", "sql-server/*.td")
+    c.run(
+        "testdrive",
+        f"--var=sa-password={SqlServer.DEFAULT_SA_PASSWORD}",
+        "sql-server/*.td",
+    )
 
 
 def workflow_mysql(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=prerequisites)
-    c.start_and_wait_for_tcp(services=["mysql"])
+    c.up(*prerequisites, "mysql")
 
-    c.run("testdrive", f"--var=mysql-root-password={password}", "mysql/*.td")
+    c.run(
+        "testdrive",
+        f"--var=mysql-root-password={MySql.DEFAULT_ROOT_PASSWORD}",
+        "mysql/*.td",
+    )

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -131,7 +131,7 @@ def run_one_scenario(
                 rm=True,
             )
 
-            c.start_and_wait_for_tcp(services=["materialized"])
+            c.up("materialized")
 
         executor = Docker(composition=c, seed=common_seed, materialized=mz)
 
@@ -264,7 +264,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     else:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
 
-    c.start_and_wait_for_tcp(services=dependencies)
+    c.up(*dependencies)
 
     scenarios = initial_scenarios.copy()
 
@@ -374,7 +374,7 @@ root_scenario: {args.root_scenario}"""
     ]
 
     with c.override(*overrides):
-        c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+        c.up("zookeeper", "kafka", "schema-registry")
         c.up("testdrive", persistent=True)
 
         # Build the list of scenarios to run

--- a/test/kafka-exactly-once/mzcompose.py
+++ b/test/kafka-exactly-once/mzcompose.py
@@ -34,9 +34,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "materialized"]
-    )
+    c.up("zookeeper", "kafka", "schema-registry", "materialized")
     c.run(
         "testdrive",
         f"--seed={args.seed}",
@@ -46,7 +44,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized()
     c.run(
         "testdrive",
         f"--seed={args.seed}",

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -129,10 +129,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     override = [Materialized(options=options)]
 
     with c.override(*override):
-        c.start_and_wait_for_tcp(services=prerequisites)
-
-        c.up("materialized")
-        c.wait_for_materialized("materialized")
+        c.up(*prerequisites, "materialized")
 
         c.run(
             "testdrive",

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -40,7 +40,7 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["localstack"])
+    c.up("localstack")
 
     for version in CONFLUENT_PLATFORM_VERSIONS:
         print(f"==> Testing Confluent Platform {version}")
@@ -50,10 +50,7 @@ def workflow_default(c: Composition) -> None:
             SchemaRegistry(tag=version),
         ]
         with c.override(*confluent_platform_services):
-            c.start_and_wait_for_tcp(
-                services=["zookeeper", "kafka", "schema-registry", "materialized"]
-            )
-            c.wait_for_materialized()
+            c.up("zookeeper", "kafka", "schema-registry", "materialized")
             c.run("testdrive", "testdrive/kafka-*.td")
             c.kill(
                 "zookeeper",

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -37,16 +37,7 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(
-        services=[
-            "zookeeper",
-            "kafka1",
-            "kafka2",
-            "kafka3",
-            "schema-registry",
-            "materialized",
-        ]
-    )
+    c.up("zookeeper", "kafka1", "kafka2", "kafka3", "schema-registry", "materialized")
     c.run("testdrive", "--kafka-addr=kafka2", "01-init.td")
     time.sleep(10)
     c.kill("kafka1")

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -41,10 +41,7 @@ def workflow_default(c: Composition) -> None:
 # Test the kafka sink resumption logic in the presence of networking problems
 #
 def workflow_sink_networking(c: Composition) -> None:
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy"]
-    )
-    c.wait_for_materialized()
+    c.up("zookeeper", "kafka", "schema-registry", "materialized", "toxiproxy")
 
     seed = random.getrandbits(16)
     for i, failure_mode in enumerate(
@@ -55,7 +52,7 @@ def workflow_sink_networking(c: Composition) -> None:
             "toxiproxy-timeout-hold.td",
         ]
     ):
-        c.start_and_wait_for_tcp(["toxiproxy"])
+        c.up("toxiproxy")
         c.run(
             "testdrive",
             "--no-reset",
@@ -79,9 +76,7 @@ def workflow_source_resumption(c: Composition) -> None:
     with c.override(
         Testdrive(no_reset=True, consistent_seed=True),
     ):
-        c.start_and_wait_for_tcp(
-            services=["materialized", "zookeeper", "kafka", "clusterd"]
-        )
+        c.up("materialized", "zookeeper", "kafka", "clusterd")
 
         c.run("testdrive", "source-resumption/setup.td")
         c.run("testdrive", "source-resumption/verify.td")

--- a/test/kafka-sasl-plain/mzcompose.py
+++ b/test/kafka-sasl-plain/mzcompose.py
@@ -116,7 +116,6 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("test-certs")
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
     c.up("materialized")
-    c.wait_for_materialized()
     c.run("testdrive", "*.td")

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -21,7 +21,7 @@ SERVICES = [
     TestCerts(),
     Zookeeper(),
     Kafka(
-        depends_on=["zookeeper", "test-certs"],
+        depends_on_extra=["test-certs"],
         environment=[
             # Default
             "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
@@ -44,7 +44,7 @@ SERVICES = [
         volumes=["secrets:/etc/kafka/secrets"],
     ),
     SchemaRegistry(
-        depends_on=["kafka", "zookeeper", "test-certs"],
+        depends_on_extra=["test-certs"],
         environment=[
             "SCHEMA_REGISTRY_KAFKASTORE_TIMEOUT_MS=10000",
             "SCHEMA_REGISTRY_HOST_NAME=schema-registry",
@@ -116,12 +116,5 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="run against the specified files",
     )
     args = parser.parse_args()
-    c.start_and_wait_for_tcp(
-        services=[
-            "zookeeper",
-            "kafka",
-            "schema-registry",
-            "materialized",
-        ]
-    )
+    c.up("zookeeper", "kafka", "schema-registry", "materialized")
     c.run("testdrive", *args.files)

--- a/test/lang/csharp/mzcompose.py
+++ b/test/lang/csharp/mzcompose.py
@@ -26,5 +26,4 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("materialized")
-    c.wait_for_materialized()
     c.run("csharp", "/workdir/test/lang/csharp/test.sh")

--- a/test/lang/java/mzcompose.py
+++ b/test/lang/java/mzcompose.py
@@ -29,5 +29,4 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("materialized")
-    c.wait_for_materialized()
     c.run("java-smoketest", "mvn", "test")

--- a/test/lang/js/mzcompose.py
+++ b/test/lang/js/mzcompose.py
@@ -29,5 +29,4 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("materialized")
-    c.wait_for_materialized()
     c.run("js", "/workdir/test/lang/js/test.sh")

--- a/test/lang/python/mzcompose.py
+++ b/test/lang/python/mzcompose.py
@@ -29,5 +29,4 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("materialized")
-    c.wait_for_materialized()
     c.run("python", "/workdir/test/lang/python/test.sh")

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -83,7 +83,7 @@ def workflow_default(c: Composition) -> None:
 
         # Assert that the default max_result_size is served when sync is disabled.
         with c.override(Materialized()):
-            c.start_and_wait_for_tcp(services=["materialized"])
+            c.up("materialized")
             c.testdrive("\n".join(["> SHOW max_result_size", "1073741824"]))
             c.stop("materialized")
 
@@ -117,19 +117,19 @@ def workflow_default(c: Composition) -> None:
                 ]
             )
         ):
-            c.start_and_wait_for_tcp(services=["materialized"])
+            c.up("materialized")
             c.testdrive("\n".join(["> SHOW max_result_size", "2147483648"]))
             c.stop("materialized")
 
         # Assert that the last value is persisted and available upon restart,
         # even if the parameter sync loop is not running.
         with c.override(Materialized()):
-            c.start_and_wait_for_tcp(services=["materialized"])
+            c.up("materialized")
             c.testdrive("\n".join(["> SHOW max_result_size", "2147483648"]))
             c.stop("materialized")
 
         # Restart Materialized with the parameter sync loop running.
-        c.start_and_wait_for_tcp(services=["materialized"])
+        c.up("materialized")
 
         # Add a rule that targets the current user with the 3GiB variant.
         ld_client.update_targeting(

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1249,10 +1249,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
 
     c.up("materialized")
-    c.wait_for_materialized()
 
     run_test(c, args)
 
@@ -1273,10 +1272,9 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
 
     c.up("materialized")
-    c.wait_for_materialized()
 
     nodes = [
         Clusterd(name="clusterd_1_1"),
@@ -1311,7 +1309,7 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Create multiple clusters with multiple nodes and replicas each"""
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
 
     parser.add_argument(
         "--workers",
@@ -1346,7 +1344,6 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
 
     c.up("testdrive", persistent=True)
     c.up("materialized")
-    c.wait_for_materialized()
 
     # Construct the requied Clusterd instances and peer them into clusters
     cluster_replicas = []

--- a/test/metabase/mzcompose.py
+++ b/test/metabase/mzcompose.py
@@ -24,5 +24,4 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     c.up("materialized", "metabase")
-    c.wait_for_materialized()
     c.run("smoketest")

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -53,14 +53,12 @@ def workflow_default(c: Composition) -> None:
 
 
 def workflow_start_confluents(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
 
 
 def workflow_versioned_mz(c: Composition) -> None:
     for mz in versioned_mz:
         c.up(mz.name)
-
-        c.wait_for_materialized(mz.name)
 
         c.run("testdrive", "test*.td")
 
@@ -69,11 +67,9 @@ def workflow_versioned_mz(c: Composition) -> None:
 
 def workflow_mz_with_options(c: Composition) -> None:
     c.up("mz_2_workers")
-    c.wait_for_materialized("mz_2_workers")
     c.kill("mz_2_workers")
 
     c.up("mz_4_workers")
-    c.wait_for_materialized("mz_4_workers")
     c.kill("mz_4_workers")
 
 
@@ -82,4 +78,3 @@ def workflow_minio(c: Composition) -> None:
 
     with c.override(mz):
         c.up("materialized")
-        c.wait_for_materialized()

--- a/test/perf-kinesis/mzcompose.py
+++ b/test/perf-kinesis/mzcompose.py
@@ -42,5 +42,4 @@ def workflow_load_test(c: Composition) -> None:
 
 def run(c: Composition, args: List[str], detach: bool) -> None:
     c.up("materialized")
-    c.wait_for_materialized()
     c.run("perf-kinesis", *args, detach=detach)

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -53,8 +53,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         consensus_uri = (
             "postgres://root@cockroach:26257?options=--search_path=consensus"
         )
-        c.start_and_wait_for_tcp(services=["cockroach"])
-        c.wait_for_cockroach()
+        c.up("cockroach")
     else:
         # empty consensus uri defaults to Maelstrom consensus implementation
         consensus_uri = ""

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -53,7 +53,7 @@ def start_deps(
     else:
         dependencies = ["zookeeper", "kafka", "schema-registry"]
 
-    c.start_and_wait_for_tcp(services=dependencies)
+    c.up(*dependencies)
 
 
 def workflow_kafka_sources(
@@ -64,25 +64,21 @@ def workflow_kafka_sources(
     seed = round(time.time())
 
     c.up("materialized")
-    c.wait_for_materialized("materialized")
 
     c.run("testdrive", f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
 
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized("materialized")
 
     # And restart again, for extra stress
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized("materialized")
 
     c.run("testdrive", f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
 
     # Do one more restart, just in case and just confirm that Mz is able to come up
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized("materialized")
 
     c.kill("materialized")
     c.rm("materialized", "testdrive", destroy_volumes=True)
@@ -97,7 +93,6 @@ def workflow_user_tables(
     seed = round(time.time())
 
     c.up("materialized")
-    c.wait_for_materialized()
 
     c.run(
         "testdrive",
@@ -142,7 +137,6 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
     seed = round(time.time())
 
     c.up("materialized")
-    c.wait_for_materialized()
 
     c.run(
         "testdrive",
@@ -156,7 +150,6 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
     # kill Mz if the failpoint has not killed it
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized()
 
     c.run("testdrive", f"--seed={seed}", "failpoints/after.td")
 
@@ -170,7 +163,6 @@ def workflow_compaction(c: Composition) -> None:
         Materialized(options=["--metrics-scraping-interval=1s"]),
     ):
         c.up("materialized")
-        c.wait_for_materialized()
 
         c.run("testdrive", "compaction/compaction.td")
 

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -43,10 +43,6 @@ def workflow_default(c: Composition) -> None:
 def initialize(c: Composition) -> None:
     c.up("materialized", "postgres", "toxiproxy")
 
-    c.wait_for_materialized()
-    c.wait_for_postgres()
-    c.wait_for_tcp(host="toxiproxy", port=8474)
-
     # We run configure-postgres.td only once for all workflows as
     # it contains CREATE USER that is not indempotent
 
@@ -56,13 +52,11 @@ def initialize(c: Composition) -> None:
 def restart_pg(c: Composition) -> None:
     c.kill("postgres")
     c.up("postgres")
-    c.wait_for_postgres()
 
 
 def restart_mz(c: Composition) -> None:
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized()
 
 
 def begin(c: Composition) -> None:

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -38,8 +38,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ).stdout
 
     c.up("materialized", "test-certs", "testdrive", "postgres")
-    c.wait_for_materialized()
-    c.wait_for_postgres()
     c.run(
         "testdrive",
         f"--var=ssl-ca={ssl_ca}",

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -30,7 +30,7 @@ SERVICES = [
     Cockroach(setup_materialize=True),
     Postgres(),
     Redpanda(auto_create_topics=True),
-    Debezium(),
+    Debezium(redpanda=True),
     Clusterd(
         name="clusterd_compute_1"
     ),  # Started by some Scenarios, defined here only for the teardown
@@ -52,8 +52,7 @@ def setup(c: Composition) -> None:
     c.up("testdrive", persistent=True)
     c.up("cockroach")
 
-    c.start_and_wait_for_tcp(services=["redpanda", "postgres", "debezium"])
-    c.wait_for_postgres()
+    c.up("redpanda", "postgres", "debezium")
 
 
 def teardown(c: Composition) -> None:

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -424,9 +424,7 @@ def workflow_default(c: Composition) -> None:
     and then making sure that the cluster continues to operate properly
     """
 
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "localstack"]
-    )
+    c.up("zookeeper", "kafka", "schema-registry", "localstack")
     for id, disruption in enumerate(disruptions):
         run_test(c, disruption, id)
 
@@ -446,7 +444,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
     with c.override(*nodes):
         c.up("materialized", *[n.name for n in nodes])
-        c.wait_for_materialized()
 
         c.sql(
             """

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -31,8 +31,7 @@ SERVICES = [
 # shorter than the timeout.
 #
 def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["localstack", "materialized", "toxiproxy"])
-    c.wait_for_materialized()
+    c.up("localstack", "materialized", "toxiproxy")
 
     # For different values of bytes_allowed, the following happens:
     # 0 - Connection is dropped immediately

--- a/test/secrets/mzcompose.py
+++ b/test/secrets/mzcompose.py
@@ -17,8 +17,7 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized")
 
     # ensure that the directory has restricted permissions
     c.exec(

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -48,8 +48,7 @@ class KafkaDisruption:
 
         c.down(destroy_volumes=True)
         c.up("testdrive", persistent=True)
-        c.start_and_wait_for_tcp(services=["redpanda", "materialized", "clusterd"])
-        c.wait_for_materialized()
+        c.up("redpanda", "materialized", "clusterd")
 
         with c.override(
             Testdrive(
@@ -163,8 +162,7 @@ class PgDisruption:
 
         c.down(destroy_volumes=True)
         c.up("testdrive", persistent=True)
-        c.start_and_wait_for_tcp(services=["postgres", "materialized", "clusterd"])
-        c.wait_for_materialized()
+        c.up("postgres", "materialized", "clusterd")
 
         with c.override(
             Testdrive(
@@ -284,7 +282,7 @@ disruptions: List[Disruption] = [
         name="kill-postgres",
         breakage=lambda c, _: c.kill("postgres"),
         expected_error="error connecting to server",
-        fixage=lambda c, _: c.start_and_wait_for_tcp(["postgres"]),
+        fixage=lambda c, _: c.up("postgres"),
     ),
     PgDisruption(
         name="drop-publication-postgres",

--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -26,7 +26,6 @@ def workflow_sqllogictest(c: Composition) -> None:
 
 def run_sqllogictest(c: Composition, command: str) -> None:
     c.up("cockroach")
-    c.wait_for_cockroach()
 
     try:
         junit_report = ci_util.junit_report_filename(c.name)

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -34,26 +34,23 @@ SERVICES = [
 def restart_mz(c: Composition) -> None:
     c.kill("materialized")
     c.up("materialized")
-    c.wait_for_materialized()
 
 
 # restart the bastion, wiping its keys in the process
 def restart_bastion(c: Composition) -> None:
     c.kill("ssh-bastion-host")
     c.rm("ssh-bastion-host")
-    c.start_and_wait_for_tcp(services=["ssh-bastion-host"])
+    c.up("ssh-bastion-host")
 
 
 def workflow_basic_ssh_features(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized", "ssh-bastion-host", "postgres"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized", "ssh-bastion-host", "postgres")
 
     c.run("testdrive", "ssh-connections.td")
 
 
 def workflow_pg_via_ssh_tunnel(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized", "ssh-bastion-host", "postgres"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized", "ssh-bastion-host", "postgres")
 
     c.run("testdrive", "setup.td")
 
@@ -68,22 +65,11 @@ def workflow_pg_via_ssh_tunnel(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.wait_for_postgres()
-
     c.run("testdrive", "--no-reset", "pg-source.td")
 
 
 def workflow_kafka_csr_via_ssh_tunnel(c: Composition) -> None:
-    c.start_and_wait_for_tcp(
-        services=[
-            "zookeeper",
-            "kafka",
-            "schema-registry",
-            "materialized",
-            "ssh-bastion-host",
-        ]
-    )
-    c.wait_for_materialized("materialized")
+    c.up("zookeeper", "kafka", "schema-registry", "materialized", "ssh-bastion-host")
 
     c.run("testdrive", "setup.td")
 
@@ -104,8 +90,7 @@ def workflow_kafka_csr_via_ssh_tunnel(c: Composition) -> None:
 # Test that if we restart the bastion AND change its server keys(s), we can
 # still reconnect in the replication stream.
 def workflow_pg_restart_bastion(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized", "ssh-bastion-host", "postgres"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized", "ssh-bastion-host", "postgres")
 
     c.run("testdrive", "setup.td")
 
@@ -125,8 +110,6 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
         f"cat /etc/ssh/keys/ssh_host_ed25519_key.pub",
         capture=True,
     ).stdout.strip()
-
-    c.wait_for_postgres()
 
     c.run("testdrive", "--no-reset", "pg-source.td")
 
@@ -157,8 +140,7 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
 
 
 def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized", "ssh-bastion-host", "postgres"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized", "ssh-bastion-host", "postgres")
 
     c.run("testdrive", "setup.td")
 
@@ -173,14 +155,11 @@ def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
         f"echo '{public_key}' > /etc/authorized_keys/mz",
     )
 
-    c.wait_for_postgres()
-
     c.run("testdrive", "--no-reset", "pg-source-ssl.td")
 
 
 def workflow_ssh_key_after_restart(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized")
 
     c.run("testdrive", "setup.td")
 
@@ -212,8 +191,7 @@ def workflow_ssh_key_after_restart(c: Composition) -> None:
 
 
 def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized"])
-    c.wait_for_materialized("materialized")
+    c.up("materialized")
 
     c.run("testdrive", "setup.td")
 

--- a/test/storage-usage/mzcompose.py
+++ b/test/storage-usage/mzcompose.py
@@ -210,9 +210,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("tests", nargs="*", default=None, help="run specified tests")
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(services=["redpanda", "postgres", "materialized"])
-    c.wait_for_postgres()
-    c.wait_for_materialized()
+    c.up("redpanda", "postgres", "materialized")
 
     c.up("testdrive", persistent=True)
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -85,8 +85,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     materialized = Materialized(default_size=args.default_size)
 
     with c.override(testdrive, materialized):
-        c.start_and_wait_for_tcp(services=dependencies)
-        c.wait_for_materialized("materialized")
+        c.up(*dependencies)
 
         if args.replicas > 1:
             c.sql("DROP CLUSTER default CASCADE")

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -33,7 +33,7 @@ def workflow_default(c: Composition) -> None:
 
 
 def workflow_with_otel(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized"])
+    c.up("materialized")
     port = c.port("materialized", 6878)
 
     # Start with fastpath
@@ -75,7 +75,7 @@ def workflow_with_otel(c: Composition) -> None:
 
 def workflow_without_otel(c: Composition) -> None:
     with c.override(Materialized()):
-        c.start_and_wait_for_tcp(services=["materialized"])
+        c.up("materialized")
         port = c.port("materialized", 6878)
 
         # Start with fastpath

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -38,13 +38,11 @@ SERVICES = [
     TestCerts(),
     Zookeeper(),
     Kafka(
-        # for some reason docker-compose wants kafka to be setup
-        # with the same volumes when overriden
-        depends_on=["zookeeper", "test-certs"],
+        depends_on_extra=["test-certs"],
         volumes=["secrets:/etc/kafka/secrets"],
     ),
     SchemaRegistry(
-        depends_on=["kafka", "zookeeper", "test-certs"],
+        depends_on_extra=["test-certs"],
         volumes=[
             "secrets:/etc/schema-registry/secrets",
         ],
@@ -156,9 +154,7 @@ def test_upgrade_from_version(
     print(">>> Version glob pattern: " + version_glob)
 
     c.down(destroy_volumes=True)
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "postgres"]
-    )
+    c.up("zookeeper", "kafka", "schema-registry", "postgres")
 
     if from_version != "current_source":
         mz_from = Materialized(
@@ -176,8 +172,6 @@ def test_upgrade_from_version(
     else:
         c.up("materialized")
 
-    c.wait_for_materialized("materialized")
-
     temp_dir = f"--temp-dir=/share/tmp/upgrade-from-{from_version}"
     seed = f"--seed={random.getrandbits(32)}"
     c.run(
@@ -193,13 +187,11 @@ def test_upgrade_from_version(
     c.rm("materialized", "testdrive")
 
     c.up("materialized")
-    c.wait_for_materialized("materialized")
 
     # Restart once more, just in case
     c.kill("materialized")
     c.rm("materialized")
     c.up("materialized")
-    c.wait_for_materialized("materialized")
 
     with c.override(
         Testdrive(
@@ -221,7 +213,7 @@ def ssl_services() -> Tuple[Kafka, SchemaRegistry, Testdrive]:
     """sets"""
 
     kafka = Kafka(
-        depends_on=["zookeeper", "test-certs"],
+        depends_on_extra=["test-certs"],
         environment=[
             # Default
             "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181",
@@ -244,7 +236,7 @@ def ssl_services() -> Tuple[Kafka, SchemaRegistry, Testdrive]:
         volumes=["secrets:/etc/kafka/secrets"],
     )
     schema_registry = SchemaRegistry(
-        depends_on=["kafka", "zookeeper", "test-certs"],
+        depends_on_extra=["test-certs"],
         environment=[
             "SCHEMA_REGISTRY_KAFKASTORE_TIMEOUT_MS=10000",
             "SCHEMA_REGISTRY_HOST_NAME=schema-registry",

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -96,7 +96,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
     scenario_class = globals()[args.scenario]
 
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("zookeeper", "kafka", "schema-registry")
 
     random.seed(args.seed)
 
@@ -119,7 +119,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         ),
     ):
         c.up("materialized")
-        c.wait_for_materialized()
         c.sql(
             """
             CREATE CLUSTER storaged REPLICAS (r1 (


### PR DESCRIPTION
This commit switches mzcompose to use native Docker Compose healthchecks in service definitions, rather than our custom `start_and_wait_for_tcp` helper method. This makes it much easier to write workflows that start services correctly, since you don't need to write anything besides `c.up` to get correct behavior.

Fix #1224.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

   * @philip-stoev you can test that this sequences the startup of Zookeeper, Kafka, and Schema Registry correctly by eyeballing the output when running locally. All containers will be created immediately, but Kafka will only be started once Zookeeper is marked healthy, and Schema Registry will only be started once Kafka is marked healthy.
   * I triggered a nightly run here: https://buildkite.com/materialize/nightlies/builds/1729

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
