### PR TITLE
.github: fix line breaks in PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,10 +50,7 @@ Delete this section if no tips.
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
 - [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
-- [ ] If this PR will require changes to cloud orchestration, there is a
-  companion cloud PR to account for those changes that is tagged with
-  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
+- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
   <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
 - [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
-
   - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->


### PR DESCRIPTION
Remove the line breaks from the newly added "cloud orchestration" bullet point in the "Checklist" section of the PR template.

### Motivation

This is a bit of a nitpick, but:

- GitHub actually interprets line breaks in paragraphs when Rendering markdown. Consequently the rendered view of the checklist is inconsistent. between points (1,2,4) and point (3). 
- The extra line between (4) and the "Add release notes here ..." comment introduces extra spacing, which I'm not sure is required.

### Tips for reviewer

See the "Checklist" of this PR for an example of the issues mentioned above.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
