### PR TITLE
[persist] Break parts along key-value boundaries if possible

### DIFF
--- a/src/persist-client/tests/machine/compaction_bounded
+++ b/src/persist-client/tests/machine/compaction_bounded
@@ -83,10 +83,10 @@ f 8 1
 part 0
 
 # compact b0, b1, b2 with enough memory for all runs, but a target size that can only hold 2 keys in mem at a time.
-# we expect `aaaa` to appear twice because we calculate part size by unconsolidated updates.
+# we expect `a` to appear twice because we calculate part size by unconsolidated updates.
 compact output=b0_1_2 inputs=(b0,b1,b2) lower=0 upper=9 since=8 target_size=50 memory_bound=1000
 ----
-parts=5 len=8
+parts=5 len=7
 
 fetch-batch input=b0_1_2
 ----
@@ -94,14 +94,13 @@ fetch-batch input=b0_1_2
 a 8 2
 <part 1>
 a 8 1
-b 8 1
 <part 2>
-b 8 1
-c 8 1
+b 8 2
 <part 3>
+c 8 1
 d 8 1
-e 8 1
 <part 4>
+e 8 1
 f 8 1
 <run 0>
 part 0

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -355,6 +355,9 @@ impl Default for ColumnarRecordsBuilder {
 }
 
 impl ColumnarRecordsBuilder {
+    /// The data required for each record, over and above the size of the key-value data itself.
+    pub const RECORD_OVERHEAD: usize = 2 * BYTES_PER_KEY_VAL_OFFSET + 2 * size_of::<u64>();
+
     /// The number of (potentially duplicated) ((Key, Val), Time, i64) records
     /// stored in Self.
     pub fn len(&self) -> usize {


### PR DESCRIPTION
- Replace some running totals with directly-calculated equivalents. I think this is normally a good idea (harder to let things fall out of sync) but also it makes the second part easier.
- Attempt to split parts along key-value boundaries as much as possible.

Previously, we'd split off a part after appending a new update that took us over the size target. This is awkward because it means every part is likely slightly oversized, but also because we won't know whether the split is a "good" split (ie. falls between two updates with inequal key-value pairs) until we try and append the _next_ update.

This change takes the opposite approach... it appends the new update and then decides whether to split out some prefix of the current set of updates as a part.

### Motivation

Desireable for #16858 - most of the interesting strategies depend on knowing that two parts don't overlap, and this should make it less common for parts in the same run to overlap.

### Tips for reviewer

This almost certainly requires additional tests! For now I'm interested in whether this seems like a dead end or not.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
