### PR TITLE
Wire up upsert primary key errors as dataflow errors

### DIFF
--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -23,7 +23,6 @@ use once_cell::sync::Lazy;
 use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
 
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::CollectionExt;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, Row, RowPacker, ScalarType};
 
 use crate::avro::DiffPair;
@@ -159,13 +158,14 @@ pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) {
     }
 }
 
-pub fn upsert_format(dps: Vec<DiffPair<Row>>, sink_id: GlobalId, from: GlobalId) -> Option<Row> {
-    let dp = dps.expect_element(|| {
-        format!(
-            "primary key error: expected at most one update per key and timestamp \
-          This can happen when the configured sink key is not a primary key of \
-          the sinked relation: sink {sink_id} created from {from}."
-        )
-    });
-    dp.after
+pub fn upsert_format(
+    dps: Vec<DiffPair<Row>>,
+    sink_id: GlobalId,
+    from: GlobalId,
+) -> Result<Option<Row>, String> {
+    let mut iter = dps.into_iter();
+    match (iter.next(), iter.next()) {
+        (Some(el), None) => Ok(el.after),
+        _ => Err(format!("primary key error: expected at most one update per key and timestamp. This can happen when the configured sink key is not a primary key of the sinked relation: sink {sink_id} created from {from}.")),
+    }
 }


### PR DESCRIPTION
### Motivation

I've seen this in [Sentry](https://materializeinc.sentry.io/issues/3866486493) a bunch and wonder if explicitly handling the problem might be more elegant. I don't intend to merge the PR as it is, but would rather like someone from the Storage team to take over :)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
