### PR TITLE
compute: use BTreeMaps rather than HashMaps for top-k rendering

### DIFF
--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -12,6 +12,7 @@
 //! Consult [TopKPlan] documentation for details.
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use differential_dataflow::hashable::Hashable;
@@ -29,7 +30,6 @@ use timely::dataflow::Scope;
 use mz_compute_client::plan::top_k::{
     BasicTopKPlan, MonotonicTop1Plan, MonotonicTopKPlan, TopKPlan,
 };
-use mz_ore::collections::HashMap;
 use mz_repr::{DatumVec, Diff, Row};
 
 use crate::render::context::CollectionBundle;
@@ -367,10 +367,7 @@ where
             G: Scope,
             G::Timestamp: Lattice,
         {
-            // Using a `BTreeMap` here might impact performance, so we keep using a `HashMap` here,
-            // pending further benchmarks.
-            #[allow(clippy::disallowed_types)]
-            let mut aggregates = HashMap::<_, std::collections::HashMap<_, _>>::new();
+            let mut aggregates = BTreeMap::new();
             let mut vector = Vec::new();
             let shared = Rc::new(RefCell::new(monoids::Top1MonoidShared {
                 order_key,
@@ -386,7 +383,9 @@ where
                     move |input, output, notificator| {
                         while let Some((time, data)) = input.next() {
                             data.swap(&mut vector);
-                            let agg_time = aggregates.entry(time.time().clone()).or_default();
+                            let agg_time = aggregates
+                                .entry(time.time().clone())
+                                .or_insert_with(BTreeMap::new);
                             for ((grp_row, row), record_time, diff) in vector.drain(..) {
                                 let monoid = monoids::Top1MonoidLocal {
                                     row,


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/17346, for testing the performance implications of replacing the `HashMap`s in top-k rendering with `BTreeMap`s.

### Motivation

  * This PR refactors existing code.

Advances #14587.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
