### PR TITLE
storage: reclock resumption frontier in async worker

### DIFF
--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -14,7 +14,7 @@ use timely::progress::Antichain;
 use timely::synchronization::Sequencer;
 use timely::worker::Worker as TimelyWorker;
 
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::IngestionDescription;
@@ -39,6 +39,8 @@ pub enum InternalStorageCommand {
         ingestion_description: IngestionDescription<CollectionMetadata>,
         /// The frontier at which we should (re-)start ingestion.
         resumption_frontier: Antichain<mz_repr::Timestamp>,
+        /// The frontier at which we should (re-)start ingestion in the source time domain.
+        source_resumption_frontier: Vec<Row>,
     },
     /// Render a sink dataflow.
     CreateSinkDataflow(

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -207,7 +207,7 @@ use timely::dataflow::Scope;
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
-use mz_repr::GlobalId;
+use mz_repr::{GlobalId, Row};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_client::types::sources::IngestionDescription;
@@ -231,6 +231,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<mz_repr::Timestamp>,
+    source_resume_upper: Vec<Row>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();
@@ -252,6 +253,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 id,
                 description.clone(),
                 resume_upper,
+                source_resume_upper,
                 storage_state,
             );
             tokens.push(token);

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -65,6 +65,7 @@ pub fn render_source<RootG, G>(
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<G::Timestamp>,
+    source_resume_upper: Vec<Row>,
     storage_state: &mut crate::storage_state::StorageState,
 ) -> (
     Vec<(Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)>,
@@ -97,6 +98,7 @@ where
         // TODO(guswynn): avoid extra clones here
         base_metrics: storage_state.source_metrics.clone(),
         resume_upper: resume_upper.clone(),
+        source_resume_upper,
         storage_metadata: description.ingestion_metadata.clone(),
         persist_clients: Arc::clone(&storage_state.persist_clients),
         source_statistics: storage_state

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -41,7 +41,7 @@ mod kafka;
 mod kinesis;
 pub mod metrics;
 mod postgres;
-mod reclock;
+pub(crate) mod reclock;
 mod resumption;
 mod s3;
 mod source_reader_pipeline;

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -545,6 +545,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 id,
                 ingestion_description,
                 resumption_frontier,
+                source_resumption_frontier,
             ) => {
                 // NOTE: If we want to share the load of async processing we
                 // have to change `handle_storage_command` and change this
@@ -558,6 +559,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     id,
                     ingestion_description,
                     resumption_frontier,
+                    source_resumption_frontier,
                 });
             }
         }
@@ -642,6 +644,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 id: ingestion_id,
                 ingestion_description,
                 resumption_frontier,
+                source_resumption_frontier,
             } => {
                 info!(
                     "worker {}/{} trying to (re-)start ingestion {ingestion_id} at resumption frontier {:?}",
@@ -700,6 +703,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         ingestion_id,
                         ingestion_description,
                         resumption_frontier,
+                        source_resumption_frontier,
                     );
                 }
             }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -94,15 +94,16 @@ use mz_ore::task::RuntimeExt;
 use mz_persist_client::cfg::PersistConfig;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::TimestampManipulation;
-use mz_repr::{Diff, GlobalId, RelationDesc, Timestamp};
+use mz_repr::{Diff, GlobalId, RelationDesc, Row, Timestamp};
 use mz_storage::internal_control::{InternalCommandSender, InternalStorageCommand};
 use mz_storage::sink::SinkBaseMetrics;
 use mz_storage::source::metrics::SourceBaseMetrics;
 use mz_storage::source::testscript::ScriptCommand;
+use mz_storage::source::types::{SourceConnectionBuilder, SourceReader};
 use mz_storage::DecodeMetrics;
 use mz_storage_client::types::sources::{
     encoding::SourceDataEncoding, GenericSourceConnection, SourceData, SourceDesc, SourceEnvelope,
-    TestScriptSourceConnection,
+    SourceTimestamp, TestScriptSourceConnection,
 };
 
 pub fn run_script_source(
@@ -263,6 +264,15 @@ where
                 let async_storage_worker = Rc::clone(&worker.storage_state.async_worker);
                 let internal_command_fabric = &mut HaltingInternalCommandSender::new();
 
+                let source_resumption_frontier = match &desc.connection {
+                    GenericSourceConnection::Kafka(c) => minimum_frontier(c),
+                    GenericSourceConnection::S3(c) => minimum_frontier(c),
+                    GenericSourceConnection::Postgres(c) => minimum_frontier(c),
+                    GenericSourceConnection::Kinesis(c) => minimum_frontier(c),
+                    GenericSourceConnection::TestScript(c) => minimum_frontier(c),
+                    GenericSourceConnection::LoadGenerator(c) => minimum_frontier(c),
+                };
+
                 // NOTE: We only feed internal commands into the worker,
                 // bypassing "external" StorageCommand and the async worker that
                 // also sits into the normal processing loop. If you ever
@@ -291,6 +301,7 @@ where
                             },
                         // TODO: test resumption as well!
                         resumption_frontier: Antichain::from_elem(Timestamp::minimum()),
+                        source_resumption_frontier,
                     },
                 );
             }
@@ -359,6 +370,12 @@ where
 
     // There is always exactly one worker.
     Ok(value.unwrap())
+}
+
+/// Calculates the minimum frontier for a particular source connection using the source specific
+/// timestamp
+fn minimum_frontier<C: SourceConnectionBuilder>(_conn: &C) -> Vec<Row> {
+    vec![<C::Reader as SourceReader>::Time::minimum().encode_row()]
 }
 
 struct HaltingInternalCommandSender {}


### PR DESCRIPTION
### Motivation

This PR is fixing a TODO I had left in the source operator that had to do an awkward loop and interact with the reclock follower in order to transalte the `IntoTime` resumption frontier that it was given to its own timestamp type.

The motivation for this change is to slowly disentangle the operators that read from a source from the act of reclocking. Their final form should be timely operators that operate on a scope of their timestamp and have no idea that their outputs are being reclocked. Once we reach the point where reclocking is just a transformation applied on top of the differential collection produced by the source ingestion we will be able to push more computation before reclocking. For example there is no reason decoding and envelope processing needs to happen in the mz time domain, we could eagerly compute those and reclock their result.

Unfortunately this PR contains a bit of boilerplate code that I didn't find a great way of getting rid off. Since our `IngestionDescription` carries a `GenericSourceConnection` we *must*, at some point in the code, perform a match statement like in this PR and then dispatch to generic methods, but a well architected ingestion pipeline would require this once and in the beginning of the pipeline. We're not there yet but I'll leave that for a future date.


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
