### PR TITLE
compute: fix typo in metric name

### DIFF
--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -22,7 +22,7 @@ impl ComputeMetrics {
     pub fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
             command_history_size: registry.register(metric!(
-                name: "mz_compute_comamnd_history_size",
+                name: "mz_compute_command_history_size",
                 help: "The size of the compute command history.",
             )),
             dataflow_count_in_history: registry.register(metric!(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -219,8 +219,8 @@ def workflow_test_github_15531(c: Composition) -> None:
         history_len = None
         dataflow_count = None
         for metric in metrics.splitlines():
-            if metric.startswith("mz_compute_comamnd_history_size"):
-                history_len = int(metric[len("mz_compute_comamnd_history_size") :])
+            if metric.startswith("mz_compute_command_history_size"):
+                history_len = int(metric[len("mz_compute_command_history_size") :])
             elif metric.startswith("mz_compute_dataflow_count_in_history"):
                 dataflow_count = int(
                     metric[len("mz_compute_dataflow_count_in_history") :]


### PR DESCRIPTION
`mz_compute_comamnd_history_size` -> `mz_compute_command_history_size`

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
