### PR TITLE
storage: Change error log to warn

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1501,7 +1501,7 @@ where
                     read_capability_changes.insert(id, updates);
                 }
             } else {
-                tracing::error!("Reference to unregistered id: {:?}", id);
+                tracing::warn!("Reference to unregistered id: {:?}", id);
             }
         }
         if !read_capability_changes.is_empty() {


### PR DESCRIPTION
As part of the builtin migrations, the adapter may ask the storage controller to drop a source/sink that may not exist. Previously in those cases, the storage controller would log an error even though it was expected that the source/sink may not exist. This commit changes error log to a warn log.

Fixes #16612

### Motivation
This PR fixes a recognized bug.

### Tips for reviewer
 * Would it be better to have two separate paths? One that errors on a missing source/sink and one that warns?

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
