### PR TITLE
persist: tiny refactor of {blob,consensus}_rtt_latency task

### DIFF
--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -191,17 +191,16 @@ async fn blob_rtt_latency_task(
         loop {
             tokio::time::sleep_until(next_measurement).await;
             let start = Instant::now();
-            // Don't spam retries if this returns an error. We're guaranteed by
-            // the method signature that we've already got metrics coverage of
-            // these, so we'll count the errors.
             match blob.get(BLOB_GET_LIVENESS_KEY).await {
-                Ok(_) => {}
+                Ok(_) => {
+                    metrics.blob.rtt_latency.set(start.elapsed().as_secs_f64());
+                }
                 Err(_) => {
-                    next_measurement = tokio::time::Instant::now() + measurement_interval;
-                    continue;
+                    // Don't spam retries if this returns an error. We're
+                    // guaranteed by the method signature that we've already got
+                    // metrics coverage of these, so we'll count the errors.
                 }
             }
-            metrics.blob.rtt_latency.set(start.elapsed().as_secs_f64());
             next_measurement = tokio::time::Instant::now() + measurement_interval;
         }
     })
@@ -232,20 +231,19 @@ async fn consensus_rtt_latency_task(
         loop {
             tokio::time::sleep_until(next_measurement).await;
             let start = Instant::now();
-            // Don't spam retries if this returns an error. We're guaranteed by
-            // the method signature that we've already got metrics coverage of
-            // these, so we'll count the errors.
             match consensus.head(CONSENSUS_HEAD_LIVENESS_KEY).await {
-                Ok(_) => {}
+                Ok(_) => {
+                    metrics
+                        .consensus
+                        .rtt_latency
+                        .set(start.elapsed().as_secs_f64());
+                }
                 Err(_) => {
-                    next_measurement = tokio::time::Instant::now() + measurement_interval;
-                    continue;
+                    // Don't spam retries if this returns an error. We're
+                    // guaranteed by the method signature that we've already got
+                    // metrics coverage of these, so we'll count the errors.
                 }
             }
-            metrics
-                .consensus
-                .rtt_latency
-                .set(start.elapsed().as_secs_f64());
             next_measurement = tokio::time::Instant::now() + measurement_interval;
         }
     })


### PR DESCRIPTION
Suggested in #17423, but we really wanted to get that one merged and didn't want to eat the CI cycle.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
