### PR TITLE
surfaces: remove uses of Hash collections

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -76,7 +76,7 @@
 
 //! Integration tests for TLS encryption and authentication.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::error::Error;
 use std::fs::{self, File};
@@ -511,7 +511,7 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
 fn start_mzcloud(
     encoding_key: EncodingKey,
     tenant_id: Uuid,
-    users: HashMap<(String, String), String>,
+    users: BTreeMap<(String, String), String>,
     now: NowFn,
     expires_in_secs: i64,
 ) -> Result<MzCloudServer, anyhow::Error> {
@@ -521,11 +521,11 @@ fn start_mzcloud(
     struct Context {
         encoding_key: EncodingKey,
         tenant_id: Uuid,
-        users: HashMap<(String, String), String>,
+        users: BTreeMap<(String, String), String>,
         now: NowFn,
         expires_in_secs: i64,
         // Uuid -> email
-        refresh_tokens: Arc<Mutex<HashMap<String, String>>>,
+        refresh_tokens: Arc<Mutex<BTreeMap<String, String>>>,
         refreshes: Arc<Mutex<u64>>,
         enable_refresh: Arc<AtomicBool>,
     }
@@ -535,7 +535,7 @@ fn start_mzcloud(
         users,
         now,
         expires_in_secs,
-        refresh_tokens: Arc::new(Mutex::new(HashMap::new())),
+        refresh_tokens: Arc::new(Mutex::new(BTreeMap::new())),
         refreshes: Arc::clone(&refreshes),
         enable_refresh: Arc::clone(&enable_refresh),
     };
@@ -654,7 +654,7 @@ fn test_auth_expiry() {
     let tenant_id = Uuid::new_v4();
     let client_id = Uuid::new_v4();
     let secret = Uuid::new_v4();
-    let users = HashMap::from([(
+    let users = BTreeMap::from([(
         (client_id.to_string(), secret.to_string()),
         "user@_.com".to_string(),
     )]);
@@ -760,7 +760,7 @@ fn test_auth_base() {
     let secret = Uuid::new_v4();
     let system_client_id = Uuid::new_v4();
     let system_secret = Uuid::new_v4();
-    let users = HashMap::from([
+    let users = BTreeMap::from([
         (
             (client_id.to_string(), secret.to_string()),
             "user@_.com".to_string(),

--- a/src/mz/src/login.rs
+++ b/src/mz/src/login.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::net::SocketAddr;
 
@@ -82,7 +82,7 @@ pub(crate) async fn generate_api_token(
     access_token_response: FronteggAuth,
     description: &String,
 ) -> Result<FronteggAPIToken, reqwest::Error> {
-    let mut body = HashMap::new();
+    let mut body = BTreeMap::new();
     body.insert("description", description);
 
     client
@@ -102,7 +102,7 @@ async fn authenticate_user(
     email: &str,
     password: &str,
 ) -> Result<FronteggAuth> {
-    let mut access_token_request_body = HashMap::new();
+    let mut access_token_request_body = BTreeMap::new();
     access_token_request_body.insert("email", email);
     access_token_request_body.insert("password", password);
 

--- a/src/mz/src/password.rs
+++ b/src/mz/src/password.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::FronteggAppPassword;
 use crate::{configuration::ValidProfile, utils::RequestBuilderExt};
@@ -19,7 +19,7 @@ pub(crate) async fn list_passwords(
     client: &Client,
     valid_profile: &ValidProfile<'_>,
 ) -> Result<Vec<FronteggAppPassword>> {
-    let mut body = HashMap::new();
+    let mut body = BTreeMap::new();
     body.insert("description", &"App password for the CLI");
 
     client

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -152,7 +152,7 @@
 //! cargo run --bin mz-pgtest -- test/pgtest/test.pt
 //! ```
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{ErrorKind, Read, Write};
 use std::net::TcpStream;
@@ -191,7 +191,7 @@ impl PgConn {
             Message::AuthenticationOk => {}
             _ => bail!("expected AuthenticationOk"),
         };
-        conn.until(vec!["ReadyForQuery"], vec!['C', 'S', 'M'], HashSet::new())?;
+        conn.until(vec!["ReadyForQuery"], vec!['C', 'S', 'M'], BTreeSet::new())?;
         Ok(conn)
     }
 
@@ -205,7 +205,7 @@ impl PgConn {
         &mut self,
         until: Vec<&str>,
         err_field_typs: Vec<char>,
-        ignore: HashSet<String>,
+        ignore: BTreeSet<String>,
     ) -> anyhow::Result<Vec<String>> {
         let mut msgs = Vec::with_capacity(until.len());
         for expect in until {
@@ -410,7 +410,7 @@ pub struct PgTest {
     addr: String,
     user: String,
     timeout: Duration,
-    conns: HashMap<String, PgConn>,
+    conns: BTreeMap<String, PgConn>,
     verbose: bool,
 }
 
@@ -418,7 +418,7 @@ impl PgTest {
     pub fn new(addr: String, user: String, timeout: Duration) -> anyhow::Result<Self> {
         let verbose = std::env::var_os("PGTEST_VERBOSE").is_some();
         let conn = PgConn::new(&addr, &user, timeout.clone(), verbose)?;
-        let mut conns = HashMap::new();
+        let mut conns = BTreeMap::new();
         conns.insert(DEFAULT_CONN.to_string(), conn);
 
         Ok(PgTest {
@@ -449,7 +449,7 @@ impl PgTest {
         conn: Option<String>,
         until: Vec<&str>,
         err_field_typs: Vec<char>,
-        ignore: HashSet<String>,
+        ignore: BTreeSet<String>,
     ) -> anyhow::Result<Vec<String>> {
         let conn = self.get_conn(conn)?;
         conn.until(until, err_field_typs, ignore)
@@ -629,7 +629,7 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: String, user: String, timeo
                         None => vec!['C', 'S', 'M'],
                     }
                 };
-                let mut ignore = HashSet::new();
+                let mut ignore = BTreeSet::new();
                 if let Some(values) = args.remove("ignore") {
                     for v in values {
                         ignore.insert(v);

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -14,7 +14,7 @@
 //!
 //! [1]: https://www.postgresql.org/docs/11/protocol-message-formats.html
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
 use std::str;
@@ -463,7 +463,7 @@ where
         VERSION_SSL => FrontendStartupMessage::SslRequest,
         VERSION_GSSENC => FrontendStartupMessage::GssEncRequest,
         _ => {
-            let mut params = HashMap::new();
+            let mut params = BTreeMap::new();
             while buf.peek_byte()? != 0 {
                 let name = buf.read_cstr()?.to_owned();
                 let value = buf.read_cstr()?.to_owned();

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use itertools::Itertools;
 use postgres::error::SqlState;
@@ -55,7 +55,7 @@ pub enum FrontendStartupMessage {
     /// Begin a connection.
     Startup {
         version: i32,
-        params: HashMap<String, String>,
+        params: BTreeMap<String, String>,
     },
 
     /// Request SSL encryption for the connection.

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::future::Future;
 use std::iter;
@@ -79,7 +79,7 @@ pub struct RunParams<'a, A> {
     /// The protocol version that the client provided in the startup message.
     pub version: i32,
     /// The parameters that the client provided in the startup message.
-    pub params: HashMap<String, String>,
+    pub params: BTreeMap<String, String>,
     /// Frontegg authentication.
     pub frontegg: Option<&'a FronteggAuthentication>,
     /// Whether this is an internal server that permits access to restricted

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -25,7 +25,7 @@
 //!       compare to expected results
 //!       if wrong, record the error
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -342,7 +342,7 @@ pub struct RunnerInner {
     internal_server_addr: SocketAddr,
     // Drop order matters for these fields.
     client: tokio_postgres::Client,
-    clients: HashMap<String, tokio_postgres::Client>,
+    clients: BTreeMap<String, tokio_postgres::Client>,
     auto_index_tables: bool,
     _shutdown_trigger: oneshot::Sender<()>,
     _server_thread: JoinOnDropHandle<()>,
@@ -749,7 +749,7 @@ impl<'a> Runner<'a> {
         }
 
         inner.client = connect(inner.server_addr, None).await;
-        inner.clients = HashMap::new();
+        inner.clients = BTreeMap::new();
 
         Ok(())
     }
@@ -925,7 +925,7 @@ impl RunnerInner {
             _server_thread: server_thread.join_on_drop(),
             _temp_dir: temp_dir,
             client,
-            clients: HashMap::new(),
+            clients: BTreeMap::new(),
             auto_index_tables: config.auto_index_tables,
         })
     }

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -77,7 +77,7 @@
 //! Durable metadata storage.
 
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
@@ -860,7 +860,7 @@ where
     /// Iterates over the items viewable in the current transaction in arbitrary
     /// order.
     pub fn for_values<F: FnMut(&K, &V)>(&self, mut f: F) {
-        let mut seen = HashSet::with_capacity(self.pending.len());
+        let mut seen = BTreeSet::new();
         for (k, v) in self.pending.iter() {
             seen.insert(k);
             // Deleted items don't exist so shouldn't be visited, but still suppress


### PR DESCRIPTION
This PR replaces Hash collections with their BTree equivalents in the `environmentd`, `mz`, `pgtest`, `pgwire`, `sqllogictest`, and `stash` crates.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Tips for reviewer

I'm trying to avoid huge PRs spanning all teams, so I'm splitting the BTree changes up a bit. This PR addresses the crates owned by @MaterializeInc/surfaces.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
