### PR TITLE
test: small visibility cleanup

### DIFF
--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -377,9 +377,9 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
 pub struct Server {
     pub inner: mz_environmentd::Server,
     pub runtime: Arc<Runtime>,
-    _temp_dir: Option<TempDir>,
     pub metrics_registry: MetricsRegistry,
-    pub _tracing_guard: Option<TracingGuard>,
+    _temp_dir: Option<TempDir>,
+    _tracing_guard: Option<TracingGuard>,
 }
 
 impl Server {


### PR DESCRIPTION
### Motivation
This PR makes a tiny change to the visibility of a struct field that was introduced in #17458. @benesch [pointed out](https://github.com/MaterializeInc/materialize/pull/17458#discussion_r1094730468) that fields shouldn't be marked as `pub` and prefixed with `_`, as `pub` suggests the field will be used where `_` suggests the field will not.

FWIW I opened https://github.com/rust-lang/rust-clippy/pull/10283 to make this an official Clippy lint

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a