### PR TITLE
ci: Restore the sql.stats.forecasts.enabled = false CRDB workaround

### DIFF
--- a/misc/cockroach/setup_materialize.sql
+++ b/misc/cockroach/setup_materialize.sql
@@ -9,6 +9,10 @@
 
 -- Sets up a CockroachDB cluster for use by Materialize.
 
+-- See: https://github.com/cockroachdb/cockroach/issues/93892
+-- See: https://github.com/MaterializeInc/materialize/issues/16726
+SET CLUSTER SETTING sql.stats.forecasts.enabled = false;
+
 CREATE SCHEMA IF NOT EXISTS consensus;
 CREATE SCHEMA IF NOT EXISTS adapter;
 CREATE SCHEMA IF NOT EXISTS storage;

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -33,6 +33,10 @@ COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true cockroach start-single-node \
     --background \
     --store=/mzdata/cockroach
 
+# See: https://github.com/cockroachdb/cockroach/issues/93892
+# See: https://github.com/MaterializeInc/materialize/issues/16726
+cockroach sql --insecure -e "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
+
 cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS consensus"
 cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS storage"
 cockroach sql --insecure -e "CREATE SCHEMA IF NOT EXISTS adapter"


### PR DESCRIPTION
Apparently cockroachdb/cockroach#93892 still occurs even with v22.2.3 so disable stats forcasts across the board until fixed.

Relates to #16726

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
