### PR TITLE
materialized: add warning about version upgrades to Docker image

### DIFF
--- a/misc/images/materialized/README.md
+++ b/misc/images/materialized/README.md
@@ -3,15 +3,15 @@
 This directory builds an all-in-one Docker image of Materialize for our internal
 development and testing.
 
-> ⚠️ **WARNING** ⚠️
+> **Warning**
 >
-> This Docker image is not officially supported by Materialize. We do not
-> offer support for this Docker image. Do not run production deployments using
-> this Docker image.
-
-> ⚠️ **WARNING** ⚠️
+> You **should not** run production deployments using this Docker image.
 >
-> The performance characteristics of this Docker image are not representative
+> This Docker image is **not** supported by Materialize.
+>
+> This Docker image does **not** support version upgrades.
+>
+> The performance characteristics of this Docker image are **not** representative
 > of the performance characteristics of our hosted offering. This image bundles
 > several services into the same container, while in our hosted offering we
 > run these services scaled across many machines.

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -12,14 +12,20 @@
 set -euo pipefail
 
 cat <<EOF >/dev/stderr
-WARNING: This Docker image is not officially supported by Materialize. We do not
-offer support for this Docker image. Do not run production deployments using
-this Docker image.
+********************************* WARNING ********************************
 
-WARNING: The performance characteristics of this Docker image are not
-representative of the performance characteristics of our hosted offering. This
-image bundles several services into the same container, while in our hosted
-offering we run these services scaled across many machines.
+You *should not* run production deployments using this Docker image.
+
+This Docker image is *not* supported by Materialize.
+
+This Docker image does *not* support version upgrades.
+
+The performance characteristics of this Docker image are *not*
+representative of the performance characteristics of our hosted offering.
+This image bundles several services into the same container, while in our
+hosted offering we run these services scaled across many machines.
+
+********************************* WARNING ********************************
 EOF
 
 COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true cockroach start-single-node \


### PR DESCRIPTION
Warn users of the Docker image that version upgrades are not supported.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
