### PR TITLE
explain: various simplifications

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -29,10 +29,10 @@ use mz_expr::{
     EvalError, Id, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::cast::CastFrom;
-use mz_ore::str::Indent;
 use mz_ore::str::StrExt;
+use mz_ore::str::{separated, Indent};
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::explain::text::{fmt_text_constant_rows, separated_text, DisplayText};
+use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{CompactScalarSeq, ExprHumanizer, Indices};
 use mz_repr::{Diff, GlobalId, RelationType, Row};
 
@@ -114,7 +114,7 @@ where
                     *ctx.as_mut() += 1;
                 }
                 if !filter.is_empty() {
-                    let predicates = separated_text(" AND ", filter);
+                    let predicates = separated(" AND ", filter);
                     writeln!(f, "{}Filter {}", ctx.as_mut(), predicates)?;
                     *ctx.as_mut() += 1;
                 }

--- a/src/adapter/src/explain/fast_path/mod.rs
+++ b/src/adapter/src/explain/fast_path/mod.rs
@@ -7,12 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for FastPathPlan structures.
+//! `EXPLAIN` support for [`FastPathPlan`].
 
 use std::collections::BTreeMap;
 
 use mz_expr::explain::ExplainMultiPlan;
-use mz_repr::explain::{AnnotatedPlan, Explain, ExplainConfig, ExplainError, UnsupportedFormat};
+use mz_repr::explain::{AnnotatedPlan, Explain, ExplainError, UnsupportedFormat};
 
 use crate::coord::peek::FastPathPlan;
 
@@ -27,19 +27,11 @@ impl<'a> Explain<'a> for Explainable<'a, FastPathPlan> {
 
     type Dot = UnsupportedFormat;
 
-    fn explain_text(
-        &'a mut self,
-        _config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
         self.as_explain_multi_plan(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        _config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
         self.as_explain_multi_plan(context)
     }
 }

--- a/src/adapter/src/explain/hir/mod.rs
+++ b/src/adapter/src/explain/hir/mod.rs
@@ -9,7 +9,7 @@
 
 //! `EXPLAIN` support for HIR structures.
 
-use mz_repr::explain::{Explain, ExplainConfig, ExplainError};
+use mz_repr::explain::{Explain, ExplainError};
 use mz_sql::plan::HirRelationExpr;
 
 use super::Explainable;
@@ -23,27 +23,15 @@ impl<'a> Explain<'a> for Explainable<'a, HirRelationExpr> {
 
     type Dot = <HirRelationExpr as Explain<'a>>::Dot;
 
-    fn explain_text(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.0.explain_text(config, context)
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.0.explain_text(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Json, ExplainError> {
-        self.0.explain_json(config, context)
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Json, ExplainError> {
+        self.0.explain_json(context)
     }
 
-    fn explain_dot(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Dot, ExplainError> {
-        self.0.explain_dot(config, context)
+    fn explain_dot(&'a mut self, context: &'a Self::Context) -> Result<Self::Dot, ExplainError> {
+        self.0.explain_dot(context)
     }
 }

--- a/src/adapter/src/explain/lir/mod.rs
+++ b/src/adapter/src/explain/lir/mod.rs
@@ -11,7 +11,7 @@
 
 use mz_compute_client::plan::Plan;
 use mz_compute_client::types::dataflows::DataflowDescription;
-use mz_repr::explain::{Explain, ExplainConfig, ExplainError};
+use mz_repr::explain::{Explain, ExplainError};
 
 use super::Explainable;
 
@@ -24,27 +24,15 @@ impl<'a> Explain<'a> for Explainable<'a, DataflowDescription<Plan>> {
 
     type Dot = <DataflowDescription<Plan> as Explain<'a>>::Dot;
 
-    fn explain_text(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.0.explain_text(config, context)
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.0.explain_text(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Json, ExplainError> {
-        self.0.explain_json(config, context)
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Json, ExplainError> {
+        self.0.explain_json(context)
     }
 
-    fn explain_dot(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Dot, ExplainError> {
-        self.0.explain_dot(config, context)
+    fn explain_dot(&'a mut self, context: &'a Self::Context) -> Result<Self::Dot, ExplainError> {
+        self.0.explain_dot(context)
     }
 }

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -9,11 +9,10 @@
 
 //! Tracing utilities for explainable plans.
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 use mz_compute_client::{plan::Plan, types::dataflows::DataflowDescription};
 use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
-use mz_repr::explain::text::{text_string, DisplayText};
 use mz_repr::explain::tracing::{PlanTrace, TraceEntry};
 use mz_repr::explain::{Explain, ExplainConfig, ExplainError, ExplainFormat};
 use mz_sql::plan::{HirRelationExpr, HirScalarExpr};
@@ -185,7 +184,7 @@ impl OptimizerTrace {
     fn drain_scalar_entries<T>(&self) -> Vec<TraceEntry<String>>
     where
         T: Clone + Debug + 'static,
-        T: DisplayText,
+        T: Display,
     {
         if let Some(trace) = self.0.downcast_ref::<PlanTrace<T>>() {
             trace
@@ -195,7 +194,7 @@ impl OptimizerTrace {
                     instant: entry.instant,
                     duration: entry.duration,
                     path: entry.path,
-                    plan: text_string(&entry.plan),
+                    plan: entry.plan.to_string(),
                 })
                 .collect()
         } else {

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -112,7 +112,7 @@ impl OptimizerTrace {
         };
         let fast_path_plan = match fast_path_plan {
             Some(mut plan) if !context.config.no_fast_path => {
-                Some(Explainable::new(&mut plan).explain(&format, context.config, &context)?)
+                Some(Explainable::new(&mut plan).explain(&format, &context)?)
             }
             _ => None,
         };
@@ -172,11 +172,7 @@ impl OptimizerTrace {
                         instant: entry.instant,
                         duration: entry.duration,
                         path: entry.path,
-                        plan: Explainable::new(&mut entry.plan).explain(
-                            format,
-                            context.config,
-                            context,
-                        )?,
+                        plan: Explainable::new(&mut entry.plan).explain(format, context)?,
                     }),
                 })
                 .collect()

--- a/src/compute-client/src/explain/mod.rs
+++ b/src/compute-client/src/explain/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for LIR structures.
+//! `EXPLAIN` support for structures defined in this crate.
 
 pub(crate) mod text;
 
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 
 use mz_expr::explain::{enforce_linear_chains, ExplainContext, ExplainMultiPlan};
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
-use mz_repr::explain::{AnnotatedPlan, Explain, ExplainConfig, ExplainError, UnsupportedFormat};
+use mz_repr::explain::{AnnotatedPlan, Explain, ExplainError, UnsupportedFormat};
 
 use crate::plan::Plan;
 use crate::types::dataflows::DataflowDescription;
@@ -29,27 +29,18 @@ impl<'a> Explain<'a> for DataflowDescription<Plan> {
 
     type Dot = UnsupportedFormat;
 
-    fn explain_text(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.as_explain_multi_plan(config, context)
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.as_explain_multi_plan(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.as_explain_multi_plan(config, context)
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.as_explain_multi_plan(context)
     }
 }
 
 impl<'a> DataflowDescription<Plan> {
     fn as_explain_multi_plan(
         &'a mut self,
-        _config: &'a ExplainConfig,
         context: &'a ExplainContext<'a>,
     ) -> Result<ExplainMultiPlan<'a, Plan>, ExplainError> {
         let plans = self
@@ -100,27 +91,18 @@ impl<'a> Explain<'a> for DataflowDescription<OptimizedMirRelationExpr> {
 
     type Dot = UnsupportedFormat;
 
-    fn explain_text(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.as_explain_multi_plan(config, context)
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.as_explain_multi_plan(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.as_explain_multi_plan(config, context)
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.as_explain_multi_plan(context)
     }
 }
 
 impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
     fn as_explain_multi_plan(
         &'a mut self,
-        config: &'a ExplainConfig,
         context: &'a ExplainContext<'a>,
     ) -> Result<ExplainMultiPlan<'a, MirRelationExpr>, ExplainError> {
         let plans = self
@@ -129,8 +111,8 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
             .rev()
             .map(|build_desc| {
                 // normalize the representation as linear chains
-                // (this implies !config.raw_plans by construction)
-                if config.linear_chains {
+                // (this implies !context.config.raw_plans by construction)
+                if context.config.linear_chains {
                     enforce_linear_chains(build_desc.plan.as_inner_mut())?;
                 };
 

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -567,16 +567,12 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for AccumulablePlan {
         // simple_aggrs
         for (i, (i_aggs, i_datum, agg)) in self.simple_aggrs.iter().enumerate() {
             write!(f, "{}simple_aggrs[{}]=", ctx.indent, i)?;
-            write!(f, "({}, {}, ", i_aggs, i_datum)?;
-            agg.fmt_text(f, &mut ())?;
-            writeln!(f, ")")?;
+            write!(f, "({}, {}, {})", i_aggs, i_datum, agg)?;
         }
         // distinct_aggrs
         for (i, (i_aggs, i_datum, agg)) in self.distinct_aggrs.iter().enumerate() {
             write!(f, "{}distinct_aggrs[{}]=", ctx.indent, i)?;
-            write!(f, "({}, {}, ", i_aggs, i_datum)?;
-            agg.fmt_text(f, &mut ())?;
-            writeln!(f, ")")?;
+            write!(f, "({}, {}, {})", i_aggs, i_datum, agg)?;
         }
         Ok(())
     }
@@ -616,15 +612,11 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for BasicPlan {
     ) -> fmt::Result {
         match self {
             BasicPlan::Single(idx, agg) => {
-                write!(f, "{}aggr=[({}, ", ctx.indent, idx)?;
-                agg.fmt_text(f, &mut ())?;
-                writeln!(f, ")")?;
+                write!(f, "{}aggr=({}, {})", ctx.indent, idx, agg)?;
             }
             BasicPlan::Multiple(aggs) => {
                 for (i, (i_datum, agg)) in aggs.iter().enumerate() {
-                    write!(f, "{}aggrs[{}]=({}, ", ctx.indent, i, i_datum)?;
-                    agg.fmt_text(f, &mut ())?;
-                    writeln!(f, ")")?;
+                    write!(f, "{}aggrs[{}]=({}, {})", ctx.indent, i, i_datum, agg)?;
                 }
             }
         }

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -71,7 +71,10 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 // Resolve the id as a string.
                 let id = match id {
                     Id::Local(id) => id.to_string(),
-                    Id::Global(id) => ctx.humanizer.humanize_id(*id).ok_or(fmt::Error)?,
+                    Id::Global(id) => ctx
+                        .humanizer
+                        .humanize_id(*id)
+                        .unwrap_or_else(|| id.to_string()),
                 };
                 // Render plan-specific fields.
                 use crate::plan::GetPlan;

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -158,7 +158,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                             writeln!(f, "{}input_val={}", ctx.indent, val)?;
                         }
                     }
-                    input.as_ref().fmt_text(f, ctx)
+                    input.fmt_text(f, ctx)
                 })?;
             }
             FlatMap {
@@ -176,7 +176,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         let key = CompactScalarSeq(key);
                         writeln!(f, "{}input_key={}", ctx.indent, key)?;
                     }
-                    input.as_ref().fmt_text(f, ctx)
+                    input.fmt_text(f, ctx)
                 })?;
             }
             Join { inputs, plan } => {
@@ -246,7 +246,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         let key = CompactScalarSeq(key);
                         writeln!(f, "{}input_key={}", ctx.indent, key)?;
                     }
-                    input.as_ref().fmt_text(f, ctx)
+                    input.fmt_text(f, ctx)
                 })?;
             }
             TopK { input, top_k_plan } => {
@@ -296,11 +296,11 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     }
                 }
                 writeln!(f)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Negate { input } => {
                 writeln!(f, "{}Negate", ctx.indent)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Threshold {
                 input,
@@ -319,7 +319,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         writeln!(f, " ensure_arrangement={}", ensure_arrangement)?;
                     }
                 };
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Union { inputs } => {
                 writeln!(f, "{}Union", ctx.indent)?;
@@ -345,7 +345,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                     input_mfp.fmt_text(f, ctx)?;
                     forms.fmt_text(f, ctx)?;
                     // Render input
-                    input.as_ref().fmt_text(f, ctx)
+                    input.fmt_text(f, ctx)
                 })?;
             }
         }
@@ -567,12 +567,12 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for AccumulablePlan {
         // simple_aggrs
         for (i, (i_aggs, i_datum, agg)) in self.simple_aggrs.iter().enumerate() {
             write!(f, "{}simple_aggrs[{}]=", ctx.indent, i)?;
-            write!(f, "({}, {}, {})", i_aggs, i_datum, agg)?;
+            writeln!(f, "({}, {}, {})", i_aggs, i_datum, agg)?;
         }
         // distinct_aggrs
         for (i, (i_aggs, i_datum, agg)) in self.distinct_aggrs.iter().enumerate() {
             write!(f, "{}distinct_aggrs[{}]=", ctx.indent, i)?;
-            write!(f, "({}, {}, {})", i_aggs, i_datum, agg)?;
+            writeln!(f, "({}, {}, {})", i_aggs, i_datum, agg)?;
         }
         Ok(())
     }
@@ -612,11 +612,11 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for BasicPlan {
     ) -> fmt::Result {
         match self {
             BasicPlan::Single(idx, agg) => {
-                write!(f, "{}aggr=({}, {})", ctx.indent, idx, agg)?;
+                writeln!(f, "{}aggr=({}, {})", ctx.indent, idx, agg)?;
             }
             BasicPlan::Multiple(aggs) => {
                 for (i, (i_datum, agg)) in aggs.iter().enumerate() {
-                    write!(f, "{}aggrs[{}]=({}, {})", ctx.indent, i, i_datum, agg)?;
+                    writeln!(f, "{}aggrs[{}]=({}, {})", ctx.indent, i, i_datum, agg)?;
                 }
             }
         }

--- a/src/expr-test-util/tests/testdata/scalar
+++ b/src/expr-test-util/tests/testdata/scalar
@@ -35,7 +35,7 @@ build-scalar
     "hello"
 )
 ----
-if (#0 > -2) then {substr(#1, 1, 4)} else {"hello"}
+case when (#0 > -2) then substr(#1, 1, 4) else "hello" end
 
 build-scalar
 (call_binary (jsonb_get_string true) #2 ("field1" string))
@@ -55,12 +55,12 @@ build-scalar
 build-scalar
 (err division_by_zero)
 ----
-(err: division by zero)
+error("division by zero")
 
 build-scalar
 (err float_overflow)
 ----
-(err: value out of range: overflow)
+error("value out of range: overflow")
 
 build-scalar
 (ok true)

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -67,32 +67,23 @@ impl<'a> Explain<'a> for MirRelationExpr {
 
     type Dot = UnsupportedFormat;
 
-    fn explain_text(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.as_explain_single_plan(config, context)
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.as_explain_single_plan(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Json, ExplainError> {
-        self.as_explain_single_plan(config, context)
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Json, ExplainError> {
+        self.as_explain_single_plan(context)
     }
 }
 
 impl<'a> MirRelationExpr {
     fn as_explain_single_plan(
         &'a mut self,
-        config: &'a ExplainConfig,
         context: &'a ExplainContext<'a>,
     ) -> Result<ExplainSinglePlan<'a, MirRelationExpr>, ExplainError> {
         // normalize the representation as linear chains
-        // (this implies !config.raw_plans by construction)
-        if config.linear_chains {
+        // (this implies !context.config.raw_plans by construction)
+        if context.config.linear_chains {
             enforce_linear_chains(self)?;
         };
 

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -319,10 +319,7 @@ impl MirRelationExpr {
                         write!(f, "{}Project ({})", ctx.indent, outputs)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -333,10 +330,7 @@ impl MirRelationExpr {
                         write!(f, "{}Map ({})", ctx.indent, scalars)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -347,10 +341,7 @@ impl MirRelationExpr {
                         write!(f, "{}FlatMap {}({})", ctx.indent, func, exprs)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -361,10 +352,7 @@ impl MirRelationExpr {
                         write!(f, "{}Filter {}", ctx.indent, predicates)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -546,10 +534,7 @@ impl MirRelationExpr {
                         }
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -581,10 +566,7 @@ impl MirRelationExpr {
                         write!(f, " monotonic={}", monotonic)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -594,10 +576,7 @@ impl MirRelationExpr {
                         write!(f, "{}Negate", ctx.indent)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -607,10 +586,7 @@ impl MirRelationExpr {
                         write!(f, "{}Threshold", ctx.indent)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| {
-                        let input = input.as_ref();
-                        input.fmt_text(f, ctx)
-                    },
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -618,7 +594,7 @@ impl MirRelationExpr {
                 write!(f, "{}Union", ctx.indent)?;
                 self.fmt_attributes(f, ctx)?;
                 ctx.indented(|ctx| {
-                    base.as_ref().fmt_text(f, ctx)?;
+                    base.fmt_text(f, ctx)?;
                     for input in inputs.iter() {
                         input.fmt_text(f, ctx)?;
                     }
@@ -632,7 +608,7 @@ impl MirRelationExpr {
                         write!(f, "{}ArrangeBy keys=[[{}]]", ctx.indent, keys)?;
                         self.fmt_attributes(f, ctx)
                     },
-                    fmt_children: |f, ctx| input.as_ref().fmt_text(f, ctx),
+                    fmt_children: |f, ctx| input.fmt_text(f, ctx),
                 }
                 .render(f, ctx)?;
             }
@@ -765,7 +741,7 @@ impl fmt::Display for MirScalarExpr {
                     {
                         if let Some(is) = func.is() {
                             write!(f, "(")?;
-                            inner_expr.as_ref().fmt(f)?;
+                            inner_expr.fmt(f)?;
                             write!(f, ") IS NOT {}", is)?;
                             return Ok(());
                         }
@@ -773,27 +749,27 @@ impl fmt::Display for MirScalarExpr {
                 }
                 if let Some(is) = func.is() {
                     write!(f, "(")?;
-                    expr.as_ref().fmt(f)?;
+                    expr.fmt(f)?;
                     write!(f, ") IS {}", is)
                 } else {
                     write!(f, "{}(", func)?;
-                    expr.as_ref().fmt(f)?;
+                    expr.fmt(f)?;
                     write!(f, ")")
                 }
             }
             CallBinary { func, expr1, expr2 } => {
                 if func.is_infix_op() {
                     write!(f, "(")?;
-                    expr1.as_ref().fmt(f)?;
+                    expr1.fmt(f)?;
                     write!(f, " {} ", func)?;
-                    expr2.as_ref().fmt(f)?;
+                    expr2.fmt(f)?;
                     write!(f, ")")
                 } else {
                     write!(f, "{}", func)?;
                     write!(f, "(")?;
-                    expr1.as_ref().fmt(f)?;
+                    expr1.fmt(f)?;
                     write!(f, ", ")?;
-                    expr2.as_ref().fmt(f)?;
+                    expr2.fmt(f)?;
                     write!(f, ")")
                 }
             }
@@ -825,11 +801,11 @@ impl fmt::Display for MirScalarExpr {
             }
             If { cond, then, els } => {
                 write!(f, "case when ")?;
-                cond.as_ref().fmt(f)?;
+                cond.fmt(f)?;
                 write!(f, " then ")?;
-                then.as_ref().fmt(f)?;
+                then.fmt(f)?;
                 write!(f, " else ")?;
-                els.as_ref().fmt(f)?;
+                els.fmt(f)?;
                 write!(f, " end")
             }
         }

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -734,43 +734,23 @@ impl fmt::Display for MirScalarExpr {
             CallUnmaterializable(func) => write!(f, "{}()", func),
             CallUnary { func, expr } => {
                 if let crate::UnaryFunc::Not(_) = *func {
-                    if let CallUnary {
-                        func,
-                        expr: inner_expr,
-                    } = expr.as_ref()
-                    {
+                    if let CallUnary { func, expr } = expr.as_ref() {
                         if let Some(is) = func.is() {
-                            write!(f, "(")?;
-                            inner_expr.fmt(f)?;
-                            write!(f, ") IS NOT {}", is)?;
-                            return Ok(());
+                            return write!(f, "({}) IS NOT {}", expr, is);
                         }
                     }
                 }
                 if let Some(is) = func.is() {
-                    write!(f, "(")?;
-                    expr.fmt(f)?;
-                    write!(f, ") IS {}", is)
+                    write!(f, "({}) IS {}", expr, is)
                 } else {
-                    write!(f, "{}(", func)?;
-                    expr.fmt(f)?;
-                    write!(f, ")")
+                    write!(f, "{}({})", func, expr)
                 }
             }
             CallBinary { func, expr1, expr2 } => {
                 if func.is_infix_op() {
-                    write!(f, "(")?;
-                    expr1.fmt(f)?;
-                    write!(f, " {} ", func)?;
-                    expr2.fmt(f)?;
-                    write!(f, ")")
+                    write!(f, "({} {} {})", expr1, func, expr2)
                 } else {
-                    write!(f, "{}", func)?;
-                    write!(f, "(")?;
-                    expr1.fmt(f)?;
-                    write!(f, ", ")?;
-                    expr2.fmt(f)?;
-                    write!(f, ")")
+                    write!(f, "{}({}, {})", func, expr1, expr2)
                 }
             }
             CallVariadic { func, exprs } => {
@@ -800,13 +780,7 @@ impl fmt::Display for MirScalarExpr {
                 }
             }
             If { cond, then, els } => {
-                write!(f, "case when ")?;
-                cond.fmt(f)?;
-                write!(f, " then ")?;
-                then.fmt(f)?;
-                write!(f, " else ")?;
-                els.fmt(f)?;
-                write!(f, " end")
+                write!(f, "case when {} then {} else {} end", cond, then, els)
             }
         }
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2453,18 +2453,6 @@ impl AggregateExpr {
     }
 }
 
-impl fmt::Display for AggregateExpr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(
-            f,
-            "{}({}{})",
-            self.func,
-            if self.distinct { "distinct " } else { "" },
-            self.expr
-        )
-    }
-}
-
 /// Describe a join implementation in dataflow.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
 pub enum JoinImplementation {

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -459,7 +459,7 @@ reduce
 (if (call_binary gt #0 #1) (call_binary eq #0 (1 int32)) false)
 [int32 int32]
 ----
-if (#0 > #1) then {(#0 = 1)} else {false}
+case when (#0 > #1) then (#0 = 1) else false end
 
 reduce
 (if (call_binary gt #0 #1) (null bool) false)
@@ -484,7 +484,7 @@ reduce
 (if (call_binary gt #0 #1) (call_binary eq #0 (1 int32)) true)
 [int32 int32]
 ----
-if (#0 > #1) then {(#0 = 1)} else {true}
+case when (#0 > #1) then (#0 = 1) else true end
 
 reduce
 (if (call_binary gt #0 #1) (null bool) true)
@@ -514,7 +514,7 @@ reduce
 (if (call_binary gt #0 #1) (1 int32) (2 int32))
 [int32 int32]
 ----
-if (#0 > #1) then {1} else {2}
+case when (#0 > #1) then 1 else 2 end
 
 reduce
 (if (null bool) true false)
@@ -641,7 +641,7 @@ reduce
 )
 [int64]
 ----
-if (#0 = 1) then {1} else {(err: division by zero)}
+case when (#0 = 1) then 1 else error("division by zero") end
 
 ## undistribute_and_or works despite multiple copies of the same expression in
 ## the intersection

--- a/src/ore/src/str.rs
+++ b/src/ore/src/str.rs
@@ -178,6 +178,12 @@ pub struct Indent {
     mark: Vec<usize>,
 }
 
+impl AsMut<Indent> for Indent {
+    fn as_mut(&mut self) -> &mut Indent {
+        self
+    }
+}
+
 impl Indent {
     /// Construct a new `Indent` where one level is represented
     /// by the given `unit` repeated `step` times.
@@ -232,33 +238,6 @@ pub trait IndentLike {
     fn indented_if<F>(&mut self, guard: bool, f: F) -> fmt::Result
     where
         F: FnMut(&mut Self) -> fmt::Result;
-}
-
-impl IndentLike for Indent {
-    fn indented<F>(&mut self, mut f: F) -> fmt::Result
-    where
-        F: FnMut(&mut Self) -> fmt::Result,
-    {
-        *self += 1;
-        let result = f(self);
-        *self -= 1;
-        result
-    }
-
-    fn indented_if<F>(&mut self, guard: bool, mut f: F) -> fmt::Result
-    where
-        F: FnMut(&mut Self) -> fmt::Result,
-    {
-        if guard {
-            *self += 1;
-        }
-        let result = f(self);
-
-        if guard {
-            *self -= 1;
-        }
-        result
-    }
 }
 
 impl<T: AsMut<Indent>> IndentLike for T {

--- a/src/repr/src/explain/text.rs
+++ b/src/repr/src/explain/text.rs
@@ -110,8 +110,7 @@ impl<'a> fmt::Display for Indices<'a> {
 
 impl<'a, T> std::fmt::Display for CompactScalarSeq<'a, T>
 where
-    T: ScalarOps,
-    T: DisplayText,
+    T: ScalarOps + fmt::Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut is_first = true;
@@ -132,16 +131,16 @@ where
                     {
                         last += 1;
                     }
-                    slice[0].fmt_text(f, &mut ())?;
+                    slice[0].fmt(f)?;
                     write!(f, "..=")?;
-                    slice[last - 1].fmt_text(f, &mut ())?;
+                    slice[last - 1].fmt(f)?;
                     slice = &slice[last..];
                 } else {
-                    slice[0].fmt_text(f, &mut ())?;
+                    slice[0].fmt(f)?;
                     slice = &slice[1..];
                 }
             } else {
-                slice[0].fmt_text(f, &mut ())?;
+                slice[0].fmt(f)?;
                 slice = &slice[1..];
             }
         }
@@ -185,50 +184,6 @@ pub fn text_string_at<'a, T: DisplayText<C>, C, F: Fn() -> C>(t: &'a T, f: F) ->
     }
 
     text_string(&TextStringAt { t, f })
-}
-
-/// Creates a type whose [`fmt::Display`] implementation outputs each item in
-/// `iter` separated by `separator`.
-///
-/// The difference between this and [`mz_ore::str::separated`] is that the latter
-/// requires the iterator items to implement [`fmt::Display`], whereas this version
-/// wants them to implement [`DisplayText<C>`] for some rendering context `C` which
-/// implements [`Default`].
-pub fn separated_text<'a, I, C>(separator: &'a str, iter: I) -> impl fmt::Display + 'a
-where
-    I: IntoIterator,
-    I::IntoIter: Clone + 'a,
-    I::Item: DisplayText<C> + 'a,
-    C: Default + 'a,
-{
-    struct Separated<'a, I, C> {
-        separator: &'a str,
-        iter: I,
-        phantom: std::marker::PhantomData<C>,
-    }
-
-    impl<'a, I, C> fmt::Display for Separated<'a, I, C>
-    where
-        C: Default,
-        I: Iterator + Clone,
-        I::Item: DisplayText<C>,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            for (i, item) in self.iter.clone().enumerate() {
-                if i != 0 {
-                    write!(f, "{}", self.separator)?;
-                }
-                item.fmt_text(f, &mut C::default())?;
-            }
-            Ok(())
-        }
-    }
-
-    Separated {
-        separator,
-        iter: iter.into_iter(),
-        phantom: std::marker::PhantomData::<C>,
-    }
 }
 
 fn write_first_rows(

--- a/src/sql/src/plan/explain/mod.rs
+++ b/src/sql/src/plan/explain/mod.rs
@@ -9,17 +9,14 @@
 
 //! `EXPLAIN` support for structures defined in this crate.
 
-use crate::plan::{HirRelationExpr, HirScalarExpr};
-use mz_expr::{
-    explain::{ExplainContext, ExplainSinglePlan},
-    visit::{Visit, VisitChildren},
-    Id, LocalId,
-};
+use mz_expr::explain::{ExplainContext, ExplainSinglePlan};
+use mz_expr::visit::{Visit, VisitChildren};
+use mz_expr::{Id, LocalId};
 use mz_ore::stack::RecursionLimitError;
-use mz_repr::{
-    explain::{AnnotatedPlan, Explain, ExplainConfig, ExplainError, ScalarOps, UnsupportedFormat},
-    RelationType,
-};
+use mz_repr::explain::{AnnotatedPlan, Explain, ExplainError, ScalarOps, UnsupportedFormat};
+use mz_repr::RelationType;
+
+use crate::plan::{HirRelationExpr, HirScalarExpr};
 
 mod text;
 
@@ -32,32 +29,23 @@ impl<'a> Explain<'a> for HirRelationExpr {
 
     type Dot = UnsupportedFormat;
 
-    fn explain_text(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Text, ExplainError> {
-        self.as_explain_single_plan(config, context)
+    fn explain_text(&'a mut self, context: &'a Self::Context) -> Result<Self::Text, ExplainError> {
+        self.as_explain_single_plan(context)
     }
 
-    fn explain_json(
-        &'a mut self,
-        config: &'a ExplainConfig,
-        context: &'a Self::Context,
-    ) -> Result<Self::Json, ExplainError> {
-        self.as_explain_single_plan(config, context)
+    fn explain_json(&'a mut self, context: &'a Self::Context) -> Result<Self::Json, ExplainError> {
+        self.as_explain_single_plan(context)
     }
 }
 
 impl<'a> HirRelationExpr {
     fn as_explain_single_plan(
         &'a mut self,
-        config: &'a ExplainConfig,
         context: &'a ExplainContext<'a>,
     ) -> Result<ExplainSinglePlan<'a, HirRelationExpr>, ExplainError> {
         // unless raw plans are explicitly requested
         // ensure that all nested subqueries are wrapped in Let blocks
-        if !config.raw_plans {
+        if !context.config.raw_plans {
             normalize_subqueries(self)?;
         }
 

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -120,7 +120,7 @@ impl HirRelationExpr {
             }
             LetRec { bindings, body } => {
                 writeln!(f, "{}Return", ctx.indent)?;
-                ctx.indented(|ctx| body.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| body.fmt_text(f, ctx))?;
                 writeln!(f, "{}With Mutually Recursive", ctx.indent)?;
                 ctx.indented(|ctx| {
                     for (_name, id, value, _type) in bindings.iter().rev() {
@@ -144,12 +144,12 @@ impl HirRelationExpr {
             Project { outputs, input } => {
                 let outputs = Indices(outputs);
                 writeln!(f, "{}Project ({})", ctx.indent, outputs)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Map { scalars, input } => {
                 let scalars = CompactScalarSeq(scalars);
                 writeln!(f, "{}Map ({})", ctx.indent, scalars)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             CallTable { func, exprs } => {
                 let exprs = CompactScalarSeq(exprs);
@@ -158,7 +158,7 @@ impl HirRelationExpr {
             Filter { predicates, input } => {
                 let predicates = separated(" AND ", predicates);
                 writeln!(f, "{}Filter {}", ctx.indent, predicates)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Join {
                 left,
@@ -173,8 +173,8 @@ impl HirRelationExpr {
                 }
                 writeln!(f)?;
                 ctx.indented(|ctx| {
-                    left.as_ref().fmt_text(f, ctx)?;
-                    right.as_ref().fmt_text(f, ctx)?;
+                    left.fmt_text(f, ctx)?;
+                    right.fmt_text(f, ctx)?;
                     Ok(())
                 })?;
             }
@@ -197,11 +197,11 @@ impl HirRelationExpr {
                     write!(f, " exp_group_size={}", expected_group_size)?;
                 }
                 writeln!(f)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Distinct { input } => {
                 writeln!(f, "{}Distinct", ctx.indent)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             TopK {
                 group_key,
@@ -226,20 +226,20 @@ impl HirRelationExpr {
                     write!(f, " offset={}", offset)?
                 }
                 writeln!(f)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Negate { input } => {
                 writeln!(f, "{}Negate", ctx.indent)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Threshold { input } => {
                 writeln!(f, "{}Threshold", ctx.indent)?;
-                ctx.indented(|ctx| input.as_ref().fmt_text(f, ctx))?;
+                ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
             Union { base, inputs } => {
                 writeln!(f, "{}Union", ctx.indent)?;
                 ctx.indented(|ctx| {
-                    base.as_ref().fmt_text(f, ctx)?;
+                    base.fmt_text(f, ctx)?;
                     for input in inputs.iter() {
                         input.fmt_text(f, ctx)?;
                     }
@@ -275,7 +275,7 @@ impl fmt::Display for HirScalarExpr {
                     {
                         if let Some(is) = func.is() {
                             write!(f, "(")?;
-                            inner_expr.as_ref().fmt(f)?;
+                            inner_expr.fmt(f)?;
                             write!(f, ") IS NOT {}", is)?;
                             return Ok(());
                         }
@@ -283,27 +283,27 @@ impl fmt::Display for HirScalarExpr {
                 }
                 if let Some(is) = func.is() {
                     write!(f, "(")?;
-                    expr.as_ref().fmt(f)?;
+                    expr.fmt(f)?;
                     write!(f, ") IS {}", is)
                 } else {
                     write!(f, "{}(", func)?;
-                    expr.as_ref().fmt(f)?;
+                    expr.fmt(f)?;
                     write!(f, ")")
                 }
             }
             CallBinary { func, expr1, expr2 } => {
                 if func.is_infix_op() {
                     write!(f, "(")?;
-                    expr1.as_ref().fmt(f)?;
+                    expr1.fmt(f)?;
                     write!(f, " {} ", func)?;
-                    expr2.as_ref().fmt(f)?;
+                    expr2.fmt(f)?;
                     write!(f, ")")
                 } else {
                     write!(f, "{}", func)?;
                     write!(f, "(")?;
-                    expr1.as_ref().fmt(f)?;
+                    expr1.fmt(f)?;
                     write!(f, ", ")?;
-                    expr2.as_ref().fmt(f)?;
+                    expr2.fmt(f)?;
                     write!(f, ")")
                 }
             }
@@ -335,11 +335,11 @@ impl fmt::Display for HirScalarExpr {
             }
             If { cond, then, els } => {
                 write!(f, "case when ")?;
-                cond.as_ref().fmt(f)?;
+                cond.fmt(f)?;
                 write!(f, " then ")?;
-                then.as_ref().fmt(f)?;
+                then.fmt(f)?;
                 write!(f, " else ")?;
-                els.as_ref().fmt(f)?;
+                els.fmt(f)?;
                 write!(f, " end")
             }
             Windowing(expr) => {
@@ -349,7 +349,7 @@ impl fmt::Display for HirScalarExpr {
                     }
                     WindowExprType::Value(scalar) => {
                         write!(f, "{}(", scalar.clone().into_expr())?;
-                        scalar.expr.as_ref().fmt(f)?;
+                        scalar.expr.fmt(f)?;
                         write!(f, ")")?
                     }
                 }
@@ -399,7 +399,7 @@ impl fmt::Display for AggregateExpr {
             if self.distinct { "distinct " } else { "" }
         )?;
 
-        self.expr.as_ref().fmt(f)?;
+        self.expr.fmt(f)?;
         write!(f, ")")
     }
 }

--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -137,7 +137,10 @@ impl HirRelationExpr {
                     writeln!(f, "{}Get {}", ctx.indent, id)?;
                 }
                 Id::Global(id) => {
-                    let humanized_id = ctx.humanizer.humanize_id(*id).ok_or(fmt::Error)?;
+                    let humanized_id = ctx
+                        .humanizer
+                        .humanize_id(*id)
+                        .unwrap_or_else(|| id.to_string());
                     writeln!(f, "{}Get {}", ctx.indent, humanized_id)?;
                 }
             },

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -234,7 +234,7 @@ where nullif(foo.a, 0) = -bar.a
 Explained Query:
   Project (#1, #3) // { arity: 2 }
     Filter (#2) IS NOT NULL AND (case when (#0 = 0) then null else #0 end) IS NOT NULL // { arity: 4 }
-      Join on=(-(#2) = if (#0 = 0) then {null} else {#0}) type=differential // { arity: 4 }
+      Join on=(-(#2) = case when (#0 = 0) then null else #0 end) type=differential // { arity: 4 }
         implementation
           %1:bar[-(#0)] » %0:foo[case when (#0 = 0) then null else #0 end]KA
         ArrangeBy keys=[[case when (#0 = 0) then null else #0 end]] // { arity: 2 }


### PR DESCRIPTION
Some cleanup work after #17360 is closed.

### Motivation

  * This PR adds a feature that has not yet been specified.

Simplifying code.

### Tips for reviewer

The PR commits of a bunch of commits that remove stuff from the `explain` modules. Some of the changes can be done either way, and others are motivated by the fact that we don't need the additional complexity at the moment (I'm happy to revert those later if we actually need them).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
