### PR TITLE
dbt-materialize: release v1.4.0

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## 1.4.0 - 2023-02-02
+## 1.4.0 - 2023-02-03
 
 * Upgrade to `dbt-postgres` v1.4.0.
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dbt-materialize Changelog
 
+## 1.4.0 - 2023-02-02
+
+* Upgrade to `dbt-postgres` v1.4.0.
+
 ## 1.3.4 - 2023-01-19
 
 * Fix a bug where the adapter would fail if the pre-installed `default` cluster

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.3.4"
+version = "1.4.0"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.3.4",
+    version="1.4.0",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
@@ -39,8 +39,8 @@ setup(
             "include/materialize/macros/**/*.sql",
         ]
     },
-    install_requires=["dbt-postgres~=1.3.0"],
+    install_requires=["dbt-postgres~=1.4.0"],
     extras_require={
-        "dev": ["dbt-tests-adapter~=1.3.0"],
+        "dev": ["dbt-tests-adapter~=1.4.0"],
     },
 )

--- a/misc/dbt-materialize/tests/adapter/test_utils.py
+++ b/misc/dbt-materialize/tests/adapter/test_utils.py
@@ -19,7 +19,9 @@ from dbt.tests.adapter.utils.fixture_cast_bool_to_text import (
     models__test_cast_bool_to_text_yml,
 )
 from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
+from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampAware
 from dbt.tests.adapter.utils.test_listagg import BaseListagg
+from dbt.tests.adapter.utils.test_timestamps import BaseCurrentTimestamps
 
 models__test_cast_bool_to_text_sql = """
 with data_bool as (
@@ -60,4 +62,23 @@ class TestCastBoolToText(BaseCastBoolToText):
 
 @pytest.mark.skip(reason="Materialize supports the list_agg() function")
 class TestListagg(BaseListagg):
+    pass
+
+
+# Materialize implements `timestamp`, which is an equivalent abbreviation for
+# `timestamp without timezone` (as required by the SQL standard)
+# See https://www.postgresql.org/docs/current/datatype-datetime.html
+class TestCurrentTimestamps(BaseCurrentTimestamps):
+    @pytest.fixture(scope="class")
+    def expected_schema(self):
+        return {
+            "current_timestamp": "timestamp with time zone",
+            "current_timestamp_in_utc_backcompat": "timestamp",
+            "current_timestamp_backcompat": "timestamp",
+        }
+
+    pass
+
+
+class TestCurrentTimestamp(BaseCurrentTimestampAware):
     pass


### PR DESCRIPTION
Closes #17258, closes #17500.

## Notes for reviewer

* The timestamp consolidation work ended up boiling down to just adding the `TestCurrentTimestamp` and `TestCurrentTimestamps` tests.
* Not including the `TestChangeRelationTypes` test since it provides redundant test coverage (see [this discussion](https://getdbt.slack.com/archives/C030A0UF5LM/p1674349920711339)). We can replace the older test with the newer one if it's deprecated at some point.