### PR TITLE
adapter: Drop peeks when dependencies drop

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -545,6 +545,8 @@ impl Coordinator {
             for PendingPeek {
                 sender: rows_tx,
                 conn_id: _,
+                cluster_id: _,
+                depends_on: _,
             } in self.cancel_pending_peeks(&conn_id)
             {
                 // Cancel messages can be sent after the connection has hung

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2271,7 +2271,7 @@ impl Coordinator {
             view_id,
             index_id,
             timeline_context,
-            &source_ids,
+            source_ids,
             id_bundle,
             in_immediate_multi_stmt_txn,
             real_time_recency_ts,
@@ -2326,7 +2326,7 @@ impl Coordinator {
         view_id: GlobalId,
         index_id: GlobalId,
         timeline_context: TimelineContext,
-        source_ids: &BTreeSet<GlobalId>,
+        source_ids: BTreeSet<GlobalId>,
         id_bundle: CollectionIdBundle,
         in_immediate_multi_stmt_txn: bool,
         real_time_recency_ts: Option<Timestamp>,
@@ -2346,7 +2346,7 @@ impl Coordinator {
                     // Determine a timestamp that will be valid for anything in any schema
                     // referenced by the first query.
                     let id_bundle =
-                        self.timedomain_for(source_ids, &timeline_context, conn_id, cluster_id)?;
+                        self.timedomain_for(&source_ids, &timeline_context, conn_id, cluster_id)?;
                     // We want to prevent compaction of the indexes consulted by
                     // determine_timestamp, not the ones listed in the query.
                     let timestamp = self.determine_timestamp(
@@ -2488,6 +2488,7 @@ impl Coordinator {
             conn_id,
             source_arity: source.arity(),
             id_bundle,
+            source_ids,
         })
     }
 

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
 use mz_compute_client::controller::error::{
-    CollectionUpdateError, DataflowCreationError, PeekError, SubscribeTargetError,
+    CollectionUpdateError, DataflowCreationError, InstanceMissing, PeekError, SubscribeTargetError,
 };
 use mz_controller::clusters::ClusterId;
 use mz_ore::halt;
@@ -362,5 +362,11 @@ impl ShouldHalt for TransformError {
             | TransformError::LetRecUnsupported
             | TransformError::IdentifierMissing(_) => false,
         }
+    }
+}
+
+impl ShouldHalt for InstanceMissing {
+    fn should_halt(&self) -> bool {
+        false
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3493,8 +3493,8 @@ pub fn plan_drop_item(
                     );
                 }
             }
-            // TODO(jkosh44) It would be nice to also check if any active subscribe relies on
-            //  entry. Unfortunately, we don't have that information readily available.
+            // TODO(jkosh44) It would be nice to also check if any active subscribe or pending peek
+            //  relies on entry. Unfortunately, we don't have that information readily available.
         }
     }
     Ok(Some(catalog_entry.id()))


### PR DESCRIPTION
This commit adds the feature that when an object is dropped, all pending peeks that depend on that object are also dropped.

Works towards resolving #16121

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
