### PR TITLE
repr: emit an error on Dummy decoding

### DIFF
--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -353,7 +353,13 @@ impl RowPacker<'_> {
                 Some(ProtoDatumOther::False) => self.push(Datum::False),
                 Some(ProtoDatumOther::True) => self.push(Datum::True),
                 Some(ProtoDatumOther::JsonNull) => self.push(Datum::JsonNull),
-                Some(ProtoDatumOther::Dummy) => self.push(Datum::Dummy),
+                Some(ProtoDatumOther::Dummy) => {
+                    // We plan to remove the `Dummy` variant soon (#17099). To prepare for that, we
+                    // emit a log to Sentry here, to notify us of any instances that might have
+                    // been made durable.
+                    tracing::error!("protobuf decoding found Dummy datum");
+                    self.push(Datum::Dummy);
+                }
                 Some(ProtoDatumOther::NumericPosInf) => self.push(Datum::from(Numeric::infinity())),
                 Some(ProtoDatumOther::NumericNegInf) => {
                     self.push(Datum::from(-Numeric::infinity()))


### PR DESCRIPTION
As discussed with @danhhz, this is a sensible change to made, regardless of whether or not we also want to do the work of manually checking all existing persist shards for the existence of `Dummy`.

### Motivation

* This PR adds a diagnostic log.

Helps with #17099.

### Tips for reviewer

I hope we can merge this before the release cutoff tomorrow, to have it in the next release.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
