### PR TITLE
Remove panic from reduce collation

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -306,7 +306,7 @@ where
     G: Scope,
     G::Timestamp: Lattice,
 {
-    // we must have more than one arrangement to collate
+    // We must have more than one arrangement to collate.
     if arrangements.len() <= 1 {
         warn!("Building a collation of {} arrangements, but expected more than one in dataflow {debug_name}",
             arrangements.len());
@@ -324,6 +324,13 @@ where
             arrangement.as_collection(move |key, val| (key.clone(), (reduction_type, val.clone())));
         to_concat.push(collection);
     }
+
+    // For each key above, we need to have exactly as many rows as there are distinct
+    // reduction types required by `aggregate_types`. We thus prepare here a properly
+    // deduplicated version of `aggregate_types` for validation during processing below.
+    let mut distinct_aggregate_types = aggregate_types.clone();
+    distinct_aggregate_types.sort_unstable();
+    distinct_aggregate_types.dedup();
 
     let debug_name = debug_name.to_string();
     use differential_dataflow::collection::concatenate;
@@ -345,42 +352,69 @@ where
 
                 // We expect not to have any negative multiplicities, but are not 100% sure it will
                 // never happen so for now just log an error if it does.
-                for (val, cnt) in input.iter() {
-                    if *cnt < 0 {
-                        warn!("[customer-data] Negative accumulation in ReduceCollation: {val:?} with count {cnt:?} in dataflow {debug_name}");
-                        soft_assert_or_log!(false, "Negative accumulation in ReduceCollation");
+                if input.iter().any(|(_val, cnt)| cnt < &0) {
+                    for (val, cnt) in input.iter() {
+                        // XXX: This reports user data, which we perhaps should not do!
+                        if *cnt < 0 {
+                            warn!("[customer-data] Negative accumulation for key {key:?} in ReduceCollation: {val:?} with count {cnt:?} in dataflow {debug_name}");
+                            soft_assert_or_log!(false, "Negative accumulation for key in ReduceCollation");
+                        }
                     }
-                }
+                } else if input.len() == distinct_aggregate_types.len() {
+                    for ((reduction_type, row), _) in input.iter() {
+                        match reduction_type {
+                            ReductionType::Accumulable => {
+                                accumulable = row.iter();
+                            }
+                            ReductionType::Hierarchical => {
+                                hierarchical = row.iter();
+                            }
+                            ReductionType::Basic => {
+                                basic = row.iter();
+                            }
+                        }
+                    }
 
-                for ((reduction_type, row), _) in input.iter() {
-                    match reduction_type {
-                        ReductionType::Accumulable => {
-                            accumulable = row.iter();
-                        }
-                        ReductionType::Hierarchical => {
-                            hierarchical = row.iter();
-                        }
-                        ReductionType::Basic => {
-                            basic = row.iter();
+                    // Merge results into the order they were asked for.
+                    let mut row_packer = row_buf.packer();
+                    let mut reconstruction_ok = true;
+                    for typ in aggregate_types.iter() {
+                        let datum = match typ {
+                            ReductionType::Accumulable => accumulable.next(),
+                            ReductionType::Hierarchical => hierarchical.next(),
+                            ReductionType::Basic => basic.next(),
+                        };
+                        if let Some(datum) = datum {
+                            row_packer.push(datum);
+                        } else {
+                            // We cannot properly reconstruct a row if aggregates are missing.
+                            // This situation is not expected, so we log an error if it occurs.
+                            reconstruction_ok = false;
+                            warn!("[customer-data] Missing {typ:?} value for key in ReduceCollation: {key} in dataflow {debug_name}");
+                            soft_assert_or_log!(false, "Missing value for key in ReduceCollation");
                         }
                     }
-                }
-
-                // Merge results into the order they were asked for.
-                let mut row_packer = row_buf.packer();
-                for typ in aggregate_types.iter() {
-                    let datum = match typ {
-                        ReductionType::Accumulable => accumulable.next(),
-                        ReductionType::Hierarchical => hierarchical.next(),
-                        ReductionType::Basic => basic.next(),
-                    };
-                    if let Some(datum) = datum {
-                        row_packer.push(datum);
-                    } else {
-                        panic!("[customer-data] Missing {typ:?} value for key: {key} in dataflow {debug_name}");
+                    // If we did not have enough values to stitch together, then we do not
+                    // generate an output row. Not outputting here corresponds to the semantics
+                    // of an equi-join on the key, similarly to the proposal in PR #17013.
+                    if reconstruction_ok {
+                        // Note that we also do not want to have anything left over to stich.
+                        // If we do, then we also have an error and would violate join semantics.
+                        if accumulable.next() == None && hierarchical.next() == None && basic.next() == None {
+                            output.push((row_buf.clone(), 1));
+                        } else {
+                            warn!("[customer-data] Found excessively large row for key in ReduceCollation: {key} in dataflow {debug_name}");
+                            soft_assert_or_log!(false, "Rows too large for key in ReduceCollation");
+                        }
                     }
+                } else {
+                    // We expected to stitch together exactly as many aggregate types
+                    // as requested by the collation. If we cannot, we log an error and
+                    // produce no output for this key.
+                    warn!("[customer-data] Aggregates in input differ ({}) from requested ({}) for key in ReduceCollation: {key} in dataflow {debug_name}",
+                        input.len(), distinct_aggregate_types.len());
+                    soft_assert_or_log!(false, "Mismatched aggregates for key in ReduceCollation");
                 }
-                output.push((row_buf.clone(), 1));
             }
         })
 }


### PR DESCRIPTION
This PR removes the panic call in the rendering of a reduce collation, which would be triggered if wrong input data were presented to the collation reduction operator. Instead, the strategy now adopted makes the reduce collation behave like other aggregates currently do: Upon being presented invalid accumulations or data, the operator reports an error to the logs and produces best-effort query results by ignoring the invalid input data.

The PR also includes a regression test for the panic, which checks the logs of the compute replica for an appropriate error. To make the regression test ignore soft assertions, however, it was necessary to make an adaptation to the service configuration in the testing framework.

Fixes #15496.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/15496

### Tips for reviewer

Note that this PR is not intended to resolve the ongoing discussion of how to handle invalid accumulations in reductions ([Slack thread](https://materializeinc.slack.com/archives/CM7ATT65S/p1675355385487949), [tracking issue](https://github.com/MaterializeInc/materialize/issues/17178)). Rather, the PR addresses inconsistent behavior in the rendering of a reduce collation and the rendering of other aggregates, which log errors and suppress invalid data instead of causing a crash. Additionally, there seems to be some consensus that avoiding panics in these situations is desirable. 

Note that the code now tries to protect against the following: (a) Negative multiplicities; (b) Mismatched numbers or types of aggregates presented to the collation; (c) Rows that contain more aggregate values than requested by the reduce collation. When these conditions are observed, errors are logged and output is not produced. 

Note that this PR gets the behavior of the reduce collation to match more closely the join semantics advocated in PR https://github.com/MaterializeInc/materialize/pull/17013. Until we remove the reduce collation, however, fixing the present code seems to be an appropriate interim measure.

I would suggest omitting whitespace when looking at the changes.

The test scenario is the repro in https://github.com/MaterializeInc/materialize/issues/15496#issuecomment-1415766444.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
  A test has been added to validate the absence of the previous panic.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
N/A
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A