### PR TITLE
storage: make sure we efficiently batch records from sources

### DIFF
--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -120,8 +120,6 @@ where
     ///
     /// This method is most efficient when the to be reclocked iterator presents data in contiguous
     /// runs with the same `FromTime`.
-    // This is dead code until we get rid of the compatibility layer
-    #[allow(dead_code)]
     pub fn reclock<'a, M: 'a>(
         &'a self,
         batch: impl IntoIterator<Item = (M, FromTime)> + 'a,
@@ -143,7 +141,7 @@ where
     }
 
     /// Reclocks a single `FromTime` timestamp into the `IntoTime` time domain.
-    fn reclock_time(
+    pub fn reclock_time(
         &self,
         src_ts: &FromTime,
     ) -> Result<Antichain<IntoTime>, ReclockError<FromTime>> {
@@ -267,7 +265,7 @@ where
     }
 
     /// Reclocks a single `FromTime` timestamp into a totally ordered `IntoTime` time domain.
-    fn reclock_time_total(&self, src_ts: &FromTime) -> Result<IntoTime, ReclockError<FromTime>>
+    pub fn reclock_time_total(&self, src_ts: &FromTime) -> Result<IntoTime, ReclockError<FromTime>>
     where
         IntoTime: TotalOrder,
     {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -996,11 +996,30 @@ where
                     // Drain all messages that can be reclocked from all the batches
                     let total_buffered: usize = untimestamped_batches.iter().map(|b| b.len()).sum();
                     let reclock_source_upper = timestamper.source_upper();
+
+                    // This is another subtle point. Normally we would be free to emit the
+                    // untimestamped messages in any order so long as the frontiers are respected.
+                    // Unfortunately, downstream decoding operators rely on the messages being
+                    // presented at the exact order produced even if the messages happen at the
+                    // same timestamp. This should be fixed, but until this happens we need to
+                    // preserve the order here.
+                    //
+                    // We will treat the vector of untimestamped batches as a flat list of messages
+                    // and we will compute the size of the reclockable prefix. The messages in this
+                    // prefix can be reclocked immediately and emitted in the original order.
+                    let mut reclockable_count = untimestamped_batches
+                        .iter()
+                        .flatten()
+                        .take_while(|(_, ts, _)| !reclock_source_upper.less_equal(ts))
+                        .count();
+
                     let msgs = untimestamped_batches
                         .iter_mut()
-                        .flat_map(|batch| batch.drain_filter_swapping(|(_, ts, _)| {
-                            !reclock_source_upper.less_equal(ts)
-                        }))
+                        .flat_map(|batch| {
+                            let drain_count = std::cmp::min(batch.len(), reclockable_count);
+                            reclockable_count = reclockable_count.saturating_sub(drain_count);
+                            batch.drain(0..drain_count)
+                        })
                         .map(|(data, time, diff)| ((data, time.clone(), diff), time));
 
                     // Accumulate updates to bytes_read for Prometheus metrics collection


### PR DESCRIPTION
Due to a common pattern in async operators, namely activating the output handle, creating a session, sending a single message, and immediately deactivating the code in `main` was creating one batch per message which had the effect of allocating a ton of small vectors and making performance much worse.

This pattern is used because there is an impedence mismatch between how output handles work and how async operators work. Ideally what we want is a handle that will buffer messages and automatically flushes when the async future gets into a `Pending` state.

This handle doesn't exist (yet) and it's complicated to write.

This PR fixes the immediate issue by rearranging the code so that output handle activation can be done once for all the messages that are currently ready and leaves the specialized async output handle for a Future(ha) date.

Fixes #17444

Link to successful nightly run: https://buildkite.com/materialize/nightlies/builds/1750#01860d93-9264-4cd4-bf41-6fce2f9b20e2

```
KafkaUpsert               |       4.401 |       4.137 |      no       | 6.4 pct   slower
KafkaUpsertUnique         |       5.452 |       4.962 |      no       | 9.9 pct   slower
```

I think some of the remaining slowness is because even though I changed the framework code to batch up messages the sources still manipulate their internal capability per-message which means that there are a lot more progress updates generated. Eventually we'll push a similar batching logic into the sources themselves which should make things a bit faster. For now we can live with a 8% perf hit

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
