### PR TITLE
ci: Add journalctl output to the buildkite artifacts

### DIFF
--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -28,5 +28,9 @@ kubectl describe all > kubectl-describe-all.log || true
 buildkite-agent artifact upload "kubectl-*.log"
 buildkite-agent artifact upload /var/log/dmesg
 
+# shellcheck disable=SC2024
+sudo journalctl --merge > journalctl-merge.log
+buildkite-agent artifact upload journalctl-merge.log
+
 ci_unimportant_heading "cloudtest: Resetting..."
 bin/ci-builder run stable test/cloudtest/reset

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -24,6 +24,10 @@ buildkite-agent artifact upload services.log
 
 buildkite-agent artifact upload /var/log/dmesg
 
+# shellcheck disable=SC2024
+sudo journalctl --merge > journalctl-merge.log
+buildkite-agent artifact upload journalctl-merge.log
+
 netstat -ant > netstat-ant.log
 buildkite-agent artifact upload netstat-ant.log
 


### PR DESCRIPTION
Buildkite hosts run an AMI image derived from Amazon Linux, which in turn derives from Red Hat.

Turns out that on such systems the actions of the OOM killer are not reflected in /var/log/dmesg. That file is only written to during kernel bootstrap. The journalctl utility must be used to capture any messages about the OOM killer.

### Motivation

The CI continues to experience OOMs but the /var/log/dmesg file was always empty.