### PR TITLE
storage: stop processing once we commit the empty frontier

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -488,7 +488,7 @@ where
                 // This future is not cancel safe but we are only passing a reference to it in the
                 // select! loop so the future stays on the stack and never gets cancelled until the
                 // end of the function.
-                _ = offset_commit_loop.as_mut() => {},
+                _ = offset_commit_loop.as_mut() => break,
             }
         }
     });


### PR DESCRIPTION
### Motivation

Fix reported panics in the nightly tests:

```
zippy-storaged-1         | thread 'timely:work-0' panicked at '`async fn` resumed after completion', /var/lib/buildkite-agent/builds/buildkite-builders-d43b1b5-i-0f05bd368667f1391-1/materialize/tests/src/storage/src/source/source_reader_pipeline.rs:381:34
zippy-storaged-1         | stack backtrace:
zippy-storaged-1         | 2023-02-02T23:19:53.722868Z  INFO mz_storage::source::kafka: kafka metadata thread: partition info has been dropped; shutting down. source_id="u116" worker_id=3 num_workers=4
zippy-storaged-1         |    0: rust_begin_unwind
zippy-storaged-1         |              at ./rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/std/src/panicking.rs:575:5
zippy-storaged-1         |    1: core::panicking::panic_fmt
zippy-storaged-1         |              at ./rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/panicking.rs:64:14
zippy-storaged-1         |    2: core::panicking::panic
zippy-storaged-1         |              at ./rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/panicking.rs:111:5
zippy-storaged-1         |    3: mz_storage::source::source_reader_pipeline::source_reader_operator::
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
