### PR TITLE
adapter: Reject ws requests above a certain size

### DIFF
--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -35,7 +35,7 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{Raw, Statement, StatementKind};
 use mz_sql::plan::Plan;
 
-use crate::http::AuthedClient;
+use crate::http::{AuthedClient, MAX_REQUEST_SIZE};
 
 use super::{init_ws, WsState};
 
@@ -61,7 +61,8 @@ pub async fn handle_sql_ws(
     State(state): State<WsState>,
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
-    ws.on_upgrade(|ws| async move { run_ws(&state, ws).await })
+    ws.max_message_size(MAX_REQUEST_SIZE)
+        .on_upgrade(|ws| async move { run_ws(&state, ws).await })
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -88,7 +88,8 @@ use itertools::Itertools;
 use reqwest::blocking::Client;
 use reqwest::Url;
 use tracing::info;
-use tungstenite::Message;
+use tungstenite::error::ProtocolError;
+use tungstenite::{Error, Message};
 
 use mz_environmentd::{WebSocketAuth, WebSocketResponse};
 use mz_ore::retry::Retry;
@@ -258,30 +259,7 @@ fn test_http_sql() {
         ))
         .unwrap();
         let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
-
-        ws.write_message(Message::Text(
-            serde_json::to_string(&WebSocketAuth::Basic {
-                user: "materialize".into(),
-                password: "".into(),
-            })
-            .unwrap(),
-        ))
-        .unwrap();
-        // Wait for initial ready response.
-        loop {
-            let resp = ws.read_message().unwrap();
-            match resp {
-                Message::Text(msg) => {
-                    let msg: WebSocketResponse = serde_json::from_str(&msg).unwrap();
-                    match msg {
-                        WebSocketResponse::ReadyForQuery(_) => break,
-                        _ => {}
-                    }
-                }
-                Message::Ping(_) => continue,
-                _ => panic!("unexpected response: {:?}", resp),
-            }
-        }
+        util::auth_with_ws(&mut ws);
 
         f.run(|tc| {
             let msg = match tc.directive.as_str() {
@@ -725,15 +703,12 @@ fn test_default_cluster_sizes() {
 fn test_max_request_size() {
     let statement = "SELECT $1::text";
     let statement_size = statement.bytes().count();
+    let server = util::start_server(util::Config::default()).unwrap();
 
     // pgwire
     {
         let param_size = mz_pgwire::MAX_REQUEST_SIZE - statement_size + 1;
         let param = std::iter::repeat("1").take(param_size).join("");
-        let config = util::Config::default()
-            .with_builtin_cluster_replica_size("1".to_string())
-            .with_default_cluster_replica_size("2".to_string());
-        let server = util::start_server(config).unwrap();
         let mut client = server.connect(postgres::NoTls).unwrap();
 
         // The specific error isn't forwarded to the client, the connection is just closed.
@@ -745,7 +720,6 @@ fn test_max_request_size() {
     {
         let param_size = mz_environmentd::http::MAX_REQUEST_SIZE - statement_size + 1;
         let param = std::iter::repeat("1").take(param_size).join("");
-        let server = util::start_server(util::Config::default()).unwrap();
         let http_url = Url::parse(&format!(
             "http://{}/api/sql",
             server.inner.http_local_addr()
@@ -755,5 +729,29 @@ fn test_max_request_size() {
         let json: serde_json::Value = serde_json::from_str(&json).unwrap();
         let res = Client::new().post(http_url).json(&json).send().unwrap();
         assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    // ws
+    {
+        let param_size = mz_environmentd::http::MAX_REQUEST_SIZE - statement_size + 1;
+        let param = std::iter::repeat("1").take(param_size).join("");
+        let ws_url = Url::parse(&format!(
+            "ws://{}/api/experimental/sql",
+            server.inner.http_local_addr()
+        ))
+        .unwrap();
+        let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
+        util::auth_with_ws(&mut ws);
+        let json =
+            format!("{{\"queries\":[{{\"query\":\"{statement}\",\"params\":[\"{param}\"]}}]}}");
+        let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+        ws.write_message(Message::Text(json.to_string())).unwrap();
+
+        // The specific error isn't forwarded to the client, the connection is just closed.
+        let err = ws.read_message().unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Protocol(ProtocolError::ResetWithoutClosingHandshake)
+        ));
     }
 }

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -76,7 +76,7 @@
 // END LINT CONFIG
 
 use std::error::Error;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -96,7 +96,7 @@ use tokio_postgres::Client;
 use tower_http::cors::AllowOrigin;
 
 use mz_controller::ControllerConfig;
-use mz_environmentd::TlsMode;
+use mz_environmentd::{TlsMode, WebSocketAuth, WebSocketResponse};
 use mz_frontegg_auth::FronteggAuthentication;
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
 use mz_ore::metrics::MetricsRegistry;
@@ -115,6 +115,8 @@ use mz_sql::catalog::EnvironmentId;
 use mz_stash::StashFactory;
 use mz_storage_client::types::connections::ConnectionContext;
 use tracing_subscriber::filter::Targets;
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{Message, WebSocket};
 
 pub static KAFKA_ADDRS: Lazy<String> =
     Lazy::new(|| env::var("KAFKA_ADDRS").unwrap_or_else(|_| "localhost:9092".into()));
@@ -651,4 +653,30 @@ pub fn wait_for_view_population(
         "SET transaction_isolation = '{current_isolation}'"
     ))?;
     Ok(())
+}
+
+pub fn auth_with_ws(ws: &mut WebSocket<MaybeTlsStream<TcpStream>>) {
+    ws.write_message(Message::Text(
+        serde_json::to_string(&WebSocketAuth::Basic {
+            user: "materialize".into(),
+            password: "".into(),
+        })
+        .unwrap(),
+    ))
+    .unwrap();
+    // Wait for initial ready response.
+    loop {
+        let resp = ws.read_message().unwrap();
+        match resp {
+            Message::Text(msg) => {
+                let msg: WebSocketResponse = serde_json::from_str(&msg).unwrap();
+                match msg {
+                    WebSocketResponse::ReadyForQuery(_) => break,
+                    _ => {}
+                }
+            }
+            Message::Ping(_) => continue,
+            _ => panic!("unexpected response: {:?}", resp),
+        }
+    }
 }


### PR DESCRIPTION
This commit adds logic to the websocket server to reject any request above 2mb.

Fixes #17487


### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
