### PR TITLE
compute: use columnation-backed arrangements explicitly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#c2e8fefce9ddad0aef5afcac0238b4dc6ae0ddcb"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#e9e1157b7ab7d2548df699c9b95b578e0e64772a"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1790,7 +1790,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#c2e8fefce9ddad0aef5afcac0238b4dc6ae0ddcb"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#e9e1157b7ab7d2548df699c9b95b578e0e64772a"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -360,7 +360,7 @@ pub fn construct<A: Allocate>(
 
         let frontier_delay = frontier_delay
             .as_collection()
-            // TODO(#16549): Use explicit arrangement
+            .arrange_named::<RowSpine<_, _, _, _>>("Arranged timely frontier_delay")
             .count_total_core::<i64>()
             .map({
                 move |((dataflow, source_id, worker, delay_pow), (sum, count))| {
@@ -396,7 +396,7 @@ pub fn construct<A: Allocate>(
         // Duration statistics derive from the non-rounded event times.
         let peek_duration = peek_duration
             .as_collection()
-            // TODO(#16549): Use explicit arrangement
+            .arrange_named::<RowSpine<_, _, _, _>>("Arranged timely peek_duration")
             .count_total_core()
             .map(|((worker, bucket), (sum, count))| {
                 Row::pack_slice(&[

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -300,7 +300,6 @@ pub fn build_compute_dataflow<A: Allocate>(
                             let oks_v = Variable::new(region, Product::new(Default::default(), 1));
                             let err_v = Variable::new(region, Product::new(Default::default(), 1));
 
-                            use differential_dataflow::operators::Consolidate;
                             context.insert_id(
                                 Id::Local(*id),
                                 CollectionBundle::from_collections(

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -14,7 +14,6 @@
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::operators::reduce::ReduceCore;
-use differential_dataflow::operators::Consolidate;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
@@ -25,7 +24,7 @@ use mz_expr::MirScalarExpr;
 use mz_repr::{Diff, Row};
 
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};
-use crate::typedefs::RowSpine;
+use crate::typedefs::{RowKeySpine, RowSpine};
 
 /// Shared function to compute an arrangement of values matching `logic`.
 fn threshold_arrangement<G, T, R, L>(
@@ -110,8 +109,7 @@ where
         .as_collection(|k, _| k.clone())
         .negate()
         .concat(&oks)
-        // TODO(#16549): Use explicit arrangement
-        .consolidate();
+        .consolidate_named::<RowKeySpine<_, _, _>>("Consolidated Threshold retractions");
     CollectionBundle::from_collections(oks, errs)
 }
 

--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
+use columnation::{CloneRegion, Columnation};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -114,4 +115,8 @@ impl RustType<ProtoGlobalId> for GlobalId {
             None => Err(TryFromProtoError::missing_field("ProtoGlobalId::kind")),
         }
     }
+}
+
+impl Columnation for GlobalId {
+    type InnerRegion = CloneRegion<GlobalId>;
 }


### PR DESCRIPTION
Specifically, we want to end up using TimelyStack as our BatchContainer, rather than the default Vec; in other words, those we typedef as RowSpine and RowKeySpine, not ever DefaultKey/ValTrace.

I did try to measure the effects of this change, but the best I can say so far is that I don't see any regression on TPC-H at scale factors 0.1 and 1 with this change on my laptop.

It seems like there are opportunities here to avoid creating Collections and to create CollectionBundles directly, as well as to omit some of the transformations that I've expanded in from helper methods that can no longer be used, but I wasn't confident enough in my understanding of this to go further with that yet.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

- Fixes #16549.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Ignoring whitespace should help.  I'm sure all reviewers will have better ideas for what names are useful when debugging than the ones I chose.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
