### PR TITLE
storage: multi-worker persist_sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4842,6 +4842,7 @@ dependencies = [
  "protobuf-src",
  "rand",
  "rdkafka",
+ "ref-cast",
  "regex",
  "serde",
  "serde_json",
@@ -4904,6 +4905,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rdkafka",
+ "ref-cast",
  "regex",
  "serde",
  "thiserror",
@@ -6228,6 +6230,26 @@ checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
  "redox_syscall",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9af2cf09ef80e610097515e80095b7f76660a92743c4185aff5406cd5ce3dd5"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c501201393982e275433bc55de7d6ae6f00e7699cd5572c5b57581cd69c881b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -116,6 +116,9 @@ class Materialized(Service):
             # f"--bootstrap-builtin-cluster-replica-size={self.default_replica_size}",
             f"--bootstrap-default-cluster-replica-size={self.default_replica_size}",
             f"--default-storage-host-size={self.default_storage_size}",
+            # We wish to test the new implementation as its the canonical one, but
+            # want to control the rollout to production.
+            "--bootstrap-system-parameter=enable_multi_worker_storage_persist_sink=true",
         ]
 
         if external_cockroach:

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -46,6 +46,7 @@ prometheus = { version = "0.13.3", default-features = false }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+ref-cast = "1"
 regex = { version = "1.7.0" }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -26,6 +26,7 @@ use once_cell::sync::Lazy;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
+use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::{Antichain, AntichainRef};
@@ -2460,8 +2461,15 @@ impl RustType<ProtoTestScriptSourceConnection> for TestScriptSourceConnection {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, RefCast)]
+#[repr(transparent)]
 pub struct SourceData(pub Result<Row, DataflowError>);
+
+impl SourceData {
+    pub fn from_ref<'a>(inner: &'a Result<Row, DataflowError>) -> &'a Self {
+        Self::ref_cast(inner)
+    }
+}
 
 impl Deref for SourceData {
     type Target = Result<Row, DataflowError>;

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -54,6 +54,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
+ref-cast = "1"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -291,7 +291,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     .dataflow_parameters
                     .enable_multi_worker_storage_persist_sink
                 {
-                    tracing::info!("rendering {} with multi-worker persist_sink", target);
+                    tracing::info!(
+                        "timely-{worker_id} rendering {target} with multi-worker persist_sink",
+                    );
                     crate::render::multi_worker_persist_sink::render(
                         into_time_scope,
                         target,
@@ -302,7 +304,9 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                         export.output_index,
                     )
                 } else {
-                    tracing::info!("rendering {} with single-worker persist_sink", target);
+                    tracing::info!(
+                        "timely-{worker_id} rendering {target} with single-worker persist_sink",
+                    );
                     crate::render::persist_sink::render(
                         into_time_scope,
                         target,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -216,6 +216,7 @@ use crate::source::types::SourcePersistSinkMetrics;
 use crate::storage_state::StorageState;
 
 mod debezium;
+mod multi_worker_persist_sink;
 mod persist_sink;
 pub mod sinks;
 pub mod sources;

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -697,10 +697,12 @@ where
                         if collection_id.is_user() {
                             trace!(
                                 "persist_sink {collection_id}/{shard_id}: \
-                                    wrote batch from worker {}: ({:?}, {:?})",
+                                    wrote batch from worker {}: ({:?}, {:?}),
+                                    containing {:?}",
                                 worker_index,
                                 batch_lower,
                                 batch_upper,
+                                batch_builder.metrics
                             );
                         }
                         batch_tokens.push(HollowBatchAndMetadata {

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -339,6 +339,11 @@ where
                 match event {
                     Event::Data(_cap, _data) => {
                         // Just read away data.
+                        // TODO(guswynn): this, and the same code in the compute version of this
+                        // code, is inefficient, and can be improved.
+                        // See
+                        // <https://github.com/MaterializeInc/materialize/pull/17589#discussion_r1106016139>
+                        // for more info.
                         continue;
                     }
                     Event::Progress(frontier) => {

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -1,0 +1,1153 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::{Collection, Hashable};
+use serde::{Deserialize, Serialize};
+use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::{
+    Broadcast, Capability, CapabilitySet, ConnectLoop, Feedback, Inspect,
+};
+use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+use timely::progress::Timestamp as TimelyTimestamp;
+use timely::PartialOrder;
+use tracing::trace;
+
+use mz_compute_client::types::sinks::{ComputeSinkDesc, PersistSinkConnection};
+use mz_ore::cast::CastFrom;
+use mz_ore::collections::HashMap;
+use mz_persist_client::batch::{Batch, BatchBuilder};
+use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::write::WriterEnrichedHollowBatch;
+use mz_persist_types::codec_impls::UnitSchema;
+use mz_repr::{Diff, GlobalId, Row, Timestamp};
+use mz_storage_client::controller::CollectionMetadata;
+use mz_storage_client::types::errors::DataflowError;
+use mz_storage_client::types::sources::SourceData;
+use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::probe::{self, ProbeNotify};
+
+use crate::compute_state::ComputeState;
+use crate::render::sinks::SinkRender;
+
+impl<G> SinkRender<G> for PersistSinkConnection<CollectionMetadata>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    fn render_continuous_sink(
+        &self,
+        compute_state: &mut ComputeState,
+        sink: &ComputeSinkDesc<CollectionMetadata>,
+        sink_id: GlobalId,
+        sinked_collection: Collection<G, Row, Diff>,
+        err_collection: Collection<G, DataflowError, Diff>,
+        probes: Vec<probe::Handle<Timestamp>>,
+    ) -> Option<Rc<dyn Any>>
+    where
+        G: Scope<Timestamp = Timestamp>,
+    {
+        let desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
+        if sink.up_to != Antichain::default() {
+            unimplemented!(
+                "UP TO is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
+            )
+        }
+
+        persist_sink(
+            sink_id,
+            &self.storage_metadata,
+            desired_collection,
+            sink.as_of.frontier.clone(),
+            compute_state,
+            probes,
+        )
+    }
+}
+
+pub(crate) fn persist_sink<G>(
+    sink_id: GlobalId,
+    target: &CollectionMetadata,
+    desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
+    as_of: Antichain<Timestamp>,
+    compute_state: &mut ComputeState,
+    probes: Vec<probe::Handle<Timestamp>>,
+) -> Option<Rc<dyn Any>>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    // There is no guarantee that `as_of` is beyond the persist shard's since. If it isn't,
+    // instantiating a `persist_source` with it would panic. So instead we leave it to
+    // `persist_source` to select an appropriate `as_of`. We only care about times beyond the
+    // current shard upper anyway.
+    let source_as_of = None;
+    let (ok_stream, err_stream, token) = mz_storage_client::source::persist_source::persist_source(
+        &desired_collection.scope(),
+        sink_id,
+        Arc::clone(&compute_state.persist_clients),
+        target.clone(),
+        source_as_of,
+        Antichain::new(), // we want all updates
+        None,             // no MFP
+        None,             // no flow control
+        // Copy the logic in DeltaJoin/Get/Join to start.
+        |_timer, count| count > 1_000_000,
+    );
+    use differential_dataflow::AsCollection;
+    let persist_collection = ok_stream
+        .as_collection()
+        .map(Ok)
+        .concat(&err_stream.as_collection().map(Err));
+
+    Some(Rc::new((
+        install_desired_into_persist(
+            sink_id,
+            target,
+            desired_collection,
+            persist_collection,
+            as_of,
+            compute_state,
+            probes,
+        ),
+        token,
+    )))
+}
+
+/// Continuously writes the difference between `persist_stream` and
+/// `desired_stream` into persist, such that the persist shard is made to
+/// contain the same updates as `desired_stream`. This is done via a multi-stage
+/// operator graph:
+///
+/// 1. `mint_batch_descriptions` emits new batch descriptions whenever the
+///    frontier of `persist_stream` advances *and `persist_frontier`* is less
+///    than `desired_frontier`. A batch description is a pair of `(lower,
+///    upper)` that tells write operators which updates to write and in the end
+///    tells the append operator what frontiers to use when calling
+///    `append`/`compare_and_append`. This is a single-worker operator.
+/// 2. `write_batches` writes the difference between `desired_stream` and
+///    `persist_stream` to persist as batches and sends those batches along.
+///    This does not yet append the batches to the persist shard, the update are
+///    only uploaded/prepared to be appended to a shard. Also: we only write
+///    updates for batch descriptions that we learned about from
+///    `mint_batch_descriptions`.
+/// 3. `append_batches` takes as input the minted batch descriptions and written
+///    batches. Whenever the frontiers sufficiently advance, we take a batch
+///    description and all the batches that belong to it and append it to the
+///    persist shard.
+fn install_desired_into_persist<G>(
+    sink_id: GlobalId,
+    target: &CollectionMetadata,
+    desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
+    persist_collection: Collection<G, Result<Row, DataflowError>, Diff>,
+    as_of: Antichain<Timestamp>,
+    compute_state: &mut crate::compute_state::ComputeState,
+    probes: Vec<probe::Handle<Timestamp>>,
+) -> Option<Rc<dyn Any>>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let persist_clients = Arc::clone(&compute_state.persist_clients);
+    let shard_id = target.data_shard;
+
+    let operator_name = format!("persist_sink {}", sink_id);
+
+    if sink_id.is_user() {
+        trace!(
+            "persist_sink {sink_id}/{shard_id}: \
+            initial as_of: {:?}",
+            as_of
+        );
+    }
+
+    let mut scope = desired_collection.inner.scope();
+
+    // The append operator keeps capabilities that it downgrades to match the
+    // current upper frontier of the persist shard. This frontier can be
+    // observed on the persist_feedback_stream. This is used by the minter
+    // operator to learn about the current persist frontier, driving it's
+    // decisions on when to mint new batches.
+    //
+    // This stream should never carry data, so we don't bother about increasing
+    // the timestamp on feeding back using the summary.
+    let (persist_feedback_handle, persist_feedback_stream) = scope.feedback(Timestamp::default());
+
+    let (batch_descriptions, mint_token) = mint_batch_descriptions(
+        sink_id,
+        operator_name.clone(),
+        target,
+        &desired_collection.inner,
+        &persist_feedback_stream,
+        as_of,
+        Arc::clone(&persist_clients),
+        compute_state,
+    );
+
+    let (written_batches, write_token) = write_batches(
+        sink_id.clone(),
+        operator_name.clone(),
+        target,
+        &batch_descriptions,
+        &desired_collection.inner,
+        &persist_collection.inner,
+        Arc::clone(&persist_clients),
+    );
+
+    let (append_frontier_stream, append_token) = append_batches(
+        sink_id.clone(),
+        operator_name,
+        target,
+        &batch_descriptions,
+        &written_batches,
+        persist_clients,
+    );
+
+    append_frontier_stream.connect_loop(persist_feedback_handle);
+
+    append_frontier_stream.probe_notify_with(probes);
+
+    let token = Rc::new((mint_token, write_token, append_token));
+
+    Some(token)
+}
+
+/// Whenever the frontier advances, this mints a new batch description (lower
+/// and upper) that writers should use for writing the next set of batches to
+/// persist.
+///
+/// Only one of the workers does this, meaning there will only be one
+/// description in the stream, even in case of multiple timely workers. Use
+/// `broadcast()` to, ahem, broadcast, the one description to all downstream
+/// write operators/workers.
+///
+/// This also keeps the shared frontier that is stored in `compute_state` in
+/// sync with the upper of the persist shard.
+fn mint_batch_descriptions<G>(
+    sink_id: GlobalId,
+    operator_name: String,
+    target: &CollectionMetadata,
+    desired_stream: &Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
+    persist_feedback_stream: &Stream<G, ()>,
+    as_of: Antichain<Timestamp>,
+    persist_clients: Arc<PersistClientCache>,
+    compute_state: &mut crate::compute_state::ComputeState,
+) -> (
+    Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
+    Rc<dyn Any>,
+)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let scope = desired_stream.scope();
+
+    // Only attempt to write from this frontier onward, as our data are not necessarily
+    // correct for times not greater or equal to this frontier.
+    let write_lower_bound = as_of;
+
+    let persist_location = target.persist_location.clone();
+    let shard_id = target.data_shard;
+    let target_relation_desc = target.relation_desc.clone();
+
+    // Only one worker is responsible for determining batch descriptions. All
+    // workers must write batches with the same description, to ensure that they
+    // can be combined into one batch that gets appended to Consensus state.
+    let hashed_id = sink_id.hashed();
+    let active_worker = usize::cast_from(hashed_id) % scope.peers() == scope.index();
+
+    // Only the "active" operator will mint batches. All other workers have an
+    // empty frontier. It's necessary to insert all of these into
+    // `compute_state.sink_write_frontier` below so we properly clear out
+    // default frontiers of non-active workers.
+    let shared_frontier = Rc::new(RefCell::new(if active_worker {
+        Antichain::from_elem(TimelyTimestamp::minimum())
+    } else {
+        Antichain::new()
+    }));
+
+    compute_state
+        .sink_write_frontiers
+        .insert(sink_id, Rc::clone(&shared_frontier));
+
+    let mut mint_op =
+        AsyncOperatorBuilder::new(format!("{} mint_batch_descriptions", operator_name), scope);
+
+    let (mut output, output_stream) = mint_op.new_output();
+
+    let mut desired_input = mint_op.new_input(desired_stream, Pipeline);
+    let mut persist_feedback_input =
+        mint_op.new_input_connection(persist_feedback_stream, Pipeline, vec![Antichain::new()]);
+
+    let shutdown_button = mint_op.build(move |mut capabilities| async move {
+        if !active_worker {
+            return;
+        }
+
+        let mut cap_set = CapabilitySet::from_elem(capabilities.pop().expect("missing capability"));
+
+        // TODO(aljoscha): We need to figure out what to do with error
+        // results from these calls.
+        let persist_client = persist_clients
+            .open(persist_location)
+            .await
+            .expect("could not open persist client");
+
+        let mut write = persist_client
+            .open_writer::<SourceData, (), Timestamp, Diff>(
+                shard_id,
+                &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
+                Arc::new(target_relation_desc),
+                Arc::new(UnitSchema),
+            )
+            .await
+            .expect("could not open persist shard");
+
+        let mut current_persist_frontier = write.upper().clone();
+
+        // Advance the persist shard's upper to at least our write lower
+        // bound.
+        if PartialOrder::less_than(&current_persist_frontier, &write_lower_bound) {
+            if sink_id.is_user() {
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        advancing to write_lower_bound: {:?}",
+                    write_lower_bound
+                );
+            }
+
+            let empty_updates: &[((SourceData, ()), Timestamp, Diff)] = &[];
+            // It's fine if we don't succeed here. This just means that
+            // someone else already advanced the persist frontier further,
+            // which is great!
+            let res = write
+                .append(
+                    empty_updates,
+                    current_persist_frontier.clone(),
+                    write_lower_bound.clone(),
+                )
+                .await
+                .expect("invalid usage");
+
+            if sink_id.is_user() {
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        advancing to write_lower_bound result: {:?}",
+                    res
+                );
+            }
+
+            current_persist_frontier.clone_from(&write_lower_bound);
+        }
+
+        // The current input frontiers.
+        let mut desired_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+        let mut persist_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+
+        // The persist_frontier as it was when we last ran through our minting logic.
+        // SUBTLE: As described below, we only mint new batch descriptions
+        // when the persist frontier moves. We therefore have to encode this
+        // one as an `Option<Antichain<T>>` where the change from `None` to
+        // `Some([minimum])` is also a change in the frontier. If we didn't
+        // do this, we would be stuck at `[minimum]`.
+        let mut emitted_persist_frontier: Option<Antichain<_>> = None;
+
+        loop {
+            tokio::select! {
+                Some(event) = desired_input.next() => {
+                    match event {
+                        Event::Data(_cap, _data) => {
+                            // Just read away data.
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            desired_frontier = frontier;
+                        }
+                    }
+                }
+                Some(event) = persist_feedback_input.next() => {
+                    match event {
+                        Event::Data(_cap, _data) => {
+                            // Just read away data.
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            persist_frontier = frontier;
+                        }
+                    }
+                }
+                else => {
+                    // All inputs are exhausted, so we can shut down.
+                    return;
+                }
+            };
+
+            if PartialOrder::less_than(&*shared_frontier.borrow(), &persist_frontier) {
+                if sink_id.is_user() {
+                    trace!(
+                        "persist_sink {sink_id}/{shard_id}: \
+                            updating shared_frontier to {:?}",
+                        persist_frontier,
+                    );
+                }
+
+                // Share that we have finished processing all times less than the persist frontier.
+                // Advancing the sink upper communicates to the storage controller that it is
+                // permitted to compact our target storage collection up to the new upper. So we
+                // must be careful to not advance the sink upper beyond our read frontier.
+                shared_frontier.borrow_mut().clear();
+                shared_frontier
+                    .borrow_mut()
+                    .extend(persist_frontier.iter().cloned());
+            }
+
+            // We only mint new batch desriptions when:
+            //  1. the desired frontier is past the persist frontier
+            //  2. the persist frontier has moved since we last emitted a
+            //     batch
+            //
+            // That last point is _subtle_: If we emitted new batch
+            // descriptions whenever the desired frontier moves but the
+            // persist frontier doesn't move, we would mint overlapping
+            // batch descriptions, which would lead to errors when trying to
+            // appent batches based on them.
+            //
+            // We never use the same lower frontier twice.
+            // We only emit new batches when the persist frontier moves.
+            // A batch description that we mint for a given `lower` will
+            // either succeed in being appended, in which case the
+            // persist frontier moves. Or it will fail because the
+            // persist frontier got moved by someone else, in which case
+            // we also won't mint a new batch description for the same
+            // frontier.
+            if PartialOrder::less_than(&persist_frontier, &desired_frontier)
+                && (emitted_persist_frontier.is_none()
+                    || PartialOrder::less_than(
+                        emitted_persist_frontier.as_ref().unwrap(),
+                        &persist_frontier,
+                    ))
+            {
+                let batch_description = (persist_frontier.to_owned(), desired_frontier.to_owned());
+
+                let lower = batch_description.0.first().unwrap();
+                let batch_ts = batch_description.0.first().unwrap().clone();
+
+                let cap = cap_set
+                    .try_delayed(&batch_ts)
+                    .ok_or_else(|| {
+                        format!(
+                            "minter cannot delay {:?} to {:?}. \
+                                Likely because we already emitted a \
+                                batch description and delayed.",
+                            cap_set, lower
+                        )
+                    })
+                    .unwrap();
+
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        new batch_description: {:?}",
+                    batch_description
+                );
+
+                let mut output = output.activate();
+                let mut session = output.session(&cap);
+                session.give(batch_description);
+
+                // WIP: We downgrade our capability so that downstream
+                // operators (writer and appender) can know when all the
+                // writers have had a chance to write updates to persist for
+                // a given batch. Just stepping forward feels a bit icky,
+                // though.
+                let new_batch_frontier = Antichain::from_elem(batch_ts.step_forward());
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        downgrading to {:?}",
+                    new_batch_frontier
+                );
+                let res = cap_set.try_downgrade(new_batch_frontier.iter());
+                match res {
+                    Ok(_) => (),
+                    Err(e) => panic!("in minter: {:?}", e),
+                }
+
+                emitted_persist_frontier.replace(persist_frontier.clone());
+            }
+        }
+    });
+
+    if sink_id.is_user() {
+        output_stream.inspect(|d| trace!("batch_description: {:?}", d));
+    }
+
+    let token = Rc::new(shutdown_button.press_on_drop());
+    (output_stream, token)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+enum BatchOrData {
+    Batch(WriterEnrichedHollowBatch<Timestamp>),
+    Data {
+        lower: Antichain<Timestamp>,
+        upper: Antichain<Timestamp>,
+        contents: Vec<(Result<Row, DataflowError>, Timestamp, Diff)>,
+    },
+}
+
+/// Writes `desired_stream - persist_stream` to persist, but only for updates
+/// that fall into batch a description that we get via `batch_descriptions`.
+/// This forwards a `HollowBatch` for any batch of updates that was written.
+fn write_batches<G>(
+    sink_id: GlobalId,
+    operator_name: String,
+    target: &CollectionMetadata,
+    batch_descriptions: &Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
+    desired_stream: &Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
+    persist_stream: &Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
+    persist_clients: Arc<PersistClientCache>,
+) -> (Stream<G, BatchOrData>, Rc<dyn Any>)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let persist_location = target.persist_location.clone();
+    let shard_id = target.data_shard;
+    let target_relation_desc = target.relation_desc.clone();
+
+    let scope = desired_stream.scope();
+    let worker_index = scope.index();
+
+    let mut write_op = AsyncOperatorBuilder::new(format!("{} write_batches", operator_name), scope);
+
+    let (mut output, output_stream) = write_op.new_output();
+
+    let mut descriptions_input = write_op.new_input(&batch_descriptions.broadcast(), Pipeline);
+    let mut desired_input = write_op.new_input(
+        desired_stream,
+        Exchange::new(
+            move |(row, _ts, _diff): &(Result<Row, DataflowError>, Timestamp, Diff)| row.hashed(),
+        ),
+    );
+    let mut persist_input = write_op.new_input_connection(
+        persist_stream,
+        Exchange::new(
+            move |(row, _ts, _diff): &(Result<Row, DataflowError>, Timestamp, Diff)| row.hashed(),
+        ),
+        // This connection specification makes sure that the persist frontier is
+        // not taken into account when determining downstream implications.
+        // We're only interested in the frontier to know when we are ready to
+        // write out new data (when the corrections have "settled"). But the
+        // persist frontier must not hold back the downstream frontier,
+        // otherwise the `append_batches` operator would never append batches
+        // because it waits for its input frontier to advance before it does so.
+        // The input frontier would never advance if we don't write new updates
+        // to persist, leading to a Catch-22-type situation.
+        vec![Antichain::new()],
+    );
+
+    // This operator accepts the current and desired update streams for a `persist` shard.
+    // It attempts to write out updates, starting from the current's upper frontier, that
+    // will cause the changes of desired to be committed to persist.
+
+    let shutdown_button = write_op.build(move |_capabilities| async move {
+        // Contains `desired - persist`, reflecting the updates we would like to commit
+        // to `persist` in order to "correct" it to track `desired`. This collection is
+        // only modified by updates received from either the `desired` or `persist` inputs.
+        let mut correction = Vec::new();
+
+        // Contains descriptions of batches for which we know that we can
+        // write data. We got these from the "centralized" operator that
+        // determines batch descriptions for all writers.
+        //
+        // `Antichain` does not implement `Ord`, so we cannot use a `BTreeMap`. We need to search
+        // through the map, so we cannot use the `mz_ore` wrapper either.
+        #[allow(clippy::disallowed_types)]
+        let mut in_flight_batches = std::collections::HashMap::<
+            (Antichain<Timestamp>, Antichain<Timestamp>),
+            Capability<Timestamp>,
+        >::new();
+
+        // TODO(aljoscha): We need to figure out what to do with error results from these calls.
+        let persist_client = persist_clients
+            .open(persist_location)
+            .await
+            .expect("could not open persist client");
+
+        let mut write = persist_client
+            .open_writer::<SourceData, (), Timestamp, Diff>(
+                shard_id,
+                &format!("compute::persist_sink::write_batches {}", sink_id),
+                Arc::new(target_relation_desc),
+                Arc::new(UnitSchema),
+            )
+            .await
+            .expect("could not open persist shard");
+
+        // The current input frontiers.
+        let mut batch_descriptions_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+        let mut desired_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+        let mut persist_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+
+        loop {
+            tokio::select! {
+                Some(event) = descriptions_input.next_mut() => {
+                    match event {
+                        Event::Data(cap, data) => {
+                            // Ingest new batch descriptions.
+                            for description in data.drain(..) {
+                                if sink_id.is_user() {
+                                    trace!(
+                                        "persist_sink {sink_id}/{shard_id}: \
+                                            write_batches: \
+                                            new_description: {:?}, \
+                                            desired_frontier: {:?}, \
+                                            batch_descriptions_frontier: {:?}, \
+                                            persist_frontier: {:?}",
+                                        description,
+                                        desired_frontier,
+                                        batch_descriptions_frontier,
+                                        persist_frontier
+                                    );
+                                }
+                                let existing = in_flight_batches.insert(
+                                    description.clone(),
+                                    cap.delayed(description.0.first().unwrap()),
+                                );
+                                assert!(
+                                    existing.is_none(),
+                                    "write_batches: sink {} got more than one \
+                                        batch for description {:?}, in-flight: {:?}",
+                                    sink_id,
+                                    description,
+                                    in_flight_batches
+                                );
+                            }
+
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            batch_descriptions_frontier = frontier;
+                        }
+                    }
+                }
+                Some(event) = desired_input.next_mut() => {
+                    match event {
+                        Event::Data(_cap, data) => {
+                            // Extract desired rows as positive contributions to `correction`.
+                            if sink_id.is_user() && !data.is_empty() {
+                                trace!(
+                                    "persist_sink {sink_id}/{shard_id}: \
+                                        updates: {:?}, \
+                                        in-flight-batches: {:?}, \
+                                        desired_frontier: {:?}, \
+                                        batch_descriptions_frontier: {:?}, \
+                                        persist_frontier: {:?}",
+                                    data,
+                                    in_flight_batches,
+                                    desired_frontier,
+                                    batch_descriptions_frontier,
+                                    persist_frontier
+                                );
+                            }
+                            correction.append(data);
+
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            desired_frontier = frontier;
+                        }
+                    }
+                }
+                Some(event) = persist_input.next_mut() => {
+                    match event {
+                        Event::Data(_cap, data) => {
+                            // Extract persist rows as negative contributions to `correction`.
+                            correction.extend(data.drain(..).map(|(d, t, r)| (d, t, -r)));
+
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            persist_frontier = frontier;
+                        }
+                    }
+                }
+                else => {
+                    // All inputs are exhausted, so we can shut down.
+                    return;
+                }
+            }
+
+            // We may have the opportunity to commit updates.
+            if !PartialOrder::less_equal(&desired_frontier, &persist_frontier) {
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        CAN emit: \
+                        persist_frontier: {:?}, \
+                        desired_frontier: {:?}",
+                    persist_frontier,
+                    desired_frontier
+                );
+                // Advance all updates to `persist`'s frontier.
+                for (row, time, diff) in correction.iter_mut() {
+                    let time_before = *time;
+                    time.advance_by(persist_frontier.borrow());
+                    if sink_id.is_user() && &time_before != time {
+                        trace!(
+                            "persist_sink {sink_id}/{shard_id}: \
+                                advanced {:?}, {}, {} to {}",
+                            row,
+                            time_before,
+                            diff,
+                            time
+                        );
+                    }
+                }
+
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        in-flight batches: {:?}, \
+                        batch_descriptions_frontier: {:?}, \
+                        desired_frontier: {:?} \
+                        persist_frontier: {:?}",
+                    in_flight_batches,
+                    batch_descriptions_frontier,
+                    desired_frontier,
+                    persist_frontier
+                );
+
+                // We can write updates for a given batch description when
+                // a) the batch is not beyond `batch_descriptions_frontier`,
+                // and b) we know that we have seen all updates that would
+                // fall into the batch, from `desired_frontier`.
+                let ready_batches = in_flight_batches
+                    .keys()
+                    .filter(|(lower, upper)| {
+                        !PartialOrder::less_equal(&batch_descriptions_frontier, lower)
+                            && !PartialOrder::less_than(&desired_frontier, upper)
+                            && !PartialOrder::less_than(&persist_frontier, lower)
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        ready batches: {:?}",
+                    ready_batches,
+                );
+
+                if !ready_batches.is_empty() {
+                    // Consolidate updates only when they are required by an
+                    // attempt to write out new updates. Otherwise, we might
+                    // spend a lot of time "consolidating" the same updates
+                    // over and over again, with no changes.
+                    consolidate_updates(&mut correction);
+
+                    // `correction` starts large as it diffs the initial snapshots,
+                    // but in steady state contains substantially fewer updates.
+                    // We should regularly shrink it to an appropriate size.
+                    // We use a 4x threshold here to ensure that we cannot enter
+                    // a resizing cycle without a linear-in-`correction.len()`
+                    // number of updates. E.g. a 2x threshold could result in
+                    // an allocation that must soon after be re-doubled back to
+                    // the current size, then halved, then doubled. We want that
+                    // pattern to require a linear number of updates rather than
+                    // a constant number.
+                    if correction.len() < correction.capacity() / 4 {
+                        correction.shrink_to_fit();
+                    }
+                }
+
+                for batch_description in ready_batches.into_iter() {
+                    let cap = in_flight_batches.remove(&batch_description).unwrap();
+
+                    if sink_id.is_user() {
+                        trace!(
+                            "persist_sink {sink_id}/{shard_id}: \
+                                emitting done batch: {:?}, cap: {:?}",
+                            batch_description,
+                            cap
+                        );
+                    }
+
+                    let (batch_lower, batch_upper) = batch_description;
+
+                    let mut to_append = correction
+                        .iter()
+                        .filter(|(_, time, _)| {
+                            batch_lower.less_equal(time) && !batch_upper.less_equal(time)
+                        })
+                        .peekable();
+
+                    if to_append.peek().is_some() {
+                        // We want to pass along the data directly if `to_append` is small, but to avoid
+                        // having to iterate through everything twice we'll check if `correction`
+                        // is small as a reasonable proxy.
+                        let minimum_batch_updates =
+                            persist_clients.cfg().sink_minimum_batch_updates();
+                        let batch_or_data = if correction.len() >= minimum_batch_updates {
+                            let batch = write
+                                .batch(
+                                    to_append.map(|(data, time, diff)| {
+                                        ((SourceData(data.clone()), ()), time, diff)
+                                    }),
+                                    batch_lower.clone(),
+                                    batch_upper.clone(),
+                                )
+                                .await
+                                .expect("invalid usage");
+
+                            if sink_id.is_user() {
+                                trace!(
+                                    "persist_sink {sink_id}/{shard_id}: \
+                                    wrote batch from worker {}: ({:?}, {:?})",
+                                    worker_index,
+                                    batch.lower(),
+                                    batch.upper()
+                                );
+                            }
+                            BatchOrData::Batch(batch.into_writer_hollow_batch())
+                        } else {
+                            BatchOrData::Data {
+                                lower: batch_lower.clone(),
+                                upper: batch_upper.clone(),
+                                contents: to_append.cloned().collect(),
+                            }
+                        };
+
+                        let mut output = output.activate();
+                        let mut session = output.session(&cap);
+                        session.give(batch_or_data);
+                    }
+                }
+            } else {
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        cannot emit: persist_frontier: {:?}, desired_frontier: {:?}",
+                    persist_frontier,
+                    desired_frontier
+                );
+            }
+        }
+    });
+
+    if sink_id.is_user() {
+        output_stream.inspect(|d| trace!("batch: {:?}", d));
+    }
+
+    let token = Rc::new(shutdown_button.press_on_drop());
+    (output_stream, token)
+}
+
+/// Fuses written batches together and appends them to persist using one
+/// `compare_and_append` call. Writing only happens for batch descriptions where
+/// we know that no future batches will arrive, that is, for those batch
+/// descriptions that are not beyond the frontier of both the
+/// `batch_descriptions` and `batches` inputs.
+///
+/// To avoid contention over the persist shard, we route all batches to a single worker.
+/// This worker may also batch up individual records sent by the upstream operator, as
+/// a way to coalesce what would otherwise be many tiny batches into fewer, larger ones.
+fn append_batches<G>(
+    sink_id: GlobalId,
+    operator_name: String,
+    target: &CollectionMetadata,
+    batch_descriptions: &Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
+    batches: &Stream<G, BatchOrData>,
+    persist_clients: Arc<PersistClientCache>,
+) -> (Stream<G, ()>, Rc<dyn Any>)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let scope = batch_descriptions.scope();
+
+    let persist_location = target.persist_location.clone();
+    let shard_id = target.data_shard;
+    let target_relation_desc = target.relation_desc.clone();
+
+    let operator_name = format!("{} append_batches", operator_name);
+    let mut append_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
+
+    // We never output anything, but we update our capabilities based on the
+    // persist frontier we know about. So someone can listen on our output
+    // frontier and learn about the persist frontier advancing.
+    let (mut _output, output_stream) = append_op.new_output();
+
+    let hashed_id = sink_id.hashed();
+    let active_worker = usize::cast_from(hashed_id) % scope.peers() == scope.index();
+
+    // This operator wants to completely control the frontier on it's output
+    // because it's used to track the latest persist frontier. We update this
+    // when we either append to persist successfully or when we learn about a
+    // new current frontier because a `compare_and_append` failed. That's why
+    // input capability tracking is not connected to the output.
+    let mut descriptions_input = append_op.new_input_connection(
+        batch_descriptions,
+        Exchange::new(move |_| hashed_id),
+        vec![Antichain::new()],
+    );
+    let mut batches_input = append_op.new_input_connection(
+        batches,
+        Exchange::new(move |_| hashed_id),
+        vec![Antichain::new()],
+    );
+
+    // This operator accepts the batch descriptions and tokens that represent
+    // written batches. Written batches get appended to persist when we learn
+    // from our input frontiers that we have seen all batches for a given batch
+    // description.
+
+    let shutdown_button = append_op.build(move |mut capabilities| async move {
+        if !active_worker {
+            return;
+        }
+
+        let mut cap_set = CapabilitySet::from_elem(capabilities.pop().expect("missing capability"));
+
+        // Contains descriptions of batches for which we know that we can
+        // write data. We got these from the "centralized" operator that
+        // determines batch descriptions for all writers.
+        //
+        // `Antichain` does not implement `Ord`, so we cannot use a `BTreeSet`. We need to search
+        // through the set, so we cannot use the `mz_ore` wrapper either.
+        #[allow(clippy::disallowed_types)]
+        let mut in_flight_descriptions = std::collections::HashSet::<
+            (Antichain<Timestamp>, Antichain<Timestamp>)
+        >::new();
+
+        #[derive(Debug, Default)]
+        struct BatchSet {
+            finished: Vec<Batch<SourceData, (), Timestamp, Diff>>,
+            incomplete: Option<BatchBuilder<SourceData, (), Timestamp, Diff>>,
+        }
+
+        let mut in_flight_batches = HashMap::<
+            (Antichain<Timestamp>, Antichain<Timestamp>),
+            BatchSet,
+        >::new();
+
+        // TODO(aljoscha): We need to figure out what to do with error results from these calls.
+        let persist_client = persist_clients
+            .open(persist_location)
+            .await
+            .expect("could not open persist client");
+
+        let mut write = persist_client
+            .open_writer::<SourceData, (), Timestamp, Diff>(
+                shard_id,
+                &format!("persist_sink::append_batches {}", sink_id),
+                Arc::new(target_relation_desc),
+                Arc::new(UnitSchema)
+            )
+            .await
+            .expect("could not open persist shard");
+
+        // The current input frontiers.
+        let mut batch_description_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+        let mut batches_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+
+        loop {
+            tokio::select! {
+                Some(event) = descriptions_input.next_mut() => {
+                    match event {
+                        Event::Data(_cap, data) => {
+                            // Ingest new batch descriptions.
+                            for batch_description in data.drain(..) {
+                                if sink_id.is_user() {
+                                    trace!(
+                                        "persist_sink {sink_id}/{shard_id}: \
+                                            append_batches: sink {}, \
+                                            new description: {:?}, \
+                                            batch_description_frontier: {:?}",
+                                        sink_id,
+                                        batch_description,
+                                        batch_description_frontier
+                                    );
+                                }
+
+                                let is_new = in_flight_descriptions.insert(batch_description.clone());
+
+                                assert!(
+                                    is_new,
+                                    "append_batches: sink {} got more than one batch \
+                                        for a given description in-flight: {:?}",
+                                    sink_id, in_flight_batches
+                                );
+                            }
+
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            batch_description_frontier = frontier;
+                        }
+                    }
+                }
+                Some(event) = batches_input.next_mut() => {
+                    match event {
+                        Event::Data(_cap, data) => {
+                            // Ingest new written batches
+                            for batch in data.drain(..) {
+                                match batch {
+                                    BatchOrData::Batch(batch) => {
+                                        let batch = write.batch_from_hollow_batch(batch);
+                                        let batch_description = (batch.lower().clone(), batch.upper().clone());
+
+                                        let batches = in_flight_batches
+                                            .entry(batch_description)
+                                            .or_default();
+
+                                        batches.finished.push(batch);
+                                    }
+                                    BatchOrData::Data { lower, upper, contents } => {
+                                        let batches = in_flight_batches
+                                            .entry((lower.clone(), upper))
+                                            .or_default();
+                                        let builder = batches.incomplete.get_or_insert_with(|| {
+                                            write.builder(lower)
+                                        });
+                                        for (data, time, diff) in contents {
+                                            persist_client.metrics().sink.forwarded_updates.inc();
+                                            builder.add(&SourceData(data), &(), &time, &diff).await.expect("invalid usage");
+                                        }
+                                    }
+                                }
+
+                            }
+
+                            continue;
+                        }
+                        Event::Progress(frontier) => {
+                            batches_frontier = frontier;
+                        }
+                    }
+                }
+                else => {
+                    // All inputs are exhausted, so we can shut down.
+                    return;
+                }
+            };
+
+            // Peel off any batches that are not beyond the frontier
+            // anymore.
+            //
+            // It is correct to consider batches that are not beyond the
+            // `batches_frontier` because it is held back by the writer
+            // operator as long as a) the `batch_description_frontier` did
+            // not advance and b) as long as the `desired_frontier` has not
+            // advanced to the `upper` of a given batch description.
+
+            let mut done_batches = in_flight_descriptions
+                .iter()
+                .filter(|(lower, _upper)| !PartialOrder::less_equal(&batches_frontier, lower))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            trace!(
+                "persist_sink {sink_id}/{shard_id}: \
+                    append_batches: in_flight: {:?}, \
+                    done: {:?}, \
+                    batch_frontier: {:?}, \
+                    batch_description_frontier: {:?}",
+                in_flight_descriptions,
+                done_batches,
+                batches_frontier,
+                batch_description_frontier
+            );
+
+            // Append batches in order, to ensure that their `lower` and
+            // `upper` lign up.
+            done_batches.sort_by(|a, b| {
+                if PartialOrder::less_than(a, b) {
+                    Ordering::Less
+                } else if PartialOrder::less_than(b, a) {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            });
+
+            for done_batch_metadata in done_batches.into_iter() {
+                in_flight_descriptions.remove(&done_batch_metadata);
+
+                let batch_set = in_flight_batches
+                    .remove(&done_batch_metadata)
+                    .unwrap_or_default();
+
+                let mut batches = batch_set.finished;
+                if let Some(builder) = batch_set.incomplete {
+                    let (_lower, upper) = &done_batch_metadata;
+                    let batch = builder.finish(upper.clone()).await.expect("invalid usage");
+                    batches.push(batch);
+                    persist_client.metrics().sink.forwarded_batches.inc();
+                }
+
+                trace!(
+                    "persist_sink {sink_id}/{shard_id}: \
+                        done batch: {:?}, {:?}",
+                    done_batch_metadata,
+                    batches
+                );
+
+                let (batch_lower, batch_upper) = done_batch_metadata;
+
+                let mut to_append = batches.iter_mut().collect::<Vec<_>>();
+
+                let result = write
+                    .compare_and_append_batch(
+                        &mut to_append[..],
+                        batch_lower.clone(),
+                        batch_upper.clone(),
+                    )
+                    .await
+                    .expect("Invalid usage");
+
+                if sink_id.is_user() {
+                    trace!(
+                        "persist_sink {sink_id}/{shard_id}: \
+                            append result for batch ({:?} -> {:?}): {:?}",
+                        batch_lower,
+                        batch_upper,
+                        result
+                    );
+                }
+
+                match result {
+                    Ok(()) => {
+                        cap_set.downgrade(batch_upper);
+                    }
+                    Err(mismatch) => {
+                        cap_set.downgrade(mismatch.current.iter());
+
+                        // Clean up in case we didn't manage to append the
+                        // batches to persist.
+                        for batch in batches {
+                            batch.delete().await;
+                        }
+                        trace!(
+                            "persist_sink({}): invalid upper! \
+                                Tried to append batch ({:?} -> {:?}) but upper \
+                                is {:?}. This is not a problem, it just means \
+                                someone else was faster than us. We will try \
+                                again with a new batch description.",
+                            sink_id,
+                            batch_lower,
+                            batch_upper,
+                            mismatch.current,
+                        );
+                    }
+                }
+            }
+        }
+    });
+
+    let token = Rc::new(shutdown_button.press_on_drop());
+    (output_stream, token)
+}

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -798,6 +798,13 @@ where
     // description.
 
     let shutdown_button = append_op.build(move |_| async move {
+        // This may SEEM unnecessary, but metrics contains extra
+        // `DeleteOnDrop`-wrapped fields that will NOT be moved into this
+        // closure otherwise, dropping and destroying
+        // those metrics. This is because rust now only moves the
+        // explicitly-referenced fields into closures.
+        let metrics = metrics;
+
         // Contains descriptions of batches for which we know that we can
         // write data. We got these from the "centralized" operator that
         // determines batch descriptions for all writers.

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -381,9 +381,7 @@ where
                     batch_description
                 );
 
-                let mut output = output.activate();
-                let mut session = output.session(&cap);
-                session.give(batch_description);
+                output.give(&cap, batch_description).await;
 
                 // WIP: We downgrade our capability so that downstream
                 // operators (writer and appender) can know when all the
@@ -715,9 +713,7 @@ where
                         })
                     }
 
-                    let mut output = output.activate();
-                    let mut session = output.session(&cap);
-                    session.give_vec(&mut batch_tokens);
+                    output.give_container(&cap, &mut batch_tokens).await;
 
                     current_upper = desired_frontier.clone();
                 }

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -136,6 +136,15 @@ impl AddAssign<&BatchMetrics> for BatchMetrics {
     }
 }
 
+impl BatchMetrics {
+    fn is_empty(&self) -> bool {
+        self.inserts == 0
+            && self.retractions == 0
+            && self.error_inserts == 0
+            && self.error_retractions == 0
+    }
+}
+
 struct BatchBuilderAndMetdata<K, V, T, D>
 where
     T: timely::progress::Timestamp
@@ -842,6 +851,18 @@ where
         let mut batch_description_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
         let mut batches_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
 
+        // Pause the source to prevent committing the snapshot,
+        // if the failpoint is configured
+        let mut pg_snapshot_pause = false;
+        (|| {
+            fail::fail_point!("pg_snapshot_pause", |val| {
+                pg_snapshot_pause = val.map_or(false, |index| {
+                    let index: usize = index.parse().unwrap();
+                    index == output_index
+                });
+            });
+        })();
+
         loop {
             tokio::select! {
                 Some(event) = descriptions_input.next_mut() => {
@@ -978,6 +999,18 @@ where
                         batch
                     })
                     .collect::<Vec<_>>();
+
+                // We evaluate this above to avoid checking an environment variable
+                // in a hot loop. Note that we only pause before we emit
+                // non-empty batches, because we do want to bump the upper
+                // with empty ones before we start ingesting the snapshot.
+                //
+                // This is a fairly complex failure case we need to check
+                // see `test/cluster/pg-snapshot-partial-failure` for more
+                // information.
+                if pg_snapshot_pause && !to_append.is_empty() && !batch_metrics.is_empty() {
+                    futures::future::pending().await
+                }
 
                 let result = write
                     .compare_and_append_batch(

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -95,10 +95,12 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::{lattice::Lattice, Collection, Hashable};
+use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::rc::SharedStream;
 use timely::dataflow::operators::{Broadcast, Capability, CapabilitySet, Inspect};
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::{Scope, Stream, StreamCore};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tracing::trace;
@@ -233,12 +235,14 @@ where
 
     let operator_name = format!("persist_sink({})", collection_id);
 
+    let desired_stream = desired_collection.inner.shared();
+
     let (batch_descriptions, mint_token) = mint_batch_descriptions(
         scope,
         collection_id,
         &operator_name,
         &target,
-        &desired_collection,
+        &desired_stream,
         Arc::clone(&persist_clients),
     );
 
@@ -248,7 +252,7 @@ where
         &operator_name,
         &target,
         &batch_descriptions,
-        &desired_collection,
+        &desired_stream,
         Arc::clone(&persist_clients),
         storage_state,
     );
@@ -282,7 +286,7 @@ fn mint_batch_descriptions<G>(
     collection_id: GlobalId,
     operator_name: &str,
     target: &CollectionMetadata,
-    desired_collection: &Collection<G, Result<Row, DataflowError>, Diff>,
+    desired_stream: &StreamCore<G, Rc<Vec<(Result<Row, DataflowError>, mz_repr::Timestamp, Diff)>>>,
     persist_clients: Arc<PersistClientCache>,
 ) -> (
     Stream<G, (Antichain<mz_repr::Timestamp>, Antichain<mz_repr::Timestamp>)>,
@@ -313,7 +317,7 @@ where
 
     let (mut output, output_stream) = mint_op.new_output();
 
-    let mut desired_input = mint_op.new_input(&desired_collection.inner, Pipeline);
+    let mut desired_input = mint_op.new_input(desired_stream, Pipeline);
 
     let shutdown_button = mint_op.build(move |capabilities| async move {
         let mut cap_set = CapabilitySet::from_elem(capabilities.into_element());
@@ -440,7 +444,7 @@ fn write_batches<G>(
     operator_name: &str,
     target: &CollectionMetadata,
     batch_descriptions: &Stream<G, (Antichain<mz_repr::Timestamp>, Antichain<mz_repr::Timestamp>)>,
-    desired_collection: &Collection<G, Result<Row, DataflowError>, Diff>,
+    desired_stream: &StreamCore<G, Rc<Vec<(Result<Row, DataflowError>, mz_repr::Timestamp, Diff)>>>,
     persist_clients: Arc<PersistClientCache>,
     storage_state: &mut StorageState,
 ) -> (Stream<G, HollowBatchAndMetadata>, Rc<dyn Any>)
@@ -465,7 +469,7 @@ where
     let (mut output, output_stream) = write_op.new_output();
 
     let mut descriptions_input = write_op.new_input(&batch_descriptions.broadcast(), Pipeline);
-    let mut desired_input = write_op.new_input(&desired_collection.inner, Pipeline);
+    let mut desired_input = write_op.new_input(desired_stream, Pipeline);
 
     // This operator accepts the current and desired update streams for a `persist` shard.
     // It attempts to write out updates, starting from the current's upper frontier, that
@@ -564,7 +568,7 @@ where
                         }
                     }
                 }
-                Some(event) = desired_input.next_mut() => {
+                Some(event) = desired_input.next() => {
                     match event {
                         Event::Data(_cap, data) => {
                             // Extract desired rows as positive contributions to `correction`.
@@ -582,9 +586,9 @@ where
                                 );
                             }
 
-                            for (row, ts, diff) in data.drain(..) {
-                                if write.upper().less_equal(&ts){
-                                    let builder = stashed_batches.entry(ts).or_insert_with(|| {
+                            for (row, ts, diff) in data.iter() {
+                                if write.upper().less_equal(ts){
+                                    let builder = stashed_batches.entry(*ts).or_insert_with(|| {
                                         BatchBuilderAndMetadata::new(
                                             write.builder(operator_batch_lower.clone()),
                                         )
@@ -593,7 +597,7 @@ where
                                     let is_value = row.is_ok();
                                     builder
                                         .builder
-                                        .add(&SourceData(row), &(), &ts, &diff)
+                                        .add(SourceData::ref_cast(row), &(), ts, diff)
                                         .await
                                         .expect("invalid usage");
 

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -7,30 +7,104 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Render an operator that persists a source collection.
+//!
+//! ## Implementation
+//!
+//! This module defines the `persist_sink` operator, that writes
+//! a collection produced by source rendering into a persist shard.
+//!
+//! It attempts to use all workers to write data to persist, and uses
+//! single-instance workers to coordinate work. The below diagram
+//! is an overview how it it shaped. There is more information
+//! in the doc comments of the top-level functions of this module.
+//!
+//!```text
+//!
+//!                                       ,------------.
+//!                                       | source     |
+//!                                       | collection |
+//!                                       +---+--------+
+//!                                       /   |
+//!                                      /    |
+//!                                     /     |
+//!                                    /      |
+//!                                   /       |
+//!                                  /        |
+//!                                 /         |
+//!                                /          |
+//!                               /     ,-+-----------------------.
+//!                              /      | mint_batch_descriptions |
+//!                             /       | one arbitrary worker    |
+//!                            |        +-,--,--------+----+------+
+//!                           ,----------´.-´         |     \
+//!                       _.-´ |       .-´            |      \
+//!                   _.-´     |    .-´               |       \
+//!                .-´  .------+----|-------+---------|--------\-----.
+//!               /    /            |       |         |         \     \
+//!        ,--------------.   ,-----------------.     |     ,-----------------.
+//!        | write_batches|   |  write_batches  |     |     |  write_batches  |
+//!        | worker 0     |   | worker 1        |     |     | worker N        |
+//!        +-----+--------+   +-+---------------+     |     +--+--------------+
+//!               \              \                    |        /
+//!                `-.            `,                  |       /
+//!                   `-._          `-.               |      /
+//!                       `-._         `-.            |     /
+//!                           `---------. `-.         |    /
+//!                                     +`---`---+-------------,
+//!                                     | append_batches       |
+//!                                     | one arbitrary worker |
+//!                                     +------+---------------+
+//!```
+//!
+//! ## Similarities with `mz_compute::sink::persist_sink`
+//!
+//! This module has many similarities with the compute version of
+//! the same concept, and in fact, is entirely derived from it.
+//!
+//! Compute requires that its `persist_sink` is _self-correcting_;
+//! that is, it corrects what the collection in persist
+//! accumulates to if the collection has values changed at
+//! previous timestamps. It does this by continually comparing
+//! the input stream with the collection as read back from persist.
+//!
+//! Source collections, while definite, cannot be reliably by
+//! re-produced once written down, which means compute's
+//! `persist_sink`'s self-correction mechanism would need to be
+//! skipped on operator startup, and would cause unnecessary read
+//! load on persist.
+//!
+//! Additionally, persisting sources requires we use bounded
+//! amounts of memory, even if a single timestamp represents
+//! a huge amount of data. This is not (currently) possible
+//! to guarantee while also performing self-correction.
+//!
+//! Because of this, we have ripped out the self-correction
+//! mechanism, and aggressively simplified the sub-operators.
+//! Some, particularly `append_batches` could be merged with
+//! the compute version, but that requires some amount of
+//! onerous refactoring that we have chosen to skip for now.
+//!
+// TODO(guswynn): merge at least the `append_batches` operator`
+
 use std::any::Any;
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use differential_dataflow::consolidation::consolidate_updates;
-use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{Collection, Hashable};
-use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
-use timely::dataflow::operators::{
-    Broadcast, Capability, CapabilitySet, ConnectLoop, Feedback, Inspect,
-};
+use timely::dataflow::operators::{Broadcast, Capability, CapabilitySet, Inspect};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
 use timely::PartialOrder;
 use tracing::trace;
 
-use mz_compute_client::types::sinks::{ComputeSinkDesc, PersistSinkConnection};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashMap;
-use mz_persist_client::batch::{Batch, BatchBuilder};
+use mz_persist_client::batch::Batch;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriterEnrichedHollowBatch;
 use mz_persist_types::codec_impls::UnitSchema;
@@ -39,106 +113,21 @@ use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
 use mz_storage_client::types::sources::SourceData;
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
-use mz_timely_util::probe::{self, ProbeNotify};
 
-use crate::compute_state::ComputeState;
-use crate::render::sinks::SinkRender;
+use crate::source::types::SourcePersistSinkMetrics;
+use crate::storage_state::StorageState;
 
-impl<G> SinkRender<G> for PersistSinkConnection<CollectionMetadata>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    fn render_continuous_sink(
-        &self,
-        compute_state: &mut ComputeState,
-        sink: &ComputeSinkDesc<CollectionMetadata>,
-        sink_id: GlobalId,
-        sinked_collection: Collection<G, Row, Diff>,
-        err_collection: Collection<G, DataflowError, Diff>,
-        probes: Vec<probe::Handle<Timestamp>>,
-    ) -> Option<Rc<dyn Any>>
-    where
-        G: Scope<Timestamp = Timestamp>,
-    {
-        let desired_collection = sinked_collection.map(Ok).concat(&err_collection.map(Err));
-        if sink.up_to != Antichain::default() {
-            unimplemented!(
-                "UP TO is not supported for persist sinks yet, and shouldn't have been accepted during parsing/planning"
-            )
-        }
-
-        persist_sink(
-            sink_id,
-            &self.storage_metadata,
-            desired_collection,
-            sink.as_of.frontier.clone(),
-            compute_state,
-            probes,
-        )
-    }
-}
-
-pub(crate) fn persist_sink<G>(
-    sink_id: GlobalId,
-    target: &CollectionMetadata,
-    desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
-    as_of: Antichain<Timestamp>,
-    compute_state: &mut ComputeState,
-    probes: Vec<probe::Handle<Timestamp>>,
-) -> Option<Rc<dyn Any>>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    // There is no guarantee that `as_of` is beyond the persist shard's since. If it isn't,
-    // instantiating a `persist_source` with it would panic. So instead we leave it to
-    // `persist_source` to select an appropriate `as_of`. We only care about times beyond the
-    // current shard upper anyway.
-    let source_as_of = None;
-    let (ok_stream, err_stream, token) = mz_storage_client::source::persist_source::persist_source(
-        &desired_collection.scope(),
-        sink_id,
-        Arc::clone(&compute_state.persist_clients),
-        target.clone(),
-        source_as_of,
-        Antichain::new(), // we want all updates
-        None,             // no MFP
-        None,             // no flow control
-        // Copy the logic in DeltaJoin/Get/Join to start.
-        |_timer, count| count > 1_000_000,
-    );
-    use differential_dataflow::AsCollection;
-    let persist_collection = ok_stream
-        .as_collection()
-        .map(Ok)
-        .concat(&err_stream.as_collection().map(Err));
-
-    Some(Rc::new((
-        install_desired_into_persist(
-            sink_id,
-            target,
-            desired_collection,
-            persist_collection,
-            as_of,
-            compute_state,
-            probes,
-        ),
-        token,
-    )))
-}
-
-/// Continuously writes the difference between `persist_stream` and
-/// `desired_stream` into persist, such that the persist shard is made to
-/// contain the same updates as `desired_stream`. This is done via a multi-stage
-/// operator graph:
+/// Continuously writes the `desired_stream` into persist
+/// This is done via a multi-stage operator graph:
 ///
 /// 1. `mint_batch_descriptions` emits new batch descriptions whenever the
-///    frontier of `persist_stream` advances *and `persist_frontier`* is less
-///    than `desired_frontier`. A batch description is a pair of `(lower,
-///    upper)` that tells write operators which updates to write and in the end
-///    tells the append operator what frontiers to use when calling
-///    `append`/`compare_and_append`. This is a single-worker operator.
-/// 2. `write_batches` writes the difference between `desired_stream` and
-///    `persist_stream` to persist as batches and sends those batches along.
+///    frontier of `desired_collection` advances. A batch description is
+///    a pair of `(lower, upper)` that tells write operators
+///    which updates to write and in the end tells the append operator
+///    what frontiers to use when calling `append`/`compare_and_append`.
+///    This is a single-worker operator.
+/// 2. `write_batches` writes the `desired_collection` to persist as
+///    batches and sends those batches along.
 ///    This does not yet append the batches to the persist shard, the update are
 ///    only uploaded/prepared to be appended to a shard. Also: we only write
 ///    updates for batch descriptions that we learned about from
@@ -147,80 +136,54 @@ where
 ///    batches. Whenever the frontiers sufficiently advance, we take a batch
 ///    description and all the batches that belong to it and append it to the
 ///    persist shard.
-fn install_desired_into_persist<G>(
-    sink_id: GlobalId,
-    target: &CollectionMetadata,
+pub(crate) fn render<G>(
+    scope: &mut G,
+    collection_id: GlobalId,
+    target: CollectionMetadata,
     desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
-    persist_collection: Collection<G, Result<Row, DataflowError>, Diff>,
-    as_of: Antichain<Timestamp>,
-    compute_state: &mut crate::compute_state::ComputeState,
-    probes: Vec<probe::Handle<Timestamp>>,
-) -> Option<Rc<dyn Any>>
+    storage_state: &mut StorageState,
+    metrics: SourcePersistSinkMetrics,
+    output_index: usize,
+) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let persist_clients = Arc::clone(&compute_state.persist_clients);
+    let persist_clients = Arc::clone(&storage_state.persist_clients);
     let shard_id = target.data_shard;
 
-    let operator_name = format!("persist_sink {}", sink_id);
-
-    if sink_id.is_user() {
-        trace!(
-            "persist_sink {sink_id}/{shard_id}: \
-            initial as_of: {:?}",
-            as_of
-        );
-    }
-
-    let mut scope = desired_collection.inner.scope();
-
-    // The append operator keeps capabilities that it downgrades to match the
-    // current upper frontier of the persist shard. This frontier can be
-    // observed on the persist_feedback_stream. This is used by the minter
-    // operator to learn about the current persist frontier, driving it's
-    // decisions on when to mint new batches.
-    //
-    // This stream should never carry data, so we don't bother about increasing
-    // the timestamp on feeding back using the summary.
-    let (persist_feedback_handle, persist_feedback_stream) = scope.feedback(Timestamp::default());
+    let operator_name = format!("persist_sink({})", shard_id);
 
     let (batch_descriptions, mint_token) = mint_batch_descriptions(
-        sink_id,
+        scope,
+        collection_id,
         operator_name.clone(),
-        target,
+        &target,
         &desired_collection.inner,
-        &persist_feedback_stream,
-        as_of,
         Arc::clone(&persist_clients),
-        compute_state,
     );
 
     let (written_batches, write_token) = write_batches(
-        sink_id.clone(),
+        scope,
+        collection_id.clone(),
         operator_name.clone(),
-        target,
+        &target,
         &batch_descriptions,
         &desired_collection.inner,
-        &persist_collection.inner,
         Arc::clone(&persist_clients),
     );
 
-    let (append_frontier_stream, append_token) = append_batches(
-        sink_id.clone(),
+    let append_token = append_batches(
+        scope,
+        collection_id.clone(),
         operator_name,
-        target,
+        &target,
         &batch_descriptions,
         &written_batches,
         persist_clients,
+        storage_state,
     );
 
-    append_frontier_stream.connect_loop(persist_feedback_handle);
-
-    append_frontier_stream.probe_notify_with(probes);
-
-    let token = Rc::new((mint_token, write_token, append_token));
-
-    Some(token)
+    Rc::new((mint_token, write_token, append_token))
 }
 
 /// Whenever the frontier advances, this mints a new batch description (lower
@@ -231,18 +194,13 @@ where
 /// description in the stream, even in case of multiple timely workers. Use
 /// `broadcast()` to, ahem, broadcast, the one description to all downstream
 /// write operators/workers.
-///
-/// This also keeps the shared frontier that is stored in `compute_state` in
-/// sync with the upper of the persist shard.
 fn mint_batch_descriptions<G>(
-    sink_id: GlobalId,
+    scope: &mut G,
+    collection_id: GlobalId,
     operator_name: String,
     target: &CollectionMetadata,
     desired_stream: &Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
-    persist_feedback_stream: &Stream<G, ()>,
-    as_of: Antichain<Timestamp>,
     persist_clients: Arc<PersistClientCache>,
-    compute_state: &mut crate::compute_state::ComputeState,
 ) -> (
     Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
     Rc<dyn Any>,
@@ -250,12 +208,6 @@ fn mint_batch_descriptions<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let scope = desired_stream.scope();
-
-    // Only attempt to write from this frontier onward, as our data are not necessarily
-    // correct for times not greater or equal to this frontier.
-    let write_lower_bound = as_of;
-
     let persist_location = target.persist_location.clone();
     let shard_id = target.data_shard;
     let target_relation_desc = target.relation_desc.clone();
@@ -263,181 +215,87 @@ where
     // Only one worker is responsible for determining batch descriptions. All
     // workers must write batches with the same description, to ensure that they
     // can be combined into one batch that gets appended to Consensus state.
-    let hashed_id = sink_id.hashed();
+    let hashed_id = collection_id.hashed();
     let active_worker = usize::cast_from(hashed_id) % scope.peers() == scope.index();
 
     // Only the "active" operator will mint batches. All other workers have an
     // empty frontier. It's necessary to insert all of these into
     // `compute_state.sink_write_frontier` below so we properly clear out
     // default frontiers of non-active workers.
-    let shared_frontier = Rc::new(RefCell::new(if active_worker {
-        Antichain::from_elem(TimelyTimestamp::minimum())
-    } else {
-        Antichain::new()
-    }));
 
-    compute_state
-        .sink_write_frontiers
-        .insert(sink_id, Rc::clone(&shared_frontier));
-
-    let mut mint_op =
-        AsyncOperatorBuilder::new(format!("{} mint_batch_descriptions", operator_name), scope);
+    let mut mint_op = AsyncOperatorBuilder::new(
+        format!("{} mint_batch_descriptions", operator_name),
+        scope.clone(),
+    );
 
     let (mut output, output_stream) = mint_op.new_output();
 
     let mut desired_input = mint_op.new_input(desired_stream, Pipeline);
-    let mut persist_feedback_input =
-        mint_op.new_input_connection(persist_feedback_stream, Pipeline, vec![Antichain::new()]);
 
     let shutdown_button = mint_op.build(move |mut capabilities| async move {
-        if !active_worker {
-            return;
-        }
-
         let mut cap_set = CapabilitySet::from_elem(capabilities.pop().expect("missing capability"));
 
-        // TODO(aljoscha): We need to figure out what to do with error
-        // results from these calls.
-        let persist_client = persist_clients
-            .open(persist_location)
-            .await
-            .expect("could not open persist client");
+        // Initialize this operators's `upper` to the `upper` of the persist shard we are writing
+        // to. Data from the source not beyond this time will be dropped, as it has already
+        // been persisted.
+        // In the future, sources will avoid passing through data not beyond this upper
+        let mut current_upper = {
+            // TODO(aljoscha): We need to figure out what to do with error
+            // results from these calls.
+            let persist_client = persist_clients
+                .open(persist_location)
+                .await
+                .expect("could not open persist client");
 
-        let mut write = persist_client
-            .open_writer::<SourceData, (), Timestamp, Diff>(
-                shard_id,
-                &format!("compute::persist_sink::mint_batch_descriptions {}", sink_id),
-                Arc::new(target_relation_desc),
-                Arc::new(UnitSchema),
-            )
-            .await
-            .expect("could not open persist shard");
-
-        let mut current_persist_frontier = write.upper().clone();
-
-        // Advance the persist shard's upper to at least our write lower
-        // bound.
-        if PartialOrder::less_than(&current_persist_frontier, &write_lower_bound) {
-            if sink_id.is_user() {
-                trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
-                        advancing to write_lower_bound: {:?}",
-                    write_lower_bound
-                );
-            }
-
-            let empty_updates: &[((SourceData, ()), Timestamp, Diff)] = &[];
-            // It's fine if we don't succeed here. This just means that
-            // someone else already advanced the persist frontier further,
-            // which is great!
-            let res = write
-                .append(
-                    empty_updates,
-                    current_persist_frontier.clone(),
-                    write_lower_bound.clone(),
+            let write = persist_client
+                .open_writer::<SourceData, (), Timestamp, Diff>(
+                    shard_id,
+                    &format!(
+                        "compute::persist_sink::mint_batch_descriptions {}",
+                        collection_id
+                    ),
+                    Arc::new(target_relation_desc),
+                    Arc::new(UnitSchema),
                 )
                 .await
-                .expect("invalid usage");
+                .expect("could not open persist shard");
 
-            if sink_id.is_user() {
-                trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
-                        advancing to write_lower_bound result: {:?}",
-                    res
-                );
+            if active_worker {
+                // VERY IMPORTANT: Only the active write worker produces
+                // batch descriptions. All other worker simply drop their capability
+                // and stop working.
+                write.upper().clone()
+            } else {
+                // The non-active workers report that they are done snapshotting.
+
+                // TODO(in later pr): add metrics back
+                return;
             }
-
-            current_persist_frontier.clone_from(&write_lower_bound);
-        }
+        };
 
         // The current input frontiers.
-        let mut desired_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
-        let mut persist_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
-
-        // The persist_frontier as it was when we last ran through our minting logic.
-        // SUBTLE: As described below, we only mint new batch descriptions
-        // when the persist frontier moves. We therefore have to encode this
-        // one as an `Option<Antichain<T>>` where the change from `None` to
-        // `Some([minimum])` is also a change in the frontier. If we didn't
-        // do this, we would be stuck at `[minimum]`.
-        let mut emitted_persist_frontier: Option<Antichain<_>> = None;
+        let mut desired_frontier;
 
         loop {
-            tokio::select! {
-                Some(event) = desired_input.next() => {
-                    match event {
-                        Event::Data(_cap, _data) => {
-                            // Just read away data.
-                            continue;
-                        }
-                        Event::Progress(frontier) => {
-                            desired_frontier = frontier;
-                        }
+            if let Some(event) = desired_input.next().await {
+                match event {
+                    Event::Data(_cap, _data) => {
+                        // Just read away data.
+                        continue;
+                    }
+                    Event::Progress(frontier) => {
+                        desired_frontier = frontier;
                     }
                 }
-                Some(event) = persist_feedback_input.next() => {
-                    match event {
-                        Event::Data(_cap, _data) => {
-                            // Just read away data.
-                            continue;
-                        }
-                        Event::Progress(frontier) => {
-                            persist_frontier = frontier;
-                        }
-                    }
-                }
-                else => {
-                    // All inputs are exhausted, so we can shut down.
-                    return;
-                }
+            } else {
+                // Input is exhausted, so we can shut down.
+                return;
             };
 
-            if PartialOrder::less_than(&*shared_frontier.borrow(), &persist_frontier) {
-                if sink_id.is_user() {
-                    trace!(
-                        "persist_sink {sink_id}/{shard_id}: \
-                            updating shared_frontier to {:?}",
-                        persist_frontier,
-                    );
-                }
-
-                // Share that we have finished processing all times less than the persist frontier.
-                // Advancing the sink upper communicates to the storage controller that it is
-                // permitted to compact our target storage collection up to the new upper. So we
-                // must be careful to not advance the sink upper beyond our read frontier.
-                shared_frontier.borrow_mut().clear();
-                shared_frontier
-                    .borrow_mut()
-                    .extend(persist_frontier.iter().cloned());
-            }
-
-            // We only mint new batch desriptions when:
-            //  1. the desired frontier is past the persist frontier
-            //  2. the persist frontier has moved since we last emitted a
-            //     batch
-            //
-            // That last point is _subtle_: If we emitted new batch
-            // descriptions whenever the desired frontier moves but the
-            // persist frontier doesn't move, we would mint overlapping
-            // batch descriptions, which would lead to errors when trying to
-            // appent batches based on them.
-            //
-            // We never use the same lower frontier twice.
-            // We only emit new batches when the persist frontier moves.
-            // A batch description that we mint for a given `lower` will
-            // either succeed in being appended, in which case the
-            // persist frontier moves. Or it will fail because the
-            // persist frontier got moved by someone else, in which case
-            // we also won't mint a new batch description for the same
-            // frontier.
-            if PartialOrder::less_than(&persist_frontier, &desired_frontier)
-                && (emitted_persist_frontier.is_none()
-                    || PartialOrder::less_than(
-                        emitted_persist_frontier.as_ref().unwrap(),
-                        &persist_frontier,
-                    ))
-            {
-                let batch_description = (persist_frontier.to_owned(), desired_frontier.to_owned());
+            // If the new frontier for the data input has progressed, produce a batch description.
+            if PartialOrder::less_than(&current_upper, &desired_frontier) {
+                // The maximal description range we can produce.
+                let batch_description = (current_upper.to_owned(), desired_frontier.to_owned());
 
                 let lower = batch_description.0.first().unwrap();
                 let batch_ts = batch_description.0.first().unwrap().clone();
@@ -455,7 +313,7 @@ where
                     .unwrap();
 
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
+                    "persist_sink {collection_id}/{shard_id}: \
                         new batch_description: {:?}",
                     batch_description
                 );
@@ -471,7 +329,7 @@ where
                 // though.
                 let new_batch_frontier = Antichain::from_elem(batch_ts.step_forward());
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
+                    "persist_sink {collection_id}/{shard_id}: \
                         downgrading to {:?}",
                     new_batch_frontier
                 );
@@ -481,12 +339,14 @@ where
                     Err(e) => panic!("in minter: {:?}", e),
                 }
 
-                emitted_persist_frontier.replace(persist_frontier.clone());
+                // After successfully emitting a new description, we can update the upper for the
+                // operator.
+                current_upper = desired_frontier.to_owned();
             }
         }
     });
 
-    if sink_id.is_user() {
+    if collection_id.is_user() {
         output_stream.inspect(|d| trace!("batch_description: {:?}", d));
     }
 
@@ -494,28 +354,21 @@ where
     (output_stream, token)
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-enum BatchOrData {
-    Batch(WriterEnrichedHollowBatch<Timestamp>),
-    Data {
-        lower: Antichain<Timestamp>,
-        upper: Antichain<Timestamp>,
-        contents: Vec<(Result<Row, DataflowError>, Timestamp, Diff)>,
-    },
-}
-
-/// Writes `desired_stream - persist_stream` to persist, but only for updates
+/// Writes `desired_stream` to persist, but only for updates
 /// that fall into batch a description that we get via `batch_descriptions`.
-/// This forwards a `HollowBatch` for any batch of updates that was written.
+/// This forwards a `HollowBatch` (with additional metadata)
+/// for any batch of updates that was written.
+///
+/// This also and updates various metrics.
 fn write_batches<G>(
-    sink_id: GlobalId,
+    scope: &mut G,
+    collection_id: GlobalId,
     operator_name: String,
     target: &CollectionMetadata,
     batch_descriptions: &Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
     desired_stream: &Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
-    persist_stream: &Stream<G, (Result<Row, DataflowError>, Timestamp, Diff)>,
     persist_clients: Arc<PersistClientCache>,
-) -> (Stream<G, BatchOrData>, Rc<dyn Any>)
+) -> (Stream<G, WriterEnrichedHollowBatch<Timestamp>>, Rc<dyn Any>)
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -523,40 +376,20 @@ where
     let shard_id = target.data_shard;
     let target_relation_desc = target.relation_desc.clone();
 
-    let scope = desired_stream.scope();
     let worker_index = scope.index();
 
-    let mut write_op = AsyncOperatorBuilder::new(format!("{} write_batches", operator_name), scope);
+    let mut write_op =
+        AsyncOperatorBuilder::new(format!("{} write_batches", operator_name), scope.clone());
 
     let (mut output, output_stream) = write_op.new_output();
 
     let mut descriptions_input = write_op.new_input(&batch_descriptions.broadcast(), Pipeline);
-    let mut desired_input = write_op.new_input(
-        desired_stream,
-        Exchange::new(
-            move |(row, _ts, _diff): &(Result<Row, DataflowError>, Timestamp, Diff)| row.hashed(),
-        ),
-    );
-    let mut persist_input = write_op.new_input_connection(
-        persist_stream,
-        Exchange::new(
-            move |(row, _ts, _diff): &(Result<Row, DataflowError>, Timestamp, Diff)| row.hashed(),
-        ),
-        // This connection specification makes sure that the persist frontier is
-        // not taken into account when determining downstream implications.
-        // We're only interested in the frontier to know when we are ready to
-        // write out new data (when the corrections have "settled"). But the
-        // persist frontier must not hold back the downstream frontier,
-        // otherwise the `append_batches` operator would never append batches
-        // because it waits for its input frontier to advance before it does so.
-        // The input frontier would never advance if we don't write new updates
-        // to persist, leading to a Catch-22-type situation.
-        vec![Antichain::new()],
-    );
+    let mut desired_input = write_op.new_input(desired_stream, Pipeline);
 
     // This operator accepts the current and desired update streams for a `persist` shard.
     // It attempts to write out updates, starting from the current's upper frontier, that
-    // will cause the changes of desired to be committed to persist.
+    // will cause the changes of desired to be committed to persist, _but only those also past the
+    // upper_.
 
     let shutdown_button = write_op.build(move |_capabilities| async move {
         // Contains `desired - persist`, reflecting the updates we would like to commit
@@ -585,7 +418,7 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("compute::persist_sink::write_batches {}", sink_id),
+                &format!("compute::persist_sink::write_batches {}", collection_id),
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema),
             )
@@ -595,7 +428,8 @@ where
         // The current input frontiers.
         let mut batch_descriptions_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
         let mut desired_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
-        let mut persist_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
+
+        let mut current_upper = Antichain::from_elem(TimelyTimestamp::minimum());
 
         loop {
             tokio::select! {
@@ -604,18 +438,16 @@ where
                         Event::Data(cap, data) => {
                             // Ingest new batch descriptions.
                             for description in data.drain(..) {
-                                if sink_id.is_user() {
+                                if collection_id.is_user() {
                                     trace!(
-                                        "persist_sink {sink_id}/{shard_id}: \
+                                        "persist_sink {collection_id}/{shard_id}: \
                                             write_batches: \
                                             new_description: {:?}, \
                                             desired_frontier: {:?}, \
-                                            batch_descriptions_frontier: {:?}, \
-                                            persist_frontier: {:?}",
+                                            batch_descriptions_frontier: {:?}",
                                         description,
                                         desired_frontier,
                                         batch_descriptions_frontier,
-                                        persist_frontier
                                     );
                                 }
                                 let existing = in_flight_batches.insert(
@@ -626,7 +458,7 @@ where
                                     existing.is_none(),
                                     "write_batches: sink {} got more than one \
                                         batch for description {:?}, in-flight: {:?}",
-                                    sink_id,
+                                    collection_id,
                                     description,
                                     in_flight_batches
                                 );
@@ -643,40 +475,25 @@ where
                     match event {
                         Event::Data(_cap, data) => {
                             // Extract desired rows as positive contributions to `correction`.
-                            if sink_id.is_user() && !data.is_empty() {
+                            if collection_id.is_user() && !data.is_empty() {
                                 trace!(
-                                    "persist_sink {sink_id}/{shard_id}: \
+                                    "persist_sink {collection_id}/{shard_id}: \
                                         updates: {:?}, \
                                         in-flight-batches: {:?}, \
                                         desired_frontier: {:?}, \
-                                        batch_descriptions_frontier: {:?}, \
-                                        persist_frontier: {:?}",
+                                        batch_descriptions_frontier: {:?}",
                                     data,
                                     in_flight_batches,
                                     desired_frontier,
                                     batch_descriptions_frontier,
-                                    persist_frontier
                                 );
                             }
-                            correction.append(data);
+                            correction.append(&mut data);
 
                             continue;
                         }
                         Event::Progress(frontier) => {
                             desired_frontier = frontier;
-                        }
-                    }
-                }
-                Some(event) = persist_input.next_mut() => {
-                    match event {
-                        Event::Data(_cap, data) => {
-                            // Extract persist rows as negative contributions to `correction`.
-                            correction.extend(data.drain(..).map(|(d, t, r)| (d, t, -r)));
-
-                            continue;
-                        }
-                        Event::Progress(frontier) => {
-                            persist_frontier = frontier;
                         }
                     }
                 }
@@ -687,41 +504,24 @@ where
             }
 
             // We may have the opportunity to commit updates.
-            if !PartialOrder::less_equal(&desired_frontier, &persist_frontier) {
+            if PartialOrder::less_equal(&current_upper, &desired_frontier) {
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
+                    "persist_sink {collection_id}/{shard_id}: \
                         CAN emit: \
-                        persist_frontier: {:?}, \
+                        current_upper: {:?}, \
                         desired_frontier: {:?}",
-                    persist_frontier,
+                    current_upper,
                     desired_frontier
                 );
-                // Advance all updates to `persist`'s frontier.
-                for (row, time, diff) in correction.iter_mut() {
-                    let time_before = *time;
-                    time.advance_by(persist_frontier.borrow());
-                    if sink_id.is_user() && &time_before != time {
-                        trace!(
-                            "persist_sink {sink_id}/{shard_id}: \
-                                advanced {:?}, {}, {} to {}",
-                            row,
-                            time_before,
-                            diff,
-                            time
-                        );
-                    }
-                }
 
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
+                    "persist_sink {collection_id}/{shard_id}: \
                         in-flight batches: {:?}, \
                         batch_descriptions_frontier: {:?}, \
-                        desired_frontier: {:?} \
-                        persist_frontier: {:?}",
+                        desired_frontier: {:?}",
                     in_flight_batches,
                     batch_descriptions_frontier,
                     desired_frontier,
-                    persist_frontier
                 );
 
                 // We can write updates for a given batch description when
@@ -733,13 +533,12 @@ where
                     .filter(|(lower, upper)| {
                         !PartialOrder::less_equal(&batch_descriptions_frontier, lower)
                             && !PartialOrder::less_than(&desired_frontier, upper)
-                            && !PartialOrder::less_than(&persist_frontier, lower)
                     })
                     .cloned()
                     .collect::<Vec<_>>();
 
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
+                    "persist_sink {collection_id}/{shard_id}: \
                         ready batches: {:?}",
                     ready_batches,
                 );
@@ -769,9 +568,9 @@ where
                 for batch_description in ready_batches.into_iter() {
                     let cap = in_flight_batches.remove(&batch_description).unwrap();
 
-                    if sink_id.is_user() {
+                    if collection_id.is_user() {
                         trace!(
-                            "persist_sink {sink_id}/{shard_id}: \
+                            "persist_sink {collection_id}/{shard_id}: \
                                 emitting done batch: {:?}, cap: {:?}",
                             batch_description,
                             cap
@@ -785,61 +584,48 @@ where
                         .filter(|(_, time, _)| {
                             batch_lower.less_equal(time) && !batch_upper.less_equal(time)
                         })
+                        .map(|(data, time, diff)| ((SourceData(data.clone()), ()), time, diff))
                         .peekable();
 
-                    if to_append.peek().is_some() {
-                        // We want to pass along the data directly if `to_append` is small, but to avoid
-                        // having to iterate through everything twice we'll check if `correction`
-                        // is small as a reasonable proxy.
-                        let minimum_batch_updates =
-                            persist_clients.cfg().sink_minimum_batch_updates();
-                        let batch_or_data = if correction.len() >= minimum_batch_updates {
-                            let batch = write
-                                .batch(
-                                    to_append.map(|(data, time, diff)| {
-                                        ((SourceData(data.clone()), ()), time, diff)
-                                    }),
-                                    batch_lower.clone(),
-                                    batch_upper.clone(),
-                                )
-                                .await
-                                .expect("invalid usage");
+                    let mut batch_tokens = if to_append.peek().is_some() {
+                        let batch = write
+                            .batch(to_append, batch_lower.clone(), batch_upper.clone())
+                            .await
+                            .expect("invalid usage");
 
-                            if sink_id.is_user() {
-                                trace!(
-                                    "persist_sink {sink_id}/{shard_id}: \
+                        if collection_id.is_user() {
+                            trace!(
+                                "persist_sink {collection_id}/{shard_id}: \
                                     wrote batch from worker {}: ({:?}, {:?})",
-                                    worker_index,
-                                    batch.lower(),
-                                    batch.upper()
-                                );
-                            }
-                            BatchOrData::Batch(batch.into_writer_hollow_batch())
-                        } else {
-                            BatchOrData::Data {
-                                lower: batch_lower.clone(),
-                                upper: batch_upper.clone(),
-                                contents: to_append.cloned().collect(),
-                            }
-                        };
+                                worker_index,
+                                batch.lower(),
+                                batch.upper()
+                            );
+                        }
 
-                        let mut output = output.activate();
-                        let mut session = output.session(&cap);
-                        session.give(batch_or_data);
-                    }
+                        vec![batch.into_writer_hollow_batch()]
+                    } else {
+                        vec![]
+                    };
+
+                    let mut output = output.activate();
+                    let mut session = output.session(&cap);
+                    session.give_vec(&mut batch_tokens);
+
+                    current_upper = desired_frontier.clone();
                 }
             } else {
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
-                        cannot emit: persist_frontier: {:?}, desired_frontier: {:?}",
-                    persist_frontier,
+                    "persist_sink {collection_id}/{shard_id}: \
+                        cannot emit: current_upper: {:?}, desired_frontier: {:?}",
+                    current_upper,
                     desired_frontier
                 );
             }
         }
     });
 
-    if sink_id.is_user() {
+    if collection_id.is_user() {
         output_stream.inspect(|d| trace!("batch: {:?}", d));
     }
 
@@ -853,22 +639,22 @@ where
 /// descriptions that are not beyond the frontier of both the
 /// `batch_descriptions` and `batches` inputs.
 ///
-/// To avoid contention over the persist shard, we route all batches to a single worker.
-/// This worker may also batch up individual records sent by the upstream operator, as
-/// a way to coalesce what would otherwise be many tiny batches into fewer, larger ones.
+/// This also keeps the shared frontier that is stored in `compute_state` in
+/// sync with the upper of the persist shard, and updates various metrics
+/// and statistics objects.
 fn append_batches<G>(
-    sink_id: GlobalId,
+    scope: &mut G,
+    collection_id: GlobalId,
     operator_name: String,
     target: &CollectionMetadata,
     batch_descriptions: &Stream<G, (Antichain<Timestamp>, Antichain<Timestamp>)>,
-    batches: &Stream<G, BatchOrData>,
+    batches: &Stream<G, WriterEnrichedHollowBatch<Timestamp>>,
     persist_clients: Arc<PersistClientCache>,
-) -> (Stream<G, ()>, Rc<dyn Any>)
+    storage_state: &mut StorageState,
+) -> Rc<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let scope = batch_descriptions.scope();
-
     let persist_location = target.persist_location.clone();
     let shard_id = target.data_shard;
     let target_relation_desc = target.relation_desc.clone();
@@ -876,42 +662,30 @@ where
     let operator_name = format!("{} append_batches", operator_name);
     let mut append_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
 
-    // We never output anything, but we update our capabilities based on the
-    // persist frontier we know about. So someone can listen on our output
-    // frontier and learn about the persist frontier advancing.
-    let (mut _output, output_stream) = append_op.new_output();
-
-    let hashed_id = sink_id.hashed();
+    let hashed_id = collection_id.hashed();
     let active_worker = usize::cast_from(hashed_id) % scope.peers() == scope.index();
 
-    // This operator wants to completely control the frontier on it's output
-    // because it's used to track the latest persist frontier. We update this
-    // when we either append to persist successfully or when we learn about a
-    // new current frontier because a `compare_and_append` failed. That's why
-    // input capability tracking is not connected to the output.
     let mut descriptions_input = append_op.new_input_connection(
         batch_descriptions,
         Exchange::new(move |_| hashed_id),
-        vec![Antichain::new()],
+        vec![],
     );
-    let mut batches_input = append_op.new_input_connection(
-        batches,
-        Exchange::new(move |_| hashed_id),
-        vec![Antichain::new()],
-    );
+    let mut batches_input =
+        append_op.new_input_connection(batches, Exchange::new(move |_| hashed_id), vec![]);
+
+    let current_upper = Rc::clone(&storage_state.source_uppers[&collection_id]);
+    if !active_worker {
+        // This worker is not writing, so make sure it's "taken out" of the
+        // calculation by advancing to the empty frontier.
+        current_upper.borrow_mut().clear();
+    }
 
     // This operator accepts the batch descriptions and tokens that represent
     // written batches. Written batches get appended to persist when we learn
     // from our input frontiers that we have seen all batches for a given batch
     // description.
 
-    let shutdown_button = append_op.build(move |mut capabilities| async move {
-        if !active_worker {
-            return;
-        }
-
-        let mut cap_set = CapabilitySet::from_elem(capabilities.pop().expect("missing capability"));
-
+    let shutdown_button = append_op.build(move |_| async move {
         // Contains descriptions of batches for which we know that we can
         // write data. We got these from the "centralized" operator that
         // determines batch descriptions for all writers.
@@ -923,15 +697,9 @@ where
             (Antichain<Timestamp>, Antichain<Timestamp>)
         >::new();
 
-        #[derive(Debug, Default)]
-        struct BatchSet {
-            finished: Vec<Batch<SourceData, (), Timestamp, Diff>>,
-            incomplete: Option<BatchBuilder<SourceData, (), Timestamp, Diff>>,
-        }
-
         let mut in_flight_batches = HashMap::<
             (Antichain<Timestamp>, Antichain<Timestamp>),
-            BatchSet,
+            Vec<Batch<_, _, _, _>>,
         >::new();
 
         // TODO(aljoscha): We need to figure out what to do with error results from these calls.
@@ -943,12 +711,27 @@ where
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
                 shard_id,
-                &format!("persist_sink::append_batches {}", sink_id),
+                &format!("persist_sink::append_batches {}", collection_id),
                 Arc::new(target_relation_desc),
                 Arc::new(UnitSchema)
             )
             .await
             .expect("could not open persist shard");
+
+        // Initialize this sink's `upper` to the `upper` of the persist shard we are writing
+        // to. Data from the source not beyond this time will be dropped, as it has already
+        // been persisted.
+        // In the future, sources will avoid passing through data not beyond this upper
+        if active_worker {
+            // VERY IMPORTANT: Only the active write worker must change the
+            // shared upper. All other workers have already cleared this
+            // upper above.
+            current_upper.borrow_mut().clone_from(write.upper()
+                                     );
+        } else {
+            // The non-active workers report that they are done snapshotting.
+            return;
+        }
 
         // The current input frontiers.
         let mut batch_description_frontier = Antichain::from_elem(TimelyTimestamp::minimum());
@@ -961,13 +744,13 @@ where
                         Event::Data(_cap, data) => {
                             // Ingest new batch descriptions.
                             for batch_description in data.drain(..) {
-                                if sink_id.is_user() {
+                                if collection_id.is_user() {
                                     trace!(
-                                        "persist_sink {sink_id}/{shard_id}: \
+                                        "persist_sink {collection_id}/{shard_id}: \
                                             append_batches: sink {}, \
                                             new description: {:?}, \
                                             batch_description_frontier: {:?}",
-                                        sink_id,
+                                        collection_id,
                                         batch_description,
                                         batch_description_frontier
                                     );
@@ -979,7 +762,7 @@ where
                                     is_new,
                                     "append_batches: sink {} got more than one batch \
                                         for a given description in-flight: {:?}",
-                                    sink_id, in_flight_batches
+                                    collection_id, in_flight_batches
                                 );
                             }
 
@@ -995,31 +778,14 @@ where
                         Event::Data(_cap, data) => {
                             // Ingest new written batches
                             for batch in data.drain(..) {
-                                match batch {
-                                    BatchOrData::Batch(batch) => {
-                                        let batch = write.batch_from_hollow_batch(batch);
-                                        let batch_description = (batch.lower().clone(), batch.upper().clone());
+                                let batch = write.batch_from_hollow_batch(batch);
+                                let batch_description = (batch.lower().clone(), batch.upper().clone());
 
-                                        let batches = in_flight_batches
-                                            .entry(batch_description)
-                                            .or_default();
+                                let batches = in_flight_batches
+                                    .entry(batch_description)
+                                    .or_insert_with(Vec::new);
 
-                                        batches.finished.push(batch);
-                                    }
-                                    BatchOrData::Data { lower, upper, contents } => {
-                                        let batches = in_flight_batches
-                                            .entry((lower.clone(), upper))
-                                            .or_default();
-                                        let builder = batches.incomplete.get_or_insert_with(|| {
-                                            write.builder(lower)
-                                        });
-                                        for (data, time, diff) in contents {
-                                            persist_client.metrics().sink.forwarded_updates.inc();
-                                            builder.add(&SourceData(data), &(), &time, &diff).await.expect("invalid usage");
-                                        }
-                                    }
-                                }
-
+                                batches.push(batch);
                             }
 
                             continue;
@@ -1051,7 +817,7 @@ where
                 .collect::<Vec<_>>();
 
             trace!(
-                "persist_sink {sink_id}/{shard_id}: \
+                "persist_sink {collection_id}/{shard_id}: \
                     append_batches: in_flight: {:?}, \
                     done: {:?}, \
                     batch_frontier: {:?}, \
@@ -1077,20 +843,12 @@ where
             for done_batch_metadata in done_batches.into_iter() {
                 in_flight_descriptions.remove(&done_batch_metadata);
 
-                let batch_set = in_flight_batches
+                let mut batches = in_flight_batches
                     .remove(&done_batch_metadata)
-                    .unwrap_or_default();
-
-                let mut batches = batch_set.finished;
-                if let Some(builder) = batch_set.incomplete {
-                    let (_lower, upper) = &done_batch_metadata;
-                    let batch = builder.finish(upper.clone()).await.expect("invalid usage");
-                    batches.push(batch);
-                    persist_client.metrics().sink.forwarded_batches.inc();
-                }
+                    .unwrap_or_else(Vec::new);
 
                 trace!(
-                    "persist_sink {sink_id}/{shard_id}: \
+                    "persist_sink {collection_id}/{shard_id}: \
                         done batch: {:?}, {:?}",
                     done_batch_metadata,
                     batches
@@ -1109,9 +867,9 @@ where
                     .await
                     .expect("Invalid usage");
 
-                if sink_id.is_user() {
+                if collection_id.is_user() {
                     trace!(
-                        "persist_sink {sink_id}/{shard_id}: \
+                        "persist_sink {collection_id}/{shard_id}: \
                             append result for batch ({:?} -> {:?}): {:?}",
                         batch_lower,
                         batch_upper,
@@ -1121,10 +879,10 @@ where
 
                 match result {
                     Ok(()) => {
-                        cap_set.downgrade(batch_upper);
+                        current_upper.borrow_mut().clone_from(&batch_upper);
                     }
                     Err(mismatch) => {
-                        cap_set.downgrade(mismatch.current.iter());
+                        // TODO(in later pr): panic
 
                         // Clean up in case we didn't manage to append the
                         // batches to persist.
@@ -1137,7 +895,7 @@ where
                                 is {:?}. This is not a problem, it just means \
                                 someone else was faster than us. We will try \
                                 again with a new batch description.",
-                            sink_id,
+                            collection_id,
                             batch_lower,
                             batch_upper,
                             mismatch.current,
@@ -1148,6 +906,5 @@ where
         }
     });
 
-    let token = Rc::new(shutdown_button.press_on_drop());
-    (output_stream, token)
+    Rc::new(shutdown_button.press_on_drop())
 }

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -1051,23 +1051,18 @@ where
                         current_upper.borrow_mut().clone_from(&batch_upper);
                     }
                     Err(mismatch) => {
-                        // TODO(in later pr): panic
-
-                        // Clean up in case we didn't manage to append the
+                        // _Best effort_ Clean up in case we didn't manage to append the
                         // batches to persist.
                         for (batch, _) in batches {
                             batch.delete().await;
                         }
-                        tracing::info!(
+                        panic!(
                             "persist_sink({}): invalid upper! \
                                 Tried to append batch ({:?} -> {:?}) but upper \
                                 is {:?}. This is not a problem, it just means \
                                 someone else was faster than us. We will try \
                                 again with a new batch description.",
-                            collection_id,
-                            batch_lower,
-                            batch_upper,
-                            mismatch.current,
+                            collection_id, batch_lower, batch_upper, mismatch.current,
                         );
                     }
                 }

--- a/src/storage/src/render/multi_worker_persist_sink.rs
+++ b/src/storage/src/render/multi_worker_persist_sink.rs
@@ -110,6 +110,7 @@ use mz_persist_client::batch::Batch;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::write::WriterEnrichedHollowBatch;
 use mz_persist_types::codec_impls::UnitSchema;
+use mz_persist_types::{Codec, Codec64};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::controller::CollectionMetadata;
 use mz_storage_client::types::errors::DataflowError;
@@ -166,9 +167,9 @@ impl BatchMetrics {
 
 struct BatchBuilderAndMetdata<K, V, T, D>
 where
-    T: timely::progress::Timestamp
-        + differential_dataflow::lattice::Lattice
-        + mz_persist_types::Codec64,
+    K: Codec,
+    V: Codec,
+    T: timely::progress::Timestamp + differential_dataflow::lattice::Lattice + Codec64,
 {
     builder: mz_persist_client::batch::BatchBuilder<K, V, T, D>,
     metrics: BatchMetrics,
@@ -176,9 +177,9 @@ where
 
 impl<K, V, T, D> BatchBuilderAndMetdata<K, V, T, D>
 where
-    T: timely::progress::Timestamp
-        + differential_dataflow::lattice::Lattice
-        + mz_persist_types::Codec64,
+    K: Codec,
+    V: Codec,
+    T: timely::progress::Timestamp + differential_dataflow::lattice::Lattice + Codec64,
 {
     fn new(bb: mz_persist_client::batch::BatchBuilder<K, V, T, D>) -> Self {
         BatchBuilderAndMetdata {

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -42,8 +42,8 @@ impl SourceSpecificMetrics {
                 help: "Whether or not the new multi-worker persist_sink is actively being used",
                 var_labels: ["source_id", "worker_id", "parent_source_id", "output"],
             )),
-            // TODO(guswynn): some of these metrics are broken when there are more than 1
-            // worker-id, and need to be fixed
+            // TODO(guswynn): some of these metrics are not clear when subsources are involved, and
+            // should be fixed
             capability: registry.register(metric!(
                 name: "mz_capability",
                 help: "The current capability for this dataflow. This corresponds to min(mz_partition_closed_ts)",
@@ -58,33 +58,33 @@ impl SourceSpecificMetrics {
             progress: registry.register(metric!(
                 name: "mz_source_progress",
                 help: "A timestamp gauge representing forward progess in the data shard",
-                var_labels: ["source_id", "output", "shard"],
+                var_labels: ["source_id", "output", "shard", "worker_id"],
             )),
             row_inserts: registry.register(metric!(
                 name: "mz_source_row_inserts",
                 help: "A counter representing the actual number of rows being inserted to the data shard",
-                var_labels: ["source_id", "output", "shard"],
+                var_labels: ["source_id", "output", "shard", "worker_id"],
             )),
             row_retractions: registry.register(metric!(
                 name: "mz_source_row_retractions",
                 help: "A counter representing the actual number of rows being retracted from the data shard",
-                var_labels: ["source_id", "output", "shard"],
+                var_labels: ["source_id", "output", "shard", "worker_id"],
             )),
             error_inserts: registry.register(metric!(
                 name: "mz_source_error_inserts",
                 help: "A counter representing the actual number of errors being inserted to the data shard",
-                var_labels: ["source_id", "output", "shard"],
+                var_labels: ["source_id", "output", "shard", "worker_id"],
             )),
             error_retractions: registry.register(metric!(
                 name: "mz_source_error_retractions",
                 help: "A counter representing the actual number of errors being retracted from the data shard",
-                var_labels: ["source_id", "output", "shard"],
+                var_labels: ["source_id", "output", "shard", "worker_id"],
             )),
             persist_sink_processed_batches: registry.register(metric!(
                 name: "mz_source_processed_batches",
                 help: "A counter representing the number of persist sink batches with actual data \
                 we have successfully processed.",
-                var_labels: ["source_id", "output", "shard"],
+                var_labels: ["source_id", "output", "shard", "worker_id"],
             )),
             offset_commit_failures: registry.register(metric!(
                 name: "mz_source_offset_commit_failures",

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -316,6 +316,7 @@ impl SourcePersistSinkMetrics {
                 parent_source_id.to_string(),
                 output_index.to_string(),
                 shard.clone(),
+                worker_id.to_string(),
             ]),
             row_inserts: base
                 .source_specific
@@ -324,6 +325,7 @@ impl SourcePersistSinkMetrics {
                     parent_source_id.to_string(),
                     output_index.to_string(),
                     shard.clone(),
+                    worker_id.to_string(),
                 ]),
             row_retractions: base
                 .source_specific
@@ -332,6 +334,7 @@ impl SourcePersistSinkMetrics {
                     parent_source_id.to_string(),
                     output_index.to_string(),
                     shard.clone(),
+                    worker_id.to_string(),
                 ]),
             error_inserts: base
                 .source_specific
@@ -340,6 +343,7 @@ impl SourcePersistSinkMetrics {
                     parent_source_id.to_string(),
                     output_index.to_string(),
                     shard.clone(),
+                    worker_id.to_string(),
                 ]),
             error_retractions: base
                 .source_specific
@@ -348,6 +352,7 @@ impl SourcePersistSinkMetrics {
                     parent_source_id.to_string(),
                     output_index.to_string(),
                     shard.clone(),
+                    worker_id.to_string(),
                 ]),
             processed_batches: base
                 .source_specific
@@ -356,6 +361,7 @@ impl SourcePersistSinkMetrics {
                     parent_source_id.to_string(),
                     output_index.to_string(),
                     shard,
+                    worker_id.to_string(),
                 ]),
         }
     }


### PR DESCRIPTION
This pr implements this design document: https://github.com/MaterializeInc/materialize/blob/9e688835d0f3ee646f9afd930dbd5b38d5a334cd/doc/developer/design/20230210_storage_persist_sink_redux.md

It also partially resolves https://github.com/MaterializeInc/materialize/issues/17221, but does not close it.

### Motivation


   * This PR refactors existing code.


### Tips for reviewer

This branch is reviewable, but is stacked on top of https://github.com/MaterializeInc/materialize/pull/18010, which will need to be merged first. The structure of the branch is fairly complex:

- The first commit copies the compute `persist_sink` into `src/storage/src/render/multi_worker_persist_sink.rs`, but doesn't connect it to anything
- https://github.com/MaterializeInc/materialize/pull/17589/commits/5fff51f3f098e7f1cd92663d892bf9db6fbeb4eb actually connects the new implementation, behind a system parameter
  - Note that this system parameter is on-by-default in mzcompose's, because we want the new implementation to be the canonical implementation tested in ci. Unfortunately, the single-worker one will be used with `bin/environmentd` workflows until the default for the flag is changed to `true`
- The other commits iteratively change the compute implementation to match what is described in the design document!
 
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - I will run nightlies and release-qualification tests on this, now published branch, but I tested the core implementation against them earlier in this pr's life, and they passed:
    - nightlies: https://buildkite.com/materialize/nightlies/builds/1796
    - release-qualification: https://buildkite.com/materialize/release-qualification/builds/87
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  - https://github.com/MaterializeInc/materialize/blob/9e688835d0f3ee646f9afd930dbd5b38d5a334cd/doc/developer/design/20230210_storage_persist_sink_redux.md
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
