### PR TITLE
sql: permit loading catalog with out-of-order dependencies

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -966,7 +966,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     Some(item) => item,
                     None => {
                         if self.status.is_ok() {
-                            self.status = Err(sql_err!("invalid id {}", &gid));
+                            self.status = Err(PlanError::InvalidId(gid));
                         }
                         return ResolvedObjectName::Error;
                     }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -25,6 +25,7 @@ use mz_repr::adt::system::Oid;
 use mz_repr::adt::varchar::InvalidVarCharMaxLengthError;
 use mz_repr::strconv;
 use mz_repr::ColumnName;
+use mz_repr::GlobalId;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::UnresolvedObjectName;
 use mz_sql_parser::parser::ParserError;
@@ -77,6 +78,7 @@ pub enum PlanError {
     UpsertSinkWithoutKey,
     InvalidNumericMaxScale(InvalidNumericMaxScaleError),
     InvalidCharLength(InvalidCharLengthError),
+    InvalidId(GlobalId),
     InvalidObject(Box<ResolvedObjectName>),
     InvalidVarCharMaxLength(InvalidVarCharMaxLengthError),
     InvalidSecret(Box<ResolvedObjectName>),
@@ -308,6 +310,7 @@ impl fmt::Display for PlanError {
             Self::InvalidVarCharMaxLength(e) => e.fmt(f),
             Self::Parser(e) => e.fmt(f),
             Self::Unstructured(e) => write!(f, "{}", e),
+            Self::InvalidId(id) => write!(f, "invalid id {}", id),
             Self::InvalidObject(i) => write!(f, "{} is not a database object", i.full_name_str()),
             Self::InvalidSecret(i) => write!(f, "{} is not a secret", i.full_name_str()),
             Self::InvalidTemporarySchema => {


### PR DESCRIPTION
We previously guaranteed that the dependency graph was linearized by GlobalId; with progress collections (#12867) this will no longer be the case. Instead, permit loading catalog items in any order and discovering their dependencies as the items load.

### Motivation

This PR adds a known-desirable feature. part of #12867

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
