### PR TITLE
Update numpy and scipy to versions supporting Python 3.11

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -21,7 +21,7 @@ kubernetes==25.3.0
 kubernetes-stubs==22.6.0.post1
 launchdarkly-api==11.0.0
 mypy==0.991
-numpy==1.22.4
+numpy==1.24.2
 pandas==1.5.2
 parameterized==0.8.1
 paramiko==2.12.0
@@ -35,7 +35,7 @@ PyMySQL==1.0.2
 pytest==7.2.1
 pyyaml==6.0
 requests==2.28.1
-scipy==1.7.3
+scipy==1.10.0
 semver==3.0.0.dev4
 shtab==1.5.8
 sqlparse==0.4.3

--- a/misc/python/materialize/feature_benchmark/aggregation.py
+++ b/misc/python/materialize/feature_benchmark/aggregation.py
@@ -43,15 +43,17 @@ class StdDevAggregation(Aggregation):
         self._num_stdevs = num_stdevs
 
     def aggregate(self) -> float:
-        stdev: float = np.std(self._data)
-        mean: float = np.mean(self._data)
+        stdev: float = np.std(self._data, dtype=float)
+        mean: float = np.mean(self._data, dtype=float)
         val = mean - (stdev * self._num_stdevs)
         return val
 
 
 class NormalDistributionAggregation(Aggregation):
     def aggregate(self) -> statistics.NormalDist:
-        return statistics.NormalDist(mu=np.mean(self._data), sigma=np.std(self._data))
+        return statistics.NormalDist(
+            mu=np.mean(self._data, dtype=float), sigma=np.std(self._data, dtype=float)
+        )
 
 
 class NoAggregation(Aggregation):


### PR DESCRIPTION
Debian testing is switching to Python 3.11, which is currently incompatible with Materialize. Updating numpy and scipy to more recent versions seems to fix this problem.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
