### PR TITLE
doc/developer: Install postgresql-client, suggest java 11 instead of java 8

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -20,14 +20,14 @@ installing Apple's developer tools, which includes a C compiler. Then it's a
 cinch to install CMake:
 
 ```
-brew install cmake
+brew install cmake postgresql
 ```
 
 On Debian-based Linux variants, it's even easier:
 
 ```shell
 sudo apt update
-sudo apt install build-essential cmake
+sudo apt install build-essential cmake postgresql-client
 ```
 
 On other platforms, you'll have to figure out how to get these tools yourself.

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -100,7 +100,7 @@ documentation. Then please update this guide with the new instructions!
 You will need JDK 8 or 11. The easiest way to install this is via Homebrew:
 
 ```shell
-brew install --cask homebrew/cask-versions/temurin8
+brew install --cask homebrew/cask-versions/temurin11
 ```
 
 Then, download and extract the Confluent Platform tarball:
@@ -120,7 +120,7 @@ If you have multiple JDKs installed and your current JAVA_HOME points to an inco
 you can explicitly run confluent with JDK 8 or 11:
 
 ```
-JAVA_HOME=$(/usr/libexec/java_home -v 1.8) confluent local services start
+JAVA_HOME=$(/usr/libexec/java_home -v 1.11) confluent local services start
 ```
 
 #### Linux
@@ -132,7 +132,7 @@ Confluent Platform:
 curl http://packages.confluent.io/deb/6.0/archive.key | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.0 stable main"
 sudo apt update
-sudo apt install openjdk-8-jre-headless confluent-community-2.13
+sudo apt install openjdk-11-jre-headless confluent-community-2.13
 echo export CONFLUENT_HOME=/ >> ~/.bashrc
 source ~/.bashrc
 confluent local services start


### PR DESCRIPTION
Install postgresql-client as it is required to connect to CockroachDB

```
$ cargo build --bin clusterd --bin environmentd
    Finished dev [unoptimized + debuginfo] target(s) in 0.50s
$ psql -At postgres://root@localhost:26257/materialize -c 'CREATE DATABASE IF NOT EXISTS materialize'
run: error: unable to execute postgres statement: [Errno 2] No such file or directory: 'psql'
hint: Have you installed and started CockroachDB?
```

﻿During startup Confluent warns about Java 8 going out of support with next major Confluent release:

> As of Confluent Platform 8.0, Java 8 is no longer supported.

### Motivation

Noticed while going through the document since I'm just getting started.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
