### PR TITLE
sql: implement remaining range functions

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -597,6 +597,7 @@ message ProtoBinaryFunc {
         google.protobuf.Empty range_overright = 178;
         google.protobuf.Empty range_adjacent = 179;
         google.protobuf.Empty range_union = 180;
+        google.protobuf.Empty range_intersection = 181;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -596,6 +596,7 @@ message ProtoBinaryFunc {
         google.protobuf.Empty range_overleft = 177;
         google.protobuf.Empty range_overright = 178;
         google.protobuf.Empty range_adjacent = 179;
+        google.protobuf.Empty range_union = 180;
     }
 }
 

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -598,6 +598,7 @@ message ProtoBinaryFunc {
         google.protobuf.Empty range_adjacent = 179;
         google.protobuf.Empty range_union = 180;
         google.protobuf.Empty range_intersection = 181;
+        google.protobuf.Empty range_difference = 182;
     }
 }
 

--- a/src/repr/src/adt/range.proto
+++ b/src/repr/src/adt/range.proto
@@ -19,5 +19,6 @@ message ProtoInvalidRangeError {
         string canonicalization_overflow = 2;
         google.protobuf.Empty invalid_range_bound_flags = 3;
         google.protobuf.Empty discontiguous_union = 4;
+        google.protobuf.Empty discontiguous_difference = 5;
     }
 }

--- a/src/repr/src/adt/range.proto
+++ b/src/repr/src/adt/range.proto
@@ -18,5 +18,6 @@ message ProtoInvalidRangeError {
         google.protobuf.Empty misordered_range_bounds = 1;
         string canonicalization_overflow = 2;
         google.protobuf.Empty invalid_range_bound_flags = 3;
+        google.protobuf.Empty discontiguous_union = 4;
     }
 }

--- a/src/repr/src/adt/range.rs
+++ b/src/repr/src/adt/range.rs
@@ -316,6 +316,27 @@ where
             inner: Some(RangeInner { lower, upper }),
         })
     }
+
+    pub fn intersection(&self, other: &Range<B>) -> Range<B> {
+        // Handle self or other being empty
+        let (s, o) = match (self.inner, other.inner) {
+            (Some(s), Some(o)) => {
+                if !self.overlaps(other) {
+                    return Range { inner: None };
+                }
+
+                (s, o)
+            }
+            _ => return Range { inner: None },
+        };
+
+        let lower = std::cmp::max(s.lower, o.lower);
+        let upper = std::cmp::min(s.upper, o.upper);
+
+        Range {
+            inner: Some(RangeInner { lower, upper }),
+        }
+    }
 }
 
 impl<'a> Range<Datum<'a>> {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3336,6 +3336,7 @@ static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
                 Operation::binary(|_ecx, lhs, rhs| Ok(rhs.call_binary(lhs, MulInterval)))
             }, 1584;
             params!(Numeric, Numeric) => MulNumeric, 1760;
+            params!(RangeAny, RangeAny) => RangeIntersection => RangeAny, 3900;
         },
         "/" => Scalar {
             params!(Int16, Int16) => DivInt16, 527;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3319,6 +3319,7 @@ static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(Time, Interval) => SubTimeInterval, 1801;
             params!(Jsonb, Int64) => JsonbDeleteInt64, 3286;
             params!(Jsonb, String) => JsonbDeleteString, 3285;
+            params!(RangeAny, RangeAny) => RangeDifference => RangeAny, 3899;
             // TODO(jamii) there should be corresponding overloads for
             // Array(Int64) and Array(String)
         },

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3290,6 +3290,7 @@ static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
                 Operation::binary(|_ecx, lhs, rhs| Ok(rhs.call_binary(lhs, AddTimeInterval)))
             }, 1849;
             params!(Numeric, Numeric) => AddNumeric, 1758;
+            params!(RangeAny, RangeAny) => RangeUnion => RangeAny, 3898;
         },
         "-" => Scalar {
             params!(Int16) => UnaryFunc::NegInt16(func::NegInt16), 559;

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -1092,6 +1092,132 @@ SELECT ('(,)'::int4range * '[1,)'::int4range)::text
 [1,)
 
 #
+# int4range difference
+
+query T
+SELECT (null - 'empty'::int4range)::text
+----
+NULL
+
+query T
+SELECT ('empty'::int4range - 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range - '(,-1)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range - 'empty'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int4range - '(,-1)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range - '(,-1)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range - '[-2,2)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range - '[1,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range - '(,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range - 'empty'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int4range - '[-2,2)'::int4range)::text
+----
+(,-2)
+
+query T
+SELECT ('(,-1)'::int4range - '[1,)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int4range - '(,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('[-2,2)'::int4range - 'empty'::int4range)::text
+----
+[-2,2)
+
+query T
+SELECT ('[-2,2)'::int4range - '(,-1)'::int4range)::text
+----
+[-1,2)
+
+query T
+SELECT ('[-2,2)'::int4range - '[1,)'::int4range)::text
+----
+[-2,1)
+
+query T
+SELECT ('[-2,2)'::int4range - '(,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::int4range - 'empty'::int4range)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::int4range - '(,-1)'::int4range)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::int4range - '[-2,2)'::int4range)::text
+----
+[2,)
+
+query T
+SELECT ('[1,)'::int4range - '(,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,)'::int4range - 'empty'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int4range - '(,-1)'::int4range)::text
+----
+[-1,)
+
+query error result of range difference would not be contiguous
+SELECT ('(,)'::int4range - '[-2,2)'::int4range)::text
+
+query T
+SELECT ('(,)'::int4range - '[1,)'::int4range)::text
+----
+(,1)
+
+#
 # int8range
 
 query T
@@ -2111,6 +2237,132 @@ SELECT ('(,)'::int8range * '[1,)'::int8range)::text
 [1,)
 
 #
+# int8range difference
+
+query T
+SELECT (null - 'empty'::int8range)::text
+----
+NULL
+
+query T
+SELECT ('empty'::int8range - 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range - '(,-1)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range - 'empty'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int8range - '(,-1)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range - '(,-1)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range - '[-2,2)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range - '[1,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range - '(,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range - 'empty'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int8range - '[-2,2)'::int8range)::text
+----
+(,-2)
+
+query T
+SELECT ('(,-1)'::int8range - '[1,)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int8range - '(,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('[-2,2)'::int8range - 'empty'::int8range)::text
+----
+[-2,2)
+
+query T
+SELECT ('[-2,2)'::int8range - '(,-1)'::int8range)::text
+----
+[-1,2)
+
+query T
+SELECT ('[-2,2)'::int8range - '[1,)'::int8range)::text
+----
+[-2,1)
+
+query T
+SELECT ('[-2,2)'::int8range - '(,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::int8range - 'empty'::int8range)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::int8range - '(,-1)'::int8range)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::int8range - '[-2,2)'::int8range)::text
+----
+[2,)
+
+query T
+SELECT ('[1,)'::int8range - '(,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,)'::int8range - 'empty'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int8range - '(,-1)'::int8range)::text
+----
+[-1,)
+
+query error result of range difference would not be contiguous
+SELECT ('(,)'::int8range - '[-2,2)'::int8range)::text
+
+query T
+SELECT ('(,)'::int8range - '[1,)'::int8range)::text
+----
+(,1)
+
+#
 # daterange
 
 query T
@@ -3051,6 +3303,129 @@ query T
 SELECT ('(,)'::daterange * '[1970-01-02,)'::daterange)::text
 ----
 [1970-01-02,)
+
+#
+# daterange difference
+
+query T
+SELECT ('empty'::daterange - 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange - '(,1969-12-31)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange - 'empty'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange - '(,1969-12-31)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange - '(,1969-12-31)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange - '[1969-12-30,1970-01-03)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange - '[1970-01-02,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange - '(,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange - 'empty'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange - '[1969-12-30,1970-01-03)'::daterange)::text
+----
+(,1969-12-30)
+
+query T
+SELECT ('(,1969-12-31)'::daterange - '[1970-01-02,)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange - '(,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange - 'empty'::daterange)::text
+----
+[1969-12-30,1970-01-03)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange - '(,1969-12-31)'::daterange)::text
+----
+[1969-12-31,1970-01-03)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange - '[1970-01-02,)'::daterange)::text
+----
+[1969-12-30,1970-01-02)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange - '(,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('[1970-01-02,)'::daterange - 'empty'::daterange)::text
+----
+[1970-01-02,)
+
+query T
+SELECT ('[1970-01-02,)'::daterange - '(,1969-12-31)'::daterange)::text
+----
+[1970-01-02,)
+
+query T
+SELECT ('[1970-01-02,)'::daterange - '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1970-01-03,)
+
+query T
+SELECT ('[1970-01-02,)'::daterange - '(,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,)'::daterange - 'empty'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::daterange - '(,1969-12-31)'::daterange)::text
+----
+[1969-12-31,)
+
+query error Expected right square bracket, found operator "\-"
+SELECT ('(,)'::daterange - '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1969-12-30,1970-01-03)
+
+query T
+SELECT ('(,)'::daterange - '[1970-01-02,)'::daterange)::text
+----
+(,1970-01-02)
 
 #
 # numrange
@@ -4510,3 +4885,300 @@ query T
 SELECT ('(,)'::numrange * '(1,)'::numrange)::text
 ----
 (1,)
+
+#
+# numrange difference
+
+query T
+SELECT ('empty'::numrange - 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange - 'empty'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange - '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '(,-1)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '(-2,2)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '[-2,2]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '[1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '(1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange - 'empty'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange - '(,-1)'::numrange)::text
+----
+[-1,-1]
+
+query T
+SELECT ('(,-1]'::numrange - '(-2,2)'::numrange)::text
+----
+(,-2]
+
+query T
+SELECT ('(,-1]'::numrange - '[-2,2]'::numrange)::text
+----
+(,-2)
+
+query T
+SELECT ('(,-1]'::numrange - '[1,)'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange - '(1,)'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::numrange - 'empty'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::numrange - '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::numrange - '(-2,2)'::numrange)::text
+----
+(,-2]
+
+query T
+SELECT ('(,-1)'::numrange - '[-2,2]'::numrange)::text
+----
+(,-2)
+
+query T
+SELECT ('(,-1)'::numrange - '[1,)'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::numrange - '(1,)'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(-2,2)'::numrange - 'empty'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('(-2,2)'::numrange - '(,-1]'::numrange)::text
+----
+(-1,2)
+
+query T
+SELECT ('(-2,2)'::numrange - '(,-1)'::numrange)::text
+----
+[-1,2)
+
+query T
+SELECT ('(-2,2)'::numrange - '[-2,2]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(-2,2)'::numrange - '[1,)'::numrange)::text
+----
+(-2,1)
+
+query T
+SELECT ('(-2,2)'::numrange - '(1,)'::numrange)::text
+----
+(-2,1]
+
+query T
+SELECT ('(-2,2)'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('[-2,2]'::numrange - 'empty'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('[-2,2]'::numrange - '(,-1]'::numrange)::text
+----
+(-1,2]
+
+query T
+SELECT ('[-2,2]'::numrange - '(,-1)'::numrange)::text
+----
+[-1,2]
+
+query error result of range difference would not be contiguous
+SELECT ('[-2,2]'::numrange - '(-2,2)'::numrange)::text
+
+query T
+SELECT ('[-2,2]'::numrange - '[1,)'::numrange)::text
+----
+[-2,1)
+
+query T
+SELECT ('[-2,2]'::numrange - '(1,)'::numrange)::text
+----
+[-2,1]
+
+query T
+SELECT ('[-2,2]'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::numrange - 'empty'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::numrange - '(,-1]'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::numrange - '(,-1)'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::numrange - '(-2,2)'::numrange)::text
+----
+[2,)
+
+query T
+SELECT ('[1,)'::numrange - '[-2,2]'::numrange)::text
+----
+(2,)
+
+query T
+SELECT ('[1,)'::numrange - '(1,)'::numrange)::text
+----
+[1,1]
+
+query T
+SELECT ('[1,)'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(1,)'::numrange - 'empty'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('(1,)'::numrange - '(,-1]'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('(1,)'::numrange - '(,-1)'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('(1,)'::numrange - '(-2,2)'::numrange)::text
+----
+[2,)
+
+query T
+SELECT ('(1,)'::numrange - '[-2,2]'::numrange)::text
+----
+(2,)
+
+query T
+SELECT ('(1,)'::numrange - '[1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(1,)'::numrange - '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,)'::numrange - 'empty'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange - '(,-1]'::numrange)::text
+----
+(-1,)
+
+query T
+SELECT ('(,)'::numrange - '(,-1)'::numrange)::text
+----
+[-1,)
+
+query error result of range difference would not be contiguous
+SELECT ('(,)'::numrange - '(-2,2)'::numrange)::text
+
+query error result of range difference would not be contiguous
+SELECT ('(,)'::numrange - '[-2,2]'::numrange)::text
+
+query T
+SELECT ('(,)'::numrange - '[1,)'::numrange)::text
+----
+(,1)
+
+query T
+SELECT ('(,)'::numrange - '(1,)'::numrange)::text
+----
+(,1]

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -366,7 +366,7 @@ FROM
 			('[  1,)'),
 			('[1  ,)'),
 			('[  1  ,)'),
-            ('[1,  2)'),
+('[1,  2)'),
 			('[1,2  )'),
 			('[1,  2  )'),
 			('[1,)  '),
@@ -839,6 +839,129 @@ SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
 [1,)
 {"(,1)","[-1,1)"}
 
+#
+# int4range union
+
+query T
+SELECT (null + 'empty'::int4range)::text
+----
+NULL
+
+query T
+SELECT ('empty'::int4range + 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range + '(,-1)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int4range + 'empty'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int4range + '(,-1)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::int4range + '(,-1)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::int4range + '[-2,2)'::int4range)::text
+----
+[-2,2)
+
+query T
+SELECT ('empty'::int4range + '[1,)'::int4range)::text
+----
+[1,)
+
+query T
+SELECT ('empty'::int4range + '(,)'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('(,-1)'::int4range + 'empty'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int4range + '[-2,2)'::int4range)::text
+----
+(,2)
+
+query error result of range union would not be contiguous
+SELECT ('(,-1)'::int4range + '[1,)'::int4range)::text
+
+query T
+SELECT ('(,-1)'::int4range + '(,)'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('[-2,2)'::int4range + 'empty'::int4range)::text
+----
+[-2,2)
+
+query T
+SELECT ('[-2,2)'::int4range + '(,-1)'::int4range)::text
+----
+(,2)
+
+query T
+SELECT ('[-2,2)'::int4range + '[1,)'::int4range)::text
+----
+[-2,)
+
+query T
+SELECT ('[-2,2)'::int4range + '(,)'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('[1,)'::int4range + 'empty'::int4range)::text
+----
+[1,)
+
+query error result of range union would not be contiguous
+SELECT ('[1,)'::int4range + '(,-1)'::int4range)::text
+
+query T
+SELECT ('[1,)'::int4range + '[-2,2)'::int4range)::text
+----
+[-2,)
+
+query T
+SELECT ('[1,)'::int4range + '(,)'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int4range + 'empty'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int4range + '(,-1)'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int4range + '[-2,2)'::int4range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int4range + '[1,)'::int4range)::text
+----
+(,)
 
 #
 # int8range
@@ -1607,6 +1730,129 @@ SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
 [1,)
 {"(,1)","[-1,1)"}
 
+#
+# int8range union
+
+query T
+SELECT (null + 'empty'::int8range)::text
+----
+NULL
+
+query T
+SELECT ('empty'::int8range + 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range + '(,-1)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int8range + 'empty'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int8range + '(,-1)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::int8range + '(,-1)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::int8range + '[-2,2)'::int8range)::text
+----
+[-2,2)
+
+query T
+SELECT ('empty'::int8range + '[1,)'::int8range)::text
+----
+[1,)
+
+query T
+SELECT ('empty'::int8range + '(,)'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('(,-1)'::int8range + 'empty'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::int8range + '[-2,2)'::int8range)::text
+----
+(,2)
+
+query error result of range union would not be contiguous
+SELECT ('(,-1)'::int8range + '[1,)'::int8range)::text
+
+query T
+SELECT ('(,-1)'::int8range + '(,)'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('[-2,2)'::int8range + 'empty'::int8range)::text
+----
+[-2,2)
+
+query T
+SELECT ('[-2,2)'::int8range + '(,-1)'::int8range)::text
+----
+(,2)
+
+query T
+SELECT ('[-2,2)'::int8range + '[1,)'::int8range)::text
+----
+[-2,)
+
+query T
+SELECT ('[-2,2)'::int8range + '(,)'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('[1,)'::int8range + 'empty'::int8range)::text
+----
+[1,)
+
+query error result of range union would not be contiguous
+SELECT ('[1,)'::int8range + '(,-1)'::int8range)::text
+
+query T
+SELECT ('[1,)'::int8range + '[-2,2)'::int8range)::text
+----
+[-2,)
+
+query T
+SELECT ('[1,)'::int8range + '(,)'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int8range + 'empty'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int8range + '(,-1)'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int8range + '[-2,2)'::int8range)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::int8range + '[1,)'::int8range)::text
+----
+(,)
 
 #
 # daterange
@@ -1951,7 +2197,7 @@ FROM
 			('[  1970-01-01,)'),
 			('[1970-01-01  ,)'),
 			('[  1970-01-01  ,)'),
-            ('[1970-01-01,  1970-01-01)'),
+('[1970-01-01,  1970-01-01)'),
 			('[1970-01-01,1970-01-01  )'),
 			('[1970-01-01,  1970-01-01  )'),
 			('[1970-01-01,)  '),
@@ -2309,6 +2555,124 @@ SELECT a::text t, array_agg(v::text ORDER BY v) FROM (
 [1970-01-02,)
 {"(,1970-01-02)","[1969-12-31,1970-01-02)"}
 
+#
+# daterange union
+query T
+SELECT ('empty'::daterange + 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange + '(,1969-12-31)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange + 'empty'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange + '(,1969-12-31)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('empty'::daterange + '(,1969-12-31)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('empty'::daterange + '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1969-12-30,1970-01-03)
+
+query T
+SELECT ('empty'::daterange + '[1970-01-02,)'::daterange)::text
+----
+[1970-01-02,)
+
+query T
+SELECT ('empty'::daterange + '(,)'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('(,1969-12-31)'::daterange + 'empty'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange + '[1969-12-30,1970-01-03)'::daterange)::text
+----
+(,1970-01-03)
+
+query error result of range union would not be contiguous
+SELECT ('(,1969-12-31)'::daterange + '[1970-01-02,)'::daterange)::text
+
+query T
+SELECT ('(,1969-12-31)'::daterange + '(,)'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange + 'empty'::daterange)::text
+----
+[1969-12-30,1970-01-03)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange + '(,1969-12-31)'::daterange)::text
+----
+(,1970-01-03)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange + '[1970-01-02,)'::daterange)::text
+----
+[1969-12-30,)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange + '(,)'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('[1970-01-02,)'::daterange + 'empty'::daterange)::text
+----
+[1970-01-02,)
+
+query error result of range union would not be contiguous
+SELECT ('[1970-01-02,)'::daterange + '(,1969-12-31)'::daterange)::text
+
+query T
+SELECT ('[1970-01-02,)'::daterange + '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1969-12-30,)
+
+query T
+SELECT ('[1970-01-02,)'::daterange + '(,)'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::daterange + 'empty'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::daterange + '(,1969-12-31)'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::daterange + '[1969-12-30,1970-01-03)'::daterange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::daterange + '[1970-01-02,)'::daterange)::text
+----
+(,)
+
 
 #
 # numrange
@@ -2653,7 +3017,7 @@ FROM
 			('[  1,)'),
 			('[1  ,)'),
 			('[  1  ,)'),
-            ('[1,  2)'),
+('[1,  2)'),
 			('[1,2  )'),
 			('[1,  2  )'),
 			('[1,)  '),
@@ -3179,3 +3543,289 @@ SELECT numrange(-1.1::numeric(38,0),1.2::numeric(38,10))::text;
 
 query error range lower bound must be less than or equal to range upper bound
 SELECT numrange(1.1::numeric(38,2),1.2::numeric(38,0))::text;
+
+#
+# numrange union
+query T
+SELECT ('empty'::numrange + 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange + '(,-1]'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange + 'empty'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange + '(,-1]'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('empty'::numrange + '(,-1]'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('empty'::numrange + '(,-1)'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::numrange + '(-2,2)'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('empty'::numrange + '[-2,2]'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('empty'::numrange + '[1,)'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('empty'::numrange + '(1,)'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('empty'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,-1]'::numrange + 'empty'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange + '(,-1)'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1]'::numrange + '(-2,2)'::numrange)::text
+----
+(,2)
+
+query T
+SELECT ('(,-1]'::numrange + '[-2,2]'::numrange)::text
+----
+(,2]
+
+query error result of range union would not be contiguous
+SELECT ('(,-1]'::numrange + '[1,)'::numrange)::text
+
+query error result of range union would not be contiguous
+SELECT ('(,-1]'::numrange + '(1,)'::numrange)::text
+
+query T
+SELECT ('(,-1]'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,-1)'::numrange + 'empty'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::numrange + '(,-1]'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1)'::numrange + '(-2,2)'::numrange)::text
+----
+(,2)
+
+query T
+SELECT ('(,-1)'::numrange + '[-2,2]'::numrange)::text
+----
+(,2]
+
+query error result of range union would not be contiguous
+SELECT ('(,-1)'::numrange + '[1,)'::numrange)::text
+
+query error result of range union would not be contiguous
+SELECT ('(,-1)'::numrange + '(1,)'::numrange)::text
+
+query T
+SELECT ('(,-1)'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(-2,2)'::numrange + 'empty'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('(-2,2)'::numrange + '(,-1]'::numrange)::text
+----
+(,2)
+
+query T
+SELECT ('(-2,2)'::numrange + '(,-1)'::numrange)::text
+----
+(,2)
+
+query T
+SELECT ('(-2,2)'::numrange + '[-2,2]'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('(-2,2)'::numrange + '[1,)'::numrange)::text
+----
+(-2,)
+
+query T
+SELECT ('(-2,2)'::numrange + '(1,)'::numrange)::text
+----
+(-2,)
+
+query T
+SELECT ('(-2,2)'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('[-2,2]'::numrange + 'empty'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('[-2,2]'::numrange + '(,-1]'::numrange)::text
+----
+(,2]
+
+query T
+SELECT ('[-2,2]'::numrange + '(,-1)'::numrange)::text
+----
+(,2]
+
+query T
+SELECT ('[-2,2]'::numrange + '(-2,2)'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('[-2,2]'::numrange + '[1,)'::numrange)::text
+----
+[-2,)
+
+query T
+SELECT ('[-2,2]'::numrange + '(1,)'::numrange)::text
+----
+[-2,)
+
+query T
+SELECT ('[-2,2]'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('[1,)'::numrange + 'empty'::numrange)::text
+----
+[1,)
+
+query error result of range union would not be contiguous
+SELECT ('[1,)'::numrange + '(,-1]'::numrange)::text
+
+query error result of range union would not be contiguous
+SELECT ('[1,)'::numrange + '(,-1)'::numrange)::text
+
+query T
+SELECT ('[1,)'::numrange + '(-2,2)'::numrange)::text
+----
+(-2,)
+
+query T
+SELECT ('[1,)'::numrange + '[-2,2]'::numrange)::text
+----
+[-2,)
+
+query T
+SELECT ('[1,)'::numrange + '(1,)'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('[1,)'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(1,)'::numrange + 'empty'::numrange)::text
+----
+(1,)
+
+query error result of range union would not be contiguous
+SELECT ('(1,)'::numrange + '(,-1]'::numrange)::text
+
+query error result of range union would not be contiguous
+SELECT ('(1,)'::numrange + '(,-1)'::numrange)::text
+
+query T
+SELECT ('(1,)'::numrange + '(-2,2)'::numrange)::text
+----
+(-2,)
+
+query T
+SELECT ('(1,)'::numrange + '[-2,2]'::numrange)::text
+----
+[-2,)
+
+query T
+SELECT ('(1,)'::numrange + '[1,)'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('(1,)'::numrange + '(,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + 'empty'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + '(,-1]'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + '(,-1)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + '(-2,2)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + '[-2,2]'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + '[1,)'::numrange)::text
+----
+(,)
+
+query T
+SELECT ('(,)'::numrange + '(1,)'::numrange)::text
+----
+(,)

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -366,7 +366,7 @@ FROM
 			('[  1,)'),
 			('[1  ,)'),
 			('[  1  ,)'),
-('[1,  2)'),
+            ('[1,  2)'),
 			('[1,2  )'),
 			('[1,  2  )'),
 			('[1,)  '),
@@ -962,6 +962,134 @@ query T
 SELECT ('(,)'::int4range + '[1,)'::int4range)::text
 ----
 (,)
+
+#
+# int4range intersection
+
+query T
+SELECT (null * 'empty'::int4range)::text
+----
+NULL
+
+query T
+SELECT ('empty'::int4range * 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range * '(,-1)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range * 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range * '(,-1)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::int4range * '(,-1)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range * '[-2,2)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range * '[1,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int4range * '(,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range * 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range * '[-2,2)'::int4range)::text
+----
+[-2,-1)
+
+query T
+SELECT ('(,-1)'::int4range * '[1,)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int4range * '(,)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('[-2,2)'::int4range * 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('[-2,2)'::int4range * '(,-1)'::int4range)::text
+----
+[-2,-1)
+
+query T
+SELECT ('[-2,2)'::int4range * '[1,)'::int4range)::text
+----
+[1,2)
+
+query T
+SELECT ('[-2,2)'::int4range * '(,)'::int4range)::text
+----
+[-2,2)
+
+query T
+SELECT ('[1,)'::int4range * 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::int4range * '(,-1)'::int4range)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::int4range * '[-2,2)'::int4range)::text
+----
+[1,2)
+
+query T
+SELECT ('[1,)'::int4range * '(,)'::int4range)::text
+----
+[1,)
+
+query T
+SELECT ('(,)'::int4range * 'empty'::int4range)::text
+----
+empty
+
+query T
+SELECT ('(,)'::int4range * '(,-1)'::int4range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,)'::int4range * '[-2,2)'::int4range)::text
+----
+[-2,2)
+
+query T
+SELECT ('(,)'::int4range * '[1,)'::int4range)::text
+----
+[1,)
 
 #
 # int8range
@@ -1855,6 +1983,134 @@ SELECT ('(,)'::int8range + '[1,)'::int8range)::text
 (,)
 
 #
+# int8range intersection
+
+query T
+SELECT (null * 'empty'::int8range)::text
+----
+NULL
+
+query T
+SELECT ('empty'::int8range * 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range * '(,-1)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range * 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range * '(,-1)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('empty'::int8range * '(,-1)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range * '[-2,2)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range * '[1,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('empty'::int8range * '(,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range * 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range * '[-2,2)'::int8range)::text
+----
+[-2,-1)
+
+query T
+SELECT ('(,-1)'::int8range * '[1,)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::int8range * '(,)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('[-2,2)'::int8range * 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('[-2,2)'::int8range * '(,-1)'::int8range)::text
+----
+[-2,-1)
+
+query T
+SELECT ('[-2,2)'::int8range * '[1,)'::int8range)::text
+----
+[1,2)
+
+query T
+SELECT ('[-2,2)'::int8range * '(,)'::int8range)::text
+----
+[-2,2)
+
+query T
+SELECT ('[1,)'::int8range * 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::int8range * '(,-1)'::int8range)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::int8range * '[-2,2)'::int8range)::text
+----
+[1,2)
+
+query T
+SELECT ('[1,)'::int8range * '(,)'::int8range)::text
+----
+[1,)
+
+query T
+SELECT ('(,)'::int8range * 'empty'::int8range)::text
+----
+empty
+
+query T
+SELECT ('(,)'::int8range * '(,-1)'::int8range)::text
+----
+(,-1)
+
+query T
+SELECT ('(,)'::int8range * '[-2,2)'::int8range)::text
+----
+[-2,2)
+
+query T
+SELECT ('(,)'::int8range * '[1,)'::int8range)::text
+----
+[1,)
+
+#
 # daterange
 
 query T
@@ -2673,6 +2929,128 @@ SELECT ('(,)'::daterange + '[1970-01-02,)'::daterange)::text
 ----
 (,)
 
+#
+# daterange intersection
+
+query T
+SELECT ('empty'::daterange * 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange * '(,1969-12-31)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange * 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange * '(,1969-12-31)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('empty'::daterange * '(,1969-12-31)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange * '[1969-12-30,1970-01-03)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange * '[1970-01-02,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('empty'::daterange * '(,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange * 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange * '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1969-12-30,1969-12-31)
+
+query T
+SELECT ('(,1969-12-31)'::daterange * '[1970-01-02,)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,1969-12-31)'::daterange * '(,)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange * 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange * '(,1969-12-31)'::daterange)::text
+----
+[1969-12-30,1969-12-31)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange * '[1970-01-02,)'::daterange)::text
+----
+[1970-01-02,1970-01-03)
+
+query T
+SELECT ('[1969-12-30,1970-01-03)'::daterange * '(,)'::daterange)::text
+----
+[1969-12-30,1970-01-03)
+
+query T
+SELECT ('[1970-01-02,)'::daterange * 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('[1970-01-02,)'::daterange * '(,1969-12-31)'::daterange)::text
+----
+empty
+
+query T
+SELECT ('[1970-01-02,)'::daterange * '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1970-01-02,1970-01-03)
+
+query T
+SELECT ('[1970-01-02,)'::daterange * '(,)'::daterange)::text
+----
+[1970-01-02,)
+
+query T
+SELECT ('(,)'::daterange * 'empty'::daterange)::text
+----
+empty
+
+query T
+SELECT ('(,)'::daterange * '(,1969-12-31)'::daterange)::text
+----
+(,1969-12-31)
+
+query T
+SELECT ('(,)'::daterange * '[1969-12-30,1970-01-03)'::daterange)::text
+----
+[1969-12-30,1970-01-03)
+
+query T
+SELECT ('(,)'::daterange * '[1970-01-02,)'::daterange)::text
+----
+[1970-01-02,)
 
 #
 # numrange
@@ -3829,3 +4207,306 @@ query T
 SELECT ('(,)'::numrange + '(1,)'::numrange)::text
 ----
 (,)
+
+#
+# numrange intersection
+
+query T
+SELECT ('empty'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange * '(,-1]'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('empty'::numrange * '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '(,-1)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '(-2,2)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '[-2,2]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '[1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '(1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('empty'::numrange * '(,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange * '(,-1)'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1]'::numrange * '(-2,2)'::numrange)::text
+----
+(-2,-1]
+
+query T
+SELECT ('(,-1]'::numrange * '[-2,2]'::numrange)::text
+----
+[-2,-1]
+
+query T
+SELECT ('(,-1]'::numrange * '[1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange * '(1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1]'::numrange * '(,)'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,-1)'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::numrange * '(,-1]'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,-1)'::numrange * '(-2,2)'::numrange)::text
+----
+(-2,-1)
+
+query T
+SELECT ('(,-1)'::numrange * '[-2,2]'::numrange)::text
+----
+[-2,-1)
+
+query T
+SELECT ('(,-1)'::numrange * '[1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::numrange * '(1,)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,-1)'::numrange * '(,)'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(-2,2)'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(-2,2)'::numrange * '(,-1]'::numrange)::text
+----
+(-2,-1]
+
+query T
+SELECT ('(-2,2)'::numrange * '(,-1)'::numrange)::text
+----
+(-2,-1)
+
+query T
+SELECT ('(-2,2)'::numrange * '[-2,2]'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('(-2,2)'::numrange * '[1,)'::numrange)::text
+----
+[1,2)
+
+query T
+SELECT ('(-2,2)'::numrange * '(1,)'::numrange)::text
+----
+(1,2)
+
+query T
+SELECT ('(-2,2)'::numrange * '(,)'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('[-2,2]'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('[-2,2]'::numrange * '(,-1]'::numrange)::text
+----
+[-2,-1]
+
+query T
+SELECT ('[-2,2]'::numrange * '(,-1)'::numrange)::text
+----
+[-2,-1)
+
+query T
+SELECT ('[-2,2]'::numrange * '(-2,2)'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('[-2,2]'::numrange * '[1,)'::numrange)::text
+----
+[1,2]
+
+query T
+SELECT ('[-2,2]'::numrange * '(1,)'::numrange)::text
+----
+(1,2]
+
+query T
+SELECT ('[-2,2]'::numrange * '(,)'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('[1,)'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::numrange * '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::numrange * '(,-1)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('[1,)'::numrange * '(-2,2)'::numrange)::text
+----
+[1,2)
+
+query T
+SELECT ('[1,)'::numrange * '[-2,2]'::numrange)::text
+----
+[1,2]
+
+query T
+SELECT ('[1,)'::numrange * '(1,)'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('[1,)'::numrange * '(,)'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('(1,)'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(1,)'::numrange * '(,-1]'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(1,)'::numrange * '(,-1)'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(1,)'::numrange * '(-2,2)'::numrange)::text
+----
+(1,2)
+
+query T
+SELECT ('(1,)'::numrange * '[-2,2]'::numrange)::text
+----
+(1,2]
+
+query T
+SELECT ('(1,)'::numrange * '[1,)'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('(1,)'::numrange * '(,)'::numrange)::text
+----
+(1,)
+
+query T
+SELECT ('(,)'::numrange * 'empty'::numrange)::text
+----
+empty
+
+query T
+SELECT ('(,)'::numrange * '(,-1]'::numrange)::text
+----
+(,-1]
+
+query T
+SELECT ('(,)'::numrange * '(,-1)'::numrange)::text
+----
+(,-1)
+
+query T
+SELECT ('(,)'::numrange * '(-2,2)'::numrange)::text
+----
+(-2,2)
+
+query T
+SELECT ('(,)'::numrange * '[-2,2]'::numrange)::text
+----
+[-2,2]
+
+query T
+SELECT ('(,)'::numrange * '[1,)'::numrange)::text
+----
+[1,)
+
+query T
+SELECT ('(,)'::numrange * '(1,)'::numrange)::text
+----
+(1,)

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -868,11 +868,6 @@ SELECT ('(,-1)'::int4range + '(,-1)'::int4range)::text
 (,-1)
 
 query T
-SELECT ('empty'::int4range + '(,-1)'::int4range)::text
-----
-(,-1)
-
-query T
 SELECT ('empty'::int4range + '[-2,2)'::int4range)::text
 ----
 [-2,2)
@@ -886,11 +881,6 @@ query T
 SELECT ('empty'::int4range + '(,)'::int4range)::text
 ----
 (,)
-
-query T
-SELECT ('(,-1)'::int4range + 'empty'::int4range)::text
-----
-(,-1)
 
 query T
 SELECT ('(,-1)'::int4range + '[-2,2)'::int4range)::text
@@ -992,11 +982,6 @@ SELECT ('(,-1)'::int4range * '(,-1)'::int4range)::text
 (,-1)
 
 query T
-SELECT ('empty'::int4range * '(,-1)'::int4range)::text
-----
-empty
-
-query T
 SELECT ('empty'::int4range * '[-2,2)'::int4range)::text
 ----
 empty
@@ -1008,11 +993,6 @@ empty
 
 query T
 SELECT ('empty'::int4range * '(,)'::int4range)::text
-----
-empty
-
-query T
-SELECT ('(,-1)'::int4range * 'empty'::int4range)::text
 ----
 empty
 
@@ -1120,11 +1100,6 @@ SELECT ('(,-1)'::int4range - '(,-1)'::int4range)::text
 empty
 
 query T
-SELECT ('empty'::int4range - '(,-1)'::int4range)::text
-----
-empty
-
-query T
 SELECT ('empty'::int4range - '[-2,2)'::int4range)::text
 ----
 empty
@@ -1138,11 +1113,6 @@ query T
 SELECT ('empty'::int4range - '(,)'::int4range)::text
 ----
 empty
-
-query T
-SELECT ('(,-1)'::int4range - 'empty'::int4range)::text
-----
-(,-1)
 
 query T
 SELECT ('(,-1)'::int4range - '[-2,2)'::int4range)::text
@@ -2013,11 +1983,6 @@ SELECT ('(,-1)'::int8range + '(,-1)'::int8range)::text
 (,-1)
 
 query T
-SELECT ('empty'::int8range + '(,-1)'::int8range)::text
-----
-(,-1)
-
-query T
 SELECT ('empty'::int8range + '[-2,2)'::int8range)::text
 ----
 [-2,2)
@@ -2031,11 +1996,6 @@ query T
 SELECT ('empty'::int8range + '(,)'::int8range)::text
 ----
 (,)
-
-query T
-SELECT ('(,-1)'::int8range + 'empty'::int8range)::text
-----
-(,-1)
 
 query T
 SELECT ('(,-1)'::int8range + '[-2,2)'::int8range)::text
@@ -2137,11 +2097,6 @@ SELECT ('(,-1)'::int8range * '(,-1)'::int8range)::text
 (,-1)
 
 query T
-SELECT ('empty'::int8range * '(,-1)'::int8range)::text
-----
-empty
-
-query T
 SELECT ('empty'::int8range * '[-2,2)'::int8range)::text
 ----
 empty
@@ -2153,11 +2108,6 @@ empty
 
 query T
 SELECT ('empty'::int8range * '(,)'::int8range)::text
-----
-empty
-
-query T
-SELECT ('(,-1)'::int8range * 'empty'::int8range)::text
 ----
 empty
 
@@ -2265,11 +2215,6 @@ SELECT ('(,-1)'::int8range - '(,-1)'::int8range)::text
 empty
 
 query T
-SELECT ('empty'::int8range - '(,-1)'::int8range)::text
-----
-empty
-
-query T
 SELECT ('empty'::int8range - '[-2,2)'::int8range)::text
 ----
 empty
@@ -2283,11 +2228,6 @@ query T
 SELECT ('empty'::int8range - '(,)'::int8range)::text
 ----
 empty
-
-query T
-SELECT ('(,-1)'::int8range - 'empty'::int8range)::text
-----
-(,-1)
 
 query T
 SELECT ('(,-1)'::int8range - '[-2,2)'::int8range)::text
@@ -3086,11 +3026,6 @@ SELECT ('(,1969-12-31)'::daterange + '(,1969-12-31)'::daterange)::text
 (,1969-12-31)
 
 query T
-SELECT ('empty'::daterange + '(,1969-12-31)'::daterange)::text
-----
-(,1969-12-31)
-
-query T
 SELECT ('empty'::daterange + '[1969-12-30,1970-01-03)'::daterange)::text
 ----
 [1969-12-30,1970-01-03)
@@ -3104,11 +3039,6 @@ query T
 SELECT ('empty'::daterange + '(,)'::daterange)::text
 ----
 (,)
-
-query T
-SELECT ('(,1969-12-31)'::daterange + 'empty'::daterange)::text
-----
-(,1969-12-31)
 
 query T
 SELECT ('(,1969-12-31)'::daterange + '[1969-12-30,1970-01-03)'::daterange)::text
@@ -3205,11 +3135,6 @@ SELECT ('(,1969-12-31)'::daterange * '(,1969-12-31)'::daterange)::text
 (,1969-12-31)
 
 query T
-SELECT ('empty'::daterange * '(,1969-12-31)'::daterange)::text
-----
-empty
-
-query T
 SELECT ('empty'::daterange * '[1969-12-30,1970-01-03)'::daterange)::text
 ----
 empty
@@ -3221,11 +3146,6 @@ empty
 
 query T
 SELECT ('empty'::daterange * '(,)'::daterange)::text
-----
-empty
-
-query T
-SELECT ('(,1969-12-31)'::daterange * 'empty'::daterange)::text
 ----
 empty
 
@@ -3328,11 +3248,6 @@ SELECT ('(,1969-12-31)'::daterange - '(,1969-12-31)'::daterange)::text
 empty
 
 query T
-SELECT ('empty'::daterange - '(,1969-12-31)'::daterange)::text
-----
-empty
-
-query T
 SELECT ('empty'::daterange - '[1969-12-30,1970-01-03)'::daterange)::text
 ----
 empty
@@ -3346,11 +3261,6 @@ query T
 SELECT ('empty'::daterange - '(,)'::daterange)::text
 ----
 empty
-
-query T
-SELECT ('(,1969-12-31)'::daterange - 'empty'::daterange)::text
-----
-(,1969-12-31)
 
 query T
 SELECT ('(,1969-12-31)'::daterange - '[1969-12-30,1970-01-03)'::daterange)::text
@@ -4310,17 +4220,7 @@ SELECT ('empty'::numrange + '(,-1]'::numrange)::text
 (,-1]
 
 query T
-SELECT ('(,-1]'::numrange + 'empty'::numrange)::text
-----
-(,-1]
-
-query T
 SELECT ('(,-1]'::numrange + '(,-1]'::numrange)::text
-----
-(,-1]
-
-query T
-SELECT ('empty'::numrange + '(,-1]'::numrange)::text
 ----
 (,-1]
 
@@ -4607,11 +4507,6 @@ SELECT ('(,-1]'::numrange * '(,-1]'::numrange)::text
 (,-1]
 
 query T
-SELECT ('empty'::numrange * '(,-1]'::numrange)::text
-----
-empty
-
-query T
 SELECT ('empty'::numrange * '(,-1)'::numrange)::text
 ----
 empty
@@ -4638,11 +4533,6 @@ empty
 
 query T
 SELECT ('empty'::numrange * '(,)'::numrange)::text
-----
-empty
-
-query T
-SELECT ('(,-1]'::numrange * 'empty'::numrange)::text
 ----
 empty
 
@@ -4900,17 +4790,7 @@ SELECT ('empty'::numrange - '(,-1]'::numrange)::text
 empty
 
 query T
-SELECT ('(,-1]'::numrange - 'empty'::numrange)::text
-----
-(,-1]
-
-query T
 SELECT ('(,-1]'::numrange - '(,-1]'::numrange)::text
-----
-empty
-
-query T
-SELECT ('empty'::numrange - '(,-1]'::numrange)::text
 ----
 empty
 


### PR DESCRIPTION
Adds `+` (union), `*` (intersection), `-` (difference) operators for generic range type.

### Motivation

This PR adds a known-desirable feature. Part of #17342

### Tips for reviewer

`slt` diff is ridiculous; I just parameterize the tests I want to generate and spot test them against PG, so hopefully does not require substantive review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
