### PR TITLE
adapter: remove read policies for dropped compute sinks

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -13,7 +13,6 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use itertools::Itertools;
 use serde_json::json;
 use timely::progress::Antichain;
 use tracing::Level;
@@ -346,15 +345,17 @@ impl Coordinator {
     }
 
     pub(crate) fn drop_compute_sinks(&mut self, sinks: Vec<ComputeSinkId>) {
-        let by_cluster = sinks
-            .into_iter()
-            .map(
-                |ComputeSinkId {
-                     cluster_id,
-                     global_id,
-                 }| (cluster_id, global_id),
-            )
-            .into_group_map();
+        let mut by_cluster: BTreeMap<_, Vec<_>> = BTreeMap::new();
+        for sink in sinks {
+            if self.drop_compute_read_policy(&sink.global_id) {
+                by_cluster
+                    .entry(sink.cluster_id)
+                    .or_default()
+                    .push(sink.global_id);
+            } else {
+                tracing::error!("Instructed to drop a compute sink that isn't one");
+            }
+        }
         let mut compute = self.controller.active_compute();
         for (cluster_id, ids) in by_cluster {
             // A cluster could have been dropped, so verify it exists.
@@ -380,11 +381,12 @@ impl Coordinator {
                 tracing::error!("Instructed to drop a non-index index");
             }
         }
+        let mut compute = self.controller.active_compute();
         for (cluster_id, ids) in by_cluster {
-            self.controller
-                .active_compute()
-                .drop_collections(cluster_id, ids)
-                .unwrap();
+            // A cluster could have been dropped, so verify it exists.
+            if compute.instance_exists(cluster_id) {
+                compute.drop_collections(cluster_id, ids).unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
This fixes a small memory leak in environmentd that occurred when a `SUBSCRIBE` completed or was aborted by the user.

### Motivation

  * This PR fixes a previously unreported bug.

environmentd leaks a small amount of memory every time a `SUBSCRIBE` completes or is cancelled.

![Screenshot 2023-02-01 at 18 04 24](https://user-images.githubusercontent.com/4521314/216111814-0c66e19f-c57a-4203-a256-8508bab05d38.png)

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
