### PR TITLE
sqllogictest: Add explicit test for TRIM BOTH (fixes #17472)

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -355,7 +355,7 @@
     description: Substring starting at `start_pos` of length `l`
     url: substring
 
-  - signature: "trim([BOTH | LEADING | TRAILING]? 'c'? FROM 's') -> str"
+  - signature: "trim([BOTH | LEADING | TRAILING]? ['c'? FROM]? 's') -> str"
     description: "Trims any character in `c` from `s` on the specified side.<br/><br/>Defaults:<br/>
       &bull; Side: `BOTH`<br/>
       &bull; `'c'`: `' '` (space)"

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -664,6 +664,11 @@ SELECT trim('xy' FROM 'yxytrimyxy');
 trim
 
 query T
+SELECT trim(BOTH 'xy' FROM 'yxytrimyxy');
+----
+trim
+
+query T
 SELECT trim(TRAILING FROM 'yxytrimyxy  ');
 ----
 yxytrimyxy
@@ -674,7 +679,17 @@ SELECT trim(FROM '  yxytrimyxy  ');
 yxytrimyxy
 
 query T
+SELECT trim(BOTH FROM '  yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
 SELECT trim('   yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
+SELECT trim(BOTH '   yxytrimyxy  ');
 ----
 yxytrimyxy
 


### PR DESCRIPTION
Was not tested explicitly before, but only implicitly since it is the default

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
