### PR TITLE
storage: cleanup dropped IDs

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -722,6 +722,53 @@ where
             .await
     }
 
+    /// Transactionally deletes any kv pair from `self` whose key is in `keys`.
+    ///
+    /// Note that:
+    /// - Unlike `delete`, this operation operates in time O(keys), and not
+    ///   O(set), however does so by parallelizing a number of point queries so
+    ///   is likely not performant for more than 10-or-so keys.
+    /// - This operation runs in a single transaction and cannot be combined
+    ///   with other transactions.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn delete_keys(&self, stash: &mut Stash, keys: BTreeSet<K>) -> Result<(), StashError>
+    where
+        K: Hash + Clone + 'static,
+        V: Clone,
+    {
+        use futures::StreamExt;
+
+        let name = self.name.to_string();
+        stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    let collection = tx.collection::<K, V>(&name).await?;
+                    let lower = tx.upper(collection.id).await?;
+                    let mut batch = collection.make_batch_lower(lower)?;
+
+                    let tx = &tx;
+
+                    let kv_results: Vec<(K, Result<Option<V>, StashError>)> =
+                        futures::stream::iter(keys.into_iter())
+                            .map(|key| async move {
+                                (key.clone(), tx.peek_key_one(collection.clone(), &key).await)
+                            })
+                            .buffer_unordered(10)
+                            .collect()
+                            .await;
+
+                    for (key, val) in kv_results {
+                        if let Some(v) = val? {
+                            collection.append_to_batch(&mut batch, &key, &v, -1);
+                        }
+                    }
+                    tx.append(vec![batch]).await?;
+                    Ok(())
+                })
+            })
+            .await
+    }
+
     /// Transactionally updates values in all KV pairs using `transform`.
     ///
     /// Note that this operation:

--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -14,7 +14,7 @@
 
 //! The public API of the storage layer.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use std::iter;
 
@@ -366,7 +366,7 @@ pub enum StorageResponse<T = mz_repr::Timestamp> {
     /// information to assert the correct implementation of our protocols at various places.
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
     /// Punctuation indicates that no more responses will be transmitted for the specified ids
-    DroppedIds(Vec<GlobalId>),
+    DroppedIds(BTreeSet<GlobalId>),
 
     /// A list of statistics updates, currently only for sources.
     StatisticsUpdates(Vec<SourceStatisticsUpdate>, Vec<SinkStatisticsUpdate>),
@@ -624,7 +624,7 @@ where
                 }
             }
             StorageResponse::DroppedIds(dropped_ids) => {
-                let mut new_drops = vec![];
+                let mut new_drops = BTreeSet::new();
 
                 for id in dropped_ids {
                     let (_, shard_frontiers) = match self.uppers.get_mut(&id) {
@@ -639,7 +639,7 @@ where
 
                     if shard_frontiers.iter().all(Option::is_none) {
                         self.uppers.remove(&id);
-                        new_drops.push(id);
+                        new_drops.insert(id);
                     }
                 }
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2194,7 +2194,7 @@ where
     }
 
     async fn reconcile_state(&mut self) {
-        self.reconcile_shards().await
+        self.reconcile_state_inner().await
     }
 }
 

--- a/src/storage-client/src/controller/command_wals.rs
+++ b/src/storage-client/src/controller/command_wals.rs
@@ -11,7 +11,7 @@
 //! or write them. This identifies shards we no longer use, but did not have the
 //! opportunity to finalize before e.g. crashing.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use differential_dataflow::lattice::Lattice;
 use timely::order::TotalOrder;
@@ -21,13 +21,13 @@ use mz_ore::now::EpochMillis;
 use mz_persist_client::ShardId;
 use mz_persist_types::Codec64;
 use mz_proto::RustType;
-use mz_repr::TimestampManipulation;
+use mz_repr::{Diff, TimestampManipulation};
 use mz_stash::{self, TypedCollection};
 
 use crate::client::{StorageCommand, StorageResponse};
-use crate::controller::{ProtoStorageCommand, ProtoStorageResponse};
+use crate::controller::{DurableCollectionMetadata, ProtoStorageCommand, ProtoStorageResponse};
 
-use super::Controller;
+use super::{Controller, StorageController};
 
 pub(super) static SHARD_FINALIZATION: TypedCollection<ShardId, ()> =
     TypedCollection::new("storage-shards-to-finalize");
@@ -70,63 +70,110 @@ where
         shards: BTreeSet<ShardId>,
     ) {
         SHARD_FINALIZATION
-            .delete(&mut self.state.stash, move |k, _v| shards.contains(k))
+            .delete_keys(&mut self.state.stash, shards)
             .await
             .expect("must be able to write to stash")
     }
 
-    /// Reconcile the state of `SHARD_FINALIZATION_WAL` with
-    /// `super::METADATA_COLLECTION` on boot.
-    pub(super) async fn reconcile_shards(&mut self) {
-        // Get all shards in the WAL.
-        let registered_shards: BTreeSet<_> = SHARD_FINALIZATION
-            .peek_one(&mut self.state.stash)
-            .await
-            .expect("must be able to read from stash")
-            .into_iter()
-            .map(|(shard_id, _)| shard_id)
-            .collect();
-
-        if registered_shards.is_empty() {
-            return;
+    pub(super) async fn reconcile_state_inner(&mut self) {
+        // Convenience method for reading from a collection in parallel.
+        async fn tx_peek<'tx, K, V>(
+            tx: &'tx mz_stash::Transaction<'tx>,
+            typed: &TypedCollection<K, V>,
+        ) -> Vec<(K, V, Diff)>
+        where
+            K: mz_stash::Data,
+            V: mz_stash::Data,
+        {
+            let collection = tx
+                .collection::<K, V>(typed.name())
+                .await
+                .expect("named collection must exist");
+            tx.peek(collection).await.expect("peek succeeds")
         }
 
-        // Get all shards we're aware of from stash.
-        let all_shard_data: BTreeMap<_, _> = super::METADATA_COLLECTION
-            .peek_one(&mut self.state.stash)
+        // Get stash metadata.
+        let (metadata, shard_finalization) = self
+            .state
+            .stash
+            .with_transaction(move |tx| {
+                Box::pin(async move {
+                    // Query all collections in parallel.
+                    Ok(futures::join!(
+                        tx_peek(&tx, &super::METADATA_COLLECTION),
+                        tx_peek(&tx, &SHARD_FINALIZATION),
+                    ))
+                })
+            })
             .await
-            .expect("must be able to read from stash")
+            .expect("stash operation succeeds");
+
+        // Partition metadata into the collections we want to have and those we failed to drop.
+        let (in_use_collections, leaked_collections): (Vec<_>, Vec<_>) =
+            metadata.into_iter().partition(|(id, _, diff)| {
+                assert_eq!(
+                    *diff, 1,
+                    "expected METADATA_COLLECTION to contain reconciled state"
+                );
+
+                self.collection(*id).is_ok()
+            });
+
+        // Get all shard IDs
+        let shard_finalization: BTreeSet<_> = shard_finalization
             .into_iter()
-            .map(
-                |(
-                    id,
-                    // TODO(guswynn): produce the schema for each shard.
-                    super::DurableCollectionMetadata {
-                        remap_shard,
-                        data_shard,
-                    },
-                )| { [(id, [remap_shard, Some(data_shard)])] },
-            )
-            .flatten()
+            .map(|(id, _, diff)| {
+                assert_eq!(
+                    diff, 1,
+                    "expected SHARD_FINALIZATION to contain reconciled state"
+                );
+
+                id
+            })
             .collect();
 
-        // Consider shards in use if they are still attached to a collection.
-        let in_use_shards: BTreeSet<_> = all_shard_data
-            .into_iter()
-            .filter_map(|(id, shards)| self.state.collections.get(&id).map(|_| shards.to_vec()))
-            .flatten()
-            .filter_map(|shard| shard)
+        // Collect all shards from in-use collections
+        let in_use_shards: BTreeSet<_> = in_use_collections
+            .iter()
+            // n.b we do not include remap shards here because they are the data shards of their own
+            // collections.
+            .map(|(_, DurableCollectionMetadata { data_shard, .. }, _)| *data_shard)
             .collect();
 
-        // Determine all shards that were marked to drop but are still in use by
-        // some present collection.
-        let shard_ids_to_keep = registered_shards
+        // Determine if there are any shards that belong to in-use collections
+        // that we have marked for finalization. This is usually inconceivable,
+        // but could happen if we e.g. crash during a migration.
+        let in_use_shards_registered_for_finalization: BTreeSet<_> = shard_finalization
             .intersection(&in_use_shards)
             .cloned()
             .collect();
 
-        // Remove any shards that are currently in use from shard finalization register.
-        self.clear_from_shard_finalization_register(shard_ids_to_keep)
-            .await;
+        // Fixup shard finalization WAL if necessary.
+        if !in_use_shards_registered_for_finalization.is_empty() {
+            self.clear_from_shard_finalization_register(in_use_shards_registered_for_finalization)
+                .await;
+        }
+
+        // If we know about collections that the adapter has forgotten about, clean that up.
+        if !leaked_collections.is_empty() {
+            let mut shards_to_finalize = Vec::with_capacity(leaked_collections.len());
+            let mut ids_to_drop = BTreeSet::new();
+
+            for (id, DurableCollectionMetadata { data_shard, .. }, _) in leaked_collections {
+                shards_to_finalize.push(data_shard);
+                ids_to_drop.insert(id);
+            }
+
+            // Note that we register the shards for finalization but do not
+            // finalize them here; this is meant to speed up startup times, as
+            // we can defer actually finalizing shards.
+            self.register_shards_for_finalization(shards_to_finalize)
+                .await;
+
+            super::METADATA_COLLECTION
+                .delete_keys(&mut self.state.stash, ids_to_drop)
+                .await
+                .expect("stash operation must succeed");
+        }
     }
 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -208,7 +208,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
             sink_tokens: BTreeMap::new(),
             sink_write_frontiers: BTreeMap::new(),
             sink_handles: BTreeMap::new(),
-            dropped_ids: Vec::new(),
+            dropped_ids: BTreeSet::new(),
             source_statistics: BTreeMap::new(),
             sink_statistics: BTreeMap::new(),
             internal_cmd_tx: command_sequencer,
@@ -273,7 +273,7 @@ pub struct StorageState {
     /// See: [SinkHandle]
     pub sink_handles: BTreeMap<GlobalId, SinkHandle>,
     /// Collection ids that have been dropped but not yet reported as dropped
-    pub dropped_ids: Vec<GlobalId>,
+    pub dropped_ids: BTreeSet<GlobalId>,
 
     /// Stats objects shared with operators to allow them to update the metrics
     /// we report in `StatisticsUpdates` responses.
@@ -957,7 +957,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         if drop_commands.remove(&ingestion.id) {
                             // Make sure that we report back that the ID was
                             // dropped.
-                            self.storage_state.dropped_ids.push(ingestion.id.clone());
+                            self.storage_state.dropped_ids.insert(ingestion.id);
 
                             false
                         } else if let Some(existing) = self.storage_state.ingestions.get(&ingestion.id) {
@@ -990,7 +990,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         if drop_commands.remove(&export.id) {
                             // Make sure that we report back that the ID was
                             // dropped.
-                            self.storage_state.dropped_ids.push(export.id.clone());
+                            self.storage_state.dropped_ids.insert(export.id);
 
                             false
                         } else if let Some(existing) = self.storage_state.exports.get(&export.id) {


### PR DESCRIPTION
We had a lingering `TODO` to clean up `GlobalId` state when we receive a `DroppedIds` response, which this PR does.

Because completing the TODO requires removing entries from `METADATA_COLLECTION`, we also need to reconcile the controller's in-memory catalog of collections with stash on boot--i.e. we want the collections we have durably recorded to mirror those we have in memory. We use this to also understand which shards to finalize.

Note that like other shard state work, the lack of introspection on shards makes it very challenging to test.

@mjibson Tagging you for review on [stash: add delete_keys API](https://github.com/MaterializeInc/materialize/pull/17462/commits/435b4764204a3055e54edce6b3b2fe63bff58058); doing full table scans seems silly when we know the keys we want to delete.

@aljoscha From our conversation earlier, tables do not have their shards finalized by the adapter; they're dropped just like any other source.

### Motivation

This PR adds a known-desirable feature. Closes #15941

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
