### PR TITLE
adapter: switch mz_storage_usage_by_shard to track (3a)

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -99,8 +99,7 @@ use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::{stack, task};
-use mz_persist_client::usage::StorageUsageClient;
-use mz_persist_client::ShardId;
+use mz_persist_client::usage::{ShardsUsage, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_secrets::SecretsController;
@@ -202,7 +201,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     },
     LinearizeReads(Vec<PendingReadTxn>),
     StorageUsageFetch,
-    StorageUsageUpdate(BTreeMap<Option<ShardId>, u64>),
+    StorageUsageUpdate(ShardsUsage),
     RealTimeRecencyTimestamp {
         conn_id: ConnectionId,
         transient_revision: u64,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use chrono::DurationRound;
+use mz_persist_client::usage::ShardsUsage;
 use rand::{rngs, Rng, SeedableRng};
 use tracing::{event, warn, Level};
 
@@ -22,7 +23,6 @@ use mz_controller::clusters::ClusterEvent;
 use mz_controller::ControllerResponse;
 use mz_ore::now::EpochMillis;
 use mz_ore::task;
-use mz_persist_client::ShardId;
 use mz_sql::ast::Statement;
 use mz_sql::plan::{Plan, SendDiffsPlan};
 use mz_storage_client::controller::CollectionMetadata;
@@ -142,17 +142,16 @@ impl Coordinator {
         // requires a slow scan of the underlying storage engine.
         task::spawn(|| "storage_usage_fetch", async move {
             let collection_metric_timer = collection_metric.start_timer();
-            let mut shard_sizes = client.shard_sizes().await;
+            let mut shard_sizes = client.shards_usage().await;
 
             // Don't record usage for shards that are no longer live.
             // Technically the storage is in use, but we never free it, and
             // we don't want to bill the customer for it.
             //
             // See: https://github.com/MaterializeInc/materialize/issues/8185
-            shard_sizes.retain(|shard_id, _| match shard_id {
-                None => true,
-                Some(shard_id) => live_shards.contains(shard_id),
-            });
+            shard_sizes
+                .by_shard
+                .retain(|shard_id, _| live_shards.contains(shard_id));
             collection_metric_timer.observe_duration();
 
             // It is not an error for shard sizes to become ready after
@@ -164,7 +163,7 @@ impl Coordinator {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn storage_usage_update(&mut self, shard_sizes: BTreeMap<Option<ShardId>, u64>) {
+    async fn storage_usage_update(&mut self, shards_usage: ShardsUsage) {
         // Similar to audit events, use the oracle ts so this is guaranteed to
         // increase. This is intentionally the timestamp of when collection
         // finished, not when it started, so that we don't write data with a
@@ -172,10 +171,17 @@ impl Coordinator {
         let collection_timestamp: EpochMillis = self.get_local_write_ts().await.timestamp.into();
 
         let mut ops = vec![];
-        for (shard_id, size_bytes) in shard_sizes {
+        for (shard_id, shard_usage) in shards_usage.by_shard {
             ops.push(catalog::Op::UpdateStorageUsage {
-                shard_id: shard_id.map(|shard_id| shard_id.to_string()),
-                size_bytes,
+                shard_id: Some(shard_id.to_string()),
+                size_bytes: shard_usage.referenced_bytes(),
+                collection_timestamp,
+            });
+        }
+        if shards_usage.unattributable_bytes > 0 {
+            ops.push(catalog::Op::UpdateStorageUsage {
+                shard_id: None,
+                size_bytes: shards_usage.unattributable_bytes,
                 collection_timestamp,
             });
         }


### PR DESCRIPTION
Before this PR it tracked (1). See #17293 for the definitions of what these categories are.

Closes #17317

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
