### PR TITLE
adapter: cleanup orphaned secrets at bootstrap

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -76,6 +76,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
+use fail::fail_point;
 use futures::StreamExt;
 use itertools::Itertools;
 use rand::seq::SliceRandom;
@@ -1055,6 +1056,27 @@ impl Coordinator {
         // Signal to the storage controller that it is now free to reconcile its
         // state with what it has learned from the adapter.
         self.controller.storage.reconcile_state().await;
+
+        // Cleanup orphaned secrets. Errors during list() or delete() do not
+        // need to prevent bootstrap from succeeding; we will retry next
+        // startup.
+        if let Ok(controller_secrets) = self.secrets_controller.list().await {
+            // Fetch all IDs from the catalog to future-proof against other
+            // things using secrets. Today, SECRET and CONNECTION objects use
+            // secrets_controller.ensure, but more things could in the future
+            // that would be easy to miss adding here.
+            let catalog_ids: BTreeSet<GlobalId> =
+                self.catalog.entries().map(|entry| entry.id()).collect();
+            let controller_secrets: BTreeSet<GlobalId> = controller_secrets.into_iter().collect();
+            let orphaned = controller_secrets.difference(&catalog_ids);
+            for id in orphaned {
+                info!("coordinator init: deleting orphaned secret {id}");
+                fail_point!("orphan_secrets");
+                if let Err(e) = self.secrets_controller.delete(*id).await {
+                    warn!("Dropping orphaned secret has encountered an error: {}", e);
+                }
+            }
+        }
 
         info!("coordinator init: bootstrap complete");
         Ok(())

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -13,6 +13,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use fail::fail_point;
 use serde_json::json;
 use timely::progress::Antichain;
 use tracing::Level;
@@ -428,6 +429,7 @@ impl Coordinator {
     }
 
     async fn drop_secrets(&mut self, secrets: Vec<GlobalId>) {
+        fail_point!("drop_secrets");
         for secret in secrets {
             if let Err(e) = self.secrets_controller.delete(secret).await {
                 warn!("Dropping secrets has encountered an error: {}", e);

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -634,8 +634,6 @@ impl Coordinator {
         let mut connection = plan.connection.connection;
 
         match connection {
-            // TODO(jkosh44) if catalog_transact fails after this or we crash, then we will leak
-            //  the secret.
             mz_storage_client::types::connections::Connection::Ssh(ref mut ssh) => {
                 let key_set = SshKeyPairSet::new()?;
                 self.secrets_controller

--- a/src/orchestrator-process/src/secrets.rs
+++ b/src/orchestrator-process/src/secrets.rs
@@ -42,6 +42,16 @@ impl SecretsController for ProcessOrchestrator {
         Ok(())
     }
 
+    async fn list(&self) -> Result<Vec<GlobalId>, anyhow::Error> {
+        let mut ids = Vec::new();
+        let mut entries = fs::read_dir(&self.secrets_dir).await?;
+        while let Some(dir) = entries.next_entry().await? {
+            let id: GlobalId = dir.file_name().to_string_lossy().parse()?;
+            ids.push(id);
+        }
+        Ok(ids)
+    }
+
     fn reader(&self) -> Arc<dyn SecretsReader> {
         Arc::new(ProcessSecretsReader {
             secrets_dir: self.secrets_dir.clone(),

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -96,6 +96,10 @@ pub trait SecretsController: Debug + Send + Sync {
     /// Deletes the specified secret.
     async fn delete(&self, id: GlobalId) -> Result<(), anyhow::Error>;
 
+    /// Lists known secrets. Unrecognized secret objects do not produce an error
+    /// and are ignored.
+    async fn list(&self) -> Result<Vec<GlobalId>, anyhow::Error>;
+
     /// Returns a reader for the secrets managed by this controller.
     fn reader(&self) -> Arc<dyn SecretsReader>;
 }
@@ -140,6 +144,10 @@ impl SecretsController for InMemorySecretsController {
     async fn delete(&self, id: GlobalId) -> Result<(), anyhow::Error> {
         self.data.lock().unwrap().remove(&id);
         Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<GlobalId>, anyhow::Error> {
+        Ok(self.data.lock().unwrap().keys().cloned().collect())
     }
 
     fn reader(&self) -> Arc<dyn SecretsReader> {


### PR DESCRIPTION
Add a list method to the secrets controller to determine orphaned secrets.

Fixes #13579

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a