### PR TITLE
deps: upgrade timely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7194,12 +7194,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
 dependencies = [
  "columnation",
  "serde",
@@ -7224,7 +7224,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#faf5eb6457e69ac2bfbbb8a0f62deda55aa2c927"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6a736009d0276b181f0a069174390b99c8bd9ae1"
 
 [[package]]
 name = "tiny-keccak"

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -17,7 +17,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::{Capability, CapabilityRef, Concat, OkErr, Operator};
+use timely::dataflow::operators::{Capability, Concat, InputCapability, OkErr, Operator};
 use timely::dataflow::{Scope, Stream};
 use timely::order::PartialOrder;
 use timely::progress::frontier::AntichainRef;
@@ -483,7 +483,7 @@ fn process_new_data(
             HashMap<Option<Result<Row, DecodeError>>, UpsertSourceData>,
         ),
     >,
-    cap: &CapabilityRef<Timestamp>,
+    cap: &InputCapability<Timestamp>,
     as_of_frontier: &Antichain<Timestamp>,
 ) {
     for DecodeResult {

--- a/src/timely-util/src/buffer.rs
+++ b/src/timely-util/src/buffer.rs
@@ -20,7 +20,7 @@ use differential_dataflow::ExchangeData;
 use timely::communication::Push;
 use timely::dataflow::channels::Bundle;
 use timely::dataflow::operators::generic::OutputHandle;
-use timely::dataflow::operators::{Capability, CapabilityRef};
+use timely::dataflow::operators::{Capability, InputCapability};
 use timely::progress::Timestamp;
 
 /// A buffer that consolidates updates
@@ -72,7 +72,7 @@ where
     }
 
     /// Give an element to the buffer
-    pub fn give(&mut self, cap: &CapabilityRef<T>, data: (D, T, R)) {
+    pub fn give(&mut self, cap: &InputCapability<T>, data: (D, T, R)) {
         // Retain a cap for the current time, which will be used on flush.
         if self.cap.as_ref().map_or(true, |t| t.time() != cap.time()) {
             // Flush on capability change

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -27,7 +27,7 @@ use timely::dataflow::channels::pushers::TeeCore;
 use timely::dataflow::channels::BundleCore;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder as OperatorBuilderRc;
 use timely::dataflow::operators::generic::{InputHandleCore, OperatorInfo, OutputWrapper};
-use timely::dataflow::operators::{Capability, CapabilityRef};
+use timely::dataflow::operators::{Capability, InputCapability};
 use timely::dataflow::{Scope, StreamCore};
 use timely::progress::{Antichain, Timestamp};
 use timely::scheduling::{Activator, SyncActivator};
@@ -112,7 +112,7 @@ struct NextFut<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>> + 
 /// An event of an input stream
 pub enum Event<'a, T: Timestamp, D> {
     /// A data event
-    Data(CapabilityRef<'a, T>, RefOrMut<'a, D>),
+    Data(InputCapability<T>, RefOrMut<'a, D>),
     /// A progress event
     Progress(Antichain<T>),
 }
@@ -131,7 +131,7 @@ impl<'handle, T: Timestamp, D: Container, P: Pull<BundleCore<T, D>>> Future
         // implementing the `WithLifetime` trait for all lifetimes 'lt and setting the associated
         // type to the output type with all lifetimes set to 'lt.
         type NextHTB<T, D> =
-            dyn for<'lt> WithLifetime<'lt, T = (CapabilityRef<'lt, T>, RefOrMut<'lt, D>)>;
+            dyn for<'lt> WithLifetime<'lt, T = (InputCapability<T>, RefOrMut<'lt, D>)>;
 
         // The polonius function encodes a safe but rejected pattern by the current borrow checker.
         // Explaining is beyond the scope of this comment but the docs have a great explanation:


### PR DESCRIPTION
###  Motivation

Pick up the `CapabilityRef` -> `InputCapability` change

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
