### PR TITLE
storage: remove uses of Hash collections

### DIFF
--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 
 use byteorder::{NetworkEndian, WriteBytesExt};
@@ -143,7 +143,7 @@ impl AvroSchemaGenerator {
                 let row_schema = build_row_schema_json(
                     &columns,
                     key_fullname.unwrap_or("row"),
-                    &HashMap::new(),
+                    &BTreeMap::new(),
                 )?;
                 Some(KeyInfo {
                     schema: Schema::parse(&row_schema).expect("valid schema constructed"),

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -228,7 +228,7 @@ impl mz_avro::AvroDecode for TimestampDecoder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use mz_avro::types::Value;
     use mz_avro::AvroDeserializer;
@@ -319,7 +319,7 @@ mod tests {
         let row_schema = build_row_schema_json(
             &crate::encode::column_names_and_types(desc),
             "data",
-            &HashMap::new(),
+            &BTreeMap::new(),
         )
         .unwrap();
         let schema = build_schema(row_schema);

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -35,8 +35,8 @@
 //! SQL type, not a series of them. Thus, in these cases, we just bail. For example, it's
 //! not possible to ingest an array or map whose element type is an Essential Union.
 
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -95,7 +95,7 @@ fn validate_schema_1(schema: SchemaNode) -> anyhow::Result<Vec<(ColumnName, Colu
 /// Get the series of (one or more) SQL columns corresponding to an Avro union.
 /// See module comments for details.
 fn get_union_columns<'a>(
-    seen_avro_nodes: &mut HashSet<usize>,
+    seen_avro_nodes: &mut BTreeSet<usize>,
     schema: SchemaNode<'a>,
     base_name: Option<&str>,
 ) -> anyhow::Result<Vec<(ColumnName, ColumnType)>> {
@@ -165,7 +165,7 @@ fn get_union_columns<'a>(
 }
 
 fn get_named_columns<'a>(
-    seen_avro_nodes: &mut HashSet<usize>,
+    seen_avro_nodes: &mut BTreeSet<usize>,
     schema: SchemaNode<'a>,
     base_name: Option<&str>,
 ) -> anyhow::Result<Vec<(ColumnName, ColumnType)>> {
@@ -186,7 +186,7 @@ fn get_named_columns<'a>(
 /// It is an error if this node should correspond to more than one column
 /// (because it is an Essential Union in the sense described in the module docs).
 fn validate_schema_2(
-    seen_avro_nodes: &mut HashSet<usize>,
+    seen_avro_nodes: &mut BTreeSet<usize>,
     schema: SchemaNode,
 ) -> anyhow::Result<ScalarType> {
     Ok(match schema.inner {
@@ -369,14 +369,14 @@ impl<C> fmt::Debug for ConfluentAvroResolver<C> {
 
 #[derive(Debug)]
 struct SchemaCache<C> {
-    cache: HashMap<i32, Result<Schema, AvroError>>,
+    cache: BTreeMap<i32, Result<Schema, AvroError>>,
     ccsr_client: C,
 }
 
 impl<C: Deref<Target = mz_ccsr::Client>> SchemaCache<C> {
     fn new(ccsr_client: C) -> Result<SchemaCache<C>, anyhow::Error> {
         Ok(SchemaCache {
-            cache: HashMap::new(),
+            cache: BTreeMap::new(),
             ccsr_client,
         })
     }

--- a/src/interchange/src/encode.rs
+++ b/src/interchange/src/encode.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use mz_repr::{ColumnName, ColumnType, Datum, RelationDesc, Row};
 
@@ -39,7 +39,7 @@ pub fn column_names_and_types(desc: RelationDesc) -> Vec<(ColumnName, ColumnType
     let mut columns: Vec<_> = desc.into_iter().collect();
 
     // Deduplicate names.
-    let mut seen = HashSet::new();
+    let mut seen = BTreeSet::new();
     for (name, _ty) in &mut columns {
         let stem_len = name.as_str().len();
         let mut i = 1;

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::iter;
 use std::rc::Rc;
 
@@ -18,7 +18,7 @@ use differential_dataflow::{
 };
 use differential_dataflow::{AsCollection, Collection};
 use itertools::{EitherOrBoth, Itertools};
-use maplit::hashmap;
+use maplit::btreemap;
 use once_cell::sync::Lazy;
 use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
 
@@ -126,8 +126,8 @@ where
 pub(crate) const TRANSACTION_TYPE_ID: GlobalId = GlobalId::Transient(1);
 pub(crate) const DBZ_ROW_TYPE_ID: GlobalId = GlobalId::Transient(2);
 
-pub static ENVELOPE_CUSTOM_NAMES: Lazy<HashMap<GlobalId, String>> = Lazy::new(|| {
-    hashmap! {
+pub static ENVELOPE_CUSTOM_NAMES: Lazy<BTreeMap<GlobalId, String>> = Lazy::new(|| {
+    btreemap! {
         TRANSACTION_TYPE_ID => "transaction".into(),
         DBZ_ROW_TYPE_ID => "row".into(),
     }

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use serde_json::{json, Map};
@@ -78,7 +78,7 @@ impl fmt::Debug for JsonEncoder {
                 "schema",
                 &format!(
                     "{:?}",
-                    build_row_schema_json(&self.value_columns, "schema", &HashMap::new())
+                    build_row_schema_json(&self.value_columns, "schema", &BTreeMap::new())
                 ),
             )
             .finish()
@@ -223,7 +223,7 @@ impl ToJson for TypedDatum<'_> {
 
 fn build_row_schema_field(
     type_namer: &mut Namer,
-    custom_names: &HashMap<GlobalId, String>,
+    custom_names: &BTreeMap<GlobalId, String>,
     typ: &ColumnType,
 ) -> serde_json::Value {
     let mut field_type = match &typ.scalar_type {
@@ -342,7 +342,7 @@ fn build_row_schema_field(
 fn build_row_schema_fields(
     columns: &[(ColumnName, ColumnType)],
     type_namer: &mut Namer,
-    custom_names: &HashMap<GlobalId, String>,
+    custom_names: &BTreeMap<GlobalId, String>,
 ) -> Vec<serde_json::Value> {
     let mut fields = Vec::new();
     let mut field_namer = Namer::default();
@@ -361,7 +361,7 @@ fn build_row_schema_fields(
 pub fn build_row_schema_json(
     columns: &[(ColumnName, ColumnType)],
     name: &str,
-    custom_names: &HashMap<GlobalId, String>,
+    custom_names: &BTreeMap<GlobalId, String>,
 ) -> Result<serde_json::Value, anyhow::Error> {
     let fields = build_row_schema_fields(columns, &mut Namer::default(), custom_names);
     let _ = mz_avro::schema::Name::parse_simple(name)?;
@@ -377,9 +377,9 @@ pub fn build_row_schema_json(
 struct Namer {
     record_index: usize,
     seen_interval: bool,
-    seen_unsigneds: HashSet<usize>,
-    seen_names: HashMap<String, String>,
-    valid_names_count: HashMap<String, usize>,
+    seen_unsigneds: BTreeSet<usize>,
+    seen_names: BTreeMap<String, String>,
+    valid_names_count: BTreeMap<String, usize>,
 }
 
 impl Namer {

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use anyhow::{anyhow, bail, Context};
 
@@ -38,7 +38,7 @@ impl DecodedDescriptors {
                 message_name.quoted(),
             )
         })?;
-        let mut seen_messages = HashSet::new();
+        let mut seen_messages = BTreeSet::new();
         seen_messages.insert(message_descriptor.name().to_owned());
         let mut columns = vec![];
         for field in message_descriptor.fields() {
@@ -114,7 +114,7 @@ impl Decoder {
 }
 
 fn derive_column_type(
-    seen_messages: &mut HashSet<String>,
+    seen_messages: &mut BTreeSet<String>,
     field: &FieldDescriptor,
 ) -> Result<ColumnType, anyhow::Error> {
     if field.is_map() {
@@ -136,7 +136,7 @@ fn derive_column_type(
 }
 
 fn derive_inner_type(
-    seen_messages: &mut HashSet<String>,
+    seen_messages: &mut BTreeSet<String>,
     ty: Kind,
 ) -> Result<ColumnType, anyhow::Error> {
     match ty {

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -74,7 +74,7 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::iter;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -129,17 +129,17 @@ struct RandomAvroGenerator<'a> {
     // Generator functions for each piece of the schema. These map keys are
     // morally `*const SchemaPiece`s, but represented as `usize`s so that they
     // implement `Send`.
-    ints: HashMap<usize, Box<dyn Generator<i32>>>,
-    longs: HashMap<usize, Box<dyn Generator<i64>>>,
-    strings: HashMap<usize, Box<dyn Generator<Vec<u8>>>>,
-    bytes: HashMap<usize, Box<dyn Generator<Vec<u8>>>>,
-    unions: HashMap<usize, Box<dyn Generator<usize>>>,
-    enums: HashMap<usize, Box<dyn Generator<usize>>>,
-    bools: HashMap<usize, Box<dyn Generator<bool>>>,
-    floats: HashMap<usize, Box<dyn Generator<f32>>>,
-    doubles: HashMap<usize, Box<dyn Generator<f64>>>,
-    decimals: HashMap<usize, Box<dyn Generator<Vec<u8>>>>,
-    array_lens: HashMap<usize, Box<dyn Generator<usize>>>,
+    ints: BTreeMap<usize, Box<dyn Generator<i32>>>,
+    longs: BTreeMap<usize, Box<dyn Generator<i64>>>,
+    strings: BTreeMap<usize, Box<dyn Generator<Vec<u8>>>>,
+    bytes: BTreeMap<usize, Box<dyn Generator<Vec<u8>>>>,
+    unions: BTreeMap<usize, Box<dyn Generator<usize>>>,
+    enums: BTreeMap<usize, Box<dyn Generator<usize>>>,
+    bools: BTreeMap<usize, Box<dyn Generator<bool>>>,
+    floats: BTreeMap<usize, Box<dyn Generator<f32>>>,
+    doubles: BTreeMap<usize, Box<dyn Generator<f64>>>,
+    decimals: BTreeMap<usize, Box<dyn Generator<Vec<u8>>>>,
+    array_lens: BTreeMap<usize, Box<dyn Generator<usize>>>,
 
     schema: SchemaNode<'a>,
 }

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -10,7 +10,7 @@
 //! Helpers for working with Kafka's client API.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::time::Duration;
 
@@ -72,7 +72,7 @@ impl ProducerContext for MzClientContext {
 /// A client context that supports rewriting broker addresses.
 pub struct BrokerRewritingClientContext<C> {
     inner: C,
-    overrides: HashMap<BrokerAddr, BrokerAddr>,
+    overrides: BTreeMap<BrokerAddr, BrokerAddr>,
     /// Opaque tokens to cleanup resources associated with overrides.
     drop_tokens: Vec<Box<dyn Any + Send + Sync>>,
 }
@@ -82,7 +82,7 @@ impl<C> BrokerRewritingClientContext<C> {
     pub fn new(inner: C) -> BrokerRewritingClientContext<C> {
         BrokerRewritingClientContext {
             inner,
-            overrides: HashMap::new(),
+            overrides: BTreeMap::new(),
             drop_tokens: vec![],
         }
     }

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -14,7 +14,7 @@
 
 //! The public API of the storage layer.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::iter;
 
@@ -471,7 +471,7 @@ pub struct PartitionedStorageState<T> {
     parts: u32,
     /// Upper frontiers for sources and sinks, both unioned across all partitions and from each
     /// individual partition.
-    uppers: HashMap<GlobalId, (MutableAntichain<T>, Vec<Option<Antichain<T>>>)>,
+    uppers: BTreeMap<GlobalId, (MutableAntichain<T>, Vec<Option<Antichain<T>>>)>,
 }
 
 impl<T> Partitionable<StorageCommand<T>, StorageResponse<T>>
@@ -484,7 +484,7 @@ where
     fn new(parts: usize) -> PartitionedStorageState<T> {
         PartitionedStorageState {
             parts: parts.try_into().expect("more than 4 billion partitions"),
-            uppers: HashMap::new(),
+            uppers: BTreeMap::new(),
         }
     }
 }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -19,7 +19,7 @@
 //! empty frontier.
 
 use std::any::Any;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::{self, Debug};
 use std::num::NonZeroI64;
@@ -660,23 +660,24 @@ pub struct StorageControllerState<T: Timestamp + Lattice + Codec64 + TimestampMa
     /// Interface for managed collections
     pub(super) collection_manager: collection_mgmt::CollectionManager,
     /// Tracks which collection is responsible for which [`IntrospectionType`].
-    pub(super) introspection_ids: HashMap<IntrospectionType, GlobalId>,
+    pub(super) introspection_ids: BTreeMap<IntrospectionType, GlobalId>,
     /// Tokens for tasks that drive updating introspection collections. Dropping
     /// this will make sure that any tasks (or other resources) will stop when
     /// needed.
     // TODO(aljoscha): Should these live somewhere else?
-    introspection_tokens: HashMap<GlobalId, Box<dyn Any + Send + Sync>>,
+    introspection_tokens: BTreeMap<GlobalId, Box<dyn Any + Send + Sync>>,
 
     /// Consolidated metrics updates to periodically write. We do not eagerly initialize this,
     /// and its contents are entirely driven by `StorageResponse::StatisticsUpdates`'s.
     source_statistics:
-        Arc<std::sync::Mutex<HashMap<GlobalId, HashMap<usize, SourceStatisticsUpdate>>>>,
+        Arc<std::sync::Mutex<BTreeMap<GlobalId, BTreeMap<usize, SourceStatisticsUpdate>>>>,
     /// Consolidated metrics updates to periodically write. We do not eagerly initialize this,
     /// and its contents are entirely driven by `StorageResponse::StatisticsUpdates`'s.
-    sink_statistics: Arc<std::sync::Mutex<HashMap<GlobalId, HashMap<usize, SinkStatisticsUpdate>>>>,
+    sink_statistics:
+        Arc<std::sync::Mutex<BTreeMap<GlobalId, BTreeMap<usize, SinkStatisticsUpdate>>>>,
 
     /// Clients for all known storage instances.
-    clients: HashMap<StorageInstanceId, RehydratingStorageClient<T>>,
+    clients: BTreeMap<StorageInstanceId, RehydratingStorageClient<T>>,
     /// Set to `true` once `initialization_complete` has been called.
     initialized: bool,
     /// Storage configuration to apply to newly provisioned instances.
@@ -877,13 +878,13 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
             pending_sink_drops: vec![],
             pending_compaction_commands: vec![],
             collection_manager,
-            introspection_ids: HashMap::new(),
-            introspection_tokens: HashMap::new(),
+            introspection_ids: BTreeMap::new(),
+            introspection_tokens: BTreeMap::new(),
             now,
             envd_epoch,
-            source_statistics: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            sink_statistics: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            clients: HashMap::new(),
+            source_statistics: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+            sink_statistics: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+            clients: BTreeMap::new(),
             initialized: false,
             config: StorageParameters::default(),
         }
@@ -1329,7 +1330,7 @@ where
         exports: Vec<(CreateExportToken, ExportDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError> {
         // Validate first, to avoid corrupting state.
-        let mut dedup_hashmap = HashMap::<&_, &_>::new();
+        let mut dedup_hashmap = BTreeMap::<&_, &_>::new();
         for (CreateExportToken { id, from_id }, desc) in exports.iter() {
             if dedup_hashmap.insert(id, desc).is_some() {
                 return Err(StorageError::SourceIdReused(*id));
@@ -1597,7 +1598,7 @@ where
         updates: &mut BTreeMap<GlobalId, ChangeBatch<Self::Timestamp>>,
     ) {
         // Location to record consequences that we need to act on.
-        let mut storage_net = HashMap::new();
+        let mut storage_net = BTreeMap::new();
         // Repeatedly extract the maximum id, and updates for it.
         while let Some(key) = updates.keys().rev().next().cloned() {
             let mut update = updates.remove(&key).unwrap();
@@ -1898,7 +1899,7 @@ where
     /// - If `id` does not belong to a collection or is not registered as a
     ///   managed collection.
     async fn reconcile_managed_collection(&self, id: GlobalId, updates: Vec<(Row, Diff)>) {
-        let mut reconciled_updates = HashMap::<Row, Diff>::with_capacity(updates.len());
+        let mut reconciled_updates = BTreeMap::<Row, Diff>::new();
 
         for (row, diff) in updates.into_iter() {
             *reconciled_updates.entry(row).or_default() += diff;

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -10,7 +10,7 @@
 //! A tokio task (and support machinery) for maintaining storage-managed
 //! collections.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
@@ -32,7 +32,7 @@ use super::persist_handles;
 pub struct CollectionManager {
     // TODO(guswynn): this should be a sync mutex, as it protects
     // normal data.
-    collections: Arc<Mutex<HashSet<GlobalId>>>,
+    collections: Arc<Mutex<BTreeSet<GlobalId>>>,
     tx: mpsc::Sender<(GlobalId, Vec<(Row, Diff)>)>,
 }
 
@@ -52,7 +52,7 @@ impl CollectionManager {
         write_handle: persist_handles::PersistWriteWorker<T>,
         now: NowFn,
     ) -> CollectionManager {
-        let collections = Arc::new(Mutex::new(HashSet::new()));
+        let collections = Arc::new(Mutex::new(BTreeSet::new()));
         let collections_outer = Arc::clone(&collections);
         let (tx, mut rx) = mpsc::channel::<(GlobalId, Vec<(Row, Diff)>)>(1);
 

--- a/src/storage-client/src/controller/persist_handles.rs
+++ b/src/storage-client/src/controller/persist_handles.rs
@@ -10,7 +10,7 @@
 //! A tokio tasks (and support machinery) for dealing with the persist handles
 //! that the storage controller needs to hold.
 
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use differential_dataflow::lattice::Lattice;
 use futures::stream::FuturesUnordered;
@@ -222,7 +222,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistWriteWorke
                                         }
                                     }
                                     PersistWriteWorkerCmd::Append(updates, response) => {
-                                        let mut ids = HashSet::new();
+                                        let mut ids = BTreeSet::new();
                                         for (id, update, upper) in updates {
                                             ids.insert(id);
                                             let (old_span, updates, old_upper) =

--- a/src/storage-client/src/controller/rehydration.rs
+++ b/src/storage-client/src/controller/rehydration.rs
@@ -15,7 +15,7 @@
 //! with the underlying client, it will reconnect the client and replay the
 //! command stream.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -80,7 +80,7 @@ where
             response_tx,
             sources: BTreeMap::new(),
             sinks: BTreeMap::new(),
-            uppers: HashMap::new(),
+            uppers: BTreeMap::new(),
             initialized: false,
             config: Default::default(),
             persist,
@@ -139,7 +139,7 @@ struct RehydrationTask<T> {
     /// The exports that have been observed.
     sinks: BTreeMap<GlobalId, CreateSinkCommand<T>>,
     /// The upper frontier information received.
-    uppers: HashMap<GlobalId, Antichain<T>>,
+    uppers: BTreeMap<GlobalId, Antichain<T>>,
     /// Set to `true` once [`StorageCommand::InitializationComplete`] has been
     /// observed.
     initialized: bool,

--- a/src/storage-client/src/controller/statistics.rs
+++ b/src/storage-client/src/controller/statistics.rs
@@ -10,7 +10,7 @@
 //! A tokio task (and support machinery) for producing storage statistics.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -28,7 +28,7 @@ use crate::controller::collection_mgmt::CollectionManager;
 pub(super) fn spawn_statistics_scraper<Stats: PackableStats + Send + 'static>(
     statistics_collection_id: GlobalId,
     collection_mgmt: CollectionManager,
-    shared_stats: Arc<Mutex<HashMap<GlobalId, HashMap<usize, Stats>>>>,
+    shared_stats: Arc<Mutex<BTreeMap<GlobalId, BTreeMap<usize, Stats>>>>,
 ) -> Box<dyn Any + Send + Sync> {
     // TODO(guswynn): Should this be configurable? Maybe via LaunchDarkly?
     const STATISTICS_INTERVAL: Duration = Duration::from_secs(30);

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -9,7 +9,7 @@
 
 //! Types and traits related to the introduction of changing collections into `dataflow`.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::{Add, AddAssign, Deref, DerefMut};
 use std::rc::Rc;
 use std::str::FromStr;
@@ -2063,7 +2063,7 @@ impl LoadGenerator {
                 let mut desc =
                     RelationDesc::empty().with_column("rowid", ScalarType::Int64.nullable(false));
                 let typs = ScalarType::enumerate();
-                let mut names = HashSet::new();
+                let mut names = BTreeSet::new();
                 for typ in typs {
                     // Cut out variant information from the debug print.
                     let mut name = format!("_{:?}", typ)

--- a/src/storage-client/src/util/antichain.rs
+++ b/src/storage-client/src/util/antichain.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use timely::order::PartialOrder;
 use timely::progress::frontier::{Antichain, MutableAntichain};
@@ -93,7 +93,7 @@ impl OffsetAntichain {
     /// careful.
     // TODO(guswynn): better document how source uppers flow through the
     // source reader pipeline.
-    pub fn as_data_offsets(&self) -> HashMap<PartitionId, MzOffset> {
+    pub fn as_data_offsets(&self) -> BTreeMap<PartitionId, MzOffset> {
         self.inner
             .iter()
             .filter_map(|(pid, offset)| {

--- a/src/storage-client/src/util/antichain.rs
+++ b/src/storage-client/src/util/antichain.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use timely::order::PartialOrder;
 use timely::progress::frontier::{Antichain, MutableAntichain};
@@ -22,7 +22,7 @@ use crate::types::sources::MzOffset;
 /// OffsetAntichain is similar to a timely `Antichain<(PartitionId, T: TotalOrder)>`,
 /// but additionally:
 ///
-/// - Uses a HashMap as the implementation to allow absence of a `PartitionId` to mean
+/// - Uses a BTreeMap as the implementation to allow absence of a `PartitionId` to mean
 /// that `PartitionId` is at `T::minimum`. This helps avoid needing to hold onto a HUGE
 /// `Antichain` for all possible `PartitionId`s
 ///     - Note this means that a partition being "finished" (like a normal "empty"
@@ -48,15 +48,15 @@ use crate::types::sources::MzOffset;
 ///     - `insert_data_up_to` updates the frontier based on a given offset
 ///     that is associated with actual data.
 ///     - `as_data_offsets` inverts the behavior of `insert_data_up_to`
-///     and returns a `HashMap<PartitionId, MzOffset>` of offets
+///     and returns a `BTreeMap<PartitionId, MzOffset>` of offets
 ///     of real committed data.
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OffsetAntichain {
-    inner: HashMap<PartitionId, MzOffset>,
+    inner: BTreeMap<PartitionId, MzOffset>,
 }
 
-impl PartialEq<HashMap<PartitionId, MzOffset>> for OffsetAntichain {
-    fn eq(&self, other: &HashMap<PartitionId, MzOffset>) -> bool {
+impl PartialEq<BTreeMap<PartitionId, MzOffset>> for OffsetAntichain {
+    fn eq(&self, other: &BTreeMap<PartitionId, MzOffset>) -> bool {
         other == &self.inner
     }
 }
@@ -65,15 +65,7 @@ impl OffsetAntichain {
     /// Initialize an Antichain where all partitions have made no progress.
     pub fn new() -> Self {
         Self {
-            inner: HashMap::new(),
-        }
-    }
-
-    /// Initialize an Antichain where all partitions have made no progress,
-    /// but with `cap` capacity in the underlying data structure.
-    pub fn with_capacity(cap: usize) -> Self {
-        Self {
-            inner: HashMap::with_capacity(cap),
+            inner: BTreeMap::new(),
         }
     }
 
@@ -215,7 +207,7 @@ impl OffsetAntichain {
     #[cfg(test)]
     pub fn from_iter<T: IntoIterator<Item = (PartitionId, MzOffset)>>(iter: T) -> Self {
         Self {
-            inner: HashMap::from_iter(iter),
+            inner: BTreeMap::from_iter(iter),
         }
     }
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -73,9 +73,10 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
-#![warn(missing_docs)]
 
 //! Materialize's storage layer.
+
+#![warn(missing_docs)]
 
 pub mod decode;
 pub mod internal_control;

--- a/src/storage/src/render/debezium.rs
+++ b/src/storage/src/render/debezium.rs
@@ -7,8 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, VecDeque};
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, VecDeque};
 use std::str::FromStr;
 
 use differential_dataflow::{Collection, Hashable};
@@ -41,7 +41,7 @@ where
     // TODO(guswynn): !!! Correctly deduplicate even in the upsert case
     input
         .unary(Pipeline, "envelope-debezium", move |_, _| {
-            let mut dedup_state = HashMap::new();
+            let mut dedup_state = BTreeMap::new();
             let envelope = envelope.clone();
             let mut data = vec![];
             move |input, output| {
@@ -193,7 +193,7 @@ where
                 let mut tx_data = vec![];
                 let mut data = vec![];
                 let mut data_buffer = VecDeque::new();
-                let mut dedup_state = HashMap::new();
+                let mut dedup_state = BTreeMap::new();
 
                 // Keep mapping of `transaction_id`s to the timestamp at which that transaction END record was read from
                 // the transaction metadata stream.  That stored timestamp will be the timestamp for all data records
@@ -201,10 +201,10 @@ where
                 // number of data rows so that we're able to process duplicates.  Otherwise, we're not able to tell the
                 // difference between "we've recieved the tx metadata and processed everything" and "we're still waiting
                 // on the tx metadata".
-                let mut tx_mapping: HashMap<String, Timestamp> = HashMap::new();
+                let mut tx_mapping: BTreeMap<String, Timestamp> = BTreeMap::new();
                 // Hold onto a capability for each `transaction_id`.  This represents the time at which we'll emit
                 // matched data rows.  This will be dropped when we've matched the indicated number of events.
-                let mut tx_cap_event_count: HashMap<String, (Capability<_>, i64)> = HashMap::new();
+                let mut tx_cap_event_count: BTreeMap<String, (Capability<_>, i64)> = BTreeMap::new();
                 move |_, _| {
                     // TODO(#11669) Revisit error handling strategy to do something optimized than just emitting
                     // everything we can and holding back the frontier to the first data error.
@@ -421,7 +421,7 @@ struct DebeziumDeduplicationState {
     // TODO(petrosagg): This is only used when unpacking MySQL row coordinates. The logic was
     // transferred as-is from the previous avro-debezium code. Find a better place to put this or
     // avoid it completely.
-    filenames_to_indices: HashMap<String, u64>,
+    filenames_to_indices: BTreeMap<String, u64>,
     projection: DebeziumDedupProjection,
 }
 
@@ -499,7 +499,7 @@ impl DebeziumDeduplicationState {
         Some(DebeziumDeduplicationState {
             last_position: None,
             messages_processed: 0.into(),
-            filenames_to_indices: HashMap::new(),
+            filenames_to_indices: BTreeMap::new(),
             projection: envelope.dedup,
         })
     }

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -103,7 +103,7 @@ where
     let persist_clients = Arc::clone(&storage_state.persist_clients);
     let button = persist_op.build(move |_capabilities| async move {
         let mut buffer = Vec::new();
-        let mut stashed_batches = HashMap::new();
+        let mut stashed_batches = BTreeMap::new();
 
         let mut write = persist_clients
             .lock()

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::Context;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -67,9 +67,9 @@ pub struct KafkaSourceReader {
     /// The most recently read offset for each partition known to this source
     /// reader. An offset of -1 indicates that no prior message has been read
     /// for the given partition.
-    last_offsets: HashMap<i32, i64>,
+    last_offsets: BTreeMap<i32, i64>,
     /// The offset to start reading from for each partition.
-    start_offsets: HashMap<i32, i64>,
+    start_offsets: BTreeMap<i32, i64>,
     /// Channel to receive Kafka statistics JSON blobs from the stats callback.
     stats_rx: crossbeam_channel::Receiver<Jsonb>,
     /// The last partition we received
@@ -176,7 +176,7 @@ impl SourceConnectionBuilder for KafkaSourceConnection {
 
         // Start offsets is a map from partition to the next offset to read
         // from.
-        let mut start_offsets: HashMap<_, i64> = self
+        let mut start_offsets: BTreeMap<_, i64> = self
             .start_offsets
             .into_iter()
             .filter(|(pid, _offset)| {
@@ -292,7 +292,7 @@ impl SourceConnectionBuilder for KafkaSourceConnection {
                 consumer: Arc::clone(&consumer),
                 worker_id,
                 worker_count,
-                last_offsets: HashMap::new(),
+                last_offsets: BTreeMap::new(),
                 start_offsets,
                 stats_rx,
                 partition_info,
@@ -433,7 +433,7 @@ impl SourceReader for KafkaSourceReader {
 impl OffsetCommitter for KafkaOffsetCommiter {
     async fn commit_offsets(
         &self,
-        offsets: HashMap<PartitionId, MzOffset>,
+        offsets: BTreeMap<PartitionId, MzOffset>,
     ) -> Result<(), anyhow::Error> {
         use rdkafka::consumer::CommitMode;
         use rdkafka::topic_partition_list::Offset;

--- a/src/storage/src/source/kafka/metrics.rs
+++ b/src/storage/src/source/kafka/metrics.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use prometheus::core::AtomicI64;
 use tracing::debug;
@@ -20,7 +20,7 @@ use crate::source::metrics::SourceBaseMetrics;
 pub(super) struct KafkaPartitionMetrics {
     labels: Vec<String>,
     base_metrics: SourceBaseMetrics,
-    partition_offset_map: HashMap<i32, DeleteOnDropGauge<'static, AtomicI64, Vec<String>>>,
+    partition_offset_map: BTreeMap<i32, DeleteOnDropGauge<'static, AtomicI64, Vec<String>>>,
 }
 
 impl KafkaPartitionMetrics {
@@ -32,7 +32,7 @@ impl KafkaPartitionMetrics {
     ) -> Self {
         let metrics = &base_metrics.partition_specific;
         Self {
-            partition_offset_map: HashMap::from_iter(ids.iter().map(|id| {
+            partition_offset_map: BTreeMap::from_iter(ids.iter().map(|id| {
                 let labels = &[topic.clone(), source_id.to_string(), format!("{}", id)];
                 (
                     *id,

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -606,7 +606,7 @@ where
 mod tests {
     use super::*;
 
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -793,11 +793,11 @@ mod tests {
                 .await,
         );
 
-        let mut remap_trace = HashSet::new();
+        let mut remap_trace = BTreeSet::new();
         remap_trace.extend(follower.inner.borrow().remap_trace.clone());
         assert_eq!(
             remap_trace,
-            HashSet::from_iter([
+            BTreeSet::from_iter([
                 // Initial state
                 (
                     Partitioned::with_range(None, None, MzOffset::from(0)),

--- a/src/storage/src/source/reclock/compat.rs
+++ b/src/storage/src/source/reclock/compat.rs
@@ -10,7 +10,7 @@
 //! Reclocking compatibility code until the whole ingestion pipeline is transformed to native
 //! timestamps
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -49,9 +49,9 @@ where
 {
     pub fn reclock_compat<'a, M>(
         &'a self,
-        batch: &'a mut HashMap<PartitionId, Vec<(M, MzOffset)>>,
+        batch: &'a mut BTreeMap<PartitionId, Vec<(M, MzOffset)>>,
     ) -> Result<impl Iterator<Item = (M, IntoTime)> + 'a, ReclockError<FromTime>> {
-        let mut reclock_results = HashMap::with_capacity(batch.len());
+        let mut reclock_results = BTreeMap::new();
         // Eagerly compute all the reclocked times to check if we need to report an error
         for (pid, updates) in batch.iter() {
             let mut pid_results = Vec::with_capacity(updates.len());

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -27,7 +27,7 @@
 //!        .  .  .  .
 //! ```
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{From, TryInto};
 use std::default::Default;
 use std::ops::AddAssign;
@@ -163,10 +163,10 @@ async fn download_objects_task(
     let source_id = source_id.to_string();
 
     struct BucketInfo {
-        keys: HashSet<String>,
+        keys: BTreeSet<String>,
         metrics: BucketMetrics,
     }
-    let mut seen_buckets: HashMap<String, BucketInfo> = HashMap::new();
+    let mut seen_buckets: BTreeMap<String, BucketInfo> = BTreeMap::new();
 
     loop {
         let msg = tokio::select! {
@@ -201,7 +201,7 @@ async fn download_objects_task(
                     }
                 } else {
                     let bi = BucketInfo {
-                        keys: HashSet::new(),
+                        keys: BTreeSet::new(),
                         metrics: BucketMetrics::new(&metrics, &source_id, &msg.bucket),
                     };
                     seen_buckets.insert(msg.bucket.clone(), bi);
@@ -429,7 +429,7 @@ async fn read_sqs_task(
         }
     };
 
-    let mut metrics: HashMap<String, ScanBucketMetrics> = HashMap::new();
+    let mut metrics: BTreeMap<String, ScanBucketMetrics> = BTreeMap::new();
 
     let mut allowed_errors = 10;
     'outer: loop {
@@ -535,7 +535,7 @@ async fn process_message(
     message: SqsMessage,
     glob: Option<&GlobMatcher>,
     base_metrics: SourceBaseMetrics,
-    metrics: &mut HashMap<String, ScanBucketMetrics>,
+    metrics: &mut BTreeMap<String, ScanBucketMetrics>,
     source_id: &str,
     tx: &Sender<S3Result<KeyInfo>>,
     client: &SqsClient,

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -24,8 +24,8 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, VecDeque};
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -119,7 +119,7 @@ pub struct RawSourceCreationConfig {
 /// current source upper, and any errors that occurred while reading that batch.
 #[derive(Clone)]
 struct SourceMessageBatch<Key, Value, Diff> {
-    messages: HashMap<
+    messages: BTreeMap<
         PartitionId,
         Vec<(
             (
@@ -252,7 +252,7 @@ where
 /// to other information it needs to communicate to various operators.
 struct SourceReaderOperatorOutput<K, V, D> {
     /// Messages and their offsets from the source reader.
-    messages: HashMap<
+    messages: BTreeMap<
         PartitionId,
         Vec<(
             (
@@ -316,7 +316,7 @@ where
         // messages after a restart, the reclock operator would be stuck and
         // not advance its downstream frontier.
         yield Some(SourceReaderOperatorOutput {
-            messages: HashMap::new(),
+            messages: BTreeMap::new(),
             status_update: None,
             unconsumed_partitions: Vec::new(),
             source_upper: initial_source_upper,
@@ -333,7 +333,7 @@ where
         let mut emission_interval = tokio::time::interval(timestamp_interval / 5);
         emission_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        let mut untimestamped_messages = HashMap::<_, Vec<_>>::new();
+        let mut untimestamped_messages = BTreeMap::<_, Vec<_>>::new();
         let mut unconsumed_partitions = Vec::new();
         let mut status_update = None;
         loop {
@@ -1428,7 +1428,7 @@ where
             // Accumulate updates to bytes_read for Prometheus metrics collection
             let mut bytes_read = 0;
             // Accumulate updates to offsets for system table metrics collection
-            let mut metric_updates = HashMap::new();
+            let mut metric_updates = BTreeMap::new();
 
             trace!(
                 "reclock({id}) {worker_id}/{worker_count}: \
@@ -1620,7 +1620,7 @@ fn handle_message<K, V, D>(
         (usize, Result<SourceOutput<K, V, D>, SourceError>),
         Tee<Timestamp, (usize, Result<SourceOutput<K, V, D>, SourceError>)>,
     >,
-    metric_updates: &mut HashMap<PartitionId, (MzOffset, Timestamp, Diff)>,
+    metric_updates: &mut BTreeMap<PartitionId, (MzOffset, Timestamp, Diff)>,
     ts: Timestamp,
     source_id: GlobalId,
 ) where

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -12,7 +12,7 @@
 // https://github.com/tokio-rs/prost/issues/237
 // #![allow(missing_docs)]
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::marker::{Send, Sync};
 use std::time::Duration;
@@ -159,7 +159,7 @@ pub trait OffsetCommitter {
     /// they are owners for.
     async fn commit_offsets(
         &self,
-        offsets: HashMap<PartitionId, MzOffset>,
+        offsets: BTreeMap<PartitionId, MzOffset>,
     ) -> Result<(), anyhow::Error>;
 }
 
@@ -422,7 +422,7 @@ pub struct SourceMetrics {
     /// The resume_upper for a source.
     pub(crate) resume_upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     /// Per-partition Prometheus metrics.
-    pub(crate) partition_metrics: HashMap<PartitionId, PartitionMetrics>,
+    pub(crate) partition_metrics: BTreeMap<PartitionId, PartitionMetrics>,
     source_name: String,
     source_id: GlobalId,
     base_metrics: SourceBaseMetrics,
@@ -460,7 +460,7 @@ impl SourceMetrics {
     /// Log updates to which offsets / timestamps read up to.
     pub fn record_partition_offsets(
         &mut self,
-        offsets: HashMap<PartitionId, (MzOffset, Timestamp, i64)>,
+        offsets: BTreeMap<PartitionId, (MzOffset, Timestamp, i64)>,
     ) {
         for (partition, (offset, timestamp, count)) in offsets {
             let metric = self
@@ -551,7 +551,7 @@ impl PartitionMetrics {
 /// Source reader operator specific Prometheus metrics
 pub struct SourceReaderMetrics {
     /// Per-partition Prometheus metrics.
-    pub(crate) partition_metrics: HashMap<PartitionId, SourceReaderPartitionMetrics>,
+    pub(crate) partition_metrics: BTreeMap<PartitionId, SourceReaderPartitionMetrics>,
     source_id: GlobalId,
     base_metrics: SourceBaseMetrics,
 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -68,7 +68,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::thread;
@@ -180,12 +180,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let async_worker = Rc::new(RefCell::new(async_worker));
 
         let storage_state = StorageState {
-            source_uppers: HashMap::new(),
-            source_tokens: HashMap::new(),
+            source_uppers: BTreeMap::new(),
+            source_tokens: BTreeMap::new(),
             decode_metrics,
-            reported_frontiers: HashMap::new(),
-            ingestions: HashMap::new(),
-            exports: HashMap::new(),
+            reported_frontiers: BTreeMap::new(),
+            ingestions: BTreeMap::new(),
+            exports: BTreeMap::new(),
             now,
             source_metrics,
             sink_metrics,
@@ -193,12 +193,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
             timely_worker_peers: timely_worker.peers(),
             connection_context,
             persist_clients,
-            sink_tokens: HashMap::new(),
-            sink_write_frontiers: HashMap::new(),
-            sink_handles: HashMap::new(),
+            sink_tokens: BTreeMap::new(),
+            sink_write_frontiers: BTreeMap::new(),
+            sink_handles: BTreeMap::new(),
             dropped_ids: Vec::new(),
-            source_statistics: HashMap::new(),
-            sink_statistics: HashMap::new(),
+            source_statistics: BTreeMap::new(),
+            sink_statistics: BTreeMap::new(),
             internal_cmd_tx: command_sequencer,
             async_worker,
         };
@@ -225,17 +225,17 @@ pub struct StorageState {
     /// frontier even as other instances are created and dropped. Ideally, the Storage
     /// module would eventually provide one source of truth on this rather than multiple,
     /// and we should aim for that but are not there yet.
-    pub source_uppers: HashMap<GlobalId, Rc<RefCell<Antichain<mz_repr::Timestamp>>>>,
+    pub source_uppers: BTreeMap<GlobalId, Rc<RefCell<Antichain<mz_repr::Timestamp>>>>,
     /// Handles to created sources, keyed by ID
-    pub source_tokens: HashMap<GlobalId, Rc<dyn Any>>,
+    pub source_tokens: BTreeMap<GlobalId, Rc<dyn Any>>,
     /// Decoding metrics reported by all dataflows.
     pub decode_metrics: DecodeMetrics,
     /// Tracks the conditional write frontiers we have reported.
-    pub reported_frontiers: HashMap<GlobalId, Antichain<Timestamp>>,
+    pub reported_frontiers: BTreeMap<GlobalId, Antichain<Timestamp>>,
     /// Descriptions of each installed ingestion.
-    pub ingestions: HashMap<GlobalId, IngestionDescription<CollectionMetadata>>,
+    pub ingestions: BTreeMap<GlobalId, IngestionDescription<CollectionMetadata>>,
     /// Descriptions of each installed export.
-    pub exports: HashMap<GlobalId, StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>>,
+    pub exports: BTreeMap<GlobalId, StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>>,
     /// Undocumented
     pub now: NowFn,
     /// Metrics for the source-specific side of dataflows.
@@ -253,22 +253,22 @@ pub struct StorageState {
     pub persist_clients: Arc<Mutex<PersistClientCache>>,
     /// Tokens that should be dropped when a dataflow is dropped to clean up
     /// associated state.
-    pub sink_tokens: HashMap<GlobalId, SinkToken>,
+    pub sink_tokens: BTreeMap<GlobalId, SinkToken>,
     /// Frontier of sink writes (all subsequent writes will be at times at or
     /// equal to this frontier)
-    pub sink_write_frontiers: HashMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
+    pub sink_write_frontiers: BTreeMap<GlobalId, Rc<RefCell<Antichain<Timestamp>>>>,
     /// See: [SinkHandle]
-    pub sink_handles: HashMap<GlobalId, SinkHandle>,
+    pub sink_handles: BTreeMap<GlobalId, SinkHandle>,
     /// Collection ids that have been dropped but not yet reported as dropped
     pub dropped_ids: Vec<GlobalId>,
 
     /// Stats objects shared with operators to allow them to update the metrics
     /// we report in `StatisticsUpdates` responses.
     pub source_statistics:
-        HashMap<GlobalId, StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>>,
+        BTreeMap<GlobalId, StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>>,
     /// The same as `source_statistics`, but for sinks.
     pub sink_statistics:
-        HashMap<GlobalId, StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>>,
+        BTreeMap<GlobalId, StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>>,
 
     /// Sender for cluster-internal storage commands. These can be sent from
     /// within workers/operators and will be distributed to all workers. For
@@ -840,8 +840,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
         // Elide any ingestions we're already aware of while determining what
         // ingestions no longer exist.
-        let mut stale_ingestions = self.storage_state.ingestions.keys().collect::<HashSet<_>>();
-        let mut stale_exports = self.storage_state.exports.keys().collect::<HashSet<_>>();
+        let mut stale_ingestions = self
+            .storage_state
+            .ingestions
+            .keys()
+            .collect::<BTreeSet<_>>();
+        let mut stale_exports = self.storage_state.exports.keys().collect::<BTreeSet<_>>();
         for command in &mut commands {
             match command {
                 StorageCommand::CreateSources(ingestions) => {

--- a/src/storage/tests/sources.rs
+++ b/src/storage/tests/sources.rs
@@ -76,7 +76,7 @@
 
 //! Basic unit tests for sources.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use mz_storage::source::testscript::ScriptCommand;
 use mz_storage_client::types::sources::{encoding::SourceDataEncoding, SourceEnvelope};
@@ -86,8 +86,10 @@ mod setup;
 #[test]
 fn test_datadriven() {
     datadriven::walk("tests/datadriven", |f| {
-        let mut sources: HashMap<String, (Vec<ScriptCommand>, SourceDataEncoding, SourceEnvelope)> =
-            HashMap::new();
+        let mut sources: BTreeMap<
+            String,
+            (Vec<ScriptCommand>, SourceDataEncoding, SourceEnvelope),
+        > = BTreeMap::new();
 
         // Note we unwrap and panic liberally here as we
         // expect tests to be properly written.


### PR DESCRIPTION
This PR replaces Hash collections with their BTree equivalents in the `storage`, `storage-client`, `interchange` and `Kafka-util` crates.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Tips for reviewer

I'm trying to avoid huge PRs spanning all teams, so I'm splitting the BTree changes up a bit. This PR addresses the crates owned by @MaterializeInc/storage.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
