### PR TITLE
Design review process revamp

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@ Delete this section if no tips.
 ### Checklist
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
-- [ ] This PR has an associated design doc, is a design doc, or is sufficiently small to not require a design.
+- [ ] This PR has an associated up-to-date design doc, is a design doc, or is sufficiently small to not require a design.
   <!-- Reference the design in the description. -->
 - [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
 - [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@ Delete this section if no tips.
 ### Checklist
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
-- [ ] This PR has an associated up-to-date design doc, is a design doc, or is sufficiently small to not require a design.
+- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
   <!-- Reference the design in the description. -->
 - [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
 - [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,6 +49,8 @@ Delete this section if no tips.
 ### Checklist
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
+- [ ] This PR has an associated design doc, is a design doc, or is sufficiently small to not require a design.
+  <!-- Reference the design in the description. -->
 - [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
 - [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
   <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -4,7 +4,7 @@
 # Summary
 [summary]: #summary
 
-One paragraph to explain the feature.
+One paragraph to explain the feature: What's wrong, what's the problem, what's the fix, what are the consequences?
 
 # Motivation
 [motivation]: #motivation
@@ -40,15 +40,17 @@ This is the technical part of the design.
 
 Describe what steps are necessary to enable this feature for users.
 
-## Testing
-[testing]: #testing
+## Testing and observability
+[testing-and-observability]: #testing-and-observability
 
+Testability and explainability are top-tier design concerns!
 Describe how you will test and roll out the implementation.
 When the deliverable is a refactoring, the existing tests may be sufficient.
 When the deliverable is a new feature, new tests are imperative.
 
 Describe what metrics can be used to monitor and observe the feature.
 What information do we need to expose internally, and what information is interesting to the user?
+How do we expose the information?
 
 Basic guidelines:
 
@@ -89,7 +91,7 @@ Why should we *not* do this?
 # Future work
 [future-work]: #future-work
 
-Describe what work could follow from this design, which new aspects it enables, and how it might affect individual parts of Materialize.
+Describe what work should follow from this design, which new aspects it enables, and how it might affect individual parts of Materialize.
 Think in larger terms.
 This section can also serve as a place to dump ideas that are related but not part of the design.
 

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -39,6 +39,7 @@ This is the technical part of the design.
 [rollout]: #rollout
 
 Describe what steps are necessary to enable this feature for users.
+How do we validate that the feature performs as expected? What monitoring and observability does it require?
 
 ## Testing and observability
 [testing-and-observability]: #testing-and-observability

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -1,6 +1,5 @@
 - Feature name: (Insert name of feature)
-- Associated issues: (Insert list of associated epics or issue)
-- Associated PRs: (List associated PRs)
+- Associated: (Insert list of associated epics, issues, or PRs)
 
 # Summary
 [summary]: #summary
@@ -10,7 +9,7 @@ One paragraph to explain the feature.
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use-cases does it enable? What is the desired outcome?
+Why are we doing this? What problems does it solve? What use cases does it enable? What is the desired outcome?
 
 # Explanation
 [explanation]: #explanation
@@ -22,7 +21,7 @@ This can mean:
 - Explain the feature using examples that demonstrate product-level changes.
 - Explain how engineers and users should think about this change, and how it influences how everyone uses the product.
 - If needed, talk though errors, backwards-compatibility, or migration strategies.
-- Discuss how this affects maintainability, or whether it introduces concets that might be hard to change in the future.
+- Discuss how this affects maintainability, or whether it introduces concepts that might be hard to change in the future.
 
 # Reference explanation
 [reference-explanation]: #reference-explanation
@@ -30,10 +29,38 @@ This can mean:
 Focus on the implementation of the feature.
 This is the technical part of the design.
 
-- It is reasonably clear how the feature is implemented.
+- Is it reasonably clear how the feature is implemented?
 - What dependencies does the feature have and introduce?
 - Focus on corner cases.
 - How can we test the feature and protect against regressions?
+
+# Rollout
+[rollout]: #rollout
+
+Describe what steps are necessary to enable this feature for users.
+
+## Testing
+[testing]: #testing
+
+Describe how you will test and roll out the implementation.
+When the deliverable is a refactoring, the existing tests may be sufficient.
+When the deliverable is a new feature, new tests are imperative.
+
+Basic guidelines:
+
+* Nearly every feature requires either Rust unit tests, sqllogictest tests, or testdrive tests.
+* Features that interact with Kubernetes additionally need a cloudtest test.
+* Features that interact with external systems additionally should be tested manually in a staging environment.
+* Features or changes to performance-critical parts of the system should be load tested.
+
+## Lifecycle
+[lifecycle]: #lifecycle
+
+If the design is risky or has the potential to be destabilizing, you should plan to roll the implementation out behind a feature flag.
+Describe the [lifecycle of the feature](https://www.notion.so/Feature-lifecycle-2fb13301803b4b7e9ba0868238bd4cfb).
+Will it start as an alpha feature behind a feature flag?
+What level of testing will be required to promote to beta?
+To stable?
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -52,7 +79,7 @@ Why should we *not* do this?
 
 - What questions need to be resolved to finalize the design?
 - What questions will need to be resolved during the implementation of the design?
-- What questions does this design rase that we should address separately?
+- What questions does this design raise that we should address separately?
 
 # Future work
 [future-work]: #future-work

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -1,4 +1,5 @@
 - Feature name: (Insert name of feature)
+- Associated issues: (Insert list of associated epics or issue)
 - Associated PRs: (List associated PRs)
 
 # Summary
@@ -46,10 +47,18 @@ Why should we *not* do this?
 - What other designs have been considered, and what were the reasons to not pick any other?
 - What is the impact of not implementing this design?
 
-## Open questions
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
 
-<!--
-// Anything currently unanswered that needs specific focus. This section may be expanded during the doc meeting as
-// other unknowns are pointed out.
-// These questions may be technical, product, or anything in-between.
--->
+- What questions need to be resolved to finalize the design?
+- What questions will need to be resolved during the implementation of the design?
+- What questions does this design rase that we should address separately?
+
+# Future work
+[future-work]: #future-work
+
+Describe what work could follow from this design, which new aspects it enables, and how it might affect individual parts of Materialize.
+Think in larger terms.
+This section can also serve as a place to dump ideas that are related but not part of the design.
+
+If you can't think of any, please note this down.

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -47,6 +47,9 @@ Describe how you will test and roll out the implementation.
 When the deliverable is a refactoring, the existing tests may be sufficient.
 When the deliverable is a new feature, new tests are imperative.
 
+Describe what metrics can be used to monitor and observe the feature.
+What information do we need to expose internally, and what information is interesting to the user?
+
 Basic guidelines:
 
 * Nearly every feature requires either Rust unit tests, sqllogictest tests, or testdrive tests.

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -19,6 +19,7 @@ This can mean:
 
 - Introduce new named concepts.
 - Explain the feature using examples that demonstrate product-level changes.
+- Explain how it builds on the current architecture.
 - Explain how engineers and users should think about this change, and how it influences how everyone uses the product.
 - If needed, talk though errors, backwards-compatibility, or migration strategies.
 - Discuss how this affects maintainability, or whether it introduces concepts that might be hard to change in the future.
@@ -57,6 +58,7 @@ Basic guidelines:
 [lifecycle]: #lifecycle
 
 If the design is risky or has the potential to be destabilizing, you should plan to roll the implementation out behind a feature flag.
+List all feature flags, their behavior and when it is safe to change their value.
 Describe the [lifecycle of the feature](https://www.notion.so/Feature-lifecycle-2fb13301803b4b7e9ba0868238bd4cfb).
 Will it start as an alpha feature behind a feature flag?
 What level of testing will be required to promote to beta?

--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -1,37 +1,50 @@
-# <Insert Name of Feature>
+- Feature name: (Insert name of feature)
+- Associated PRs: (List associated PRs)
 
-## Summary
+# Summary
+[summary]: #summary
 
-<!--
-// Brief, high-level overview. A few sentences long.
-// Be sure to capture the customer impact - framing this as a release note may be useful.
--->
+One paragraph to explain the feature.
 
-## Goals
+# Motivation
+[motivation]: #motivation
 
-<!--
-// Enumerate the concrete goals that are in scope for the project.
--->
+Why are we doing this? What use-cases does it enable? What is the desired outcome?
 
-## Non-Goals
+# Explanation
+[explanation]: #explanation
 
-<!--
-// Enumerate potential goals that are explicitly out of scope for the project
-// ie. what could we do or what do we want to do in the future - but are not doing now
--->
+Explain the design as if it were part of Materialize and you were teaching the team about it.
+This can mean:
 
-## Description
+- Introduce new named concepts.
+- Explain the feature using examples that demonstrate product-level changes.
+- Explain how engineers and users should think about this change, and how it influences how everyone uses the product.
+- If needed, talk though errors, backwards-compatibility, or migration strategies.
+- Discuss how this affects maintainability, or whether it introduces concets that might be hard to change in the future.
 
-<!--
-// Describe the approach in detail. If there is no clear frontrunner, feel free to list all approaches in alternatives.
-// If applicable, be sure to call out any new testing/validation that will be required
--->
+# Reference explanation
+[reference-explanation]: #reference-explanation
 
-## Alternatives
+Focus on the implementation of the feature.
+This is the technical part of the design.
 
-<!--
-// Similar to the Description section. List of alternative approaches considered, pros/cons or why they were not chosen
--->
+- It is reasonably clear how the feature is implemented.
+- What dependencies does the feature have and introduce?
+- Focus on corner cases.
+- How can we test the feature and protect against regressions?
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Conclusion and alternatives
+[conclusion-and-alternatives]: #conclusion-and-alternatives
+
+- Why is the design the best to solve the problem?
+- What other designs have been considered, and what were the reasons to not pick any other?
+- What is the impact of not implementing this design?
 
 ## Open questions
 

--- a/doc/developer/design/20230126_designs_reviews.md
+++ b/doc/developer/design/20230126_designs_reviews.md
@@ -1,4 +1,4 @@
-- Feature name: designs_revisited
+- Feature name: designs-revisited
 - Associated issues: None
 - Associated PRs: #17482
 
@@ -21,7 +21,7 @@ To address this, we analyze the current shortcomings and propose updates to the 
 We aim at creating a design process that is lightweight, captures reviews and specific snapshots in time, is open, while providing a clear benefit to engineers.
 Let's break down these aspects.
 
-A design review process needs to empower engineers to focus on the task at hands.
+A design review process needs to empower engineers to focus on the task at hand.
 It helps to talk about goals, how they fit into the product roadmap, and outline solutions.
 An engineer can present different solutions, and it's expected that new alternatives come up while working on a design.
 Explaining trade-offs helps to motivate a specific solution.
@@ -35,7 +35,7 @@ This ensures that we uphold a high standard, and it increases the visibility of 
 Designs in Notion do not achieve this goal.
 
 The most important aspect is that this process provides a benefit to the engineer and the company.
-It allows to create confidence that their work fits into the overall architecture and that dependencies are surfaced.
+It allows us to create confidence that their work fits into the overall architecture and that dependencies are surfaced.
 Additionally, a good design document serves as a point-in-time documentation, helping others understand trade-offs and seemingly odd choices.
 
 # Reference explanation
@@ -48,6 +48,7 @@ This raises the question of why we did not follow it recently.
 To address this, we propose the following steps, some of which are part of the change around this document:
 * Revisit the design doc [README](./README.md) to make expectations clearer.
 * Update the [pull request template](/.github/pull_request_template.md) to include a step reminding engineers to think about design documents.
+* Update the [template](./00000000_template.md) to match what we're outlining in this design.
 
 Specifically, the current interpretation of design documents is to write one for large changes, where it is not clear what large means.
 Instead, we propose that each change should come with a design doc unless it is small enough to be non-contentious or immediately clear what needs to be done.
@@ -67,7 +68,7 @@ Notable examples for RFC-style processes follow:
 * Ember's design process follows Rust's process, but is less formal.
 
 One alternative is to not change the current design doc process and leave it as-is, which defaults to engineers creating designs in Notion.
-The benefit is that we don't add (percieved) overhead, at the expense of the problems mentioned here.
+The benefit is that we don't add (perceived) overhead, but at the expense of the problems mentioned here.
 Specifically, it doesn't capture discussions well, and does not permit external users to understand design choices.
 
 ## RFC-style process

--- a/doc/developer/design/20230126_designs_reviews.md
+++ b/doc/developer/design/20230126_designs_reviews.md
@@ -1,22 +1,22 @@
-# Scaling our design process
+- Feature name: designs_revisited
+- Associated issues: None
+- Associated PRs: #17482
 
-## Summary
+# Summary
+[summary]: #summary
 
-<!--
-// Brief, high-level overview. A few sentences long.
-// Be sure to capture the customer impact - framing this as a release note may be useful.
--->
+We're updating the design review process to make it easier for engineers to write design documents, allow for better reviews, and document the expectations around changes and their design more clearly.
+
+# Motivation
+[motivation]: #motivation
 
 The current design process we're using at Materialize shows its limitations.
 Engineers write designs in Notion because it's easy to start, but we lack any established review process, and following discussions is difficult.
 Writing designs as pull-requests is perceived to be more tedious than simply writing the content in Notion.
 To address this, we analyze the current shortcomings and propose updates to the existing process.
 
-## Goals
-
-<!--
-// Enumerate the concrete goals that are in scope for the project.
--->
+# Explanation
+[explanation]: #explanation
 
 We aim at creating a design process that is lightweight, captures reviews and specific snapshots in time, is open, while providing a clear benefit to engineers.
 Let's break down these aspects.
@@ -38,29 +38,8 @@ The most important aspect is that this process provides a benefit to the enginee
 It allows to create confidence that their work fits into the overall architecture and that dependencies are surfaced.
 Additionally, a good design document serves as a point-in-time documentation, helping others understand trade-offs and seemingly odd choices.
 
-## Non-Goals
-
-<!--
-// Enumerate potential goals that are explicitly out of scope for the project
-// ie. what could we do or what do we want to do in the future - but are not doing now
--->
-
-Updating the design process does not aim at introducing an RFC-style process.
-It is something to consider in the future, but seems to be too heavyweight at the moment.
-Additionally, it would require tooling to enforce certain state transitions, which we don't have the capacity for at the moment.
-
-Notable examples for RFC-style processes follow:
-* Rust's RFC process aims at creating high-quality designs, while giving authors the confidence that they get the attention they deserve.
-  It is rather heavy-weight and has an own bot to ensure proper state transitions and to nag reviewers.
-  We can learn from it that good guidance seems to result in better design.
-* Ember's design process follows Rust's process, but is less formal.
-
-## Description
-
-<!--
-// Describe the approach in detail. If there is no clear frontrunner, feel free to list all approaches in alternatives.
-// If applicable, be sure to call out any new testing/validation that will be required
--->
+# Reference explanation
+[reference-explanation]: #reference-explanation
 
 The current design process fulfills most of the requirements outlined above.
 It is lightweight, encourages open discussions and has short review cycles.
@@ -74,19 +53,24 @@ Specifically, the current interpretation of design documents is to write one for
 Instead, we propose that each change should come with a design doc unless it is small enough to be non-contentious or immediately clear what needs to be done.
 By default, engineers should write design docs.
 
-## Alternatives
+# Conclusion and alternatives
+[conclusion-and-alternatives]: #conclusion-and-alternatives
 
-<!--
-// Similar to the Description section. List of alternative approaches considered, pros/cons or why they were not chosen
--->
+Updating the design process does not aim at introducing an RFC-style process.
+It is something to consider in the future, but seems to be too heavyweight at the moment.
+Additionally, it would require tooling to enforce certain state transitions, which we don't have the capacity for at the moment.
 
-### Design docs in Notion
+Notable examples for RFC-style processes follow:
+* Rust's RFC process aims at creating high-quality designs, while giving authors the confidence that they get the attention they deserve.
+  It is rather heavy-weight and has an own bot to ensure proper state transitions and to nag reviewers.
+  We can learn from it that good guidance seems to result in better design.
+* Ember's design process follows Rust's process, but is less formal.
 
 One alternative is to not change the current design doc process and leave it as-is, which defaults to engineers creating designs in Notion.
 The benefit is that we don't add (percieved) overhead, at the expense of the problems mentioned here.
 Specifically, it doesn't capture discussions well, and does not permit external users to understand design choices.
 
-### RFC-style process
+## RFC-style process
 
 Rust's [RFC process](https://rust-lang.github.io/rfcs/0002-rfc-process.html) demonstrates that guidelines can encourage good designs.
 It requires engineers to follow a specific set of steps to shepherd their proposals from an initial idea through reviews to a final design.
@@ -94,10 +78,14 @@ It requires engineers to follow a specific set of steps to shepherd their propos
 These steps seem to be involved, and require tooling/awareness to be carried out correctly.
 We see this as a viable alternative once the company grows further and needs to make technically difficult decisions, but it seems to heavyweight to implement it at this point.
 
-## Open questions
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
 
-<!--
-// Anything currently unanswered that needs specific focus. This section may be expanded during the doc meeting as
-// other unknowns are pointed out.
-// These questions may be technical, product, or anything in-between.
--->
+It is unclear if the changes we suggest will solve the problems around our current design document approach.
+It seems we need to try out different approaches to test if they improve the situation, and this is one of such experiments.
+
+# Future work
+[future-work]: #future-work
+
+In the future, we might want to have a more formalized design document process, where we have set of states a design needs to advance through to be approved.
+This could be supported by appropriate tooling.

--- a/doc/developer/design/20230126_designs_reviews.md
+++ b/doc/developer/design/20230126_designs_reviews.md
@@ -31,7 +31,7 @@ Capturing discussions is an important aspect to understand how an opinion was fo
 We need to capture both, and Notion doesn't give us a good way to capture discussions and specific versions.
 
 Materialize defaults to leading discussions in the open, unless it's not permissible.
-This ensures that we uphold a high standard, and it gives engineers outside visibility into their work.
+This ensures that we uphold a high standard, and it increases the visibility of each engineer's contributions.
 Designs in Notion do not achieve this goal.
 
 The most important aspect is that this process provides a benefit to the engineer and the company.
@@ -49,7 +49,7 @@ Updating the design process does not aim at introducing an RFC-style process.
 It is something to consider in the future, but seems to be too heavyweight at the moment.
 Additionally, it would require tooling to enforce certain state transitions, which we don't have the capacity for at the moment.
 
-Notable example for RFC-style processes follow:
+Notable examples for RFC-style processes follow:
 * Rust's RFC process aims at creating high-quality designs, while giving authors the confidence that they get the attention they deserve.
   It is rather heavy-weight and has an own bot to ensure proper state transitions and to nag reviewers.
   We can learn from it that good guidance seems to result in better design.
@@ -69,6 +69,10 @@ This raises the question of why we did not follow it recently.
 To address this, we propose the following steps, some of which are part of the change around this document:
 * Revisit the design doc [README](./README.md) to make expectations clearer.
 * Update the [pull request template](/.github/pull_request_template.md) to include a step reminding engineers to think about design documents.
+
+Specifically, the current interpretation of design documents is to write one for large changes, where it is not clear what large means.
+Instead, we propose that each change should come with a design doc unless it is small enough to be non-contentious or immediately clear what needs to be done.
+By default, engineers should write design docs.
 
 ## Alternatives
 

--- a/doc/developer/design/20230126_designs_reviews.md
+++ b/doc/developer/design/20230126_designs_reviews.md
@@ -1,0 +1,99 @@
+# Scaling our design process
+
+## Summary
+
+<!--
+// Brief, high-level overview. A few sentences long.
+// Be sure to capture the customer impact - framing this as a release note may be useful.
+-->
+
+The current design process we're using at Materialize shows its limitations.
+Engineers write designs in Notion because it's easy to start, but we lack any established review process, and following discussions is difficult.
+Writing designs as pull-requests is perceived to be more tedious than simply writing the content in Notion.
+To address this, we analyze the current shortcomings and propose updates to the existing process.
+
+## Goals
+
+<!--
+// Enumerate the concrete goals that are in scope for the project.
+-->
+
+We aim at creating a design process that is lightweight, captures reviews and specific snapshots in time, is open, while providing a clear benefit to engineers.
+Let's break down these aspects.
+
+A design review process needs to empower engineers to focus on the task at hands.
+It helps to talk about goals, how they fit into the product roadmap, and outline solutions.
+An engineer can present different solutions, and it's expected that new alternatives come up while working on a design.
+Explaining trade-offs helps to motivate a specific solution.
+
+Creating a design is an iterative process.
+Capturing discussions is an important aspect to understand how an opinion was formed and how designs changed during the review.
+We need to capture both, and Notion doesn't give us a good way to capture discussions and specific versions.
+
+Materialize defaults to leading discussions in the open, unless it's not permissible.
+This ensures that we uphold a high standard, and it gives engineers outside visibility into their work.
+Designs in Notion do not achieve this goal.
+
+The most important aspect is that this process provides a benefit to the engineer and the company.
+It allows to create confidence that their work fits into the overall architecture and that dependencies are surfaced.
+Additionally, a good design document serves as a point-in-time documentation, helping others understand trade-offs and seemingly odd choices.
+
+## Non-Goals
+
+<!--
+// Enumerate potential goals that are explicitly out of scope for the project
+// ie. what could we do or what do we want to do in the future - but are not doing now
+-->
+
+Updating the design process does not aim at introducing an RFC-style process.
+It is something to consider in the future, but seems to be too heavyweight at the moment.
+Additionally, it would require tooling to enforce certain state transitions, which we don't have the capacity for at the moment.
+
+Notable example for RFC-style processes follow:
+* Rust's RFC process aims at creating high-quality designs, while giving authors the confidence that they get the attention they deserve.
+  It is rather heavy-weight and has an own bot to ensure proper state transitions and to nag reviewers.
+  We can learn from it that good guidance seems to result in better design.
+* Ember's design process follows Rust's process, but is less formal.
+
+## Description
+
+<!--
+// Describe the approach in detail. If there is no clear frontrunner, feel free to list all approaches in alternatives.
+// If applicable, be sure to call out any new testing/validation that will be required
+-->
+
+The current design process fulfills most of the requirements outlined above.
+It is lightweight, encourages open discussions and has short review cycles.
+This raises the question of why we did not follow it recently.
+
+To address this, we propose the following steps, some of which are part of the change around this document:
+* Revisit the design doc [README](./README.md) to make expectations clearer.
+* Update the [pull request template](/.github/pull_request_template.md) to include a step reminding engineers to think about design documents.
+
+## Alternatives
+
+<!--
+// Similar to the Description section. List of alternative approaches considered, pros/cons or why they were not chosen
+-->
+
+### Design docs in Notion
+
+One alternative is to not change the current design doc process and leave it as-is, which defaults to engineers creating designs in Notion.
+The benefit is that we don't add (percieved) overhead, at the expense of the problems mentioned here.
+Specifically, it doesn't capture discussions well, and does not permit external users to understand design choices.
+
+### RFC-style process
+
+Rust's [RFC process](https://rust-lang.github.io/rfcs/0002-rfc-process.html) demonstrates that guidelines can encourage good designs.
+It requires engineers to follow a specific set of steps to shepherd their proposals from an initial idea through reviews to a final design.
+
+These steps seem to be involved, and require tooling/awareness to be carried out correctly.
+We see this as a viable alternative once the company grows further and needs to make technically difficult decisions, but it seems to heavyweight to implement it at this point.
+
+## Open questions
+
+<!--
+// Anything currently unanswered that needs specific focus. This section may be expanded during the doc meeting as
+// other unknowns are pointed out.
+// These questions may be technical, product, or anything in-between.
+-->

--- a/doc/developer/design/20230126_designs_reviews.md
+++ b/doc/developer/design/20230126_designs_reviews.md
@@ -51,6 +51,8 @@ To address this, we propose the following steps, some of which are part of the c
 * Revisit the design doc [README](./README.md) to make expectations clearer.
 * Update the [template](./00000000_template.md) to match what we're outlining in this design.
 * Update the [pull request template](/.github/pull_request_template.md) to include a step reminding engineers to write a design document.
+* Mark the design documents in Notion as deprecated.
+  We considered moving the design documents from Notion to GitHub, but decided against it due to the lack of rigorousness and missing discussions.
 
 Specifically, the current interpretation of design documents is to write one for large changes, where it is not clear what large means.
 Instead, we propose that each change should come with a design doc unless it is small enough to be non-contentious or immediately clear what needs to be done.

--- a/doc/developer/design/20230126_designs_reviews.md
+++ b/doc/developer/design/20230126_designs_reviews.md
@@ -1,11 +1,13 @@
 - Feature name: designs-revisited
-- Associated issues: None
-- Associated PRs: #17482
+- Associated issues and PRs: [#17482][#17482]
+
+[#17482]: https://github.com/MaterializeInc/materialize/pull/17482
 
 # Summary
 [summary]: #summary
 
-We're updating the design review process to make it easier for engineers to write design documents, allow for better reviews, and document the expectations around changes and their design more clearly.
+We're updating the design review process to make it easier for engineers to write design documents, allow for better reviews, and clearly document expectations.
+We accompany the update with refined design document requirements.
 
 # Motivation
 [motivation]: #motivation
@@ -47,8 +49,8 @@ This raises the question of why we did not follow it recently.
 
 To address this, we propose the following steps, some of which are part of the change around this document:
 * Revisit the design doc [README](./README.md) to make expectations clearer.
-* Update the [pull request template](/.github/pull_request_template.md) to include a step reminding engineers to think about design documents.
 * Update the [template](./00000000_template.md) to match what we're outlining in this design.
+* Update the [pull request template](/.github/pull_request_template.md) to include a step reminding engineers to write a design document.
 
 Specifically, the current interpretation of design documents is to write one for large changes, where it is not clear what large means.
 Instead, we propose that each change should come with a design doc unless it is small enough to be non-contentious or immediately clear what needs to be done.
@@ -62,28 +64,25 @@ It is something to consider in the future, but seems to be too heavyweight at th
 Additionally, it would require tooling to enforce certain state transitions, which we don't have the capacity for at the moment.
 
 Notable examples for RFC-style processes follow:
-* Rust's RFC process aims at creating high-quality designs, while giving authors the confidence that they get the attention they deserve.
+* Rust's [RFC process](https://rust-lang.github.io/rfcs/) aims at creating high-quality designs, while giving authors the confidence that they get the attention they deserve.
   It is rather heavy-weight and has an own bot to ensure proper state transitions and to nag reviewers.
   We can learn from it that good guidance seems to result in better design.
-* Ember's design process follows Rust's process, but is less formal.
+  Rust's [RFC process](https://rust-lang.github.io/rfcs/0002-rfc-process.html) demonstrates that guidelines can encourage good designs.
+  It requires engineers to follow a specific set of steps to shepherd their proposals from an initial idea through reviews to a final design.
+
+  These steps seem to be involved, and require tooling/awareness to be carried out correctly.
+  We see this as a viable alternative once the company grows further and needs to make technically difficult decisions, but it seems to heavyweight to implement it at this point.
+* Ember's [design process](https://rfcs.emberjs.com/) follows Rust's process, but is less formal.
 
 One alternative is to not change the current design doc process and leave it as-is, which defaults to engineers creating designs in Notion.
 The benefit is that we don't add (perceived) overhead, but at the expense of the problems mentioned here.
 Specifically, it doesn't capture discussions well, and does not permit external users to understand design choices.
 
-## RFC-style process
-
-Rust's [RFC process](https://rust-lang.github.io/rfcs/0002-rfc-process.html) demonstrates that guidelines can encourage good designs.
-It requires engineers to follow a specific set of steps to shepherd their proposals from an initial idea through reviews to a final design.
-
-These steps seem to be involved, and require tooling/awareness to be carried out correctly.
-We see this as a viable alternative once the company grows further and needs to make technically difficult decisions, but it seems to heavyweight to implement it at this point.
-
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
 It is unclear if the changes we suggest will solve the problems around our current design document approach.
-It seems we need to try out different approaches to test if they improve the situation, and this is one of such experiments.
+We belive that it is a first step into the right direction, and with more experience we can decide whether it fulfills our goals or whether we need to refine the process.
 
 # Future work
 [future-work]: #future-work

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -1,13 +1,16 @@
-# Design Document
 
-## What's the purpose of a design document?
+# What's the purpose of a design document?
 
-A design doc is a tool for the author to gather feedback on a technical
+A design doc is a tool for the author to explain and gather feedback on a technical
 decision, providing an opportunity for anything they hadn't thought of to be
 surfaced early on and to have their thinking validated. It also serves as
 historical documentation for why a thing was done a certain way. The idea is to
 go slower at the beginning and get everything out on the table so we can go
 fast when implementing.
+
+Design docs should contain enough information that a coworker could both justify and do the implementation rather than the author: this is a step along the path of transferring the work that makes it more likely "we", collectively, understand what we are looking at.
+It should record enough information that a coworker could review, diagnose, and debug the implementation of the design.
+A great design would have this property, that it acts as a map for understanding and fixing the feature, as well as implementing it.
 
 Design docs go hand in hand with a discussion meeting. Asynchronous,
 text-only communication tends to drag out the process and doesn't get the
@@ -19,7 +22,7 @@ upfront work that goes into the doc (see [template](./00000000_template.md)) to 
 meeting, and it's best if attendees have time to read and digest the doc
 prior to the meeting.
 
-Note: design doc meetings are not an approval board or review body and the
+Note that design doc meetings are not an approval board or review body and the
 process is not design by committee. The author is responsible for driving to
 a conclusion. That doesn't mean that the author is solely responsible for
 making a decision, but does mean that the author is responsible for getting
@@ -32,7 +35,7 @@ Examples:
 * [Cluster SQL API](https://github.com/MaterializeInc/materialize/pull/10680)
 * [`WITH MUTUALLY RECURSIVE`](https://github.com/MaterializeInc/materialize/pull/16445)
 
-## When should you make a design document?
+# When should you make a design document?
 
 Design docs should be written for all changes where an implementation does not immediately follow from the problem.
 Some specific times when you should write a design document:
@@ -45,26 +48,26 @@ Some specific times when you should write a design document:
 Many smaller changes do still benefit from a quick design doc to clarify thinking.
 Err on the side of writing a design document.
 
-## How should you make a design document?
+# How should you make a design document?
 
-### Creation
+## Creation
 1. Copy the [template](./00000000_template.md) to a new date-prefixed file in `doc/developer/design` and fill it in.
 2. Submit a pull request---this makes it easy for others to add written comments.
 3. Announce that the design doc is ready for review in #eng-announce.
 
-### Discussion
+## Discussion
 4. Address comments, discuss, and iterate on the document in the PR.
 5. Gather explicit approvals from relevant stakeholders.
    Typically, there is a small set of people who have a vested interest in the area the design touches.
    If it's not clear who that is, ask a TL, EM, or in #eng-general.
 6. Keep the design doc open while working on the feature and keep it updated as you're refining the design.
 
-### Finalization
+## Finalization
 6. Announce the intent to close commenting on the design document in #eng-announce.
    Tag people that should be aware of the design and ask for their feedback.
 7. Allow two business days for any final comments.
 8. If no comments have raised new issues or if no one has asked for additional time to review, merge the design document.
 
-## How should you push back on aspects of a design document?
+# How should you push back on aspects of a design document?
 
 Consult the draft [Raising an objection about a design](https://rustacean-principles.netlify.app/how_to_rustacean/show_up/raising_an_objection.html) Rustacean doc for guidance.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -3,7 +3,7 @@
 ## What's the purpose of a design document?
 
 A design doc is a tool for the author to gather feedback on a technical
-decision, providing an opportunity for anything they hadn’t thought of to be
+decision, providing an opportunity for anything they hadn't thought of to be
 surfaced early on and to have their thinking validated. It also serves as
 historical documentation for why a thing was done a certain way. The idea is to
 go slower at the beginning and get everything out on the table so we can go
@@ -13,7 +13,7 @@ Design docs go hand in hand with a discussion meeting. Asynchronous,
 text-only communication tends to drag out the process and doesn't get the
 same kind of broad feedback as having a short, in-person meeting.
 
-It’s not expected that all questions will be answered prior to the meeting,
+It's not expected that all questions will be answered prior to the meeting,
 but the meeting should not be an open-ended brainstorming process. There is
 upfront work that goes into the doc (see template) to allow for a productive
 meeting, and it's best if attendees have time to read and digest the doc
@@ -23,19 +23,19 @@ Note: design doc meetings are not an approval board or review body and the
 process is not design by committee. The author is responsible for driving to
 a conclusion. That doesn't mean that the author is solely responsible for
 making a decision, but does mean that the author is responsible for getting
-the knowledge they need to understand the space (from eg. talking to peers),
+the knowledge they need to understand the space (from e.g., talking to peers),
 ensuring that critical concerns or open questions are addressed, and
 determining at what point a good decision has been reached. Not every design
 doc will lead to complete consensus.
 
-Examples (in spirit - these were done prior to the template)
-EOS: https://github.com/MaterializeInc/materialize/issues/2915#issuecomment-729093536
-S3 sources: https://github.com/MaterializeInc/materialize/issues/4914
+Examples:
+* [Cluster SQL API](https://github.com/MaterializeInc/materialize/pull/10680)
+* [`WITH MUTUALLY RECURSIVE`](https://github.com/MaterializeInc/materialize/pull/16445)
 
 ## When should you make a design document?
 
 Some specific times when you should write a design document:
-1. If the change is large/cross-cutting, eg. will be spread over multiple PRs
+1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs
 2. If the change will take more than a week to implement or will proceed in phases that need clearly delimited scope
 3. If there are multiple alternative implementations and no clear best option
 4. If it's going to involve multiple people coordinating changes
@@ -48,15 +48,18 @@ thinking. Err on the side of writing a design document.
 
 ### Creation
 1. Copy the template to a new date-prefixed file in `doc/developer/design` and fill it in.
-2. Submit a pull request - this makes it easy for others to add written comments.
+2. Submit a pull request---this makes it easy for others to add written comments.
 3. Announce that the design doc is ready for review in #eng-announce.
 
 ### Discussion
-4. Address comments, discuss, and iterate on the document in the PR
-5. Gather explicit approvals from relevant stakeholders. Typically there is a small set of people who have a vested interest in the area the design touches. If it's not clear who that is, ask a TL, EM, or in #engineering.
+4. Address comments, discuss, and iterate on the document in the PR.
+5. Gather explicit approvals from relevant stakeholders.
+   Typically, there is a small set of people who have a vested interest in the area the design touches.
+   If it's not clear who that is, ask a TL, EM, or in #engineering.
 
 ### Finalization
 6. Announce the intent to close commenting on the design document in #eng-announce.
+   Tag people that should be aware of the design and ask for their feedback.
 7. Allow two business days for any final comments.
 8. If no comments have raised new issues or if no one has asked for additional time to review, merge the design document.
 

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -56,6 +56,7 @@ thinking. Err on the side of writing a design document.
 5. Gather explicit approvals from relevant stakeholders.
    Typically, there is a small set of people who have a vested interest in the area the design touches.
    If it's not clear who that is, ask a TL, EM, or in #eng-general.
+6. Keep the design doc open while working on the feature and keep it updated as you're refining the design.
 
 ### Finalization
 6. Announce the intent to close commenting on the design document in #eng-announce.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -55,7 +55,7 @@ thinking. Err on the side of writing a design document.
 4. Address comments, discuss, and iterate on the document in the PR.
 5. Gather explicit approvals from relevant stakeholders.
    Typically, there is a small set of people who have a vested interest in the area the design touches.
-   If it's not clear who that is, ask a TL, EM, or in #engineering.
+   If it's not clear who that is, ask a TL, EM, or in #eng-general.
 
 ### Finalization
 6. Announce the intent to close commenting on the design document in #eng-announce.

--- a/doc/developer/design/README.md
+++ b/doc/developer/design/README.md
@@ -15,7 +15,7 @@ same kind of broad feedback as having a short, in-person meeting.
 
 It's not expected that all questions will be answered prior to the meeting,
 but the meeting should not be an open-ended brainstorming process. There is
-upfront work that goes into the doc (see template) to allow for a productive
+upfront work that goes into the doc (see [template](./00000000_template.md)) to allow for a productive
 meeting, and it's best if attendees have time to read and digest the doc
 prior to the meeting.
 
@@ -34,20 +34,21 @@ Examples:
 
 ## When should you make a design document?
 
+Design docs should be written for all changes where an implementation does not immediately follow from the problem.
 Some specific times when you should write a design document:
-1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs
-2. If the change will take more than a week to implement or will proceed in phases that need clearly delimited scope
-3. If there are multiple alternative implementations and no clear best option
-4. If it's going to involve multiple people coordinating changes
-5. If it changes a customer-facing/public API, or a major private API (for example, the API for implementing new sinks)
+1. If the change is large/cross-cutting, e.g., will be spread over multiple PRs.
+2. If the change will take more than a week to implement or will proceed in phases that need clearly delimited scope.
+3. If there are multiple alternative implementations and no clear best option.
+4. If it's going to involve multiple people coordinating changes.
+5. If it changes a customer-facing/public API, or a major private API (for example, the API for implementing new sinks).
 
-Many smaller changes do still benefit from a quick design doc to clarify
-thinking. Err on the side of writing a design document.
+Many smaller changes do still benefit from a quick design doc to clarify thinking.
+Err on the side of writing a design document.
 
 ## How should you make a design document?
 
 ### Creation
-1. Copy the template to a new date-prefixed file in `doc/developer/design` and fill it in.
+1. Copy the [template](./00000000_template.md) to a new date-prefixed file in `doc/developer/design` and fill it in.
 2. Submit a pull request---this makes it easy for others to add written comments.
 3. Announce that the design doc is ready for review in #eng-announce.
 


### PR DESCRIPTION
Update the design doc process.

### Motivation

The current design doc process amounts to "no process," which is not a great place to be in. In this design doc revamp, I try to consolidate different threads and suggest that we move design docs back to Git.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
