### PR TITLE
surfaces: populate mz_object_dependencies correctly

### DIFF
--- a/test/testdrive/mz-depends.td
+++ b/test/testdrive/mz-depends.td
@@ -61,3 +61,25 @@ source          subsource
 conn     dep_conn
 -----------------
 pg_conn ssh_conn
+
+
+# Assert that we actually are populating all the system objects.
+> SELECT COUNT(*) > 200 FROM mz_internal.mz_object_dependencies WHERE object_id LIKE 's%'
+true
+
+# Ensure there are no duplicates
+> WITH cte AS (
+    SELECT * FROM mz_internal.mz_object_dependencies
+    GROUP BY object_id, referenced_object_id
+    HAVING count(*) > 1
+  )
+  SELECT count(*) FROM cte
+0
+
+# This isn't a full cycle check, but checks if 2 objects depend on each other
+> SELECT
+  COUNT(*)
+  FROM mz_internal.mz_object_dependencies AS first
+  JOIN mz_internal.mz_object_dependencies AS second
+  ON first.object_id = second.referenced_object_id AND first.referenced_object_id = second.object_id;
+0


### PR DESCRIPTION
The implementation for `mz_object_dependencies` was very messed up. It didn't re-populate after restart, and missed some types of items. This pr fixes these by only ever adding and deleting the rows in `pack_item_update`!

@mjibson I also removed the special handling for builtins. My understanding is that on `open`, the builtins are added to the in-memory catalog, and then we will end up calling `pack_item_update` as part of the later `load_catalog_items` call right? If I didn't remove that special handling, I ended up getting duplicate rows, so I want to make sure my understanding of bootstrap is correct!

### Motivation


  * This PR fixes a recognized bug.

Closes https://github.com/MaterializeInc/materialize/issues/17578


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - fixes mz_internal.mz_object_dependencies 

