### PR TITLE
expr: don't panic on internal func type error

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3651,7 +3651,9 @@ impl<T: for<'a> EagerUnaryFunc<'a>> LazyUnaryFunc for T {
             // If we can convert to the input type then we call the function
             Ok(input) => self.call(input).into_result(temp_storage),
             // If we can't and we got a non-null datum something went wrong in the planner
-            Err(Ok(datum)) if !datum.is_null() => panic!("invalid input type"),
+            Err(Ok(datum)) if !datum.is_null() => {
+                Err(EvalError::Internal("invalid input type".into()))
+            }
             // Otherwise we just propagate NULLs and errors
             Err(res) => res,
         }


### PR DESCRIPTION
Fixes #14391

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a