### PR TITLE
ccsr,npm,cloud-res,orchestrator-k8s: remove uses of Hash collections

### DIFF
--- a/src/ccsr/src/client.rs
+++ b/src/ccsr/src/client.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt;
 
@@ -106,7 +106,7 @@ impl Client {
         version: String,
     ) -> Result<(Subject, Vec<Subject>), GetBySubjectError> {
         let mut subjects = vec![];
-        let mut seen = HashSet::new();
+        let mut seen = BTreeSet::new();
         let mut subjects_queue = vec![(subject.to_owned(), version)];
         while let Some((subject, version)) = subjects_queue.pop() {
             let req = self.make_request(Method::GET, &["subjects", &subject, "versions", &version]);

--- a/src/ccsr/src/config.rs
+++ b/src/ccsr/src/config.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -30,7 +30,7 @@ pub struct ClientConfig {
     root_certs: Vec<Certificate>,
     identity: Option<Identity>,
     auth: Option<Auth>,
-    dns_overrides: HashMap<String, Vec<SocketAddr>>,
+    dns_overrides: BTreeMap<String, Vec<SocketAddr>>,
 }
 
 impl ClientConfig {
@@ -42,7 +42,7 @@ impl ClientConfig {
             root_certs: Vec::new(),
             identity: None,
             auth: None,
-            dns_overrides: HashMap::new(),
+            dns_overrides: BTreeMap::new(),
         }
     }
 

--- a/src/cloud-resources/src/lib.rs
+++ b/src/cloud-resources/src/lib.rs
@@ -77,7 +77,7 @@
 //! Abstractions for management of cloud resources that have no equivalent when running
 //! locally, like AWS PrivateLink endpoints.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt::{self, Debug};
 
 use async_trait::async_trait;
@@ -146,7 +146,7 @@ pub trait CloudResourceController: Debug + Send + Sync {
     async fn delete_vpc_endpoint(&self, id: GlobalId) -> Result<(), anyhow::Error>;
 
     /// Lists existing `VpcEndpoint` Kubernetes objects.
-    async fn list_vpc_endpoints(&self) -> Result<HashSet<GlobalId>, anyhow::Error>;
+    async fn list_vpc_endpoints(&self) -> Result<BTreeSet<GlobalId>, anyhow::Error>;
 }
 
 /// Returns the name to use for the VPC endpoint with the given ID.

--- a/src/npm/src/lib.rs
+++ b/src/npm/src/lib.rs
@@ -126,7 +126,7 @@
 //! The "/js/vendor/PACKAGE.js" will automatically switch between the production
 //! and development assets based on the presence of the `dev-web` feature.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -326,7 +326,7 @@ expected: {}
     // Clean up any stray files. This is more important than it might seem,
     // since files in `CSS_VENDOR` and `JS_PROD_VENDOR` are blindly bundled into
     // the binary at build time by the `include_dir` macro.
-    let mut known_paths = HashSet::new();
+    let mut known_paths = BTreeSet::new();
     for pkg in NPM_PACKAGES {
         if pkg.css_file.is_some() {
             known_paths.insert(pkg.css_path());

--- a/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
+++ b/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
@@ -9,7 +9,7 @@
 
 //! Management of K8S objects, such as VpcEndpoints.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use async_trait::async_trait;
@@ -82,7 +82,7 @@ impl CloudResourceController for KubernetesOrchestrator {
         }
     }
 
-    async fn list_vpc_endpoints(&self) -> Result<HashSet<GlobalId>, anyhow::Error> {
+    async fn list_vpc_endpoints(&self) -> Result<BTreeSet<GlobalId>, anyhow::Error> {
         Ok(self
             .vpc_endpoint_api
             .list(&ListParams::default())


### PR DESCRIPTION
This PR replaces Hash collections with their BTree equivalents in the `ccsr`, `npm`, `cloud-resources` and `orchestrator-kubernetes` crates.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Tips for reviewer

I'm trying to avoid huge PRs spanning all teams, so I'm splitting the BTree changes up a bit. This PR addresses the crates owned by @benesch.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
