### PR TITLE
secrets: remove uses of Hash collections

### DIFF
--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -76,7 +76,7 @@
 
 //! Abstractions for secure management of user secrets.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
@@ -118,13 +118,13 @@ pub trait SecretsReader: Debug + Send + Sync {
 
 #[derive(Debug)]
 pub struct InMemorySecretsController {
-    data: Arc<Mutex<HashMap<GlobalId, Vec<u8>>>>,
+    data: Arc<Mutex<BTreeMap<GlobalId, Vec<u8>>>>,
 }
 
 impl InMemorySecretsController {
     pub fn new() -> Self {
         Self {
-            data: Arc::new(Mutex::new(HashMap::new())),
+            data: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 }


### PR DESCRIPTION
This PR replaces Hash collections with their BTree equivalents in the `secrets` crate.

### Motivation

   * This PR refactors existing code.

Advances #14587.

### Tips for reviewer

I'm trying to avoid huge PRs spanning all teams, so I'm splitting the BTree changes up a bit. This PR addresses the crates owned by @MaterializeInc/cloud.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a
  companion cloud PR to account for those changes that is tagged with
  the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
