### PR TITLE
persist*: remove uses of Hash collections

### DIFF
--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -9,7 +9,7 @@
 
 //! Benchmarks for different persistent Write implementations.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -84,7 +84,7 @@ fn bench_consensus_compare_and_set_all_iters(
                 || format!("bench_compare_and_set-{}", idx),
                 async move {
                     // Keep track of the current SeqNo per shard ID.
-                    let mut current: HashMap<usize, Option<SeqNo>> = HashMap::new();
+                    let mut current: BTreeMap<usize, Option<SeqNo>> = BTreeMap::new();
 
                     for _iter in 0..iters {
                         let futs = FuturesUnordered::new();

--- a/src/persist-client/examples/maelstrom/api.rs
+++ b/src/persist-client/examples/maelstrom/api.rs
@@ -22,7 +22,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct MsgId(pub usize);
 
 impl MsgId {

--- a/src/persist-client/examples/maelstrom/node.rs
+++ b/src/persist-client/examples/maelstrom/node.rs
@@ -16,7 +16,7 @@
 //! [service]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/services.md
 //! [ruby examples]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/demo/ruby/node.rb
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::{BufRead, Write};
 use std::sync::{Arc, Mutex};
 
@@ -95,7 +95,7 @@ where
         let core = Core {
             write: Box::new(write),
             next_msg_id: MsgId(0),
-            callbacks: HashMap::new(),
+            callbacks: BTreeMap::new(),
         };
         Node {
             args,
@@ -186,7 +186,7 @@ where
 struct Core {
     write: Box<dyn Write + Send + Sync>,
     next_msg_id: MsgId,
-    callbacks: HashMap<MsgId, oneshot::Sender<Body>>,
+    callbacks: BTreeMap<MsgId, oneshot::Sender<Body>>,
 }
 
 impl std::fmt::Debug for Core {

--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -9,7 +9,7 @@
 
 //! Implementations of Maelstrom services as persist external durability
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -52,14 +52,14 @@ pub struct MaelstromConsensus {
     // It also secondarily means that more stale expectations make it to the
     // Maelstrom CaS call (with the `head` alternative we'd discover some then),
     // but this is mostly a side benefit.
-    cache: Mutex<HashMap<(String, SeqNo), Vec<u8>>>,
+    cache: Mutex<BTreeMap<(String, SeqNo), Vec<u8>>>,
 }
 
 impl MaelstromConsensus {
     pub fn new(handle: Handle) -> Arc<dyn Consensus + Send + Sync> {
         Arc::new(MaelstromConsensus {
             handle,
-            cache: Mutex::new(HashMap::new()),
+            cache: Mutex::new(BTreeMap::new()),
         })
     }
 
@@ -238,14 +238,14 @@ impl Blob for MaelstromBlob {
 #[derive(Debug)]
 pub struct CachingBlob {
     blob: Arc<dyn Blob + Send + Sync>,
-    cache: Mutex<HashMap<String, Vec<u8>>>,
+    cache: Mutex<BTreeMap<String, Vec<u8>>>,
 }
 
 impl CachingBlob {
     pub fn new(blob: Arc<dyn Blob + Send + Sync>) -> Arc<dyn Blob + Send + Sync> {
         Arc::new(CachingBlob {
             blob,
-            cache: Mutex::new(HashMap::new()),
+            cache: Mutex::new(BTreeMap::new()),
         })
     }
 }

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -9,7 +9,7 @@
 
 //! An implementation of the Maelstrom txn-list-append workload using persist
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -366,7 +366,7 @@ impl Transactor {
         }
     }
 
-    async fn read(&mut self) -> Result<HashMap<MaelstromKey, MaelstromVal>, MaelstromError> {
+    async fn read(&mut self) -> Result<BTreeMap<MaelstromKey, MaelstromVal>, MaelstromError> {
         let (updates, as_of) = self.read_short_lived().await?;
 
         let long_lived = self.read_long_lived(&as_of).await;
@@ -451,8 +451,8 @@ impl Transactor {
             u64,
             i64,
         )>,
-    ) -> Result<HashMap<MaelstromKey, MaelstromVal>, MaelstromError> {
-        let mut ret = HashMap::new();
+    ) -> Result<BTreeMap<MaelstromKey, MaelstromVal>, MaelstromError> {
+        let mut ret = BTreeMap::new();
         for ((k, v), _, d) in updates {
             if d != 1 {
                 return Err(MaelstromError {
@@ -480,12 +480,12 @@ impl Transactor {
     }
 
     fn eval_txn(
-        state: &HashMap<MaelstromKey, MaelstromVal>,
+        state: &BTreeMap<MaelstromKey, MaelstromVal>,
         req_ops: &[ReqTxnOp],
     ) -> (Vec<(MaelstromKey, MaelstromVal, i64)>, Vec<ResTxnOp>) {
         let mut res_ops = Vec::new();
         let mut updates = Vec::new();
-        let mut txn_state = HashMap::new();
+        let mut txn_state = BTreeMap::new();
 
         for req_op in req_ops.iter() {
             match req_op {

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -589,8 +589,8 @@ mod types {
 }
 
 mod impls {
-    use std::collections::hash_map::Entry;
-    use std::collections::HashMap;
+    use std::collections::btree_map::Entry;
+    use std::collections::BTreeMap;
     use std::fmt::Debug;
     use std::hash::Hash;
     use std::time::Duration;
@@ -614,7 +614,7 @@ mod impls {
 
     #[derive(Clone)]
     pub struct SequentialSource {
-        offsets: HashMap<u64, u64>,
+        offsets: BTreeMap<u64, u64>,
         num_partitions: u64,
         current_partition: u64,
         wait_time: Duration,
@@ -630,7 +630,7 @@ mod impls {
             assert!(num_partitions > 0, "number of partitions must be > 0");
 
             Self {
-                offsets: HashMap::new(),
+                offsets: BTreeMap::new(),
                 num_partitions,
                 current_partition: 0,
                 wait_time,
@@ -706,7 +706,7 @@ mod impls {
     {
         now_fn: NowFn,
         timestamp_interval: Duration,
-        cache: HashMap<ST, (ST, Timestamp)>,
+        cache: BTreeMap<ST, (ST, Timestamp)>,
         current_ts: u64,
         consensus: C,
         // Current version (as far as we know) of the timestamp bindings in consensus. This is a
@@ -717,14 +717,14 @@ mod impls {
     impl<ST, C> ConsensusTimestamper<ST, C>
     where
         C: IteratedConsensus<ST, Timestamp, u64>,
-        ST: Eq + Hash + Clone,
+        ST: Ord + Clone,
     {
         #[allow(unused)]
         pub async fn new(now_fn: NowFn, timestamp_interval: Duration, mut consensus: C) -> Self
         where
             Self: Sized,
         {
-            let mut cache = HashMap::new();
+            let mut cache = BTreeMap::new();
 
             let current_ts = consensus.current_upper().await;
             // We know this time is one dimensional.

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -9,8 +9,8 @@
 
 //! A cache of [PersistClient]s indexed by [PersistLocation]s.
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -39,8 +39,8 @@ use crate::{PersistClient, PersistConfig, PersistLocation};
 pub struct PersistClientCache {
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
-    blob_by_uri: HashMap<String, Arc<dyn Blob + Send + Sync>>,
-    consensus_by_uri: HashMap<String, Arc<dyn Consensus + Send + Sync>>,
+    blob_by_uri: BTreeMap<String, Arc<dyn Blob + Send + Sync>>,
+    consensus_by_uri: BTreeMap<String, Arc<dyn Consensus + Send + Sync>>,
     cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
     rtt_latency_tasks: Vec<Arc<JoinHandle<()>>>,
 }
@@ -52,8 +52,8 @@ impl PersistClientCache {
         PersistClientCache {
             cfg,
             metrics: Arc::new(metrics),
-            blob_by_uri: HashMap::new(),
-            consensus_by_uri: HashMap::new(),
+            blob_by_uri: BTreeMap::new(),
+            consensus_by_uri: BTreeMap::new(),
             cpu_heavy_runtime: Arc::new(CpuHeavyRuntime::new()),
             rtt_latency_tasks: Vec::new(),
         }

--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -9,7 +9,7 @@
 
 //! CLI introspection tools for persist
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -262,7 +262,7 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
     let shard_id = args.shard_id();
     let state_versions = args.open().await?;
 
-    let mut rollup_keys = HashSet::new();
+    let mut rollup_keys = BTreeSet::new();
     let mut state_iter = match state_versions
         .fetch_all_live_states::<K, V, u64, D>(&shard_id)
         .await
@@ -289,7 +289,7 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
         return Err(anyhow!("unknown shard"));
     }
 
-    let mut rollup_states = HashMap::with_capacity(rollup_keys.len());
+    let mut rollup_states = BTreeMap::new();
     for key in rollup_keys {
         let rollup_buf = state_versions
             .blob
@@ -522,9 +522,9 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
         }
     };
 
-    let mut known_parts = HashSet::new();
-    let mut known_rollups = HashSet::new();
-    let mut known_writers = HashSet::new();
+    let mut known_parts = BTreeSet::new();
+    let mut known_rollups = BTreeSet::new();
+    let mut known_writers = BTreeSet::new();
     while let Some(v) = state_iter.next() {
         for writer_id in v.collections.writers.keys() {
             known_writers.insert(writer_id.clone());
@@ -559,7 +559,7 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
     let shard_id = args.shard_id();
     let state_versions = args.open().await?;
 
-    let mut s3_contents_before = HashMap::new();
+    let mut s3_contents_before = BTreeMap::new();
     let () = state_versions
         .blob
         .list_keys_and_metadata(&BlobKeyPrefix::Shard(&shard_id).to_string(), &mut |b| {
@@ -583,8 +583,8 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
         }
     };
 
-    let mut referenced_parts = HashMap::new();
-    let mut referenced_rollups = HashSet::new();
+    let mut referenced_parts = BTreeMap::new();
+    let mut referenced_rollups = BTreeSet::new();
     while let Some(state) = state_iter.next() {
         state.collections.trace.map_batches(|b| {
             for part in b.parts.iter() {
@@ -599,8 +599,8 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
         }
     }
 
-    let mut current_parts = HashMap::new();
-    let mut current_rollups = HashSet::new();
+    let mut current_parts = BTreeMap::new();
+    let mut current_rollups = BTreeSet::new();
     state_iter.state().collections.trace.map_batches(|b| {
         for part in b.parts.iter() {
             current_parts.insert(

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -9,7 +9,7 @@
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::time::Instant;
@@ -85,10 +85,10 @@ impl<K, V, T, D> Clone for GarbageCollector<K, V, T, D> {
 /// - GarbageCollector works by `Consensus::scan`-ing for every live version of
 ///   state (ignoring what the request things the prev_state_seqno was for the
 ///   reasons mentioned immediately above). It then walks through them in a
-///   loop, accumulating a HashSet of every referenced blob key. When it finds
+///   loop, accumulating a BTreeSet of every referenced blob key. When it finds
 ///   the version corresponding to the new_seqno_since, it removes every blob in
-///   that version of the state from the HashSet and exits the loop. This
-///   results in the HashSet containing every blob eligible for deletion. It
+///   that version of the state from the BTreeSet and exits the loop. This
+///   results in the BTreeSet containing every blob eligible for deletion. It
 ///   deletes those blobs and then truncates the state to the new_seqno_since to
 ///   indicate that this work doesn't need to be done again.
 /// - Note that these requests are being processed concurrently, so it's always
@@ -232,10 +232,10 @@ where
             return;
         }
 
-        let mut deleteable_batch_blobs = HashSet::new();
+        let mut deleteable_batch_blobs = BTreeSet::new();
         let mut deleteable_rollup_blobs = Vec::new();
         let mut live_diffs = 0;
-        let mut seqno_held_parts = HashSet::new();
+        let mut seqno_held_parts = BTreeSet::new();
 
         let mut state_count = 0;
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1184,7 +1184,7 @@ where
 
 #[cfg(test)]
 pub mod datadriven {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use anyhow::anyhow;
@@ -1213,8 +1213,8 @@ pub mod datadriven {
         pub state_versions: Arc<StateVersions>,
         pub machine: Machine<String, (), u64, i64>,
         pub gc: GarbageCollector<String, (), u64, i64>,
-        pub batches: HashMap<String, HollowBatch<u64>>,
-        pub listens: HashMap<String, Listen<String, (), u64, i64>>,
+        pub batches: BTreeMap<String, HollowBatch<u64>>,
+        pub listens: BTreeMap<String, Listen<String, (), u64, i64>>,
         pub routine: Vec<RoutineMaintenance>,
     }
 
@@ -1247,8 +1247,8 @@ pub mod datadriven {
                 state_versions,
                 machine,
                 gc,
-                batches: HashMap::default(),
-                listens: HashMap::default(),
+                batches: BTreeMap::default(),
+                listens: BTreeMap::default(),
                 routine: Vec::new(),
             }
         }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -9,7 +9,7 @@
 
 //! Prometheus monitoring metrics.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -1004,12 +1004,12 @@ pub struct ShardsMetrics {
     // We hand out `Arc<ShardMetrics>` to read and write handles, but store it
     // here as `Weak`. This allows us to discover if it's no longer in use and
     // so we can remove it from the map.
-    shards: Arc<Mutex<HashMap<ShardId, Weak<ShardMetrics>>>>,
+    shards: Arc<Mutex<BTreeMap<ShardId, Weak<ShardMetrics>>>>,
 }
 
 impl ShardsMetrics {
     fn new(registry: &MetricsRegistry) -> Self {
-        let shards = Arc::new(Mutex::new(HashMap::new()));
+        let shards = Arc::new(Mutex::new(BTreeMap::new()));
         let shards_count = Arc::clone(&shards);
         ShardsMetrics {
             _count: registry.register_computed_gauge(
@@ -1114,7 +1114,7 @@ impl ShardsMetrics {
     }
 
     fn compute<F: FnMut(&ShardMetrics)>(
-        shards: &Arc<Mutex<HashMap<ShardId, Weak<ShardMetrics>>>>,
+        shards: &Arc<Mutex<BTreeMap<ShardId, Weak<ShardMetrics>>>>,
         mut f: F,
     ) {
         let mut shards = shards.lock().expect("mutex poisoned");

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -10,7 +10,7 @@
 //! A columnar representation of one blob's worth of data
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use arrow2::array::{Array, PrimitiveArray, StructArray};
@@ -483,7 +483,7 @@ impl DynColumnMut {
 /// called to verify that all columns have been accounted for.
 #[derive(Debug)]
 pub struct ColumnsRef<'a> {
-    cols: HashMap<&'a str, &'a DynColumnRef>,
+    cols: BTreeMap<&'a str, &'a DynColumnRef>,
 }
 
 impl<'a> ColumnsRef<'a> {
@@ -514,7 +514,7 @@ impl<'a> ColumnsRef<'a> {
 /// called to verify that all columns have been accounted for.
 #[derive(Debug)]
 pub struct ColumnsMut<'a> {
-    cols: HashMap<&'a str, &'a mut DynColumnMut>,
+    cols: BTreeMap<&'a str, &'a mut DynColumnMut>,
 }
 
 impl<'a> ColumnsMut<'a> {

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -9,7 +9,7 @@
 
 //! Configuration for [crate::location] implementations.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -66,7 +66,7 @@ impl BlobConfig {
     ) -> Result<Self, ExternalError> {
         let url = Url::parse(value)
             .map_err(|err| anyhow!("failed to parse blob location {} as a url: {}", &value, err))?;
-        let mut query_params = url.query_pairs().collect::<HashMap<_, _>>();
+        let mut query_params = url.query_pairs().collect::<BTreeMap<_, _>>();
 
         let config = match url.scheme() {
             "file" => {

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -9,7 +9,7 @@
 
 //! In-memory implementations for testing and benchmarking.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
@@ -27,7 +27,7 @@ use crate::location::{
 #[cfg(test)]
 #[derive(Debug)]
 pub struct MemMultiRegistry {
-    blob_by_path: HashMap<String, Arc<tokio::sync::Mutex<MemBlobCore>>>,
+    blob_by_path: BTreeMap<String, Arc<tokio::sync::Mutex<MemBlobCore>>>,
 }
 
 #[cfg(test)]
@@ -35,7 +35,7 @@ impl MemMultiRegistry {
     /// Constructs a new, empty [MemMultiRegistry].
     pub fn new() -> Self {
         MemMultiRegistry {
-            blob_by_path: HashMap::new(),
+            blob_by_path: BTreeMap::new(),
         }
     }
 
@@ -59,7 +59,7 @@ impl MemMultiRegistry {
 
 #[derive(Debug, Default)]
 struct MemBlobCore {
-    dataz: HashMap<String, Bytes>,
+    dataz: BTreeMap<String, Bytes>,
 }
 
 impl MemBlobCore {
@@ -145,20 +145,20 @@ impl Blob for MemBlob {
 pub struct MemConsensus {
     // TODO: This was intended to be a tokio::sync::Mutex but that seems to
     // regularly deadlock in the `concurrency` test.
-    data: Arc<Mutex<HashMap<String, Vec<VersionedData>>>>,
+    data: Arc<Mutex<BTreeMap<String, Vec<VersionedData>>>>,
 }
 
 impl Default for MemConsensus {
     fn default() -> Self {
         Self {
-            data: Arc::new(Mutex::new(HashMap::new())),
+            data: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 }
 
 impl MemConsensus {
     fn scan_store(
-        store: &HashMap<String, Vec<VersionedData>>,
+        store: &BTreeMap<String, Vec<VersionedData>>,
         key: &str,
         from: SeqNo,
         limit: usize,


### PR DESCRIPTION
This PR replaces Hash collections with their BTree equivalents in the `persist`, `persist-client`, and `persist-types` crates.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Tips for reviewer

I'm trying to avoid huge PRs spanning all teams, so I'm splitting the BTree changes up a bit. This PR addresses the crates owned by @MaterializeInc/persist.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A