### PR TITLE
docker: Use CRDB 23.2.3 in the Materialize image

### DIFF
--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM cockroachdb/cockroach:v22.2.0 AS crdb
+FROM cockroachdb/cockroach:v22.2.3 AS crdb
 
 MZFROM ubuntu-base
 


### PR DESCRIPTION
This is needed in order to avoid hitting cockroachdb/cockroach#93892

### Motivation

  * This PR fixes a previously unreported bug.

- cockroachdb/cockroach#93892 continued to be seen in the CI as many tests use the default CRDB instance.

- there is also some anecdotal evidence that the `FATAL: disk stall detected: unable to sync log files within 20s` may be better