### PR TITLE
avro,build-id,testdrive: remove uses of Hash collections

### DIFF
--- a/src/avro/benches/serde_json.rs
+++ b/src/avro/benches/serde_json.rs
@@ -27,17 +27,17 @@
 extern crate test;
 
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 fn make_big_json_record() -> Value {
-    let mut address = HashMap::new();
+    let mut address = BTreeMap::new();
     address.insert("street".to_owned(), "street".to_owned());
     address.insert("city".to_owned(), "city".to_owned());
     address.insert("state_prov".to_owned(), "state_prov".to_owned());
     address.insert("country".to_owned(), "country".to_owned());
     address.insert("zip".to_owned(), "zip".to_owned());
     let address_json = serde_json::to_value(address).unwrap();
-    let mut big_record = std::collections::HashMap::new();
+    let mut big_record = std::collections::BTreeMap::new();
     big_record.insert(
         "username".to_owned(),
         serde_json::to_value("username").unwrap(),

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -34,7 +34,7 @@ use crate::schema::{
     RecordField, ResolvedDefaultValueField, ResolvedRecordField, SchemaNode, SchemaPiece,
     SchemaPieceOrNamed,
 };
-use crate::types::{AvroMap, Scalar, Value};
+use crate::types::{Scalar, Value};
 use crate::{
     util::{safe_len, zag_i32, zag_i64, TsUnit},
     TrivialDecoder, ValueDecoder,
@@ -730,7 +730,7 @@ pub mod public_decoders {
 
     use super::{AvroDecodable, AvroMapAccess, StatefulAvroDecodable};
     use crate::error::{DecodeError, Error as AvroError};
-    use crate::types::{AvroMap, DecimalValue, Scalar, Value};
+    use crate::types::{DecimalValue, Scalar, Value};
     use crate::{
         AvroArrayAccess, AvroDecode, AvroDeserializer, AvroRead, AvroRecordAccess, ValueOrReader,
     };
@@ -1202,7 +1202,7 @@ pub mod public_decoders {
                 let val = a.decode_field(d)?;
                 entries.insert(name, val);
             }
-            Ok(Value::Map(AvroMap(entries)))
+            Ok(Value::Map(entries))
         }
     }
 }
@@ -1254,7 +1254,7 @@ pub fn give_value<D: AvroDecode>(d: D, v: &Value) -> Result<D::Out, AvroError> {
             let mut a = ValueArrayAccess::new(val);
             d.array(&mut a)
         }
-        Value::Map(AvroMap(val)) => {
+        Value::Map(val) => {
             let vals: Vec<_> = val.clone().into_iter().collect();
             let mut m = ValueMapAccess::new(vals.as_slice());
             d.map(&mut m)

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -734,7 +734,7 @@ pub mod public_decoders {
     use crate::{
         AvroArrayAccess, AvroDecode, AvroDeserializer, AvroRead, AvroRecordAccess, ValueOrReader,
     };
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     macro_rules! define_simple_decoder {
         ($name:ident, $out:ty, $($scalar_branch:ident);*) => {
@@ -1196,7 +1196,7 @@ pub mod public_decoders {
             Ok(Value::Fixed(buf.len(), buf))
         }
         fn map<M: AvroMapAccess>(self, m: &mut M) -> Result<Value, AvroError> {
-            let mut entries = HashMap::new();
+            let mut entries = BTreeMap::new();
             while let Some((name, a)) = m.next_entry()? {
                 let d = ValueDecoder;
                 let val = a.decode_field(d)?;

--- a/src/avro/src/encode.rs
+++ b/src/avro/src/encode.rs
@@ -22,7 +22,6 @@
 // of which can be found in the LICENSE file at the root of this repository.
 
 use crate::schema::{Schema, SchemaNode, SchemaPiece};
-use crate::types::AvroMap;
 use crate::types::{DecimalValue, Value};
 use crate::util::{zig_i32, zig_i64};
 
@@ -129,7 +128,7 @@ pub fn encode_ref(value: &Value, schema: SchemaNode, buffer: &mut Vec<u8>) {
                 buffer.push(0u8);
             }
         }
-        Value::Map(AvroMap(items)) => {
+        Value::Map(items) => {
             if let SchemaPiece::Map(inner) = schema.inner {
                 if !items.is_empty() {
                     encode_long(items.len() as i64, buffer);
@@ -190,7 +189,7 @@ mod tests {
         let mut buf = Vec::new();
         let empty: BTreeMap<String, Value> = BTreeMap::new();
         encode(
-            &Value::Map(AvroMap(empty)),
+            &Value::Map(empty),
             &r#"{"type": "map", "values": "int"}"#.parse().unwrap(),
             &mut buf,
         );

--- a/src/avro/src/encode.rs
+++ b/src/avro/src/encode.rs
@@ -171,7 +171,7 @@ pub fn encode_to_vec(value: &Value, schema: &Schema) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_encode_empty_array() {
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_encode_empty_map() {
         let mut buf = Vec::new();
-        let empty: HashMap<String, Value> = HashMap::new();
+        let empty: BTreeMap<String, Value> = BTreeMap::new();
         encode(
             &Value::Map(AvroMap(empty)),
             &r#"{"type": "map", "values": "int"}"#.parse().unwrap(),

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -40,7 +40,7 @@ use crate::util::{self};
 use crate::{Codec, SchemaResolutionError};
 
 use sha2::Sha256;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Header {
@@ -326,13 +326,13 @@ impl<R: AvroRead> Iterator for Reader<R> {
 
 pub struct SchemaResolver<'a> {
     pub named: Vec<Option<NamedSchemaPiece>>,
-    pub indices: HashMap<FullName, usize>,
+    pub indices: BTreeMap<FullName, usize>,
     pub human_readable_field_path: Vec<String>,
     pub current_human_readable_path_start: usize,
-    pub writer_to_reader_names: HashMap<usize, usize>,
-    pub reader_to_writer_names: HashMap<usize, usize>,
-    pub reader_to_resolved_names: HashMap<usize, usize>,
-    pub reader_fullnames: HashMap<usize, &'a FullName>,
+    pub writer_to_reader_names: BTreeMap<usize, usize>,
+    pub reader_to_writer_names: BTreeMap<usize, usize>,
+    pub reader_to_resolved_names: BTreeMap<usize, usize>,
+    pub reader_fullnames: BTreeMap<usize, &'a FullName>,
     pub reader_schema: &'a Schema,
 }
 
@@ -479,7 +479,7 @@ impl<'a> SchemaResolver<'a> {
                     .iter()
                     .enumerate()
                     .map(|(i, s)| (s, i))
-                    .collect::<HashMap<_, _>>();
+                    .collect::<BTreeMap<_, _>>();
                 let symbols = w_symbols
                     .iter()
                     .map(|s| {

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -35,8 +35,8 @@ use crate::schema::{
     SchemaPieceRefOrNamed,
 };
 use crate::schema::{ResolvedRecordField, Schema};
-use crate::types::{AvroMap, Value};
-use crate::util::{self};
+use crate::types::Value;
+use crate::util;
 use crate::{Codec, SchemaResolutionError};
 
 use sha2::Sha256;
@@ -64,7 +64,7 @@ impl Header {
             return Err(AvroError::Decode(DecodeError::WrongHeaderMagic(buf)));
         }
 
-        if let Value::Map(AvroMap(meta)) = decode(meta_schema.top_node(), reader)? {
+        if let Value::Map(meta) = decode(meta_schema.top_node(), reader)? {
             // TODO: surface original parse schema errors instead of coalescing them here
             let json = meta
                 .get("avro.schema")

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -25,8 +25,8 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -54,7 +54,7 @@ pub fn resolve_schemas(
     reader_schema: &Schema,
 ) -> Result<Schema, AvroError> {
     let r_indices = reader_schema.indices.clone();
-    let (reader_to_writer_names, writer_to_reader_names): (HashMap<_, _>, HashMap<_, _>) =
+    let (reader_to_writer_names, writer_to_reader_names): (BTreeMap<_, _>, BTreeMap<_, _>) =
         writer_schema
             .indices
             .iter()
@@ -68,7 +68,7 @@ pub fn resolve_schemas(
         .indices
         .iter()
         .map(|(f, i)| (*i, f))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
     let mut resolver = SchemaResolver {
         named: Default::default(),
         indices: Default::default(),
@@ -278,7 +278,7 @@ pub enum SchemaPiece {
     Record {
         doc: Documentation,
         fields: Vec<RecordField>,
-        lookup: HashMap<String, usize>,
+        lookup: BTreeMap<String, usize>,
     },
     /// An `enum` Avro schema.
     Enum {
@@ -338,7 +338,7 @@ impl SchemaPiece {
 #[derive(Clone, PartialEq)]
 pub struct Schema {
     pub(crate) named: Vec<NamedSchemaPiece>,
-    pub(crate) indices: HashMap<FullName, usize>,
+    pub(crate) indices: BTreeMap<FullName, usize>,
     pub top: SchemaPieceOrNamed,
 }
 
@@ -395,7 +395,7 @@ impl Schema {
 /// function that maps from `Discriminant<Schema> -> Discriminant<Value>`. Conversion into this
 /// intermediate type should be especially fast, as the number of enum variants is small, which
 /// _should_ compile into a jump-table for the conversion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SchemaKind {
     // Fixed-length types
     Null,
@@ -519,7 +519,7 @@ pub struct Name {
     pub aliases: Option<Vec<String>>,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FullName {
     name: String,
     namespace: String,
@@ -750,16 +750,16 @@ pub struct UnionSchema {
 
     // Used to ensure uniqueness of anonymous schema inputs, and provide constant time finding of the
     // schema index given a value.
-    anon_variant_index: HashMap<SchemaKind, usize>,
+    anon_variant_index: BTreeMap<SchemaKind, usize>,
 
     // Same as above, for named input references
-    named_variant_index: HashMap<usize, usize>,
+    named_variant_index: BTreeMap<usize, usize>,
 }
 
 impl UnionSchema {
     pub(crate) fn new(schemas: Vec<SchemaPieceOrNamed>) -> Result<Self, AvroError> {
-        let mut avindex = HashMap::new();
-        let mut nvindex = HashMap::new();
+        let mut avindex = BTreeMap::new();
+        let mut nvindex = BTreeMap::new();
         for (i, schema) in schemas.iter().enumerate() {
             match schema {
                 SchemaPieceOrNamed::Piece(sp) => {
@@ -811,7 +811,7 @@ impl UnionSchema {
     pub fn match_ref(
         &self,
         other: SchemaPieceRefOrNamed,
-        names_map: &HashMap<usize, usize>,
+        names_map: &BTreeMap<usize, usize>,
     ) -> Option<(usize, &SchemaPieceOrNamed)> {
         match other {
             SchemaPieceRefOrNamed::Piece(sp) => self.match_piece(sp),
@@ -826,7 +826,7 @@ impl UnionSchema {
     pub fn match_(
         &self,
         other: &SchemaPieceOrNamed,
-        names_map: &HashMap<usize, usize>,
+        names_map: &BTreeMap<usize, usize>,
     ) -> Option<(usize, &SchemaPieceOrNamed)> {
         self.match_ref(other.as_ref(), names_map)
     }
@@ -842,7 +842,7 @@ impl PartialEq for UnionSchema {
 #[derive(Default)]
 struct SchemaParser {
     named: Vec<Option<NamedSchemaPiece>>,
-    indices: HashMap<FullName, usize>,
+    indices: BTreeMap<FullName, usize>,
 }
 
 impl SchemaParser {
@@ -990,7 +990,7 @@ impl SchemaParser {
         default_namespace: &str,
         complex: &Map<String, Value>,
     ) -> Result<SchemaPiece, AvroError> {
-        let mut lookup = HashMap::new();
+        let mut lookup = BTreeMap::new();
 
         let fields: Vec<RecordField> = complex
             .get("fields")
@@ -1074,7 +1074,7 @@ impl SchemaParser {
                     .ok_or_else(|| ParseSchemaError::new("Unable to parse `symbols` in enum"))
             })?;
 
-        let mut unique_symbols: HashSet<&String> = HashSet::new();
+        let mut unique_symbols: BTreeSet<&String> = BTreeSet::new();
         for symbol in symbols.iter() {
             if unique_symbols.contains(symbol) {
                 return Err(ParseSchemaError::new(format!(
@@ -1487,7 +1487,7 @@ impl<'a> SchemaNodeOrNamed<'a> {
         };
         let piece = cloner.clone_piece_or_named(self.inner);
         let named: Vec<NamedSchemaPiece> = cloner.named.into_iter().map(Option::unwrap).collect();
-        let indices: HashMap<FullName, usize> = named
+        let indices: BTreeMap<FullName, usize> = named
             .iter()
             .enumerate()
             .map(|(i, nsp)| (nsp.name.clone(), i))
@@ -1507,7 +1507,7 @@ impl<'a> SchemaNodeOrNamed<'a> {
 
 struct SchemaSubtreeDeepCloner<'a> {
     old_root: &'a Schema,
-    old_to_new_names: HashMap<usize, usize>,
+    old_to_new_names: BTreeMap<usize, usize>,
     named: Vec<Option<NamedSchemaPiece>>,
 }
 
@@ -1822,7 +1822,7 @@ impl<'a> SchemaNode<'a> {
                 let map = map
                     .iter()
                     .map(|(k, v)| node.json_to_value(v).map(|v| (k.clone(), v)))
-                    .collect::<Result<HashMap<_, _>, ParseSchemaError>>()?;
+                    .collect::<Result<BTreeMap<_, _>, ParseSchemaError>>()?;
                 AvroValue::Map(AvroMap(map))
             }
             (String(s), SchemaPiece::Fixed { size }) if s.len() == *size => {
@@ -1846,7 +1846,7 @@ struct SchemaSerContext<'a> {
     // it is only ever mutated in one stack frame at a time.
     // But AFAICT serde doesn't expose a way to
     // provide some mutable context to every node in the tree...
-    seen_named: Rc<RefCell<HashMap<usize, FullName>>>,
+    seen_named: Rc<RefCell<BTreeMap<usize, FullName>>>,
     /// The namespace of this node's parent, or "" by default
     enclosing_ns: &'a str,
 }
@@ -2359,7 +2359,7 @@ mod tests {
                 }
             "#;
 
-        let mut lookup = HashMap::new();
+        let mut lookup = BTreeMap::new();
         lookup.insert("a".to_owned(), 0);
         lookup.insert("b".to_owned(), 1);
 

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -46,7 +46,6 @@ use types::{DecimalValue, Value as AvroValue};
 use crate::error::Error as AvroError;
 use crate::reader::SchemaResolver;
 use crate::types;
-use crate::types::AvroMap;
 use crate::util::MapHelper;
 
 pub fn resolve_schemas(
@@ -1823,7 +1822,7 @@ impl<'a> SchemaNode<'a> {
                     .iter()
                     .map(|(k, v)| node.json_to_value(v).map(|v| (k.clone(), v)))
                     .collect::<Result<BTreeMap<_, _>, ParseSchemaError>>()?;
-                AvroValue::Map(AvroMap(map))
+                AvroValue::Map(map)
             }
             (String(s), SchemaPiece::Fixed { size }) if s.len() == *size => {
                 AvroValue::Fixed(*size, s.clone().into_bytes())

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -27,10 +27,8 @@
 // https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
 #![allow(clippy::extra_unused_lifetimes)]
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
-use std::hash::BuildHasher;
-use std::u8;
 
 use chrono::NaiveDateTime;
 use enum_kinds::EnumKind;
@@ -99,7 +97,7 @@ impl From<Scalar> for Value {
 // This simple wrapper exists so we can Debug-print the values deterministically, i.e. in sorted order
 // by keys.
 #[derive(Clone, PartialEq)]
-pub struct AvroMap(pub HashMap<String, Value>);
+pub struct AvroMap(pub BTreeMap<String, Value>);
 
 impl fmt::Debug for AvroMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -233,7 +231,7 @@ impl<'a> ToAvro for &'a [u8] {
     }
 }
 
-impl<T, S: BuildHasher> ToAvro for HashMap<String, T, S>
+impl<T> ToAvro for BTreeMap<String, T>
 where
     T: ToAvro,
 {
@@ -246,7 +244,7 @@ where
     }
 }
 
-impl<'a, T, S: BuildHasher> ToAvro for HashMap<&'a str, T, S>
+impl<'a, T> ToAvro for BTreeMap<&'a str, T>
 where
     T: ToAvro,
 {
@@ -288,7 +286,7 @@ pub struct Record<'a> {
     /// Ordered according to the fields in the schema given to create this
     /// `Record` object. Any unset field defaults to `Value::Null`.
     pub fields: Vec<(String, Value)>,
-    schema_lookup: &'a HashMap<String, usize>,
+    schema_lookup: &'a BTreeMap<String, usize>,
     schema_fields: &'a Vec<RecordField>,
 }
 

--- a/src/avro/src/writer.rs
+++ b/src/avro/src/writer.rs
@@ -23,7 +23,7 @@
 
 //! Logic handling writing in Avro format at user level.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{Seek, SeekFrom, Write};
 
@@ -302,7 +302,7 @@ impl<W: Write> Writer<W> {
     fn header(&self) -> Result<Vec<u8>, Error> {
         let schema_bytes = serde_json::to_string(&self.schema)?.into_bytes();
 
-        let mut metadata = HashMap::with_capacity(2);
+        let mut metadata = BTreeMap::new();
         metadata.insert("avro.schema", Value::Bytes(schema_bytes));
         if let Some(codec) = self.codec {
             metadata.insert("avro.codec", codec.avro());

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -95,7 +95,6 @@ use std::str::FromStr;
 
 use chrono::{NaiveDate, NaiveDateTime};
 use mz_avro::schema::resolve_schemas;
-use mz_avro::types::AvroMap;
 use mz_avro::{
     error::Error as AvroError,
     from_avro_datum, to_avro_datum,
@@ -134,16 +133,14 @@ static SCHEMAS_TO_VALIDATE: Lazy<Vec<(&'static str, Value)>> = Lazy::new(|| {
         ),
         (
             r#"{"type": "map", "values": "long"}"#,
-            Value::Map(AvroMap(
+            Value::Map(
                 [
                     ("a".to_string(), Value::Long(1i64)),
                     ("b".to_string(), Value::Long(3i64)),
                     ("c".to_string(), Value::Long(2i64)),
                 ]
-                .iter()
-                .cloned()
-                .collect(),
-            )),
+                .into(),
+            ),
         ),
         (
             r#"["string", "null", "long"]"#,
@@ -195,15 +192,13 @@ static DEFAULT_VALUE_EXAMPLES: Lazy<Vec<(&'static str, &'static str, Value)>> = 
         (
             r#"{"type": "map", "values": "int"}"#,
             r#"{"a": 1, "b": 2}"#,
-            Value::Map(AvroMap(
+            Value::Map(
                 [
                     ("a".to_string(), Value::Int(1)),
                     ("b".to_string(), Value::Int(2)),
                 ]
-                .iter()
-                .cloned()
-                .collect(),
-            )),
+                .into(),
+            ),
         ),
         //(r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
         (
@@ -936,11 +931,7 @@ fn test_complex_resolutions() {
                 ),
                 (
                     "f0_2".to_owned(),
-                    Value::Map(AvroMap(
-                        vec![("a".to_string(), Value::Long(42))]
-                            .into_iter()
-                            .collect(),
-                    )),
+                    Value::Map([("a".to_string(), Value::Long(42))].into()),
                 ),
             ]),
         ),

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -95,7 +95,6 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use chrono::NaiveDateTime;
-use mz_avro::types::AvroMap;
 use mz_avro::{types::DecimalValue, types::Value, Schema};
 use once_cell::sync::Lazy;
 
@@ -225,12 +224,12 @@ static VALID_SCHEMAS: Lazy<Vec<(&'static str, Value)>> = Lazy::new(|| {
         // Map examples
         (
             r#"{"type": "map", "values": "long"}"#,
-            Value::Map(AvroMap(BTreeMap::new())),
+            Value::Map(BTreeMap::new()),
         ),
         (
             r#"{"type": "map",
              "values": {"type": "enum", "name": "Test", "symbols": ["A", "B"]}}"#,
-            Value::Map(AvroMap(BTreeMap::new())),
+            Value::Map(BTreeMap::new()),
         ),
         // Union examples
         (
@@ -309,7 +308,7 @@ static VALID_SCHEMAS: Lazy<Vec<(&'static str, Value)>> = Lazy::new(|| {
                 ("bytesField".into(), Value::Bytes(vec![0])),
                 ("nullField".into(), Value::Null),
                 ("arrayField".into(), Value::Array(vec![Value::Double(0.0)])),
-                ("mapField".into(), Value::Map(AvroMap(BTreeMap::new()))),
+                ("mapField".into(), Value::Map(BTreeMap::new())),
                 (
                     "unionField".into(),
                     Value::Union {

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -91,7 +91,7 @@
 //! Port of tests from:
 //!     - https://github.com/apache/avro/blob/master/lang/py/avro/test/test_schema.py
 //!     - https://github.com/apache/avro/tree/master/lang/c/tests/schema_tests
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use chrono::NaiveDateTime;
@@ -225,12 +225,12 @@ static VALID_SCHEMAS: Lazy<Vec<(&'static str, Value)>> = Lazy::new(|| {
         // Map examples
         (
             r#"{"type": "map", "values": "long"}"#,
-            Value::Map(AvroMap(HashMap::new())),
+            Value::Map(AvroMap(BTreeMap::new())),
         ),
         (
             r#"{"type": "map",
              "values": {"type": "enum", "name": "Test", "symbols": ["A", "B"]}}"#,
-            Value::Map(AvroMap(HashMap::new())),
+            Value::Map(AvroMap(BTreeMap::new())),
         ),
         // Union examples
         (
@@ -309,7 +309,7 @@ static VALID_SCHEMAS: Lazy<Vec<(&'static str, Value)>> = Lazy::new(|| {
                 ("bytesField".into(), Value::Bytes(vec![0])),
                 ("nullField".into(), Value::Null),
                 ("arrayField".into(), Value::Array(vec![Value::Double(0.0)])),
-                ("mapField".into(), Value::Map(AvroMap(HashMap::new()))),
+                ("mapField".into(), Value::Map(AvroMap(BTreeMap::new()))),
                 (
                     "unionField".into(),
                     Value::Union {

--- a/src/build-id/src/lib.rs
+++ b/src/build-id/src/lib.rs
@@ -111,10 +111,10 @@
 /// (2) The running binary must be in ELF format and running on Linux.
 #[cfg(target_os = "linux")]
 pub unsafe fn all_build_ids(
-) -> Result<std::collections::HashMap<std::path::PathBuf, Vec<u8>>, anyhow::Error> {
+) -> Result<std::collections::BTreeMap<std::path::PathBuf, Vec<u8>>, anyhow::Error> {
     // local imports to avoid polluting the namespace for macOS builds
-    use std::collections::hash_map::Entry;
-    use std::collections::HashMap;
+    use std::collections::btree_map::Entry;
+    use std::collections::BTreeMap;
     use std::ffi::{c_int, CStr, OsStr};
     use std::os::unix::ffi::OsStrExt;
     use std::path::{Path, PathBuf};
@@ -126,7 +126,7 @@ pub unsafe fn all_build_ids(
     use mz_ore::cast::CastFrom;
 
     struct CallbackState {
-        map: HashMap<PathBuf, Vec<u8>>,
+        map: BTreeMap<PathBuf, Vec<u8>>,
         is_first: bool,
         fatal_error: Option<anyhow::Error>,
     }
@@ -244,7 +244,7 @@ pub unsafe fn all_build_ids(
         0
     }
     let mut state = CallbackState {
-        map: HashMap::new(),
+        map: BTreeMap::new(),
         is_first: true,
         fatal_error: None,
     };

--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use serde_json::json;
 
-use mz_avro::types::{AvroMap, DecimalValue, ToAvro, Value};
+use mz_avro::types::{DecimalValue, ToAvro, Value};
 use mz_avro::Schema;
 use mz_ore::cast::CastFrom;
 use mz_repr::adt::jsonb::JsonbRef;
@@ -385,7 +385,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                             (key.to_string(), value)
                         })
                         .collect();
-                    Value::Map(AvroMap(elements))
+                    Value::Map(elements)
                 }
                 ScalarType::Record { fields, .. } => {
                     let list = datum.unwrap_list();

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
 use std::future::Future;
@@ -147,7 +147,7 @@ pub struct Config {
 pub struct State {
     // === Testdrive state. ===
     arg_vars: BTreeMap<String, String>,
-    cmd_vars: HashMap<String, String>,
+    cmd_vars: BTreeMap<String, String>,
     seed: u32,
     temp_path: PathBuf,
     _tempfile: Option<tempfile::TempDir>,
@@ -177,7 +177,7 @@ pub struct State {
     kafka_config: ClientConfig,
     kafka_default_partitions: usize,
     kafka_producer: rdkafka::producer::FutureProducer<MzClientContext>,
-    kafka_topics: HashMap<String, usize>,
+    kafka_topics: BTreeMap<String, usize>,
 
     // === AWS state. ===
     aws_account: String,
@@ -190,10 +190,10 @@ pub struct State {
     sqs_queues_created: BTreeSet<String>,
 
     // === Database driver state. ===
-    mysql_clients: HashMap<String, mysql_async::Conn>,
-    postgres_clients: HashMap<String, tokio_postgres::Client>,
+    mysql_clients: BTreeMap<String, mysql_async::Conn>,
+    postgres_clients: BTreeMap<String, tokio_postgres::Client>,
     sql_server_clients:
-        HashMap<String, tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>>,
+        BTreeMap<String, tiberius::Client<tokio_util::compat::Compat<tokio::net::TcpStream>>>,
 }
 
 impl State {
@@ -576,10 +576,10 @@ impl Run for PosCommand {
             Command::Builtin(builtin) => Some(builtin.name.clone()),
             _ => None,
         };
-        let subst = |msg: &str, vars: &HashMap<String, String>| {
+        let subst = |msg: &str, vars: &BTreeMap<String, String>| {
             substitute_vars(msg, vars, &ignore_prefix, false).map_err(wrap_err)
         };
-        let subst_re = |msg: &str, vars: &HashMap<String, String>| {
+        let subst_re = |msg: &str, vars: &BTreeMap<String, String>| {
             substitute_vars(msg, vars, &ignore_prefix, true).map_err(wrap_err)
         };
 
@@ -683,7 +683,7 @@ impl Run for PosCommand {
 /// Substituted `${}`-delimited variables from `vars` into `msg`
 fn substitute_vars(
     msg: &str,
-    vars: &HashMap<String, String>,
+    vars: &BTreeMap<String, String>,
     ignore_prefix: &Option<String>,
     regex_escape: bool,
 ) -> Result<String, anyhow::Error> {
@@ -858,7 +858,7 @@ pub async fn create_state(
             .create_with_context(MzClientContext)
             .with_context(|| format!("opening Kafka producer connection: {}", config.kafka_addr))?;
 
-        let topics = HashMap::new();
+        let topics = BTreeMap::new();
 
         (
             config.kafka_addr.to_owned(),
@@ -877,7 +877,7 @@ pub async fn create_state(
     let mut state = State {
         // === Testdrive state. ===
         arg_vars: config.arg_vars.clone(),
-        cmd_vars: HashMap::new(),
+        cmd_vars: BTreeMap::new(),
         seed,
         temp_path,
         _tempfile,
@@ -920,9 +920,9 @@ pub async fn create_state(
         sqs_queues_created: BTreeSet::new(),
 
         // === Database driver state. ===
-        mysql_clients: HashMap::new(),
-        postgres_clients: HashMap::new(),
-        sql_server_clients: HashMap::new(),
+        mysql_clients: BTreeMap::new(),
+        postgres_clients: BTreeMap::new(),
+        sql_server_clients: BTreeMap::new(),
     };
     state.initialize_cmd_vars().await?;
     Ok((state, pgconn_task))

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context};
 use byteorder::{NetworkEndian, WriteBytesExt};
 use futures::stream::{FuturesUnordered, StreamExt};
-use maplit::hashmap;
+use maplit::btreemap;
 use prost::Message;
 use prost_reflect::{DescriptorPool, DynamicMessage, MessageDescriptor};
 use rdkafka::message::{Header, OwnedHeaders};
@@ -332,7 +332,7 @@ pub async fn run_ingest(
         for row in iter {
             let row = action::substitute_vars(
                 row,
-                &hashmap! { "kafka-ingest.iteration".into() => iteration.to_string() },
+                &btreemap! { "kafka-ingest.iteration".into() => iteration.to_string() },
                 &None,
                 false,
             )?;

--- a/src/testdrive/src/action/kinesis/verify.rs
+++ b/src/testdrive/src/action/kinesis/verify.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 use std::str;
 use std::time::Instant;
 
@@ -30,7 +30,7 @@ pub async fn run_verify(
 
     let mut shard_iterators = get_shard_iterators(&state.kinesis_client, &stream_name).await?;
     let timer = Instant::now();
-    let mut records: HashSet<String> = HashSet::new();
+    let mut records: BTreeSet<String> = BTreeSet::new();
     while let Some(iterator) = shard_iterators.pop_front() {
         if let Some(iterator) = &iterator {
             let output = state

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -74,7 +74,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fs::File;
 use std::io;
@@ -455,7 +455,7 @@ async fn main() {
     }
 
     let mut error_count = 0;
-    let mut error_files = HashSet::new();
+    let mut error_files = BTreeSet::new();
     let mut junit = match args.junit_report {
         Some(filename) => match File::create(&filename) {
             Ok(file) => Some((file, junit_report::TestSuite::new("testdrive"))),

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -31,7 +31,7 @@ use serde_json::Value as JsonValue;
 // testdrive modules can import just this one.
 
 pub use mz_avro::schema::{Schema, SchemaKind, SchemaNode, SchemaPiece, SchemaPieceOrNamed};
-pub use mz_avro::types::{AvroMap, DecimalValue, ToAvro, Value};
+pub use mz_avro::types::{DecimalValue, ToAvro, Value};
 pub use mz_avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
 pub use mz_interchange::avro::parse_schema;
 
@@ -163,7 +163,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, anyhow::
                     )?,
                 );
             }
-            Ok(Value::Map(AvroMap(map)))
+            Ok(Value::Map(map))
         }
         (val, SchemaPiece::Union(us)) => {
             let variants = us.variants();

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -17,7 +17,7 @@
 // The original source code is subject to the terms of the MIT license, a copy
 // of which can be found in the LICENSE file at the root of this repository.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 
@@ -148,7 +148,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, anyhow::
             Ok(builder.avro())
         }
         (JsonValue::Object(items), SchemaPiece::Map(m)) => {
-            let mut map = HashMap::new();
+            let mut map = BTreeMap::new();
             for (k, v) in items {
                 let (inner, name) = m.get_piece_and_name(schema.root);
                 map.insert(

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -8,8 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::borrow::ToOwned;
-use std::collections::hash_map;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{btree_map, BTreeMap};
 use std::error::Error;
 use std::str::FromStr;
 
@@ -120,7 +119,7 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, PosErro
             });
         }
     };
-    let mut args = HashMap::new();
+    let mut args = BTreeMap::new();
     for el in builtin_reader {
         let (pos, token) = el?;
         let pieces: Vec<_> = token.splitn(2, '=').collect();
@@ -574,10 +573,10 @@ impl<'a> Iterator for BuiltinReader<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ArgMap(HashMap<String, String>);
+pub struct ArgMap(BTreeMap<String, String>);
 
 impl ArgMap {
-    pub fn values_mut(&mut self) -> hash_map::ValuesMut<String, String> {
+    pub fn values_mut(&mut self) -> btree_map::ValuesMut<String, String> {
         self.0.values_mut()
     }
 
@@ -642,7 +641,7 @@ impl ArgMap {
 
 impl IntoIterator for ArgMap {
     type Item = (String, String);
-    type IntoIter = hash_map::IntoIter<String, String>;
+    type IntoIter = btree_map::IntoIter<String, String>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()


### PR DESCRIPTION
This PR replaces Hash collections with their BTree equivalents in the `avro`, `build-id`, and `testdrive` crates.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Tips for reviewer

I'm trying to avoid huge PRs spanning all teams, so I'm splitting the BTree changes up a bit. This PR addresses the crates owned by @umanwizard and @MaterializeInc/qa.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
