### PR TITLE
compute: frontier logging for index imports

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -235,7 +235,7 @@ For per-worker frontier information, see
 Field       | Type       | Meaning
 ------------|------------|--------
 `export_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
-`import_id` | [`text`]   | The ID of the input source object for the dataflow. Corresponds to either [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables) or [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views).
+`import_id` | [`text`]   | The ID of the input source object for the dataflow. Corresponds to either [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables) or [`mz_compute_exports.export_id`](#mz_compute_exports).
 `time`      | [`mz_timestamp`] | The next timestamp at which the source instantiation may change.
 
 ### `mz_message_counts`
@@ -421,7 +421,7 @@ corresponding [dataflow] frontiers.
 Field       | Type          | Meaning
 ------------|---------------|--------
 `export_id` | [`text`]      | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
-`import_id` | [`text`]      | The ID of the input source object for the dataflow. Corresponds to either [`mz_sources.id`](../mz_catalog#mz_sources) or [`mz_tables.id`](../mz_catalog#mz_tables) or [`mz_materialized_views.id`](../mz_catalog#mz_materialized_views).
+`import_id` | [`text`]      | The ID of the input source object for the dataflow. Corresponds to either [`mz_sources.id`](../mz_catalog#mz_sources) or [`mz_tables.id`](../mz_catalog#mz_tables) or [`mz_compute_exports.export_id`](#mz_compute_exports).
 `worker_id` | [`bigint`]    | The ID of the worker thread hosting the dataflow.
 `delay`     | [`interval`]  | The upper bound of the bucket as an interval.
 `count`     | [`bigint`]    | The (noncumulative) count of delay measurements in this bucket.
@@ -467,7 +467,7 @@ For frontier information aggregated across all workers, see
 Field       | Type       | Meaning
 ------------|------------|--------
 `export_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports).
-`source_id` | [`text`]   | The ID of the input source object for the dataflow. Corresponds to either [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables) or [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views).
+`source_id` | [`text`]   | The ID of the input source object for the dataflow. Corresponds to either [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources) or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables) or [`mz_compute_exports.export_id`](#mz_compute_exports).
 `worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
 `time`      | [`mz_timestamp`] | The next timestamp at which the dataflow may change.
 

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1201,7 +1201,7 @@ pub const MZ_WORKER_COMPUTE_FRONTIERS: BuiltinLog = BuiltinLog {
 pub const MZ_WORKER_COMPUTE_IMPORT_FRONTIERS: BuiltinLog = BuiltinLog {
     name: "mz_worker_compute_import_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
-    variant: LogVariant::Compute(ComputeLog::SourceFrontierCurrent),
+    variant: LogVariant::Compute(ComputeLog::ImportFrontierCurrent),
 };
 
 pub const MZ_RAW_WORKER_COMPUTE_DELAYS: BuiltinLog = BuiltinLog {

--- a/src/compute-client/src/logging.proto
+++ b/src/compute-client/src/logging.proto
@@ -57,7 +57,7 @@ message ProtoComputeLog {
         google.protobuf.Empty peek_current = 4;
         google.protobuf.Empty peek_duration = 5;
         google.protobuf.Empty frontier_delay = 6;
-        google.protobuf.Empty source_frontier_current = 7;
+        google.protobuf.Empty import_frontier_current = 7;
     }
 }
 message ProtoLogVariant {

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -266,7 +266,7 @@ pub enum ComputeLog {
     PeekCurrent,
     PeekDuration,
     FrontierDelay,
-    SourceFrontierCurrent,
+    ImportFrontierCurrent,
 }
 
 impl RustType<ProtoComputeLog> for ComputeLog {
@@ -280,7 +280,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
                 ComputeLog::PeekCurrent => PeekCurrent(()),
                 ComputeLog::PeekDuration => PeekDuration(()),
                 ComputeLog::FrontierDelay => FrontierDelay(()),
-                ComputeLog::SourceFrontierCurrent => SourceFrontierCurrent(()),
+                ComputeLog::ImportFrontierCurrent => ImportFrontierCurrent(()),
             }),
         }
     }
@@ -294,7 +294,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
             Some(PeekCurrent(())) => Ok(ComputeLog::PeekCurrent),
             Some(PeekDuration(())) => Ok(ComputeLog::PeekDuration),
             Some(FrontierDelay(())) => Ok(ComputeLog::FrontierDelay),
-            Some(SourceFrontierCurrent(())) => Ok(ComputeLog::SourceFrontierCurrent),
+            Some(ImportFrontierCurrent(())) => Ok(ComputeLog::ImportFrontierCurrent),
             None => Err(TryFromProtoError::missing_field("ProtoComputeLog::kind")),
         }
     }
@@ -317,7 +317,7 @@ pub static DEFAULT_LOG_VARIANTS: Lazy<Vec<LogVariant>> = Lazy::new(|| {
         LogVariant::Compute(ComputeLog::DataflowCurrent),
         LogVariant::Compute(ComputeLog::DataflowDependency),
         LogVariant::Compute(ComputeLog::FrontierCurrent),
-        LogVariant::Compute(ComputeLog::SourceFrontierCurrent),
+        LogVariant::Compute(ComputeLog::ImportFrontierCurrent),
         LogVariant::Compute(ComputeLog::FrontierDelay),
         LogVariant::Compute(ComputeLog::PeekCurrent),
         LogVariant::Compute(ComputeLog::PeekDuration),
@@ -741,7 +741,7 @@ impl LogVariant {
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("time", ScalarType::MzTimestamp.nullable(false)),
 
-            LogVariant::Compute(ComputeLog::SourceFrontierCurrent) => RelationDesc::empty()
+            LogVariant::Compute(ComputeLog::ImportFrontierCurrent) => RelationDesc::empty()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("import_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
@@ -814,7 +814,7 @@ impl LogVariant {
             LogVariant::Compute(ComputeLog::DataflowCurrent) => vec![],
             LogVariant::Compute(ComputeLog::DataflowDependency) => vec![],
             LogVariant::Compute(ComputeLog::FrontierCurrent) => vec![],
-            LogVariant::Compute(ComputeLog::SourceFrontierCurrent) => vec![],
+            LogVariant::Compute(ComputeLog::ImportFrontierCurrent) => vec![],
             LogVariant::Compute(ComputeLog::FrontierDelay) => vec![],
             LogVariant::Compute(ComputeLog::PeekCurrent) => vec![],
             LogVariant::Compute(ComputeLog::PeekDuration) => vec![],

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -419,22 +419,22 @@ where
         if let Err(frontier) = event {
             if let Some(previous) = previous_time {
                 for dataflow_id in dataflow_ids.iter() {
-                    logger.log(ComputeEvent::SourceFrontier(
-                        *dataflow_id,
-                        source_id,
-                        previous,
-                        -1,
-                    ));
+                    logger.log(ComputeEvent::ImportFrontier {
+                        import_id: source_id,
+                        export_id: *dataflow_id,
+                        time: previous,
+                        diff: -1,
+                    });
                 }
             }
             if let Some(time) = frontier.get(0) {
                 for dataflow_id in dataflow_ids.iter() {
-                    logger.log(ComputeEvent::SourceFrontier(
-                        *dataflow_id,
-                        source_id,
-                        *time,
-                        1,
-                    ));
+                    logger.log(ComputeEvent::ImportFrontier{
+                        import_id: source_id,
+                        export_id: *dataflow_id,
+                        time: *time,
+                        diff: 1,
+                    });
                 }
                 previous_time = Some(*time);
             } else {

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -108,9 +108,8 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::AsCollection;
 use timely::communication::Allocate;
 use timely::dataflow::operators::to_stream::ToStream;
-use timely::dataflow::operators::InspectCore;
 use timely::dataflow::scopes::Child;
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::Scope;
 use timely::order::Product;
 use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
@@ -120,7 +119,7 @@ use timely::PartialOrder;
 use mz_compute_client::plan::Plan;
 use mz_compute_client::types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
 use mz_expr::Id;
-use mz_repr::{Diff, GlobalId, Row};
+use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::source::persist_source;
 use mz_storage_client::source::persist_source::FlowControl;
@@ -129,8 +128,7 @@ use mz_timely_util::probe::{self, ProbeNotify};
 
 use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::ComputeState;
-use crate::logging::compute::ComputeEvent;
-use crate::logging::compute::Logger;
+use crate::logging::compute::LogImportFrontiers;
 pub use context::CollectionBundle;
 use context::{ArrangementFlavor, Context};
 
@@ -233,14 +231,13 @@ pub fn build_compute_dataflow<A: Allocate>(
                     // For the moment, assert that it is either trivial or `None`.
                     assert!(mfp.map(|x| x.is_identity()).unwrap_or(true));
 
-                    // If logging is enabled, intercept frontier advancements coming from persist to track materialization lags.
-                    // Note that we do this here instead of in the server.rs worker loop since we want to catch the wall-clock
-                    // time of the frontier advancement for each dataflow as early as possible.
+                    // If logging is enabled, log source frontier advancements. Note that we do
+                    // this here instead of in the server.rs worker loop since we want to catch the
+                    // wall-clock time of the frontier advancement for each dataflow as early as
+                    // possible.
                     if let Some(logger) = compute_state.compute_logger.clone() {
                         let export_ids = dataflow.export_ids().collect();
-                        ok_stream = intercept_source_instantiation_frontiers(
-                            &ok_stream, logger, *source_id, export_ids,
-                        );
+                        ok_stream = ok_stream.log_import_frontiers(logger, *source_id, export_ids);
                     }
 
                     let (oks, errs) = (
@@ -281,7 +278,8 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Import declared indexes into the rendering context.
                 for (idx_id, idx) in &dataflow.index_imports {
-                    context.import_index(compute_state, &mut tokens, *idx_id, &idx.0);
+                    let export_ids = dataflow.export_ids().collect();
+                    context.import_index(compute_state, &mut tokens, export_ids, *idx_id, &idx.0);
                 }
 
                 // Build declared objects.
@@ -367,7 +365,8 @@ pub fn build_compute_dataflow<A: Allocate>(
 
                 // Import declared indexes into the rendering context.
                 for (idx_id, idx) in &dataflow.index_imports {
-                    context.import_index(compute_state, &mut tokens, *idx_id, &idx.0);
+                    let export_ids = dataflow.export_ids().collect();
+                    context.import_index(compute_state, &mut tokens, export_ids, *idx_id, &idx.0);
                 }
 
                 // Build declared objects.
@@ -403,47 +402,6 @@ pub fn build_compute_dataflow<A: Allocate>(
     })
 }
 
-// This helper function adds an operator to track source instantiation frontier advancements
-// in a dataflow. The tracking supports instrospection sources populated by compute logging.
-fn intercept_source_instantiation_frontiers<G>(
-    source_instantiation: &Stream<G, (Row, mz_repr::Timestamp, Diff)>,
-    logger: Logger,
-    source_id: GlobalId,
-    dataflow_ids: Vec<GlobalId>,
-) -> Stream<G, (Row, mz_repr::Timestamp, Diff)>
-where
-    G: Scope<Timestamp = mz_repr::Timestamp>,
-{
-    let mut previous_time = None;
-    source_instantiation.inspect_container(move |event| {
-        if let Err(frontier) = event {
-            if let Some(previous) = previous_time {
-                for dataflow_id in dataflow_ids.iter() {
-                    logger.log(ComputeEvent::ImportFrontier {
-                        import_id: source_id,
-                        export_id: *dataflow_id,
-                        time: previous,
-                        diff: -1,
-                    });
-                }
-            }
-            if let Some(time) = frontier.get(0) {
-                for dataflow_id in dataflow_ids.iter() {
-                    logger.log(ComputeEvent::ImportFrontier{
-                        import_id: source_id,
-                        export_id: *dataflow_id,
-                        time: *time,
-                        diff: 1,
-                    });
-                }
-                previous_time = Some(*time);
-            } else {
-                previous_time = None;
-            }
-        }
-    })
-}
-
 // This implementation block allows child timestamps to vary from parent timestamps,
 // but requires the parent timestamp to be `repr::Timestamp`.
 impl<'g, G, T> Context<Child<'g, G, T>, Row>
@@ -455,6 +413,7 @@ where
         &mut self,
         compute_state: &mut ComputeState,
         tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
+        export_ids: Vec<GlobalId>,
         idx_id: GlobalId,
         idx: &IndexDesc,
     ) {
@@ -465,7 +424,7 @@ where
             );
 
             let token = traces.to_drop().clone();
-            let (ok_arranged, ok_button) = traces.oks_mut().import_frontier_core(
+            let (mut ok_arranged, ok_button) = traces.oks_mut().import_frontier_core(
                 &self.scope.parent,
                 &format!("Index({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
@@ -477,8 +436,18 @@ where
                 self.as_of_frontier.clone(),
                 self.until.clone(),
             );
+
+            // If logging is enabled, log import frontier advancements. Note that we do
+            // this here instead of in the server.rs worker loop since we want to catch the
+            // wall-clock time of the frontier advancement for each dataflow as early as
+            // possible.
+            if let Some(logger) = compute_state.compute_logger.clone() {
+                ok_arranged = ok_arranged.log_import_frontiers(logger, idx_id, export_ids);
+            }
+
             let ok_arranged = ok_arranged.enter(&self.scope);
             let err_arranged = err_arranged.enter(&self.scope);
+
             self.update_id(
                 Id::Global(idx.on_id),
                 CollectionBundle::from_expressions(

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -830,12 +830,16 @@ impl<'w, A: Allocate> Worker<'w, A> {
             compute_state.pending_peeks.clear();
             // We compact away removed frontiers, and so only need to reset ids we continue to use.
             // We must remember, though, to compensate what already was sent to logging sources.
-            for (id, frontier) in compute_state.reported_frontiers.iter_mut() {
+            for (&id, frontier) in compute_state.reported_frontiers.iter_mut() {
                 if let Some(logger) = &compute_state.compute_logger {
-                    if let Some(time) = frontier.get(0) {
+                    if let Some(&time) = frontier.get(0) {
                         use crate::logging::compute::ComputeEvent;
-                        logger.log(ComputeEvent::Frontier(*id, *time, -1));
-                        logger.log(ComputeEvent::Frontier(*id, Timestamp::minimum(), 1));
+                        logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
+                        logger.log(ComputeEvent::Frontier {
+                            id,
+                            time: Timestamp::minimum(),
+                            diff: 1,
+                        });
                     }
                 }
                 *frontier = timely::progress::Antichain::from_elem(<_>::minimum());

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -106,6 +106,34 @@ true
     time > 0
 16
 
+> CREATE MATERIALIZED VIEW mvv AS SELECT * FROM vv
+
+> SELECT COUNT(*)
+  FROM (SELECT DISTINCT delays.export_id, delays.import_id
+        FROM
+            mz_internal.mz_raw_worker_compute_delays AS delays)
+3
+
+> SELECT COUNT(*)
+  FROM (SELECT DISTINCT import_frontiers.export_id, import_frontiers.import_id
+        FROM
+            mz_internal.mz_worker_compute_import_frontiers AS import_frontiers)
+3
+
+> DROP MATERIALIZED VIEW mvv
+
+> SELECT COUNT(*)
+  FROM (SELECT DISTINCT delays.export_id, delays.import_id
+        FROM
+            mz_internal.mz_raw_worker_compute_delays AS delays)
+2
+
+> SELECT COUNT(*)
+  FROM (SELECT DISTINCT import_frontiers.export_id, import_frontiers.import_id
+        FROM
+            mz_internal.mz_worker_compute_import_frontiers AS import_frontiers)
+2
+
 > DROP INDEX vv_primary_idx
 
 > SELECT COUNT(*)


### PR DESCRIPTION
This PR adds frontiers of index imports to `mz_internal.mz_worker_compute_import_frontiers`.

The approach taken is the same as for source imports, by connecting an `inspect_container` dataflow operator to the output stream of each imported index.

### Motivation

  * This PR fixes a recognized bug.

Fixes #14102.

### Tips for reviewer

Look at the commits separately!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add frontiers of index imports to `mz_internal.mz_worker_compute_import_frontiers`.
