### PR TITLE
adapter: fix TODO, add Timestamp::from_duration

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -151,9 +151,13 @@ mod read_policy;
 mod sequencer;
 mod sql;
 
-// TODO: We can have only two consts here, instead of three,
-// once there exists a `const` way to convert between a `Timestamp`
-// and a `Duration`
+// TODO: We can have only two consts here, instead of three, once there exists a `const` way to
+// convert between a `Timestamp` and a `Duration`, and unwrap a result in const contexts. Currently 
+// unstable compiler features that would allow this are:
+// * `const_option`: https://github.com/rust-lang/rust/issues/67441
+// * `const_result`: https://github.com/rust-lang/rust/issues/82814
+// * `const_num_from_num`: https://github.com/rust-lang/rust/issues/87852
+// * `const_precise_live_drops`: https://github.com/rust-lang/rust/issues/73255
 
 /// `DEFAULT_LOGICAL_COMPACTION_WINDOW`, in milliseconds.
 /// The default is set to a second to track the default timestamp frequency for sources.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -152,7 +152,7 @@ mod sequencer;
 mod sql;
 
 // TODO: We can have only two consts here, instead of three, once there exists a `const` way to
-// convert between a `Timestamp` and a `Duration`, and unwrap a result in const contexts. Currently 
+// convert between a `Timestamp` and a `Duration`, and unwrap a result in const contexts. Currently
 // unstable compiler features that would allow this are:
 // * `const_option`: https://github.com/rust-lang/rust/issues/67441
 // * `const_result`: https://github.com/rust-lang/rust/issues/82814


### PR DESCRIPTION
### Motivation

This PR fixes a TODO in the `adapter` crate that I noticed when reading through the code base:

> // TODO: We can have only two consts here, instead of three,
> // once there exists a `const` way to convert between a `Timestamp`
> // and a `Duration`

Specifically it adds a new `const fn from_duration(duration: Duration)` on a `mz_repr::Timestamp`. 

An issue with the implementation though is that [`Duration::as_millis`](https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.as_millis) returns a `u128`, meanwhile, internally `Timestamp` uses a `u64`. So it's possible that a large enough `Duration` would overflow what could fit in `Timestamp`. To support `const` contexts we can't return a `Result<...>` but we can panic (as of Rust 1.57). So I opted to check for overflow and panic if necessary.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
