### PR TITLE
persist: store encoded size in State's rollups field

### DIFF
--- a/src/persist-client/src/cli/inspect.rs
+++ b/src/persist-client/src/cli/inspect.rs
@@ -254,8 +254,8 @@ pub async fn fetch_state_rollups(args: &StateArgs) -> Result<impl serde::Seriali
         .await
         .check_ts_codec()?;
     while let Some(v) = state_iter.next() {
-        for key in v.collections.rollups.values() {
-            rollup_keys.insert(key.clone());
+        for rollup in v.collections.rollups.values() {
+            rollup_keys.insert(rollup.key.clone());
         }
     }
 
@@ -486,7 +486,7 @@ pub async fn unreferenced_blobs(args: &StateArgs) -> Result<impl serde::Serializ
             }
         }
         for rollup in v.collections.rollups.values() {
-            known_rollups.insert(rollup.clone());
+            known_rollups.insert(rollup.key.clone());
         }
     }
 
@@ -534,8 +534,8 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
                 );
             }
         });
-        for rollup_key in state.collections.rollups.values() {
-            referenced_rollups.insert(rollup_key.complete(&shard_id).to_string());
+        for rollup in state.collections.rollups.values() {
+            referenced_rollups.insert(rollup.key.complete(&shard_id).to_string());
         }
     }
 
@@ -549,8 +549,8 @@ pub async fn blob_usage(args: &StateArgs) -> Result<(), anyhow::Error> {
             );
         }
     });
-    for rollup_key in state_iter.state().collections.rollups.values() {
-        current_rollups.insert(rollup_key.complete(&shard_id).to_string());
+    for rollup in state_iter.state().collections.rollups.values() {
+        current_rollups.insert(rollup.key.complete(&shard_id).to_string());
     }
 
     // There's a bit of a race condition between fetching s3 and state, but

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -35,6 +35,11 @@ message ProtoHollowBatch {
     repeated string deprecated_keys = 2;
 }
 
+message ProtoHollowRollup {
+    string key = 1;
+    optional uint64 encoded_size_bytes = 2;
+}
+
 message ProtoTrace {
     ProtoU64Antichain since = 1;
     repeated ProtoHollowBatch spine = 2;
@@ -80,16 +85,21 @@ message ProtoStateRollup {
     uint64 walltime_ms = 15;
     string hostname = 14;
     uint64 last_gc_req = 10;
-    map<uint64, string> rollups = 12;
+    map<uint64, ProtoHollowRollup> rollups = 16;
 
     ProtoTrace trace = 7;
     map<string, ProtoLeasedReaderState> leased_readers = 8;
     map<string, ProtoCriticalReaderState> critical_readers = 13;
     map<string, ProtoWriterState> writers = 9;
+
+    // MIGRATION: We previously stored rollups as a `SeqNo -> string Key` map,
+    // but now the value is a `struct HollowRollup`.
+    map<uint64, string> deprecated_rollups = 12;
 }
 
 enum ProtoStateField {
-    ROLLUPS = 0;
+    DEPRECATED_ROLLUPS = 0; // Proto doesn't let us reorder this down, sadly
+    ROLLUPS = 8;
     HOSTNAME = 7;
     LAST_GC_REQ = 1;
     LEASED_READERS = 2;


### PR DESCRIPTION
Like we do for encoded batch parts. This is the last piece needed to allow us to reason about the total size of the data that persist expects there to be in s3 purely by looking at state.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
