### PR TITLE
test: Fix test_storage_usage_doesnt_update_between_restarts

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -623,7 +623,7 @@ fn test_storage_usage_updates_between_restarts() {
 #[test]
 fn test_storage_usage_doesnt_update_between_restarts() {
     let data_dir = tempfile::tempdir().unwrap();
-    let storage_usage_collection_interval = Duration::from_secs(60);
+    let storage_usage_collection_interval = Duration::from_secs(10);
     let config = util::Config::default()
         .with_storage_usage_collection_interval(storage_usage_collection_interval)
         .data_directory(data_dir.path());
@@ -645,10 +645,12 @@ fn test_storage_usage_doesnt_update_between_restarts() {
         }).unwrap()
     };
 
-    std::thread::sleep(Duration::from_secs(2));
-
     // Another storage usage collection should not be scheduled immediately.
     {
+        // Give plenty of time so we don't accidentally do another collection if this test is slow.
+        let storage_usage_collection_interval = Duration::from_secs(60 * 10);
+        let config =
+            config.with_storage_usage_collection_interval(storage_usage_collection_interval);
         let server = util::start_server(config).unwrap();
         let mut client = server.connect(postgres::NoTls).unwrap();
 


### PR DESCRIPTION
Fixes #17457

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
