### PR TITLE
persist: push the Mutex into PersistClientCache

### DIFF
--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -84,7 +84,6 @@ use axum::routing;
 use fail::FailScenario;
 use futures::future;
 use once_cell::sync::Lazy;
-use tokio::sync::Mutex;
 use tracing::info;
 
 use mz_build_info::{build_info, BuildInfo};
@@ -264,10 +263,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         )
     });
 
-    let persist_clients = Arc::new(Mutex::new(PersistClientCache::new(
+    let persist_clients = Arc::new(PersistClientCache::new(
         PersistConfig::new(&BUILD_INFO, SYSTEM_TIME.clone()),
         &metrics_registry,
-    )));
+    ));
 
     // Start storage server.
     let (_storage_server, storage_client) = mz_storage::serve(mz_storage::Config {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -24,7 +24,7 @@ use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::progress::reachability::logging::TrackerEvent;
 use timely::worker::Worker as TimelyWorker;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use tracing::{error, info, span, Level};
 use uuid::Uuid;
 
@@ -83,7 +83,7 @@ pub struct ComputeState {
     pub compute_logger: Option<logging::compute::Logger>,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers.
-    pub persist_clients: Arc<Mutex<PersistClientCache>>,
+    pub persist_clients: Arc<PersistClientCache>,
     /// History of commands received by this workers and all its peers.
     pub command_history: ComputeCommandHistory,
     /// Max size in bytes of any result.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -57,7 +57,7 @@ pub struct Config {
     /// Metrics registry through which dataflow metrics will be reported.
     pub metrics_registry: MetricsRegistry,
     /// `persist` client cache.
-    pub persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
+    pub persist_clients: Arc<PersistClientCache>,
 }
 
 /// A client managing access to the local portion of a Timely cluster
@@ -71,7 +71,7 @@ struct ClusterClient<C> {
     /// The compute metrics.
     compute_metrics: ComputeMetrics,
     /// Handle to the persist infrastructure.
-    persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
+    persist_clients: Arc<PersistClientCache>,
     /// The handle to the Tokio runtime.
     tokio_handle: tokio::runtime::Handle,
 }
@@ -129,7 +129,7 @@ impl ClusterClient<PartitionedClient> {
         timely_container: TimelyContainerRef,
         trace_metrics: TraceMetrics,
         compute_metrics: ComputeMetrics,
-        persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
+        persist_clients: Arc<PersistClientCache>,
         tokio_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
@@ -147,7 +147,7 @@ impl ClusterClient<PartitionedClient> {
         epoch: ComputeStartupEpoch,
         trace_metrics: TraceMetrics,
         compute_metrics: ComputeMetrics,
-        persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
+        persist_clients: Arc<PersistClientCache>,
         tokio_executor: Handle,
     ) -> Result<TimelyContainer, Error> {
         info!("Building timely container with config {config:?}");
@@ -374,7 +374,7 @@ struct Worker<'w, A: Allocate> {
     compute_metrics: ComputeMetrics,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
-    persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
+    persist_clients: Arc<PersistClientCache>,
 }
 
 impl<'w, A: Allocate> Worker<'w, A> {

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -102,7 +102,6 @@ use serde::{Deserialize, Serialize};
 use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 use tokio::sync::mpsc::{self, UnboundedSender};
-use tokio::sync::Mutex;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use uuid::Uuid;
 
@@ -142,7 +141,7 @@ pub struct ControllerConfig {
     /// A process-global cache of (blob_uri, consensus_uri) ->
     /// PersistClient.
     /// This is intentionally shared between workers.
-    pub persist_clients: Arc<Mutex<PersistClientCache>>,
+    pub persist_clients: Arc<PersistClientCache>,
     /// The stash URL for the storage controller.
     pub storage_stash_url: String,
     /// The clusterd image to use when starting new cluster processes.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -102,7 +102,6 @@ use jsonwebtoken::DecodingKey;
 use once_cell::sync::Lazy;
 use opentelemetry::trace::TraceContextExt;
 use prometheus::IntGauge;
-use tokio::sync::Mutex;
 use tower_http::cors::{self, AllowOrigin};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -713,7 +712,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         PersistConfig::new(&mz_environmentd::BUILD_INFO, now.clone()),
         &metrics_registry,
     );
-    let persist_clients = Arc::new(Mutex::new(persist_clients));
+    let persist_clients = Arc::new(persist_clients);
     let orchestrator = Arc::new(TracingOrchestrator::new(orchestrator, args.tracing.clone()));
     let controller = ControllerConfig {
         build_info: &mz_environmentd::BUILD_INFO,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -339,7 +339,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Initialize storage usage client.
     let storage_usage_client = StorageUsageClient::open(
         config.controller.persist_location.blob_uri.clone(),
-        &mut *config.controller.persist_clients.lock().await,
+        &config.controller.persist_clients,
     )
     .await
     .context("opening storage usage client")?;

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -91,7 +91,6 @@ use postgres::{NoTls, Socket};
 use regex::Regex;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
-use tokio::sync::Mutex;
 use tokio_postgres::config::Host;
 use tokio_postgres::Client;
 use tower_http::cors::AllowOrigin;
@@ -285,7 +284,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
     // with local postgres.
     persist_cfg.consensus_connection_pool_max_size = 1;
     let persist_clients = PersistClientCache::new(persist_cfg, &metrics_registry);
-    let persist_clients = Arc::new(Mutex::new(persist_clients));
+    let persist_clients = Arc::new(persist_clients);
     let postgres_factory = StashFactory::new(&metrics_registry);
     let secrets_controller = Arc::clone(&orchestrator);
     let connection_context = ConnectionContext::for_tests(orchestrator.reader());

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -660,7 +660,7 @@ mod tests {
     }
 
     pub async fn new_test_client() -> PersistClient {
-        let mut cache = new_test_client_cache();
+        let cache = new_test_client_cache();
         cache
             .open(PersistLocation {
                 blob_uri: "mem://".to_owned(),

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -30,7 +30,7 @@ impl StorageUsageClient {
     /// Creates a new StorageUsageClient pointed to a specific Blob
     pub async fn open(
         blob_uri: String,
-        client_cache: &mut PersistClientCache,
+        client_cache: &PersistClientCache,
     ) -> Result<StorageUsageClient, ExternalError> {
         let blob = client_cache.open_blob(blob_uri).await?;
         let metrics = Arc::clone(&client_cache.metrics);

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -50,7 +50,7 @@ use postgres_protocol::types;
 use regex::Regex;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::oneshot;
 use tokio_postgres::types::FromSql;
 use tokio_postgres::types::Kind as PgKind;
 use tokio_postgres::types::Type as PgType;
@@ -814,7 +814,7 @@ impl RunnerInner {
             PersistConfig::new(&mz_environmentd::BUILD_INFO, now.clone()),
             &metrics_registry,
         );
-        let persist_clients = Arc::new(Mutex::new(persist_clients));
+        let persist_clients = Arc::new(persist_clients);
         let postgres_factory = StashFactory::new(&metrics_registry);
         let secrets_controller = Arc::clone(&orchestrator);
         let connection_context = ConnectionContext::for_tests(orchestrator.reader());

--- a/src/storage-client/src/source/persist_source.rs
+++ b/src/storage-client/src/source/persist_source.rs
@@ -24,7 +24,6 @@ use timely::dataflow::operators::{Capability, OkErr};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use timely::scheduling::Activator;
-use tokio::sync::Mutex;
 
 use mz_expr::MfpPlan;
 use mz_persist_client::cache::PersistClientCache;
@@ -63,7 +62,7 @@ use mz_timely_util::buffer::ConsolidateBuffer;
 pub fn persist_source<G, YFn>(
     scope: &G,
     source_id: GlobalId,
-    persist_clients: Arc<Mutex<PersistClientCache>>,
+    persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
     as_of: Option<Antichain<Timestamp>>,
     until: Antichain<Timestamp>,
@@ -107,7 +106,7 @@ where
 pub fn persist_source_core<G, YFn>(
     scope: &G,
     source_id: GlobalId,
-    persist_clients: Arc<Mutex<PersistClientCache>>,
+    persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
     as_of: Option<Antichain<Timestamp>>,
     until: Antichain<Timestamp>,

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -96,7 +96,7 @@ impl<T: Timestamp + Lattice + Codec64> ResumptionFrontierCalculator<T>
     // have to specialize this some more.
     type State = Vec<WriteHandle<SourceData, (), T, Diff>>;
 
-    async fn initialize_state(&self, client_cache: &mut PersistClientCache) -> Self::State {
+    async fn initialize_state(&self, client_cache: &PersistClientCache) -> Self::State {
         let mut handles = vec![];
         for (id, export) in self.source_exports.iter() {
             // Explicit destructuring to force a compile error when the metadata change

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -107,8 +107,6 @@ where
         let mut stashed_batches = BTreeMap::new();
 
         let mut write = persist_clients
-            .lock()
-            .await
             .open(metadata.persist_location)
             .await
             .expect("could not open persist client")

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use timely::dataflow::Scope;
-use tokio::sync::Mutex;
 
 use mz_interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
 use mz_ore::now::NowFn;
@@ -206,7 +205,7 @@ where
 /// Args for creating a healthchecker.  Not done inline because it requires async.
 pub struct HealthcheckerArgs {
     /// persist_clients
-    pub persist_clients: Arc<Mutex<PersistClientCache>>,
+    pub persist_clients: Arc<PersistClientCache>,
     /// location of persist
     pub persist_location: PersistLocation,
     /// id of status shard for updates

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -40,7 +40,7 @@ pub struct Config {
     /// Configuration for source and sink connection.
     pub connection_context: ConnectionContext,
     /// `persist` client cache.
-    pub persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
+    pub persist_clients: Arc<PersistClientCache>,
 }
 
 /// A handle to a running dataflow server.

--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -82,11 +82,7 @@ where
         // See <https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick>
         interval.tick().await;
 
-        let mut calc_state = {
-            // The lock MUST be dropped before we enter the main loop.
-            let mut persist_clients = persist_clients.lock().await;
-            calc.initialize_state(&mut persist_clients).await
-        };
+        let mut calc_state = calc.initialize_state(&persist_clients).await;
 
         while !upper.is_empty() {
             interval.tick().await;

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -204,7 +204,7 @@ where
                 blob_uri: "mem://".to_string(),
                 consensus_uri: "mem://".to_string(),
             };
-            let mut persist_cache =
+            let persist_cache =
                 mz_persist_client::cache::PersistClientCache::new(persistcfg, &metrics_registry);
 
             // create a client for use with the `until` closure later.
@@ -212,7 +212,7 @@ where
                 .block_on(persist_cache.open(persist_location.clone()))
                 .unwrap();
 
-            let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_cache));
+            let persist_clients = Arc::new(persist_cache);
 
             let connection_context = mz_storage_client::types::connections::ConnectionContext {
                 librdkafka_log_level: tracing::Level::INFO,


### PR DESCRIPTION
This is immediately motivated by #16797, which hooks up dynamic LaunchDarkly configurations to PersistConfig. To do this, we need a `&PersistConfig`, but it's currently passed around locked up inside the Mutex around PersistClientCache.

I could plumb a copy of PersistConfig to the necessary places instead, but we've discussed it being desirable to push the Mutex inside PersistClientCache anyway. Specifically to systematically address a category of bugs where the Mutex guard is accidentally held longer than intended.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

@petrosagg setting you as the explicit reviewer since this is something we discussed when it first went in. I believe you've mentioned since that you'd be okay doing this, but I wanted to be sure.

I'm still undecided on one mutex vs three. Thoughts?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
