### PR TITLE
sql: allow returning NULL from upper, lower range fns

### DIFF
--- a/src/expr/src/scalar/func/impls/range.rs
+++ b/src/expr/src/scalar/func/impls/range.rs
@@ -97,7 +97,7 @@ impl LazyUnaryFunc for RangeLower {
             .scalar_type
             .unwrap_range_element_type()
             .clone()
-            .nullable(input_type.nullable)
+            .nullable(true)
     }
 
     fn propagates_nulls(&self) -> bool {
@@ -150,7 +150,7 @@ impl LazyUnaryFunc for RangeUpper {
             .scalar_type
             .unwrap_range_element_type()
             .clone()
-            .nullable(input_type.nullable)
+            .nullable(true)
     }
 
     fn propagates_nulls(&self) -> bool {

--- a/test/sqllogictest/range.slt
+++ b/test/sqllogictest/range.slt
@@ -534,6 +534,31 @@ SELECT a::text AS t FROM int4range_values EXCEPT SELECT column1::text FROM (VALU
 ----
 NULL
 
+#
+# int4range upper, lower
+query TT
+SELECT DISTINCT lower(a), upper(a) FROM int4range_values;
+----
+NULL
+NULL
+NULL
+1
+NULL
+2
+1
+NULL
+2
+NULL
+0
+1
+0
+2
+-1
+1
+-1
+2
+
+
 # test that lower and upper roundtrip through range constructor function
 query T
 SELECT
@@ -1676,6 +1701,31 @@ SELECT a::text AS t FROM int8range_values EXCEPT SELECT column1::text FROM (VALU
 ----
 NULL
 
+#
+# int8range upper, lower
+query TT
+SELECT DISTINCT lower(a), upper(a) FROM int8range_values;
+----
+NULL
+NULL
+NULL
+1
+NULL
+2
+1
+NULL
+2
+NULL
+0
+1
+0
+2
+-1
+1
+-1
+2
+
+
 # test that lower and upper roundtrip through range constructor function
 query T
 SELECT
@@ -2711,6 +2761,28 @@ empty
 [1970-01-02,)
 [1970-01-02,)
 NULL
+
+#
+# daterange upper, lower
+query TT
+SELECT DISTINCT lower(a), upper(a) FROM daterange_values;
+----
+NULL
+NULL
+NULL
+1970-01-01
+NULL
+1970-01-02
+1970-01-01
+NULL
+1970-01-02
+NULL
+1969-12-31
+1970-01-01
+1969-12-31
+1970-01-02
+1970-01-01
+1970-01-02
 
 # test that lower and upper roundtrip through range constructor function
 query T
@@ -3847,6 +3919,22 @@ SELECT a::text AS t FROM numrange_values EXCEPT SELECT column1::text FROM (VALUE
 ) t;
 ----
 NULL
+
+#
+# numrange upper, lower
+query TT
+SELECT DISTINCT lower(a), upper(a) FROM numrange_values;
+----
+NULL
+NULL
+NULL
+1
+1
+NULL
+0
+0
+-1
+1
 
 # test that lower and upper roundtrip through range constructor function
 query T


### PR DESCRIPTION
`introduces_nulls` doesn't make the output type nullable, and upper and lower both should return NULL when their range bounds are infinite.

### Motivation

This PR fixes a recognized bug. #17596

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
