### PR TITLE
compute: add reconciliation metrics

### DIFF
--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -7,15 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_ore::metrics::UIntGauge;
-
 use mz_ore::metric;
-use mz_ore::metrics::MetricsRegistry;
+use mz_ore::metrics::raw::IntCounterVec;
+use mz_ore::metrics::{IntCounter, MetricsRegistry, UIntGauge};
 
 #[derive(Clone, Debug)]
 pub struct ComputeMetrics {
     pub command_history_size: UIntGauge,
     pub dataflow_count_in_history: UIntGauge,
+    pub reconciliation_reused_dataflows: IntCounter,
+    pub reconciliation_replaced_dataflows: IntCounterVec,
 }
 
 impl ComputeMetrics {
@@ -29,6 +30,42 @@ impl ComputeMetrics {
                 name: "mz_compute_dataflow_count_in_history",
                 help: "The number of dataflow descriptions in the compute command history.",
             )),
+            reconciliation_reused_dataflows: registry.register(metric!(
+                name: "mz_compute_reconciliation_reused_dataflows",
+                help: "The number of dataflows that were reused during compute reconciliation.",
+            )),
+            reconciliation_replaced_dataflows: registry.register(metric!(
+                name: "mz_compute_reconciliation_replaced_dataflows",
+                help: "The number of dataflows that were replaced during compute reconciliation.",
+                var_labels: ["reason"],
+            )),
+        }
+    }
+
+    /// Record the reconciliation result for a single dataflow.
+    ///
+    /// Reconciliation is recorded as successful if the given properties all hold. Otherwise it is
+    /// recorded as unsuccessful, with a reason based on the first property that does not hold.
+    pub fn record_dataflow_reconciliation(
+        &self,
+        compatible: bool,
+        uncompacted: bool,
+        subscribe_free: bool,
+    ) {
+        if !compatible {
+            self.reconciliation_replaced_dataflows
+                .with_label_values(&["incompatible"])
+                .inc();
+        } else if !uncompacted {
+            self.reconciliation_replaced_dataflows
+                .with_label_values(&["compacted"])
+                .inc();
+        } else if !subscribe_free {
+            self.reconciliation_replaced_dataflows
+                .with_label_values(&["subscribe"])
+                .inc();
+        } else {
+            self.reconciliation_reused_dataflows.inc();
         }
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -770,6 +770,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
                                 } else {
                                     new_dataflows.push(dataflow.clone());
                                 }
+
+                                compute_state.metrics.record_dataflow_reconciliation(
+                                    compatible,
+                                    uncompacted,
+                                    subscribe_free,
+                                );
                             } else {
                                 new_dataflows.push(dataflow.clone());
                             }

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -110,7 +110,7 @@ pub struct MetricsRegistry {
 /// A wrapper for metrics to require delete on drop semantics
 ///
 /// The wrapper behaves like regular metrics but only provides functions to create delete-on-drop
-/// variants. This way, no metrics if this type can be leaked.
+/// variants. This way, no metrics of this type can be leaked.
 ///
 /// In situations where the delete-on-drop behavior is not desired or in legacy code, use the raw
 /// variants of the metrics, as defined in [self::raw].


### PR DESCRIPTION
This commit adds Prometheus metrics that provide visibility into how well compute reconciliation works. These metrics track the number of successful reconciliations (i.e. dataflows that could be reused) as well as the number of unsuccessful reconciliations (dataflows that had to be replaced by fresh ones). For unsuccessful reconciliations a label is provided that records the reason why the old dataflow had to be replaced.

### Motivation

  * This PR adds a known-desirable feature.

Closes #17547.

### Tips for reviewer

Please let me know if:
* ... you think the new metrics should be something else than counters. Gauges that reset on each reconciliation would also make sense, I think.
* ... there are other metrics that would be useful to collect around reconciliation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
