### PR TITLE
Platform checks: Add Cast, String checks, extend JsonbType (fixes #17471)

### DIFF
--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -11,6 +11,7 @@
 from materialize.checks.aggregation import *  # noqa: F401 F403
 from materialize.checks.alter_index import *  # noqa: F401 F403
 from materialize.checks.boolean_type import *  # noqa: F401 F403
+from materialize.checks.cast import *  # noqa: F401 F403
 from materialize.checks.cluster import *  # noqa: F401 F403
 from materialize.checks.commit import *  # noqa: F401 F403
 from materialize.checks.constant_plan import *  # noqa: F401 F403
@@ -47,6 +48,7 @@ from materialize.checks.roles import *  # noqa: F401 F403
 from materialize.checks.rollback import *  # noqa: F401 F403
 from materialize.checks.sink import *  # noqa: F401 F403
 from materialize.checks.source_errors import *  # noqa: F401 F403
+from materialize.checks.string import *  # noqa: F401 F403
 from materialize.checks.temporal_types import *  # noqa: F401 F403
 from materialize.checks.text_bytea_types import *  # noqa: F401 F403
 from materialize.checks.threshold import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/cast.py
+++ b/misc/python/materialize/checks/cast.py
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+
+class Cast(Check):
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > CREATE TABLE cast_table (f1 INT);
+            > INSERT INTO cast_table VALUES (0);
+            """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE MATERIALIZED VIEW cast_view1 AS SELECT f1::bool AS c1, f1::int AS c2, f1::float AS c3, f1::numeric AS c4, f1::real AS c5, f1::text AS c6, f1::uint2 AS c7, f1::uint4 AS c8, f1::uint8 AS c9, f1::text AS c10, cast(f1 AS bool) AS c11 FROM cast_table WHERE f1 >= 0;
+                > INSERT INTO cast_table VALUES (1);
+            """,
+                """
+                > CREATE MATERIALIZED VIEW cast_view2 AS SELECT f1::bool AS c1, f1::int AS c2, f1::float AS c3, f1::numeric AS c4, f1::real AS c5, f1::text AS c6, f1::text AS c7, cast(f1 AS bool) AS c8 FROM cast_table;
+                > INSERT INTO cast_table VALUES (-1);
+            """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > SELECT * FROM cast_view1;
+            false 0 0 0 0 0 0 0 0 0 false
+            true 1 1 1 1 1 1 1 1 1 true
+
+            > SELECT * FROM cast_view2;
+            false 0 0 0 0 0 0 false
+            true 1 1 1 1 1 1 true
+            true -1 -1 -1 -1 -1 -1 true
+            """
+            )
+        )

--- a/misc/python/materialize/checks/jsonb_type.py
+++ b/misc/python/materialize/checks/jsonb_type.py
@@ -19,7 +19,7 @@ class JsonbType(Check):
             dedent(
                 """
             > CREATE TABLE jsonb_type_table (jsonb_col JSONB);
-            > INSERT INTO jsonb_type_table VALUES ('{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}')
+            > INSERT INTO jsonb_type_table VALUES ('{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}');
         """
             )
         )
@@ -30,16 +30,40 @@ class JsonbType(Check):
             for s in [
                 """
                 > CREATE MATERIALIZED VIEW jsonb_type_view1 AS
-                  SELECT jsonb_col, '{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}'::JSONB
-                  FROM jsonb_type_table;
-
+                    WITH cte AS (SELECT '{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}'::JSONB AS cte_jsonb_col)
+                    SELECT
+                      jsonb_col AS c1,
+                      '{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}'::JSONB AS c2,
+                      jsonb_col -> 'number_element' AS c3,
+                      cte_jsonb_col -> 'number_element' AS c4,
+                      jsonb_col ->> 'number_element' AS c5,
+                      jsonb_col #> '{array_element,1}' AS c6,
+                      jsonb_col #>> '{array_element,1}' AS c7,
+                      jsonb_col || '{"another_null": null}'::jsonb AS c8,
+                      jsonb_col - 'object_element' AS c9,
+                      jsonb_col @> '{"boolean_element": true}' AS c10,
+                      jsonb_col <@ '{"boolean_element": true}' AS c11,
+                      jsonb_col ? 'number_element' AS c12
+                    FROM jsonb_type_table, cte;
                 > INSERT INTO jsonb_type_table SELECT * FROM jsonb_type_table LIMIT 1;
                 """,
                 """
                 > CREATE MATERIALIZED VIEW jsonb_type_view2 AS
-                  SELECT jsonb_col, '{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}'::JSONB
-                  FROM jsonb_type_table;
-
+                    WITH cte AS (SELECT '{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}'::JSONB AS cte_jsonb_col)
+                    SELECT
+                      jsonb_col AS c1,
+                      '{"object_element":{"a":"b"},"array_element": [1,2], "string_element":"abc", "number_element":123.456, "boolean_element": true, "null_element":null}'::JSONB AS c2,
+                      jsonb_col -> 'number_element' AS c3,
+                      cte_jsonb_col -> 'number_element' AS c4,
+                      jsonb_col ->> 'number_element' AS c5,
+                      jsonb_col #> '{array_element,1}' AS c6,
+                      jsonb_col #>> '{array_element,1}' AS c7,
+                      jsonb_col || '{"another_null": null}'::jsonb AS c8,
+                      jsonb_col - 'object_element' AS c9,
+                      jsonb_col @> '{"boolean_element": true}' AS c10,
+                      jsonb_col <@ '{"boolean_element": true}' AS c11,
+                      jsonb_col ? 'number_element' AS c12
+                    FROM jsonb_type_table, cte;
                 > INSERT INTO jsonb_type_table SELECT * FROM jsonb_type_table LIMIT 1;
                 """,
             ]
@@ -50,14 +74,14 @@ class JsonbType(Check):
             dedent(
                 """
                 > SELECT * FROM jsonb_type_view1;
-                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}"
-                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}"
-                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}"
+                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" 123.456 123.456 123.456 2  2  "{\\"another_null\\":null,\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"string_element\\":\\"abc\\"}" true false true
+                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" 123.456 123.456 123.456 2  2  "{\\"another_null\\":null,\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"string_element\\":\\"abc\\"}" true false true
+                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" 123.456 123.456 123.456 2  2  "{\\"another_null\\":null,\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"string_element\\":\\"abc\\"}" true false true
 
                 > SELECT * FROM jsonb_type_view2;
-                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}"
-                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}"
-                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}"
+                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" 123.456 123.456 123.456 2  2  "{\\"another_null\\":null,\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"string_element\\":\\"abc\\"}" true false true
+                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" 123.456 123.456 123.456 2  2  "{\\"another_null\\":null,\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"string_element\\":\\"abc\\"}" true false true
+                "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" 123.456 123.456 123.456 2  2  "{\\"another_null\\":null,\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"object_element\\":{\\"a\\":\\"b\\"},\\"string_element\\":\\"abc\\"}" "{\\"array_element\\":[1,2],\\"boolean_element\\":true,\\"null_element\\":null,\\"number_element\\":123.456,\\"string_element\\":\\"abc\\"}" true false true
             """
             )
         )

--- a/misc/python/materialize/checks/string.py
+++ b/misc/python/materialize/checks/string.py
@@ -1,0 +1,83 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+
+class String(Check):
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > CREATE TABLE string_table (f1 STRING, f2 STRING, f3 STRING, f4 INT, f5 INT, f6 INT[]);
+            > INSERT INTO string_table VALUES (' foobar ', ' abc ', ' xyz ', 2, 3, '{1,NULL,3}');
+            """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE MATERIALIZED VIEW string_view1 AS SELECT
+                    f1 BETWEEN f2 AND f3 AS c1,
+                    'foo' BETWEEN 'abc' AND 'xyz' AS c2,
+                    f1 NOT BETWEEN f2 AND f3 AS c3,
+                    substring(f1 FROM f4 FOR f5) AS c4,
+                    substring(f1 FROM f4) AS c5,
+                    substring(f1 FOR f5) AS c6,
+                    trim(BOTH f1) AS c7,
+                    trim(LEADING f1) AS c8,
+                    trim(TRAILING f1) AS c9,
+                    trim(LEADING ' f' FROM f1) AS c10,
+                    trim(' fr' FROM f1) AS c11,
+                    array_to_string(f6, ',', 'NULL') AS c12
+                  FROM string_table;
+                > INSERT INTO string_table VALUES (' foo ', ' abc ', ' xyz ', 2, 3, '{1,2,3,4,NULL,NULL}');
+            """,
+                """
+                > CREATE MATERIALIZED VIEW string_view2 AS SELECT
+                    f1 BETWEEN f2 AND f3 AS c1,
+                    'foo' BETWEEN 'abc' AND 'xyz' AS c2,
+                    f1 NOT BETWEEN f2 AND f3 AS c3,
+                    substring(f1 FROM f4 FOR f5) AS c4,
+                    substring(f1 FROM f4) AS c5,
+                    substring(f1 FOR f5) AS c6,
+                    trim(BOTH f1) AS c7,
+                    trim(LEADING f1) AS c8,
+                    trim(TRAILING f1) AS c9,
+                    trim(LEADING ' f' FROM f1) AS c10,
+                    trim(' fr' FROM f1) AS c11,
+                    array_to_string(f6, ',', 'NULL') AS c12
+                  FROM string_table;
+                > INSERT INTO string_table VALUES (' bar ', 'abc', 'xyz', 2, 3, '{NULL}');
+            """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > SELECT * FROM string_view1;
+            true true false foo "foobar " " fo" "foobar" "foobar " " foobar" "oobar " "ooba" 1,NULL,3
+            true true false foo "foo " " fo" foo "foo " " foo" "oo " oo 1,2,3,4,NULL,NULL
+            false true true bar "bar " " ba" bar "bar " " bar" "bar " ba NULL
+
+            > SELECT * FROM string_view2;
+            true true false foo "foobar " " fo" "foobar" "foobar " " foobar" "oobar " "ooba" 1,NULL,3
+            true true false foo "foo " " fo" foo "foo " " foo" "oo " oo 1,2,3,4,NULL,NULL
+            false true true bar "bar " " ba" bar "bar " " bar" "bar " ba NULL
+            """
+            )
+        )


### PR DESCRIPTION
Those are considered interesting as they don't have standard syntax and are thus more likely to break during serialization roundtrips.

Locally I tested all with RestartEntireMz scenario and they were green:

    bin/mzcompose --find platform-checks run default --scenario=RestartEntireMz --check=JsonbType

I'm a bit disappointed that this doesn't seem to find any issues. ;)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
