### PR TITLE
adapter: Return error for failed dataflows

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -795,7 +795,8 @@ impl Coordinator {
                             .entry(idx.cluster_id)
                             .or_insert_with(Default::default)
                             .extend(dataflow.export_ids());
-                        let dataflow_plan = vec![self.finalize_dataflow(dataflow, idx.cluster_id)];
+                        let dataflow_plan =
+                            vec![self.must_finalize_dataflow(dataflow, idx.cluster_id)];
                         self.controller
                             .active_compute()
                             .create_dataflows(idx.cluster_id, dataflow_plan)
@@ -827,7 +828,7 @@ impl Coordinator {
                     let df = self
                         .dataflow_builder(mview.cluster_id)
                         .build_materialized_view_dataflow(entry.id(), as_of, internal_view_id)?;
-                    self.ship_dataflow(df, mview.cluster_id).await;
+                    self.must_ship_dataflow(df, mview.cluster_id).await;
                 }
                 CatalogItem::Sink(sink) => {
                     // Re-create the sink.

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -86,40 +86,52 @@ impl Coordinator {
     }
 
     /// Finalizes a dataflow and then broadcasts it to all workers.
-    /// Utility method for the more general [`Self::ship_dataflows`]
-    pub(crate) async fn ship_dataflow(
+    /// Utility method for the more general [`Self::must_ship_dataflows`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if the dataflow fails to ship.
+    pub(crate) async fn must_ship_dataflow(
         &mut self,
         dataflow: DataflowDesc,
         instance: ComputeInstanceId,
     ) {
-        self.ship_dataflows(vec![dataflow], instance).await
+        self.must_ship_dataflows(vec![dataflow], instance).await
     }
 
     /// Finalizes a list of dataflows and then broadcasts it to all workers.
-    async fn ship_dataflows(&mut self, dataflows: Vec<DataflowDesc>, instance: ComputeInstanceId) {
-        self.ship_dataflows_fallible(dataflows, instance)
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the dataflows fail to ship.
+    async fn must_ship_dataflows(
+        &mut self,
+        dataflows: Vec<DataflowDesc>,
+        instance: ComputeInstanceId,
+    ) {
+        self.ship_dataflows(dataflows, instance)
             .await
             .expect("failed to ship dataflows");
     }
 
     /// Finalizes a dataflow and then broadcasts it to all workers.
-    /// Utility method for the more general [`Self::ship_dataflows_fallible`]
+    /// Utility method for the more general [`Self::ship_dataflows`]
     ///
     /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version
-    /// [`Self::ship_dataflow`].
-    pub(crate) async fn ship_dataflow_fallible(
+    /// [`Self::must_ship_dataflow`].
+    pub(crate) async fn ship_dataflow(
         &mut self,
         dataflow: DataflowDesc,
         instance: ComputeInstanceId,
     ) -> Result<(), AdapterError> {
-        self.ship_dataflows_fallible(vec![dataflow], instance).await
+        self.ship_dataflows(vec![dataflow], instance).await
     }
 
     /// Finalizes a list of dataflows and then broadcasts it to all workers.
     ///
     /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version
-    /// [`Self::ship_dataflows`].
-    async fn ship_dataflows_fallible(
+    /// [`Self::must_ship_dataflows`].
+    async fn ship_dataflows(
         &mut self,
         dataflows: Vec<DataflowDesc>,
         instance: ComputeInstanceId,
@@ -128,7 +140,7 @@ impl Coordinator {
         let mut dataflow_plans = Vec::with_capacity(dataflows.len());
         for dataflow in dataflows.into_iter() {
             output_ids.extend(dataflow.export_ids());
-            let mut plan = self.finalize_dataflow_fallible(dataflow, instance)?;
+            let mut plan = self.finalize_dataflow(dataflow, instance)?;
             // If the only outputs of the dataflow are sinks, we might
             // be able to turn off the computation early, if they all
             // have non-trivial `up_to`s.
@@ -169,7 +181,7 @@ impl Coordinator {
     /// Panics if as_of is < the `since` frontiers.
     ///
     /// Panics if the dataflow descriptions contain an invalid plan.
-    pub(crate) fn finalize_dataflow(
+    pub(crate) fn must_finalize_dataflow(
         &self,
         dataflow: DataflowDesc,
         compute_instance: ComputeInstanceId,
@@ -178,7 +190,7 @@ impl Coordinator {
         // before calling this function. We don't have plumbing yet to rollback catalog
         // operations if this function fails, and environmentd will be in an unsafe
         // state if we do not correctly clean up the catalog.
-        self.finalize_dataflow_fallible(dataflow, compute_instance)
+        self.finalize_dataflow(dataflow, compute_instance)
             .expect("Dataflow planning failed; unrecoverable error")
     }
 
@@ -193,12 +205,12 @@ impl Coordinator {
     /// frontiers of dataflow inputs (sources and imported arrangements).
     ///
     /// This method will return an error if the finalization fails. DO NOT call this
-    /// method for DDL. Instead, use the non-fallible version [`Self::finalize_dataflow`].
+    /// method for DDL. Instead, use the non-fallible version [`Self::must_finalize_dataflow`].
     ///
     /// # Panics
     ///
     /// Panics if as_of is < the `since` frontiers.
-    pub(crate) fn finalize_dataflow_fallible(
+    pub(crate) fn finalize_dataflow(
         &self,
         mut dataflow: DataflowDesc,
         compute_instance: ComputeInstanceId,
@@ -771,7 +783,7 @@ fn eval_unmaterializable_func(
 impl Coordinator {
     #[allow(dead_code)]
     async fn verify_ship_dataflow_no_error(&mut self) {
-        // ship_dataflow, ship_dataflows, and finalize_dataflow are not allowed
+        // must_ship_dataflow, must_ship_dataflows, and must_finalize_dataflow are not allowed
         // to have a `Result` return because these functions are called after
         // `catalog_transact`, after which no errors are allowed. This test exists to
         // prevent us from incorrectly teaching those functions how to return errors
@@ -782,11 +794,11 @@ impl Coordinator {
         let compute_instance = ComputeInstanceId::User(1);
 
         let df = DataflowDesc::new("".into());
-        let _: () = self.ship_dataflow(df.clone(), compute_instance).await;
+        let _: () = self.must_ship_dataflow(df.clone(), compute_instance).await;
         let _: () = self
-            .ship_dataflows(vec![df.clone()], compute_instance)
+            .must_ship_dataflows(vec![df.clone()], compute_instance)
             .await;
         let _: DataflowDescription<mz_compute_client::plan::Plan> =
-            self.finalize_dataflow(df, compute_instance);
+            self.must_finalize_dataflow(df, compute_instance);
     }
 }

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -105,7 +105,8 @@ impl Coordinator {
     /// Finalizes a dataflow and then broadcasts it to all workers.
     /// Utility method for the more general [`Self::ship_dataflows_fallible`]
     ///
-    /// Returns an error on failure. DO NOT call this for DDL.
+    /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version
+    /// [`Self::ship_dataflow`].
     pub(crate) async fn ship_dataflow_fallible(
         &mut self,
         dataflow: DataflowDesc,
@@ -116,7 +117,8 @@ impl Coordinator {
 
     /// Finalizes a list of dataflows and then broadcasts it to all workers.
     ///
-    /// Returns an error on failure. DO NOT call this for DDL.
+    /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version
+    /// [`Self::ship_dataflows`].
     async fn ship_dataflows_fallible(
         &mut self,
         dataflows: Vec<DataflowDesc>,
@@ -191,7 +193,7 @@ impl Coordinator {
     /// frontiers of dataflow inputs (sources and imported arrangements).
     ///
     /// This method will return an error if the finalization fails. DO NOT call this
-    /// method for DDL. Instead, use the non-fallible version [`finalize_dataflow`].
+    /// method for DDL. Instead, use the non-fallible version [`Self::finalize_dataflow`].
     ///
     /// # Panics
     ///

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -251,11 +251,7 @@ impl Coordinator {
                 if let Some(pending_subscribe) = self.pending_subscribes.get_mut(&sink_id) {
                     let remove = pending_subscribe.process_response(response);
                     if remove {
-                        self.metrics
-                            .active_subscribes
-                            .with_label_values(&[pending_subscribe.session_type])
-                            .dec();
-                        self.pending_subscribes.remove(&sink_id);
+                        self.remove_subscribe(&sink_id);
                     }
                 }
             }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -264,7 +264,7 @@ impl crate::coord::Coordinator {
         let peek_plan = fast_path_plan.map_or_else(
             // finalize the dataflow and produce a PeekPlan::SlowPath as a default
             || {
-                let mut desc = self.finalize_dataflow(dataflow, compute_instance);
+                let mut desc = self.finalize_dataflow_fallible(dataflow, compute_instance)?;
                 // We have the opportunity to name an `until` frontier that will prevent work we needn't perform.
                 // By default, `until` will be `Antichain::new()`, which prevents no updates and is safe.
                 if let Some(as_of) = desc.as_of.as_ref() {
@@ -274,17 +274,17 @@ impl crate::coord::Coordinator {
                         }
                     }
                 }
-                PeekPlan::SlowPath(PeekDataflowPlan {
+                Ok::<_, AdapterError>(PeekPlan::SlowPath(PeekDataflowPlan {
                     desc,
                     id: index_id,
                     key,
                     permutation,
                     thinned_arity,
-                })
+                }))
             },
             // produce a PeekPlan::FastPath if possible
-            PeekPlan::FastPath,
-        );
+            |plan| Ok::<_, AdapterError>(PeekPlan::FastPath(plan)),
+        )?;
         Ok(peek_plan)
     }
 

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -264,7 +264,7 @@ impl crate::coord::Coordinator {
         let peek_plan = fast_path_plan.map_or_else(
             // finalize the dataflow and produce a PeekPlan::SlowPath as a default
             || {
-                let mut desc = self.finalize_dataflow_fallible(dataflow, compute_instance)?;
+                let mut desc = self.finalize_dataflow(dataflow, compute_instance)?;
                 // We have the opportunity to name an `until` frontier that will prevent work we needn't perform.
                 // By default, `until` will be `Antichain::new()`, which prevents no updates and is safe.
                 if let Some(as_of) = desc.as_of.as_ref() {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1581,7 +1581,7 @@ impl Coordinator {
                 )
                 .await;
 
-                self.ship_dataflow(df, cluster_id).await;
+                self.must_ship_dataflow(df, cluster_id).await;
 
                 Ok(ExecuteResponse::CreatedMaterializedView)
             }
@@ -1652,7 +1652,7 @@ impl Coordinator {
             .await
         {
             Ok(df) => {
-                self.ship_dataflow(df, cluster_id).await;
+                self.must_ship_dataflow(df, cluster_id).await;
                 self.set_index_options(id, options).expect("index enabled");
                 Ok(ExecuteResponse::CreatedIndex)
             }
@@ -2657,7 +2657,7 @@ impl Coordinator {
             },
         );
 
-        match self.ship_dataflow_fallible(dataflow, cluster_id).await {
+        match self.ship_dataflow(dataflow, cluster_id).await {
             Ok(_) => {}
             Err(e) => {
                 self.active_conns


### PR DESCRIPTION
This commit adds a meaningful error message when we are unable to plan a dataflow. Additionally, it returns this error to the user instead of panicking when possible. For DDL we have no choice but to panic or risk leaving the adapter in an inconsistent state.

Works towards fixing #17446

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
