### PR TITLE
proto: remove RustType impl for HashMap

### DIFF
--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -77,7 +77,7 @@
 //! Generated protobuf code and companion impls.
 
 use proptest::prelude::Strategy;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::{char::CharTryFromError, num::TryFromIntError};
 use uuid::Uuid;
 
@@ -290,25 +290,6 @@ pub trait RustType<Proto>: Sized {
 pub trait ProtoMapEntry<K, V> {
     fn from_rust<'a>(entry: (&'a K, &'a V)) -> Self;
     fn into_rust(self) -> Result<(K, V), TryFromProtoError>;
-}
-
-/// Blanket implementation for `HashMap<K, V>` where there exists `T` such
-/// that `T` implements `ProtoMapEntry<K, V>`.
-impl<K, V, T> RustType<Vec<T>> for HashMap<K, V>
-where
-    K: std::cmp::Eq + std::hash::Hash,
-    T: ProtoMapEntry<K, V>,
-{
-    fn into_proto(&self) -> Vec<T> {
-        self.iter().map(T::from_rust).collect()
-    }
-
-    fn from_proto(proto: Vec<T>) -> Result<Self, TryFromProtoError> {
-        proto
-            .into_iter()
-            .map(T::into_rust)
-            .collect::<Result<HashMap<_, _>, _>>()
-    }
 }
 
 macro_rules! rust_type_id(


### PR DESCRIPTION
This PR removes the `RustType` impl for `HashMap`.

When we start disallowing Hash types globally for the codebase, this impl would trigger a warning. Since we would like to discourage use of `HashMap`s anyway, it seems sensible to remove the impl, rather than whitelisting it.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
