### PR TITLE
adapter: Fix bug in initialize_read_policies

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -253,7 +253,7 @@ impl crate::coord::Coordinator {
                         id_bundles
                             .entry(Some(time.clone()))
                             .or_default()
-                            .extend(&id_bundle);
+                            .extend(id_bundle);
                     }
                     read_holds.extend(new_read_holds);
                 }

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -250,12 +250,15 @@ impl crate::coord::Coordinator {
                     let TimelineState { read_holds, .. } =
                         self.ensure_timeline_state(&timeline).await;
                     for (time, id_bundle) in &new_read_holds.holds {
-                        id_bundles.insert(Some(time.clone()), id_bundle.clone());
+                        id_bundles
+                            .entry(Some(time.clone()))
+                            .or_default()
+                            .extend(&id_bundle);
                     }
                     read_holds.extend(new_read_holds);
                 }
                 TimelineContext::TimestampIndependent | TimelineContext::TimestampDependent => {
-                    id_bundles.insert(None, id_bundle);
+                    id_bundles.entry(None).or_default().extend(&id_bundle);
                 }
             }
         }

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -238,7 +238,7 @@ impl crate::coord::Coordinator {
     ) {
         let mut compute_policy_updates: BTreeMap<ComputeInstanceId, Vec<_>> = BTreeMap::new();
         let mut storage_policy_updates = Vec::new();
-        let mut id_bundles = HashMap::new();
+        let mut id_bundles: HashMap<_, CollectionIdBundle> = HashMap::new();
 
         // Update the Coordinator's timeline read hold state and organize all id bundles by time.
         for (timeline_context, id_bundle) in self.partition_ids_by_timeline_context(id_bundle) {


### PR DESCRIPTION
Previously, when initializing read policies, we were grouping all IdBundles by the timestamp of their read holds, in a HashMap. Instead of extending the keys of the HashMaps, we were overwriting them. So we would end up forgetting all but the last occurrence of each timestamp. This commit fixes this issue by extending each key of the HasMap, instead of overwriting it.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
