### PR TITLE
persist: make trace_push_batch benchmark faster under `cargo test`

### DIFF
--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -214,8 +214,15 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
 
 pub fn bench_trace_push_batch(c: &mut Criterion) {
     let mut g = c.benchmark_group("trace");
-    const NUM_BATCHES: usize = 20_000;
-    g.bench_function(BenchmarkId::new("push_batch", NUM_BATCHES), |b| {
-        b.iter(|| trace_push_batch_one_iter(NUM_BATCHES));
+    // The larger number is a nice one when compiling with release optimizations
+    // and no debug_assertions, but it takes too long with cargo test
+    // --all-targets.
+    let num_batches = if cfg!(debug_assertions) {
+        1_000
+    } else {
+        20_000
+    };
+    g.bench_function(BenchmarkId::new("push_batch", num_batches), |b| {
+        b.iter(|| trace_push_batch_one_iter(num_batches));
     });
 }


### PR DESCRIPTION

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
