### PR TITLE
persist: Part min/max calc + small refactor to PartBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4253,6 +4253,7 @@ dependencies = [
  "anyhow",
  "arrow2",
  "bytes",
+ "ordered-float",
  "workspace-hack",
 ]
 

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrow2 = { git = "https://github.com/jorgecarleitao/arrow2.git", features = ["io_ipc", "io_parquet"] }
 bytes = "1.3.0"
+ordered-float = "3.4.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -22,7 +22,6 @@ use arrow2::datatypes::DataType as ArrowLogicalType;
 use arrow2::io::parquet::write::Encoding;
 use arrow2::types::NativeType;
 use bytes::BufMut;
-use ordered_float::OrderedFloat;
 
 use crate::columnar::sealed::ColumnRef;
 use crate::columnar::{
@@ -326,46 +325,8 @@ data_primitive!(i8, ColumnFormat::I8);
 data_primitive!(i16, ColumnFormat::I16);
 data_primitive!(i32, ColumnFormat::I32);
 data_primitive!(i64, ColumnFormat::I64);
-
-impl Data for f32 {
-    const TYPE: DataType = DataType {
-        optional: false,
-        format: ColumnFormat::F32,
-    };
-    type Ref<'a> = OrderedFloat<f32>;
-    type Col = Buffer<f32>;
-    type Mut = Vec<f32>;
-}
-
-impl Data for Option<f32> {
-    const TYPE: DataType = DataType {
-        optional: true,
-        format: ColumnFormat::F32,
-    };
-    type Ref<'a> = Option<OrderedFloat<f32>>;
-    type Col = PrimitiveArray<f32>;
-    type Mut = MutablePrimitiveArray<f32>;
-}
-
-impl Data for f64 {
-    const TYPE: DataType = DataType {
-        optional: false,
-        format: ColumnFormat::F64,
-    };
-    type Ref<'a> = OrderedFloat<f64>;
-    type Col = Buffer<f64>;
-    type Mut = Vec<f64>;
-}
-
-impl Data for Option<f64> {
-    const TYPE: DataType = DataType {
-        optional: true,
-        format: ColumnFormat::F64,
-    };
-    type Ref<'a> = Option<OrderedFloat<f64>>;
-    type Col = PrimitiveArray<f64>;
-    type Mut = MutablePrimitiveArray<f64>;
-}
+data_primitive!(f32, ColumnFormat::F32);
+data_primitive!(f64, ColumnFormat::F64);
 
 impl Data for Vec<u8> {
     const TYPE: DataType = DataType {
@@ -564,6 +525,8 @@ arrowable_primitive!(i8, Encoding::Plain);
 arrowable_primitive!(i16, Encoding::Plain);
 arrowable_primitive!(i32, Encoding::Plain);
 arrowable_primitive!(i64, Encoding::Plain);
+arrowable_primitive!(f32, Encoding::Plain);
+arrowable_primitive!(f64, Encoding::Plain);
 
 impl ColumnRef for BinaryArray<i32> {
     fn len(&self) -> usize {
@@ -694,159 +657,5 @@ impl<T: Debug> Schema<T> for TodoSchema<T> {
 
     fn encoder<'a>(&self, _cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
         panic!("TODO")
-    }
-}
-
-impl ColumnRef for Buffer<f32> {
-    fn len(&self) -> usize {
-        self.len()
-    }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        let array = PrimitiveArray::new(f32::PRIMITIVE.into(), self.clone(), None);
-        (Encoding::Plain, Box::new(array.clone()))
-    }
-    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
-        let array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<f32>>()
-            .ok_or_else(|| {
-                format!(
-                    "expected PrimitiveArray<f32> but was {:?}",
-                    array.data_type()
-                )
-            })?;
-        if array.validity().is_some() {
-            return Err(format!(
-                "unexpected validity for non-optional {}",
-                std::any::type_name::<f32>()
-            ));
-        }
-        Ok(array.values().clone())
-    }
-}
-
-impl ColumnGet<f32> for Buffer<f32> {
-    fn get<'a>(&'a self, idx: usize) -> OrderedFloat<f32> {
-        OrderedFloat(self[idx])
-    }
-}
-
-impl ColumnPush<f32> for Vec<f32> {
-    fn push<'a>(&mut self, val: OrderedFloat<f32>) {
-        <Vec<f32>>::push(self, val.0)
-    }
-}
-
-impl ColumnRef for PrimitiveArray<f32> {
-    fn len(&self) -> usize {
-        self.len()
-    }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        (Encoding::Plain, Box::new(self.clone()))
-    }
-    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
-        let array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<f32>>()
-            .ok_or_else(|| {
-                format!(
-                    "expected PrimitiveArray<f32> but was {:?}",
-                    array.data_type()
-                )
-            })?;
-        Ok(array.clone())
-    }
-}
-
-impl ColumnGet<Option<f32>> for PrimitiveArray<f32> {
-    fn get<'a>(&'a self, idx: usize) -> Option<OrderedFloat<f32>> {
-        if self.validity().map_or(true, |x| x.get_bit(idx)) {
-            Some(OrderedFloat(self.value(idx)))
-        } else {
-            None
-        }
-    }
-}
-
-impl ColumnPush<Option<f32>> for MutablePrimitiveArray<f32> {
-    fn push<'a>(&mut self, val: Option<OrderedFloat<f32>>) {
-        <MutablePrimitiveArray<f32>>::push(self, val.map(|f| f.0))
-    }
-}
-
-impl ColumnRef for Buffer<f64> {
-    fn len(&self) -> usize {
-        self.len()
-    }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        let array = PrimitiveArray::new(f64::PRIMITIVE.into(), self.clone(), None);
-        (Encoding::Plain, Box::new(array.clone()))
-    }
-    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
-        let array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<f64>>()
-            .ok_or_else(|| {
-                format!(
-                    "expected PrimitiveArray<f64> but was {:?}",
-                    array.data_type()
-                )
-            })?;
-        if array.validity().is_some() {
-            return Err(format!(
-                "unexpected validity for non-optional {}",
-                std::any::type_name::<f64>()
-            ));
-        }
-        Ok(array.values().clone())
-    }
-}
-
-impl ColumnGet<f64> for Buffer<f64> {
-    fn get<'a>(&'a self, idx: usize) -> OrderedFloat<f64> {
-        OrderedFloat(self[idx])
-    }
-}
-
-impl ColumnPush<f64> for Vec<f64> {
-    fn push<'a>(&mut self, val: OrderedFloat<f64>) {
-        <Vec<f64>>::push(self, val.0)
-    }
-}
-
-impl ColumnRef for PrimitiveArray<f64> {
-    fn len(&self) -> usize {
-        self.len()
-    }
-    fn to_arrow(&self) -> (Encoding, Box<dyn Array>) {
-        (Encoding::Plain, Box::new(self.clone()))
-    }
-    fn from_arrow(array: &Box<dyn Array>) -> Result<Self, String> {
-        let array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<f64>>()
-            .ok_or_else(|| {
-                format!(
-                    "expected PrimitiveArray<f64> but was {:?}",
-                    array.data_type()
-                )
-            })?;
-        Ok(array.clone())
-    }
-}
-
-impl ColumnGet<Option<f64>> for PrimitiveArray<f64> {
-    fn get<'a>(&'a self, idx: usize) -> Option<OrderedFloat<f64>> {
-        if self.validity().map_or(true, |x| x.get_bit(idx)) {
-            Some(OrderedFloat(self.value(idx)))
-        } else {
-            None
-        }
-    }
-}
-
-impl ColumnPush<Option<f64>> for MutablePrimitiveArray<f64> {
-    fn push<'a>(&mut self, val: Option<OrderedFloat<f64>>) {
-        <MutablePrimitiveArray<f64>>::push(self, val.map(|f| f.0))
     }
 }

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -84,7 +84,7 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
     /// TODO: We may want to eventually separate this into In and Out types
     /// because one wants to be covariant and the other wants to be
     /// contravariant.
-    type Ref<'a>
+    type Ref<'a>: Debug
     where
         Self: 'a;
 

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -232,8 +232,9 @@ pub fn validate_roundtrip<T: Codec + Default + PartialEq + Debug>(
     val: &T,
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
-    schema.encoder(part.key_mut())?.encode(val);
-    part.push_ts_diff(1, 1);
+    let (keys, _vals, mut ts_diff) = part.mut_handles();
+    schema.encoder(keys)?.encode(val);
+    ts_diff.push(1, 1);
     let part = part.finish()?;
 
     let mut actual = T::default();

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -48,6 +48,7 @@
 //! column structure. It also provides a [PartEncoder] and [PartDecoder] for
 //! amortizing any downcasting that does need to happen.
 
+use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use crate::codec_impls::UnitSchema;
@@ -84,7 +85,7 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
     /// TODO: We may want to eventually separate this into In and Out types
     /// because one wants to be covariant and the other wants to be
     /// contravariant.
-    type Ref<'a>: Debug
+    type Ref<'a>: Debug + Ord
     where
         Self: 'a;
 
@@ -99,6 +100,11 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
 pub trait ColumnGet<T: Data>: ColumnRef {
     /// Retrieves the value at index.
     fn get<'a>(&'a self, idx: usize) -> T::Ref<'a>;
+
+    /// Compares values at given indices.
+    fn cmp<'a>(&'a self, idx0: usize, idx1: usize) -> Ordering {
+        self.get(idx0).cmp(&self.get(idx1))
+    }
 }
 
 /// A type that may be added into a column of `[T]`.

--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -48,7 +48,6 @@
 //! column structure. It also provides a [PartEncoder] and [PartDecoder] for
 //! amortizing any downcasting that does need to happen.
 
-use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use crate::codec_impls::UnitSchema;
@@ -85,7 +84,7 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
     /// TODO: We may want to eventually separate this into In and Out types
     /// because one wants to be covariant and the other wants to be
     /// contravariant.
-    type Ref<'a>: Debug + Ord
+    type Ref<'a>: Debug
     where
         Self: 'a;
 
@@ -100,11 +99,6 @@ pub trait Data: Debug + Send + Sync + Sized + 'static {
 pub trait ColumnGet<T: Data>: ColumnRef {
     /// Retrieves the value at index.
     fn get<'a>(&'a self, idx: usize) -> T::Ref<'a>;
-
-    /// Compares values at given indices.
-    fn cmp<'a>(&'a self, idx0: usize, idx1: usize) -> Ordering {
-        self.get(idx0).cmp(&self.get(idx1))
-    }
 }
 
 /// A type that may be added into a column of `[T]`.

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -89,6 +89,7 @@ use crate::columnar::Schema;
 
 pub mod codec_impls;
 pub mod columnar;
+mod ord;
 pub mod parquet;
 pub mod part;
 

--- a/src/persist-types/src/ord.rs
+++ b/src/persist-types/src/ord.rs
@@ -1,0 +1,85 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cmp::Ordering;
+
+use crate::columnar::Data;
+
+// WIP we might be able to replace this with `Box<dyn ColumnGet>` if we added an
+// Ord bound to ColumnGet.
+#[derive(Debug)]
+pub enum ColOrd<'a> {
+    I64(&'a <i64 as Data>::Col),
+    String(&'a <String as Data>::Col),
+}
+
+impl<'a> ColOrd<'a> {
+    fn cmp(&self, idx0: usize, idx1: usize) -> Ordering {
+        match self {
+            ColOrd::I64(x) => x[idx0].cmp(&x[idx1]),
+            ColOrd::String(x) => x.value(idx0).cmp(x.value(idx1)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ColsOrd<'a> {
+    cols: &'a [ColOrd<'a>],
+}
+
+impl<'a> ColsOrd<'a> {
+    pub fn new(cols: &'a [ColOrd<'a>]) -> Self {
+        ColsOrd { cols }
+    }
+
+    pub fn key(&'a self, idx: usize) -> ColsOrdKey<'a> {
+        ColsOrdKey {
+            idx,
+            cols_ord: self,
+        }
+    }
+
+    fn cmp(&self, idx0: usize, idx1: usize) -> Ordering {
+        for col in self.cols.iter() {
+            let cmp = col.cmp(idx0, idx1);
+            if cmp != Ordering::Equal {
+                return cmp;
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+#[derive(Debug)]
+pub struct ColsOrdKey<'a> {
+    pub idx: usize,
+    cols_ord: &'a ColsOrd<'a>,
+}
+
+impl<'a> PartialEq for ColsOrdKey<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<'a> Eq for ColsOrdKey<'a> {}
+
+impl<'a> PartialOrd for ColsOrdKey<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> Ord for ColsOrdKey<'a> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Important! Make sure this is used correctly (only ColsOrdKeys issues by
+        assert_eq!(self.cols_ord as *const _, other.cols_ord as *const _);
+        self.cols_ord.cmp(self.idx, other.idx)
+    }
+}

--- a/src/persist-types/src/ord.rs
+++ b/src/persist-types/src/ord.rs
@@ -9,21 +9,68 @@
 
 use std::cmp::Ordering;
 
-use crate::columnar::Data;
+use crate::columnar::{ColumnGet, Data};
 
-// WIP we might be able to replace this with `Box<dyn ColumnGet>` if we added an
-// Ord bound to ColumnGet.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ColOrd<'a> {
+    Bool(&'a <bool as Data>::Col),
+    I8(&'a <i8 as Data>::Col),
+    I16(&'a <i16 as Data>::Col),
+    I32(&'a <i32 as Data>::Col),
     I64(&'a <i64 as Data>::Col),
+    U8(&'a <u8 as Data>::Col),
+    U16(&'a <u16 as Data>::Col),
+    U32(&'a <u32 as Data>::Col),
+    U64(&'a <u64 as Data>::Col),
+    F32(&'a <f32 as Data>::Col),
+    F64(&'a <f64 as Data>::Col),
+    Bytes(&'a <Vec<u8> as Data>::Col),
     String(&'a <String as Data>::Col),
+    OptBool(&'a <Option<bool> as Data>::Col),
+    OptI8(&'a <Option<i8> as Data>::Col),
+    OptI16(&'a <Option<i16> as Data>::Col),
+    OptI32(&'a <Option<i32> as Data>::Col),
+    OptI64(&'a <Option<i64> as Data>::Col),
+    OptU8(&'a <Option<u8> as Data>::Col),
+    OptU16(&'a <Option<u16> as Data>::Col),
+    OptU32(&'a <Option<u32> as Data>::Col),
+    OptU64(&'a <Option<u64> as Data>::Col),
+    OptF32(&'a <Option<f32> as Data>::Col),
+    OptF64(&'a <Option<f64> as Data>::Col),
+    OptBytes(&'a <Option<Vec<u8>> as Data>::Col),
+    OptString(&'a <Option<String> as Data>::Col),
 }
 
 impl<'a> ColOrd<'a> {
     fn cmp(&self, idx0: usize, idx1: usize) -> Ordering {
-        match self {
-            ColOrd::I64(x) => x[idx0].cmp(&x[idx1]),
-            ColOrd::String(x) => x.value(idx0).cmp(x.value(idx1)),
+        match *self {
+            ColOrd::Bool(x) => ColumnGet::<bool>::cmp(x, idx0, idx1),
+            ColOrd::I8(x) => ColumnGet::<i8>::cmp(x, idx0, idx1),
+            ColOrd::I16(x) => ColumnGet::<i16>::cmp(x, idx0, idx1),
+            ColOrd::I32(x) => ColumnGet::<i32>::cmp(x, idx0, idx1),
+            ColOrd::I64(x) => ColumnGet::<i64>::cmp(x, idx0, idx1),
+            ColOrd::U8(x) => ColumnGet::<u8>::cmp(x, idx0, idx1),
+            ColOrd::U16(x) => ColumnGet::<u16>::cmp(x, idx0, idx1),
+            ColOrd::U32(x) => ColumnGet::<u32>::cmp(x, idx0, idx1),
+            ColOrd::U64(x) => ColumnGet::<u64>::cmp(x, idx0, idx1),
+            ColOrd::F32(x) => ColumnGet::<f32>::cmp(x, idx0, idx1),
+            ColOrd::F64(x) => ColumnGet::<f64>::cmp(x, idx0, idx1),
+            ColOrd::Bytes(x) => ColumnGet::<Vec<u8>>::cmp(x, idx0, idx1),
+            ColOrd::String(x) => ColumnGet::<String>::cmp(x, idx0, idx1),
+            ColOrd::OptBool(x) => ColumnGet::<Option<bool>>::cmp(x, idx0, idx1),
+            ColOrd::OptI8(x) => ColumnGet::<Option<i8>>::cmp(x, idx0, idx1),
+            ColOrd::OptI16(x) => ColumnGet::<Option<i16>>::cmp(x, idx0, idx1),
+            ColOrd::OptI32(x) => ColumnGet::<Option<i32>>::cmp(x, idx0, idx1),
+            ColOrd::OptI64(x) => ColumnGet::<Option<i64>>::cmp(x, idx0, idx1),
+            ColOrd::OptU8(x) => ColumnGet::<Option<u8>>::cmp(x, idx0, idx1),
+            ColOrd::OptU16(x) => ColumnGet::<Option<u16>>::cmp(x, idx0, idx1),
+            ColOrd::OptU32(x) => ColumnGet::<Option<u32>>::cmp(x, idx0, idx1),
+            ColOrd::OptU64(x) => ColumnGet::<Option<u64>>::cmp(x, idx0, idx1),
+            ColOrd::OptF32(x) => ColumnGet::<Option<f32>>::cmp(x, idx0, idx1),
+            ColOrd::OptF64(x) => ColumnGet::<Option<f64>>::cmp(x, idx0, idx1),
+            ColOrd::OptBytes(x) => ColumnGet::<Option<Vec<u8>>>::cmp(x, idx0, idx1),
+            ColOrd::OptString(x) => ColumnGet::<Option<String>>::cmp(x, idx0, idx1),
         }
     }
 }

--- a/src/persist-types/src/ord.rs
+++ b/src/persist-types/src/ord.rs
@@ -60,10 +60,10 @@ impl<'a> ColOrd<'a> {
             ColOrd::F64(x) => OrderedFloat(ColumnGet::<f64>::get(x, idx0))
                 .cmp(&OrderedFloat(ColumnGet::get(x, idx1))),
             ColOrd::Bytes(x) => {
-                ColumnGet::<Vec<u8>>::get(x, idx0).cmp(&ColumnGet::<Vec<u8>>::get(x, idx1))
+                ColumnGet::<Vec<u8>>::get(x, idx0).cmp(ColumnGet::<Vec<u8>>::get(x, idx1))
             }
             ColOrd::String(x) => {
-                ColumnGet::<String>::get(x, idx0).cmp(&ColumnGet::<String>::get(x, idx1))
+                ColumnGet::<String>::get(x, idx0).cmp(ColumnGet::<String>::get(x, idx1))
             }
             ColOrd::OptBool(x) => {
                 ColumnGet::<Option<bool>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
@@ -89,11 +89,11 @@ impl<'a> ColOrd<'a> {
                 ColumnGet::<Option<u64>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
             }
             ColOrd::OptF32(x) => ColumnGet::<Option<f32>>::get(x, idx0)
-                .map(|x| OrderedFloat(x))
-                .cmp(&ColumnGet::get(x, idx1).map(|x| OrderedFloat(x))),
+                .map(OrderedFloat)
+                .cmp(&ColumnGet::get(x, idx1).map(OrderedFloat)),
             ColOrd::OptF64(x) => ColumnGet::<Option<f64>>::get(x, idx0)
-                .map(|x| OrderedFloat(x))
-                .cmp(&ColumnGet::get(x, idx1).map(|x| OrderedFloat(x))),
+                .map(OrderedFloat)
+                .cmp(&ColumnGet::get(x, idx1).map(OrderedFloat)),
             ColOrd::OptBytes(x) => {
                 ColumnGet::<Option<Vec<u8>>>::get(x, idx0)
                     .cmp(&ColumnGet::<Option<Vec<u8>>>::get(x, idx1))
@@ -157,6 +157,7 @@ impl<'a> PartialOrd for ColsOrdKey<'a> {
 impl<'a> Ord for ColsOrdKey<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
         // Important! Make sure this is used correctly (only ColsOrdKeys issues by
+        #![allow(clippy::as_conversions)]
         assert_eq!(self.cols_ord as *const _, other.cols_ord as *const _);
         self.cols_ord.cmp(self.idx, other.idx)
     }

--- a/src/persist-types/src/ord.rs
+++ b/src/persist-types/src/ord.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
 use crate::columnar::{ColumnGet, Data};
@@ -45,32 +46,62 @@ pub enum ColOrd<'a> {
 impl<'a> ColOrd<'a> {
     fn cmp(&self, idx0: usize, idx1: usize) -> Ordering {
         match *self {
-            ColOrd::Bool(x) => ColumnGet::<bool>::cmp(x, idx0, idx1),
-            ColOrd::I8(x) => ColumnGet::<i8>::cmp(x, idx0, idx1),
-            ColOrd::I16(x) => ColumnGet::<i16>::cmp(x, idx0, idx1),
-            ColOrd::I32(x) => ColumnGet::<i32>::cmp(x, idx0, idx1),
-            ColOrd::I64(x) => ColumnGet::<i64>::cmp(x, idx0, idx1),
-            ColOrd::U8(x) => ColumnGet::<u8>::cmp(x, idx0, idx1),
-            ColOrd::U16(x) => ColumnGet::<u16>::cmp(x, idx0, idx1),
-            ColOrd::U32(x) => ColumnGet::<u32>::cmp(x, idx0, idx1),
-            ColOrd::U64(x) => ColumnGet::<u64>::cmp(x, idx0, idx1),
-            ColOrd::F32(x) => ColumnGet::<f32>::cmp(x, idx0, idx1),
-            ColOrd::F64(x) => ColumnGet::<f64>::cmp(x, idx0, idx1),
-            ColOrd::Bytes(x) => ColumnGet::<Vec<u8>>::cmp(x, idx0, idx1),
-            ColOrd::String(x) => ColumnGet::<String>::cmp(x, idx0, idx1),
-            ColOrd::OptBool(x) => ColumnGet::<Option<bool>>::cmp(x, idx0, idx1),
-            ColOrd::OptI8(x) => ColumnGet::<Option<i8>>::cmp(x, idx0, idx1),
-            ColOrd::OptI16(x) => ColumnGet::<Option<i16>>::cmp(x, idx0, idx1),
-            ColOrd::OptI32(x) => ColumnGet::<Option<i32>>::cmp(x, idx0, idx1),
-            ColOrd::OptI64(x) => ColumnGet::<Option<i64>>::cmp(x, idx0, idx1),
-            ColOrd::OptU8(x) => ColumnGet::<Option<u8>>::cmp(x, idx0, idx1),
-            ColOrd::OptU16(x) => ColumnGet::<Option<u16>>::cmp(x, idx0, idx1),
-            ColOrd::OptU32(x) => ColumnGet::<Option<u32>>::cmp(x, idx0, idx1),
-            ColOrd::OptU64(x) => ColumnGet::<Option<u64>>::cmp(x, idx0, idx1),
-            ColOrd::OptF32(x) => ColumnGet::<Option<f32>>::cmp(x, idx0, idx1),
-            ColOrd::OptF64(x) => ColumnGet::<Option<f64>>::cmp(x, idx0, idx1),
-            ColOrd::OptBytes(x) => ColumnGet::<Option<Vec<u8>>>::cmp(x, idx0, idx1),
-            ColOrd::OptString(x) => ColumnGet::<Option<String>>::cmp(x, idx0, idx1),
+            ColOrd::Bool(x) => ColumnGet::<bool>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::I8(x) => ColumnGet::<i8>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::I16(x) => ColumnGet::<i16>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::I32(x) => ColumnGet::<i32>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::I64(x) => ColumnGet::<i64>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::U8(x) => ColumnGet::<u8>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::U16(x) => ColumnGet::<u16>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::U32(x) => ColumnGet::<u32>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::U64(x) => ColumnGet::<u64>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::F32(x) => OrderedFloat(ColumnGet::<f32>::get(x, idx0))
+                .cmp(&OrderedFloat(ColumnGet::get(x, idx1))),
+            ColOrd::F64(x) => OrderedFloat(ColumnGet::<f64>::get(x, idx0))
+                .cmp(&OrderedFloat(ColumnGet::get(x, idx1))),
+            ColOrd::Bytes(x) => {
+                ColumnGet::<Vec<u8>>::get(x, idx0).cmp(&ColumnGet::<Vec<u8>>::get(x, idx1))
+            }
+            ColOrd::String(x) => {
+                ColumnGet::<String>::get(x, idx0).cmp(&ColumnGet::<String>::get(x, idx1))
+            }
+            ColOrd::OptBool(x) => {
+                ColumnGet::<Option<bool>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptI8(x) => ColumnGet::<Option<i8>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::OptI16(x) => {
+                ColumnGet::<Option<i16>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptI32(x) => {
+                ColumnGet::<Option<i32>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptI64(x) => {
+                ColumnGet::<Option<i64>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptU8(x) => ColumnGet::<Option<u8>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1)),
+            ColOrd::OptU16(x) => {
+                ColumnGet::<Option<u16>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptU32(x) => {
+                ColumnGet::<Option<u32>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptU64(x) => {
+                ColumnGet::<Option<u64>>::get(x, idx0).cmp(&ColumnGet::get(x, idx1))
+            }
+            ColOrd::OptF32(x) => ColumnGet::<Option<f32>>::get(x, idx0)
+                .map(|x| OrderedFloat(x))
+                .cmp(&ColumnGet::get(x, idx1).map(|x| OrderedFloat(x))),
+            ColOrd::OptF64(x) => ColumnGet::<Option<f64>>::get(x, idx0)
+                .map(|x| OrderedFloat(x))
+                .cmp(&ColumnGet::get(x, idx1).map(|x| OrderedFloat(x))),
+            ColOrd::OptBytes(x) => {
+                ColumnGet::<Option<Vec<u8>>>::get(x, idx0)
+                    .cmp(&ColumnGet::<Option<Vec<u8>>>::get(x, idx1))
+            }
+            ColOrd::OptString(x) => {
+                ColumnGet::<Option<String>>::get(x, idx0)
+                    .cmp(&ColumnGet::<Option<String>>::get(x, idx1))
+            }
         }
     }
 }

--- a/src/persist-types/src/parquet.rs
+++ b/src/persist-types/src/parquet.rs
@@ -85,8 +85,9 @@ pub fn validate_roundtrip<T: Default + PartialEq + Debug, S: Schema<T>>(
     val: &T,
 ) -> Result<(), String> {
     let mut part = PartBuilder::new(schema, &UnitSchema);
-    schema.encoder(part.key_mut())?.encode(val);
-    part.push_ts_diff(1, 1);
+    let (keys, _vals, mut ts_diff) = part.mut_handles();
+    schema.encoder(keys)?.encode(val);
+    ts_diff.push(1, 1);
     let part = part.finish()?;
 
     let mut encoded = Vec::new();

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -784,15 +784,15 @@ mod tests {
         let mut part = PartBuilder::new(&StringSchema, &UnitSchema);
         {
             let mut keys = StringSchema.encoder(part.key_mut()).unwrap();
-            keys.encode(&format!("foo"));
-            keys.encode(&format!("foo"));
-            keys.encode(&format!("foo"));
-            keys.encode(&format!("bar"));
-            keys.encode(&format!("foo"));
-            keys.encode(&format!("baz"));
-            keys.encode(&format!("foo"));
-            keys.encode(&format!("qux"));
-            keys.encode(&format!("qux"));
+            keys.encode(&"foo".to_string());
+            keys.encode(&"foo".to_string());
+            keys.encode(&"foo".to_string());
+            keys.encode(&"bar".to_string());
+            keys.encode(&"foo".to_string());
+            keys.encode(&"baz".to_string());
+            keys.encode(&"foo".to_string());
+            keys.encode(&"qux".to_string());
+            keys.encode(&"qux".to_string());
         }
         part.push_ts_diff(3, 1);
         part.push_ts_diff(1, 1);

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -11,7 +11,6 @@
 
 use std::any::Any;
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -26,7 +25,7 @@ use crate::columnar::{ColumnFormat, ColumnGet, ColumnPush, Data, DataType, Schem
 use crate::ord::{ColOrd, ColsOrd, ColsOrdKey};
 
 /// A columnar representation of one blob's worth of data.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Part {
     len: usize,
     key: Vec<(String, DynColumnRef)>,

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -791,6 +791,8 @@ mod tests {
             keys.encode(&format!("foo"));
             keys.encode(&format!("baz"));
             keys.encode(&format!("foo"));
+            keys.encode(&format!("qux"));
+            keys.encode(&format!("qux"));
         }
         part.push_ts_diff(3, 1);
         part.push_ts_diff(1, 1);
@@ -799,6 +801,8 @@ mod tests {
         part.push_ts_diff(1, 1);
         part.push_ts_diff(1, 1);
         part.push_ts_diff(1, 1);
+        part.push_ts_diff(1, 1);
+        part.push_ts_diff(1, -1);
         let part = part.finish().unwrap();
         let consolidated = part.consolidate();
         eprintln!("{:?}", consolidated);

--- a/src/persist-types/src/part.rs
+++ b/src/persist-types/src/part.rs
@@ -519,9 +519,36 @@ impl DynColumnRef {
 
     fn to_col_ord<'a>(&'a self) -> ColOrd<'a> {
         match (self.0.optional, self.0.format) {
+            (false, ColumnFormat::Bool) => ColOrd::Bool(self.expect_downcast::<bool>()),
+            (false, ColumnFormat::I8) => ColOrd::I8(self.expect_downcast::<i8>()),
+            (false, ColumnFormat::I16) => ColOrd::I16(self.expect_downcast::<i16>()),
+            (false, ColumnFormat::I32) => ColOrd::I32(self.expect_downcast::<i32>()),
             (false, ColumnFormat::I64) => ColOrd::I64(self.expect_downcast::<i64>()),
+            (false, ColumnFormat::U8) => ColOrd::U8(self.expect_downcast::<u8>()),
+            (false, ColumnFormat::U16) => ColOrd::U16(self.expect_downcast::<u16>()),
+            (false, ColumnFormat::U32) => ColOrd::U32(self.expect_downcast::<u32>()),
+            (false, ColumnFormat::U64) => ColOrd::U64(self.expect_downcast::<u64>()),
+            (false, ColumnFormat::F32) => ColOrd::F32(self.expect_downcast::<f32>()),
+            (false, ColumnFormat::F64) => ColOrd::F64(self.expect_downcast::<f64>()),
+            (false, ColumnFormat::Bytes) => ColOrd::Bytes(self.expect_downcast::<Vec<u8>>()),
             (false, ColumnFormat::String) => ColOrd::String(self.expect_downcast::<String>()),
-            _ => panic!("WIP"),
+            (true, ColumnFormat::Bool) => ColOrd::OptBool(self.expect_downcast::<Option<bool>>()),
+            (true, ColumnFormat::I8) => ColOrd::OptI8(self.expect_downcast::<Option<i8>>()),
+            (true, ColumnFormat::I16) => ColOrd::OptI16(self.expect_downcast::<Option<i16>>()),
+            (true, ColumnFormat::I32) => ColOrd::OptI32(self.expect_downcast::<Option<i32>>()),
+            (true, ColumnFormat::I64) => ColOrd::OptI64(self.expect_downcast::<Option<i64>>()),
+            (true, ColumnFormat::U8) => ColOrd::OptU8(self.expect_downcast::<Option<u8>>()),
+            (true, ColumnFormat::U16) => ColOrd::OptU16(self.expect_downcast::<Option<u16>>()),
+            (true, ColumnFormat::U32) => ColOrd::OptU32(self.expect_downcast::<Option<u32>>()),
+            (true, ColumnFormat::U64) => ColOrd::OptU64(self.expect_downcast::<Option<u64>>()),
+            (true, ColumnFormat::F32) => ColOrd::OptF32(self.expect_downcast::<Option<f32>>()),
+            (true, ColumnFormat::F64) => ColOrd::OptF64(self.expect_downcast::<Option<f64>>()),
+            (true, ColumnFormat::Bytes) => {
+                ColOrd::OptBytes(self.expect_downcast::<Option<Vec<u8>>>())
+            }
+            (true, ColumnFormat::String) => {
+                ColOrd::OptString(self.expect_downcast::<Option<String>>())
+            }
         }
     }
 

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -338,14 +338,13 @@ fn decode_legacy(part: &ColumnarRecords) -> Vec<Row> {
 
 fn encode_structured(schema: &RelationDesc, rows: &[Row]) -> Part {
     let mut part = PartBuilder::new(schema, &UnitSchema);
-    let mut encoder = schema.encoder(part.key_mut()).unwrap();
+    let (keys, _vals, mut ts_diff) = part.mut_handles();
+    let mut encoder = schema.encoder(keys).unwrap();
     for row in rows.iter() {
         encoder.encode(row);
+        ts_diff.push(1, 1);
     }
     drop(encoder);
-    for _ in rows.iter() {
-        part.push_ts_diff(1, 1);
-    }
     part.finish().unwrap()
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Builds off of https://github.com/MaterializeInc/materialize/pull/17383 , adds in a min/max calculation per column of a `Part`, and refactors `key_mut|val_mut` to be a single call that returns handles to key/val/tsdiff. This lets us more easily mutably borrow `PartBuilder` when using encoders

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
