### PR TITLE
persist: fix hot loop error path in {blob,consensus}_rtt_latency

### DIFF
--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -197,6 +197,7 @@ async fn blob_rtt_latency_task(
             match blob.get(BLOB_GET_LIVENESS_KEY).await {
                 Ok(_) => {}
                 Err(_) => {
+                    next_measurement = tokio::time::Instant::now() + measurement_interval;
                     continue;
                 }
             }
@@ -237,6 +238,7 @@ async fn consensus_rtt_latency_task(
             match consensus.head(CONSENSUS_HEAD_LIVENESS_KEY).await {
                 Ok(_) => {}
                 Err(_) => {
+                    next_measurement = tokio::time::Instant::now() + measurement_interval;
                     continue;
                 }
             }


### PR DESCRIPTION
The error path didn't update next_measurement, so this ended up in a hot loop.


### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
