### PR TITLE
adapter: improve schema resolution

### DIFF
--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -18,6 +18,7 @@ use mz_adapter::{AdapterError, AdapterNotice, StartupMessage};
 use mz_expr::EvalError;
 use mz_repr::{ColumnName, NotNullViolation, RelationDesc};
 use mz_sql::ast::NoticeSeverity;
+use mz_sql::plan::PlanError;
 
 // Pgwire protocol versions are represented as 32-bit integers, where the
 // high 16 bits represent the major version and the low 16 bits represent the
@@ -349,6 +350,7 @@ impl ErrorResponse {
             AdapterError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
             AdapterError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,
             AdapterError::ParseError(_) => SqlState::SYNTAX_ERROR,
+            AdapterError::PlanError(PlanError::InvalidSchemaName) => SqlState::INVALID_SCHEMA_NAME,
             AdapterError::PlanError(_) => SqlState::INTERNAL_ERROR,
             AdapterError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -88,6 +88,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Returns the cluster to use if one is not explicitly specified.
     fn active_cluster(&self) -> &str;
 
+    /// Returns the resolved search paths for the current user. (Invalid search paths are skipped.)
+    fn search_path(&self) -> &[(ResolvedDatabaseSpecifier, SchemaSpecifier)];
+
     /// Returns the descriptor of the named prepared statement on the session, or
     /// None if the prepared statement does not exist.
     fn get_prepared_statement_desc(&self, name: &str) -> Option<&StatementDesc>;
@@ -841,6 +844,10 @@ impl SessionCatalog for DummyCatalog {
 
     fn active_cluster(&self) -> &str {
         "dummy"
+    }
+
+    fn search_path(&self) -> &[(ResolvedDatabaseSpecifier, SchemaSpecifier)] {
+        &[]
     }
 
     fn get_prepared_statement_desc(&self, _: &str) -> Option<&StatementDesc> {

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -551,32 +551,3 @@ macro_rules! generate_extracted_config {
 }
 
 pub(crate) use generate_extracted_config;
-
-#[cfg(test)]
-mod tests {
-    use std::error::Error;
-
-    use mz_ore::collections::CollectionExt;
-
-    use super::*;
-    use crate::catalog::DummyCatalog;
-    use crate::names;
-
-    #[test]
-    fn normalized_create() -> Result<(), Box<dyn Error>> {
-        let scx = &mut StatementContext::new(None, &DummyCatalog);
-
-        let parsed = mz_sql_parser::parser::parse_statements("create view foo as select 1 as bar")?
-            .into_element();
-
-        let (stmt, _) = names::resolve(scx.catalog, parsed)?;
-
-        // Ensure that all identifiers are quoted.
-        assert_eq!(
-            r#"CREATE VIEW "dummy"."public"."foo" AS SELECT 1 AS "bar""#,
-            create_statement(scx, stmt)?,
-        );
-
-        Ok(())
-    }
-}

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -138,6 +138,7 @@ pub enum PlanError {
         name: String,
         supported_azs: BTreeSet<String>,
     },
+    InvalidSchemaName,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -373,6 +374,7 @@ impl fmt::Display for PlanError {
                 })
             },
             Self::InvalidPrivatelinkAvailabilityZone { name, ..} => write!(f, "invalid AWS PrivateLink availability zone {}", name.quoted()),
+            Self::InvalidSchemaName => write!(f, "no schema has been selected to create in"),
         }
     }
 }

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -41,6 +41,9 @@ SELECT current_schemas(true)
 ----
 {mz_catalog,pg_catalog}
 
+statement error no schema has been selected to create in
+CREATE TABLE t (i INT)
+
 statement ok
 CREATE SCHEMA foo
 ----
@@ -59,6 +62,14 @@ query T
 SELECT current_schemas(true)
 ----
 {mz_catalog,pg_catalog,foo}
+
+statement ok
+CREATE TABLE t (i INT)
+
+query T
+SELECT count(*) from t
+----
+0
 
 statement ok
 SET search_path = pg_catalog

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query T
+show search_path
+----
+public
+
+# TODO: Check `search_path = 'bar', 'foo'` later once we correctly support multi
+# variable settings. That is, where the first schema of search_path doesn't exist
+# but the second does.
+
+statement ok
+SET search_path = 'foo'
+
+query T
+show search_path
+----
+foo
+
+query T
+SELECT current_schema()
+----
+NULL
+
+query T
+SELECT current_schemas(false)
+----
+{}
+
+query T
+SELECT current_schemas(true)
+----
+{mz_catalog,pg_catalog}
+
+statement ok
+CREATE SCHEMA foo
+----
+
+query T
+SELECT current_schema()
+----
+foo
+
+query T
+SELECT current_schemas(false)
+----
+{foo}
+
+query T
+SELECT current_schemas(true)
+----
+{mz_catalog,pg_catalog,foo}
+
+statement ok
+SET search_path = pg_catalog
+
+query T
+show search_path
+----
+pg_catalog
+
+query T
+SELECT current_schema()
+----
+pg_catalog
+
+query T
+SELECT current_schemas(true)
+----
+{mz_catalog,pg_catalog}
+
+query T
+SELECT current_schemas(false)
+----
+{pg_catalog}


### PR DESCRIPTION
Improve schema resolution:

- Correct `current_schema[s]()` implementations.
- Use the session's `search_path` to determine the schema in which to create new objects.

See #6754

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a