### PR TITLE
test: Use CRDB v22.2.3 across the board when testing

### DIFF
--- a/misc/cockroach/setup_materialize.sql
+++ b/misc/cockroach/setup_materialize.sql
@@ -9,12 +9,6 @@
 
 -- Sets up a CockroachDB cluster for use by Materialize.
 
--- See: https://github.com/cockroachdb/cockroach/issues/93892
--- See: https://github.com/MaterializeInc/materialize/issues/16726
--- TODO: remove this workaround before upgrading to CockroachDB 22.2 in
--- production.
-SET CLUSTER SETTING sql.stats.forecasts.enabled = false;
-
 CREATE SCHEMA IF NOT EXISTS consensus;
 CREATE SCHEMA IF NOT EXISTS adapter;
 CREATE SCHEMA IF NOT EXISTS storage;

--- a/misc/python/materialize/cloudtest/k8s/cockroach.py
+++ b/misc/python/materialize/cloudtest/k8s/cockroach.py
@@ -30,6 +30,7 @@ from kubernetes.client import (
 
 from materialize import ROOT
 from materialize.cloudtest.k8s import K8sConfigMap, K8sService, K8sStatefulSet
+from materialize.mzcompose.services import Cockroach
 
 
 class CockroachConfigMap(K8sConfigMap):
@@ -80,7 +81,7 @@ class CockroachStatefulSet(K8sStatefulSet):
 
         container = V1Container(
             name="cockroach",
-            image="cockroachdb/cockroach:v22.2.0",
+            image=f"cockroachdb/cockroach:{Cockroach.DEFAULT_COCKROACH_TAG}",
             args=["start-single-node", "--insecure"],
             ports=ports,
             volume_mounts=volume_mounts,

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -435,7 +435,7 @@ class MySql(Service):
 
 
 class Cockroach(Service):
-    DEFAULT_COCKROACH_TAG = "v22.2.0"
+    DEFAULT_COCKROACH_TAG = "v22.2.3"
 
     def __init__(
         self,


### PR DESCRIPTION
- Have the CRDB tag to use only in a single location in the code
- Upgrade to v22.2.3 in order to get the fix for cockroachdb/cockroach#93892
- remove the `SET CLUSTER SETTING` workaround that was previously used, which was not active across all test frameworks and workflows anyway.

Relates to #11431

### Motivation

#11431 was affecting the CI because the workaround did not apply to all possible tests, workflows and frameworks.
