### PR TITLE
adapter: remove deferred_object_name_rewrite migration

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -11,13 +11,10 @@ use semver::Version;
 use std::collections::BTreeMap;
 
 use mz_ore::collections::CollectionExt;
-use mz_sql::ast::{
-    display::AstDisplay, CreateSourceStatement, CreateSourceSubsource, CreateSubsourceOptionName,
-    CreateSubsourceStatement, DeferredObjectName, Raw, RawObjectName, ReferencedSubsources,
-    Statement, UnresolvedObjectName,
-};
+use mz_sql::ast::display::AstDisplay;
+use mz_sql::ast::{Raw, Statement};
 
-use crate::catalog::{Catalog, ConnCatalog, SerializedCatalogItem, SYSTEM_CONN_ID};
+use crate::catalog::{Catalog, SerializedCatalogItem};
 
 use super::storage::Transaction;
 
@@ -62,12 +59,9 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
     // it. You probably should be adding a basic AST migration above, unless
     // you are really certain you want one of these crazy migrations.
     let cat = Catalog::load_catalog_items(&mut tx, catalog)?;
-    let conn_cat = cat.for_system_session();
+    let _conn_cat = cat.for_system_session();
 
-    rewrite_items(&mut tx, |item| {
-        deferred_object_name_rewrite(&conn_cat, item)?;
-        Ok(())
-    })?;
+    rewrite_items(&mut tx, |_item| Ok(()))?;
     tx.commit().await.map_err(|e| e.into())
 }
 
@@ -96,7 +90,12 @@ pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> 
 // adding "progress" subsources.
 // TODO: delete in version v0.45 (released in v0.43 + 1 additional release)
 fn subsource_type_option_rewrite(stmt: &mut mz_sql::ast::Statement<Raw>) {
-    if let Statement::CreateSubsource(CreateSubsourceStatement { with_options, .. }) = stmt {
+    use mz_sql::ast::CreateSubsourceOptionName;
+
+    if let Statement::CreateSubsource(mz_sql::ast::CreateSubsourceStatement {
+        with_options, ..
+    }) = stmt
+    {
         if !with_options.iter().any(|option| {
             matches!(
                 option.name,
@@ -116,42 +115,3 @@ fn subsource_type_option_rewrite(stmt: &mut mz_sql::ast::Statement<Raw>) {
 // ****************************************************************************
 // Semantic migrations -- Weird migrations that require access to the catalog
 // ****************************************************************************
-
-// Rewrites all subsource references to be qualified by their IDs, which is the
-// mechanism by which `DeferredObjectName` differentiates between user input and
-// created objects.
-fn deferred_object_name_rewrite(
-    cat: &ConnCatalog,
-    stmt: &mut mz_sql::ast::Statement<Raw>,
-) -> Result<(), anyhow::Error> {
-    if let Statement::CreateSource(CreateSourceStatement {
-        referenced_subsources: Some(ReferencedSubsources::Subset(create_source_subsources)),
-        ..
-    }) = stmt
-    {
-        for CreateSourceSubsource { subsource, .. } in create_source_subsources {
-            let object_name = subsource.as_mut().unwrap();
-            let name: UnresolvedObjectName = match object_name {
-                DeferredObjectName::Deferred(name) => name.clone(),
-                DeferredObjectName::Named(..) => continue,
-            };
-
-            let partial_subsource_name =
-                mz_sql::normalize::unresolved_object_name(name.clone()).expect("resolvable");
-            let qualified_subsource_name = cat
-                .resolve_item_name(&partial_subsource_name)
-                .expect("known to exist");
-            let entry = cat
-                .state
-                .try_get_entry_in_schema(qualified_subsource_name, SYSTEM_CONN_ID)
-                .expect("known to exist");
-            let id = entry.id();
-
-            *subsource = Some(DeferredObjectName::Named(RawObjectName::Id(
-                id.to_string(),
-                name,
-            )));
-        }
-    }
-    Ok(())
-}

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -847,25 +847,8 @@ pub fn plan_create_source(
                 let name = subsource.reference.clone();
 
                 let target = match &subsource.subsource {
-                    Some(subsource) => match subsource {
-                        DeferredObjectName::Named(target) => target.clone(),
-                        DeferredObjectName::Deferred(name) => {
-                            // TODO: remove this after the next release, we need
-                            // it only so we can load the catalog to do the
-                            // proper rewrite.
-                            let partial_subsource_name =
-                                normalize::unresolved_object_name(name.clone())?;
-                            let item = scx.catalog.resolve_item(&partial_subsource_name).unwrap();
-
-                            ResolvedObjectName::Object {
-                                id: item.id(),
-                                qualifiers: item.name().qualifiers.clone(),
-                                full_name: scx.catalog.resolve_full_name(item.name()),
-                                print_id: true,
-                            }
-                        }
-                    },
-                    None => {
+                    Some(DeferredObjectName::Named(target)) => target.clone(),
+                    _ => {
                         sql_bail!("[internal error] subsources must be named during purification")
                     }
                 };


### PR DESCRIPTION
Migrations no longer need to be kept in perpetuity.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
