### PR TITLE
adapter: correctly determine prepending pg_catalog for types

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1277,6 +1277,7 @@ pub struct ConnCatalog<'a> {
     conn_id: ConnectionId,
     cluster: String,
     database: Option<DatabaseId>,
+    // Schemas from the session's search_path var that exist in the catalog.
     search_path: Vec<(ResolvedDatabaseSpecifier, SchemaSpecifier)>,
     user: User,
     prepared_statements: Option<Cow<'a, BTreeMap<String, PreparedStatement>>>,
@@ -1303,6 +1304,11 @@ impl ConnCatalog<'_> {
         }
     }
 
+    /// Returns the schemas:
+    /// - mz_catalog
+    /// - pg_catalog
+    /// - temp (if requested)
+    /// - schemas of the search_path session var that exist
     fn effective_search_path(
         &self,
         include_temp_schema: bool,
@@ -6198,7 +6204,7 @@ impl ExprHumanizer for ConnCatalog<'_> {
                     SchemaSpecifier::Id(self.state.get_pg_catalog_schema_id().clone());
 
                 let res = if self
-                    .effective_search_path(true)
+                    .search_path
                     .iter()
                     .any(|(_, schema)| schema == &pg_catalog_schema)
                 {


### PR DESCRIPTION
Previously we would never prepend the pg_catalog string to the output, because effective_search_path always returns the pg_catalog schema. I think this function intended to use only the user's session variable, which is the search_path field.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a