### PR TITLE
compute: log frontiers of subscribes

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -53,7 +53,7 @@ pub enum ComputeEvent {
     },
     /// Peek command, true for install and false for retire.
     Peek(Peek, bool),
-    /// Available frontier information for views.
+    /// Available frontier information for dataflow exports.
     Frontier(GlobalId, Timestamp, i64),
     // Available frontier information for source instantiations.
     SourceFrontier(GlobalId, GlobalId, Timestamp, i8),

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -138,3 +138,13 @@ true
 
 ! SELECT * FROM mz_internal.mz_active_peeks AS OF 0
 contains: Timestamp (0) is not valid for all inputs
+
+# Test that logged subscribe frontiers advance beyond 0.
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE (SELECT true FROM mz_internal.mz_compute_frontiers WHERE export_id LIKE 't%' AND time > 0)
+> FETCH 1 c WITH (timeout='5s');
+<TIMESTAMP> 1 true
+> COMMIT


### PR DESCRIPTION
This PR adds logging for export frontiers of subscribe dataflows. This has the effect that `mz_compute_frontiers` shows a useful value instead of `0` for subscribe dataflows.

### Motivation

  * This PR fixes a recognized bug.

Fixes #15246.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Make `mz_internal.mz_compute_frontiers` show correct frontier values for `SUBSCRIBE` dataflows, instead of `0`.

