### PR TITLE
Extend documentation on compute clients

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -663,7 +663,10 @@ impl<T> ComputeInstanceRef<'_, T> {
     }
 }
 
-/// State maintained about individual collections.
+/// State maintained about individual compute collections.
+///
+/// A compute collection is either an index, or a storage sink, or a subscribe, exported by a
+/// compute dataflow.
 #[derive(Debug)]
 pub struct CollectionState<T> {
     /// Whether this collection is a log collection.


### PR DESCRIPTION
This PR extends our existing documentation on the compute communication clients, particularly around their internal state management. The intention is to document the properties that ensure that clients always correctly clean up their state, so we are hopefully aware of them when we make changes to these parts in the future.

The PR also adds two checks to the compute controller to:

  1. ensure that `InitializationComplete` is only sent once, as required by the compute protocol
  2. ensure that no subscribes are created during the initialization phase

### Motivation

   * This PR refactors existing code.

Part of #17096.

### Tips for reviewer

Let me know if there are other aspects of the client implementations you would like to see documented/justified as part of the compute communication stack review!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
