### PR TITLE
persist: keep metrics per raw s3 call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,6 +4179,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "postgres-openssl",
+ "prometheus",
  "prost",
  "prost-build",
  "protobuf-src",

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -107,7 +107,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
     {
         let metrics_registry = metrics_registry.clone();
         info!(
-            "serving internal HTTP server on {}",
+            "serving internal HTTP server on http://{}/metrics",
             args.internal_http_listen_addr
         );
         mz_ore::task::spawn(

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -41,6 +41,7 @@ mz-proto = { path = "../proto" }
 openssl = { version = "0.10.43", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
+prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -11,6 +11,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{Counter, IntCounter, MetricsRegistry, UIntGauge};
+use prometheus::IntCounterVec;
 
 /// Metrics specific to S3Blob's internal workings.
 #[derive(Debug, Clone)]
@@ -19,11 +20,24 @@ pub struct S3BlobMetrics {
     pub(crate) operation_attempt_timeouts: IntCounter,
     pub(crate) connect_timeouts: IntCounter,
     pub(crate) read_timeouts: IntCounter,
+    pub(crate) get_part: IntCounter,
+    pub(crate) set_single: IntCounter,
+    pub(crate) set_multi_create: IntCounter,
+    pub(crate) set_multi_part: IntCounter,
+    pub(crate) set_multi_complete: IntCounter,
+    pub(crate) delete_head: IntCounter,
+    pub(crate) delete_object: IntCounter,
+    pub(crate) list_objects: IntCounter,
 }
 
 impl S3BlobMetrics {
     /// Returns a new [S3BlobMetrics] instance connected to the given registry.
     pub fn new(registry: &MetricsRegistry) -> Self {
+        let operations: IntCounterVec = registry.register(metric!(
+            name: "mz_persist_s3_operations",
+            help: "number of raw s3 calls on behalf of Blob interface methods",
+            var_labels: ["op"],
+        ));
         Self {
             operation_timeouts: registry.register(metric!(
                 name: "mz_persist_s3_operation_timeouts",
@@ -41,6 +55,14 @@ impl S3BlobMetrics {
                 name: "mz_persist_s3_read_timeouts",
                 help: "number of timeouts waiting on first response byte from S3",
             )),
+            get_part: operations.with_label_values(&["get_part"]),
+            set_single: operations.with_label_values(&["set_single"]),
+            set_multi_create: operations.with_label_values(&["set_multi_create"]),
+            set_multi_part: operations.with_label_values(&["set_multi_part"]),
+            set_multi_complete: operations.with_label_values(&["set_multi_complete"]),
+            delete_head: operations.with_label_values(&["delete_head"]),
+            delete_object: operations.with_label_values(&["delete_object"]),
+            list_objects: operations.with_label_values(&["list_objects"]),
         }
     }
 }


### PR DESCRIPTION
This will help with computing the realtime costs of our usage (and
potentially would also help with future debugging of prod issues).

Result of open-loop sanity check

    mz_persist_s3_operations{op="delete_head"} 0
    mz_persist_s3_operations{op="delete_object"} 0
    mz_persist_s3_operations{op="get_part"} 131
    mz_persist_s3_operations{op="list_objects"} 0
    mz_persist_s3_operations{op="set_multi_complete"} 0
    mz_persist_s3_operations{op="set_multi_create"} 0
    mz_persist_s3_operations{op="set_multi_part"} 0
    mz_persist_s3_operations{op="set_single"} 73

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
