### PR TITLE
Platform checks: Add ESCAPE to LIKE/ILIKE (part of #17471)

### DIFF
--- a/misc/python/materialize/checks/like.py
+++ b/misc/python/materialize/checks/like.py
@@ -20,8 +20,8 @@ class Like(Check):
         return Testdrive(
             dedent(
                 """
-            > CREATE TABLE like_regex_table (f1 STRING, f2 STRING);
-            > INSERT INTO like_regex_table VALUES ('abc', 'abc');
+            > CREATE TABLE like_regex_table (f1 STRING, f2 STRING, f3 STRING, f4 STRING);
+            > INSERT INTO like_regex_table VALUES ('abc', 'abc', 'a~%', '~');
             """
             )
         )
@@ -31,12 +31,12 @@ class Like(Check):
             Testdrive(dedent(s))
             for s in [
                 """
-                > CREATE MATERIALIZED VIEW like_regex_view1 AS SELECT f1 LIKE f2 AS c1, f1 ILIKE f2 AS c2, f1 LIKE 'x_z' AS c3, f1 ILIKE 'a_c' AS c4 FROM like_regex_table;
-                > INSERT INTO like_regex_table VALUES ('klm', 'klm');
+                > CREATE MATERIALIZED VIEW like_regex_view1 AS SELECT f1 LIKE f2 AS c1, f1 ILIKE f2 AS c2, f1 LIKE 'x_z' AS c3, f1 ILIKE 'a_c' AS c4, f1 LIKE 'a~%' ESCAPE '~' AS c5, f1 LIKE f3 ESCAPE '~' AS c6, f1 LIKE f3 ESCAPE f4 AS c7 FROM like_regex_table;
+                > INSERT INTO like_regex_table VALUES ('klm', 'klm', 'k_m', 'k');
             """,
                 """
-                > CREATE MATERIALIZED VIEW like_regex_view2 AS SELECT f1 LIKE f2 AS c1, f1 ILIKE f2 AS c2, f1 LIKE 'x_z' AS c3, f1 ILIKE 'a_c' AS c4 FROM like_regex_table;
-                > INSERT INTO like_regex_table VALUES ('xyz', 'xyz');
+                > CREATE MATERIALIZED VIEW like_regex_view2 AS SELECT f1 LIKE f2 AS c1, f1 ILIKE f2 AS c2, f1 LIKE 'x_z' AS c3, f1 ILIKE 'a_c' AS c4, f1 LIKE 'a~%' ESCAPE '~' AS c5, f1 LIKE f3 ESCAPE '~' AS c6, f1 LIKE f3 ESCAPE f4 AS c7 FROM like_regex_table;
+                > INSERT INTO like_regex_table VALUES ('xyz', 'xyz', 'x_%', '_');
             """,
             ]
         ]
@@ -46,14 +46,14 @@ class Like(Check):
             dedent(
                 """
             > SELECT * FROM like_regex_view1;
-            true true false true
-            true true false false
-            true true true false
+            true true false true false false false
+            true true false false false true false
+            true true true false false true false
 
             > SELECT * FROM like_regex_view2;
-            true true false true
-            true true false false
-            true true true false
+            true true false true false false false
+            true true false false false true false
+            true true true false false true false
             """
             )
         )


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
