### PR TITLE
test: Add test stash allowing opening and closing

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6573,22 +6573,23 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 mod tests {
     use itertools::Itertools;
     use std::collections::{BTreeMap, BTreeSet};
+    use std::iter;
 
     use mz_controller::clusters::ClusterId;
     use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
     use mz_ore::collections::CollectionExt;
-    use mz_ore::now::NOW_ZERO;
+    use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
     use mz_repr::{GlobalId, RelationDesc, RelationType, ScalarType};
     use mz_sql::catalog::CatalogDatabase;
     use mz_sql::names;
     use mz_sql::names::{
-        ObjectQualifiers, PartialObjectName, QualifiedObjectName, ResolvedDatabaseSpecifier,
-        SchemaSpecifier,
+        DatabaseId, ObjectQualifiers, PartialObjectName, QualifiedObjectName,
+        ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier,
     };
     use mz_sql::plan::StatementContext;
     use mz_sql::DEFAULT_SCHEMA;
     use mz_sql_parser::ast::Expr;
-    use mz_stash::Stash;
+    use mz_stash::DebugStashFactory;
 
     use crate::catalog::{
         Catalog, CatalogItem, Index, MaterializedView, Op, Table, SYSTEM_CONN_ID,
@@ -6675,7 +6676,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog_revision() {
-        Stash::with_debug_stash(move |stash| async move {
+        let debug_stash_factory = DebugStashFactory::new()
+            .await
+            .expect("unable to open debug stash factory");
+        {
+            let stash = debug_stash_factory
+                .open_debug()
+                .await
+                .expect("unable to open debug stash");
             let mut catalog = Catalog::open_debug_stash(stash, NOW_ZERO.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -6694,21 +6702,18 @@ mod tests {
                 .await
                 .expect("failed to transact");
             assert_eq!(catalog.transient_revision(), 2);
-            drop(catalog);
-
-            // TODO: Test that re-opening the same stash resets the
-            // transient_revision to 1. The current debug stash implementation
-            // doesn't allow for stash reuse.
-
-            /*
+        }
+        {
+            let stash = debug_stash_factory
+                .open_debug()
+                .await
+                .expect("unable to open debug stash");
             let catalog = Catalog::open_debug_stash(stash, NOW_ZERO.clone())
                 .await
-                .unwrap();
+                .expect("unable to open debug catalog");
+            // Re-opening the same stash resets the transient_revision to 1.
             assert_eq!(catalog.transient_revision(), 1);
-            */
-        })
-        .await
-        .expect("unable to open debug stash");
+        }
     }
 
     #[tokio::test]
@@ -7515,5 +7520,63 @@ mod tests {
             async {}
         })
         .await;
+    }
+
+    // Test that if a large catalog item is somehow committed, then we can still load the catalog.
+    #[tokio::test]
+    async fn test_large_catalog_item() {
+        let view_def = "CREATE VIEW \"materialize\".\"public\".\"v\" AS SELECT 1 FROM (SELECT 1";
+        let column = ", 1";
+        let view_def_size = view_def.bytes().count();
+        let column_size = column.bytes().count();
+        let column_count =
+            (mz_sql_parser::parser::MAX_STATEMENT_BATCH_SIZE - view_def_size) / column_size + 1;
+        let columns = iter::repeat(column).take(column_count).join("");
+        let create_sql = format!("{view_def}{columns})");
+        let create_sql_check = create_sql.clone();
+        assert!(mz_sql_parser::parser::parse_statements(&create_sql).is_ok());
+        assert!(mz_sql_parser::parser::parse_statements_with_limit(&create_sql).is_err());
+
+        let debug_stash_factory = DebugStashFactory::new().await.unwrap();
+        let id = GlobalId::User(1);
+        {
+            let stash = debug_stash_factory.open_debug().await.unwrap();
+            let mut catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
+                .await
+                .expect("unable to open debug catalog");
+            let item = catalog.state().parse_view_item(create_sql).unwrap();
+            catalog
+                .transact(
+                    SYSTEM_TIME().into(),
+                    None,
+                    vec![Op::CreateItem {
+                        item,
+                        name: QualifiedObjectName {
+                            qualifiers: ObjectQualifiers {
+                                database_spec: ResolvedDatabaseSpecifier::Id(DatabaseId::new(1)),
+                                schema_spec: SchemaSpecifier::Id(SchemaId::new(3)),
+                            },
+                            item: "v".to_string(),
+                        },
+                        oid: 1,
+                        id,
+                    }],
+                    |_catalog| Ok(()),
+                )
+                .await
+                .expect("failed to transact");
+        }
+        {
+            let stash = debug_stash_factory.open_debug().await.unwrap();
+            let catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
+                .await
+                .expect("unable to open debug catalog");
+            let view = catalog.get_entry(&id);
+            assert_eq!("v", view.name.item);
+            match &view.item {
+                CatalogItem::View(view) => assert_eq!(create_sql_check, view.create_sql),
+                item => panic!("expected view, got {}", item.typ()),
+            }
+        }
     }
 }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6676,14 +6676,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog_revision() {
-        let debug_stash_factory = DebugStashFactory::new()
-            .await
-            .expect("unable to open debug stash factory");
+        let debug_stash_factory = DebugStashFactory::new().await;
         {
-            let stash = debug_stash_factory
-                .open_debug()
-                .await
-                .expect("unable to open debug stash");
+            let stash = debug_stash_factory.open_debug().await;
             let mut catalog = Catalog::open_debug_stash(stash, NOW_ZERO.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -6704,10 +6699,7 @@ mod tests {
             assert_eq!(catalog.transient_revision(), 2);
         }
         {
-            let stash = debug_stash_factory
-                .open_debug()
-                .await
-                .expect("unable to open debug stash");
+            let stash = debug_stash_factory.open_debug().await;
             let catalog = Catalog::open_debug_stash(stash, NOW_ZERO.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -7537,14 +7529,17 @@ mod tests {
         assert!(mz_sql_parser::parser::parse_statements(&create_sql).is_ok());
         assert!(mz_sql_parser::parser::parse_statements_with_limit(&create_sql).is_err());
 
-        let debug_stash_factory = DebugStashFactory::new().await.unwrap();
+        let debug_stash_factory = DebugStashFactory::new().await;
         let id = GlobalId::User(1);
         {
-            let stash = debug_stash_factory.open_debug().await.unwrap();
+            let stash = debug_stash_factory.open_debug().await;
             let mut catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
                 .await
                 .expect("unable to open debug catalog");
-            let item = catalog.state().parse_view_item(create_sql).unwrap();
+            let item = catalog
+                .state()
+                .parse_view_item(create_sql)
+                .expect("unable to parse view");
             catalog
                 .transact(
                     SYSTEM_TIME().into(),
@@ -7567,7 +7562,7 @@ mod tests {
                 .expect("failed to transact");
         }
         {
-            let stash = debug_stash_factory.open_debug().await.unwrap();
+            let stash = debug_stash_factory.open_debug().await;
             let catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
                 .await
                 .expect("unable to open debug catalog");

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -94,7 +94,7 @@ use timely::progress::Antichain;
 mod postgres;
 mod transaction;
 
-pub use crate::postgres::{Stash, StashFactory};
+pub use crate::postgres::{DebugStashFactory, Stash, StashFactory};
 pub use crate::transaction::Transaction;
 
 pub type Diff = i64;
@@ -243,6 +243,14 @@ impl From<&str> for StashError {
     fn from(e: &str) -> StashError {
         StashError {
             inner: InternalStashError::Other(e.into()),
+        }
+    }
+}
+
+impl From<std::io::Error> for StashError {
+    fn from(e: std::io::Error) -> StashError {
+        StashError {
+            inner: InternalStashError::Other(e.to_string()),
         }
     }
 }

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1078,6 +1078,8 @@ impl Drop for DebugStashFactory {
                 Ok::<_, StashError>(())
             })
         })
+        // Note that we are joining on a tokio task here, which blocks the current runtime from making other progress on the current worker thread.
+        // Because this only happens on shutdown and is only used in tests, we have determined that its okay
         .join();
 
         match result {

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1006,6 +1006,7 @@ pub struct DebugStashFactory {
 }
 
 impl DebugStashFactory {
+    /// Returns a new factory that will generate a random schema one time, then use it on any opened Stash.
     pub async fn try_new() -> Result<DebugStashFactory, StashError> {
         let url =
             std::env::var("COCKROACH_URL").expect("COCKROACH_URL environment variable is not set");

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -997,7 +997,7 @@ impl Consolidator {
     }
 }
 
-/// Stash factory to use for tests that allow creating multiple stashes.
+/// Stash factory to use for tests that uses a random schema for a stash, which is re-used on all stash openings. The schema is dropped when this factory is dropped.
 pub struct DebugStashFactory {
     url: String,
     schema: String,

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -444,32 +444,9 @@ impl Stash {
         F: FnOnce(Stash) -> Fut,
         Fut: Future<Output = T>,
     {
-        let url =
-            std::env::var("COCKROACH_URL").expect("COCKROACH_URL environment variable is not set");
-        let rng: usize = rand::thread_rng().gen();
-        let schema = format!("schema_{rng}");
-        let tls = mz_postgres_util::make_tls(&tokio_postgres::Config::new()).unwrap();
-
-        let (client, connection) = tokio_postgres::connect(&url, tls.clone()).await?;
-        mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
-            if let Err(e) = connection.await {
-                tracing::error!("postgres stash connection error: {}", e);
-            }
-        });
-        client
-            .batch_execute(&format!("CREATE SCHEMA {schema}"))
-            .await?;
-
-        let factory = StashFactory::new(&MetricsRegistry::new());
-        let stash = factory.open(url, Some(schema.clone()), tls).await?;
-        let res = f(stash).await;
-
-        // Ignore errors when dropping, better to return `res`.
-        let _ = client
-            .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
-            .await;
-
-        Ok(res)
+        let factory = DebugStashFactory::new().await?;
+        let stash = factory.open_debug().await?;
+        Ok(f(stash).await)
     }
 
     /// Verifies stash invariants. Should only be called by tests.
@@ -1017,5 +994,88 @@ impl Consolidator {
         );
         self.client = Some(client);
         Ok(())
+    }
+}
+
+/// Stash factory to use for tests that allow creating multiple stashes.
+pub struct DebugStashFactory {
+    url: String,
+    schema: String,
+    tls: MakeTlsConnector,
+    stash_factory: StashFactory,
+}
+
+impl DebugStashFactory {
+    pub async fn new() -> Result<DebugStashFactory, StashError> {
+        let url =
+            std::env::var("COCKROACH_URL").expect("COCKROACH_URL environment variable is not set");
+        let rng: usize = rand::thread_rng().gen();
+        let schema = format!("schema_{rng}");
+        let tls = mz_postgres_util::make_tls(&tokio_postgres::Config::new()).unwrap();
+
+        let (client, connection) = tokio_postgres::connect(&url, tls.clone()).await?;
+        mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
+            if let Err(e) = connection.await {
+                tracing::error!("postgres stash connection error: {e}");
+            }
+        });
+        client
+            .batch_execute(&format!("CREATE SCHEMA {schema}"))
+            .await?;
+
+        let stash_factory = StashFactory::new(&MetricsRegistry::new());
+
+        Ok(DebugStashFactory {
+            url,
+            schema,
+            tls,
+            stash_factory,
+        })
+    }
+
+    pub async fn open_debug(&self) -> Result<Stash, StashError> {
+        self.stash_factory
+            .open(
+                self.url.clone(),
+                Some(self.schema.clone()),
+                self.tls.clone(),
+            )
+            .await
+    }
+}
+
+impl Drop for DebugStashFactory {
+    fn drop(&mut self) {
+        let url = self.url.clone();
+        let schema = self.schema.clone();
+        let tls = self.tls.clone();
+        let result = std::thread::spawn(move || {
+            let async_runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            async_runtime.block_on(async {
+                let (client, connection) = tokio_postgres::connect(&url, tls).await?;
+                mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
+                    if let Err(e) = connection.await {
+                        tracing::error!("postgres stash connection error: {e}");
+                    }
+                });
+                client
+                    .batch_execute(&format!("DROP SCHEMA {} CASCADE", &schema))
+                    .await?;
+                Ok::<_, StashError>(())
+            })
+        })
+        .join();
+
+        match result {
+            Ok(result) => {
+                if let Err(e) = result {
+                    tracing::error!("unable to cleanup debug stash: {e}");
+                }
+            }
+
+            Err(_) => tracing::error!("unable to cleanup debug stash"),
+        }
     }
 }


### PR DESCRIPTION
This commit adds the functionality to open and close a stash multiple times within a single test. In order to test the functionality a new test was added for #17573.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
