### PR TITLE
scratch: Print only rounded seconds remaining

### DIFF
--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -231,7 +231,7 @@ async def setup(
 
     done = False
     async for remaining in ui.async_timeout_loop(60, 5):
-        say(f"Waiting for instance to become ready: {remaining}s remaining")
+        say(f"Waiting for instance to become ready: {remaining:0.0f}s remaining")
         try:
             i.reload()
             if is_ready(i):
@@ -246,7 +246,7 @@ async def setup(
 
     done = False
     async for remaining in ui.async_timeout_loop(300, 5):
-        say(f"Checking whether setup has completed: {remaining}s remaining")
+        say(f"Checking whether setup has completed: {remaining:0.0f}s remaining")
         try:
             mssh(i, "[[ -f /opt/provision/done ]]")
             done = True


### PR DESCRIPTION
### Motivation

Since the seconds have a high enough resolution and the subsecond part can be of inconsistent length

Previously:
```
scratch> Checking whether setup has completed: 187.186673083s remaining
scratch> Checking whether setup has completed: 182.2380561s remaining
```
Now:
```
scratch> Checking whether setup has completed: 187s remaining
scratch> Checking whether setup has completed: 182s remaining
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
