### PR TITLE
sql: error if a CSR URL contains a path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,7 @@ dependencies = [
  "rand",
  "rdkafka",
  "regex",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -53,6 +53,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
+reqwest = "0.11.13"
 semver = "1.0.16"
 serde = "1.0.152"
 serde_json = "1.0.89"

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2900,6 +2900,9 @@ impl CsrConnectionOptionExtracted {
         let _ = url
             .host_str()
             .ok_or_else(|| sql_err!("invalid CONNECTION: URL must specify domain name"))?;
+        if url.path() != "/" {
+            sql_bail!("invalid CONNECTION: URL must have an empty path");
+        }
         let cert = self.ssl_certificate;
         let key = self.ssl_key.map(|secret| secret.into());
         let tls_identity = match (cert, key) {

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -357,6 +357,11 @@ contains: requires both SSL KEY and SSL CERTIFICATE
   );
 contains: requires both SSL KEY and SSL CERTIFICATE
 
+! CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}/FOO/BAR/BAZ'
+  );
+contains: URL must have an empty path
+
 ## SSH
 ! CREATE CONNECTION missing_user TO SSH TUNNEL (
     USER 'foo'


### PR DESCRIPTION
Migrate all existing CSR URLs to empty their paths in case we do support this in the future, because we don't want the behavior to suddenly change on those users.

Fixes #16131

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Error on Confluent Schema Registry URLs with non-empty paths. The paths were already silently ignored, so there is no change in behavior.