### PR TITLE
explain: implement `timing` option

### DIFF
--- a/misc/python/materialize/cli/optbench.py
+++ b/misc/python/materialize/cli/optbench.py
@@ -155,6 +155,7 @@ def init(
 @click.option("--db-host", **Opt.db_host)
 @click.option("--db-user", **Opt.db_user)
 @click.option("--db-pass", **Opt.db_pass)
+@click.option("--db-require-ssl", **Opt.db_require_ssl)
 def run(
     scenario: Scenario,
     samples: int,

--- a/misc/python/materialize/optbench/util.py
+++ b/misc/python/materialize/optbench/util.py
@@ -8,22 +8,34 @@
 # by the Apache License, Version 2.0.
 
 from pathlib import Path
-from typing import cast
+from re import match
+from typing import Callable, Dict, Optional
 
 import numpy as np
 
 from . import Scenario
 
 
-def str_to_ns(time: str) -> np.timedelta64:
-    """Parses a time format `hh:mm:ss.up_to_9_digits` to a `np.timedelta64`."""
-    h, m, s = time.split(":")
-    s, ns = s.split(".")
-    ns = ns.ljust(9, "0")
-    ns = map(
-        lambda t, unit: np.timedelta64(t, unit), [h, m, s, ns], ["h", "m", "s", "ns"]
-    )
-    return cast(np.timedelta64, sum(ns))
+def duration_to_timedelta(duration: str) -> Optional[np.timedelta64]:
+    """Converts a duration like `{time}.{frac}{unit}` to a `np.timedelta64`."""
+
+    frac_to_ns: Dict[str, Callable[[str], str]] = {
+        "s": lambda frac: frac.ljust(9, "0")[0:9],
+        "ms": lambda frac: frac.ljust(6, "0")[0:6],
+        "us": lambda frac: frac.ljust(3, "0")[0:3],
+        "ns": lambda frac: "0",  # ns units should not have frac
+    }
+
+    p = r"(?P<time>[0-9]+)(\.(?P<frac>[0-9]+))?(?P<unit>s|ms|µs|ns)"
+    m = match(p, duration)
+
+    if m is None:
+        return None
+    else:
+        unit = "us" if m.group("unit") == "µs" else m.group("unit")
+        time = np.timedelta64(m.group("time"), unit)
+        frac = np.timedelta64(frac_to_ns[unit](m.group("frac") or "0"), "ns")
+        return time + frac
 
 
 def results_path(repository: Path, scenario: Scenario, mz_version: str) -> Path:

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2850,11 +2850,11 @@ impl Coordinator {
                 let rows = trace
                     .into_iter()
                     .map(|entry| {
+                        // The trace would have to take over 584 years to overflow a u64.
+                        let span_duration =
+                            u64::try_from(entry.span_duration.as_nanos()).unwrap_or(u64::MAX);
                         Row::pack_slice(&[
-                            Datum::from(
-                                // The trace would have to take over 584 years to overflow a u64.
-                                u64::try_from(entry.duration.as_nanos()).unwrap_or(u64::MAX),
-                            ),
+                            Datum::from(span_duration),
                             Datum::from(entry.path.as_str()),
                             Datum::from(entry.plan.as_str()),
                         ])

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -163,13 +163,15 @@ impl OptimizerTrace {
                 .map(|mut entry| match fast_path_plan {
                     Some(fast_path_plan) if !context.config.no_fast_path => Ok(TraceEntry {
                         instant: entry.instant,
-                        duration: entry.duration,
+                        span_duration: entry.span_duration,
+                        full_duration: entry.full_duration,
                         path: entry.path,
                         plan: fast_path_plan.clone(),
                     }),
                     _ => Ok(TraceEntry {
                         instant: entry.instant,
-                        duration: entry.duration,
+                        span_duration: entry.span_duration,
+                        full_duration: entry.full_duration,
                         path: entry.path,
                         plan: Explainable::new(&mut entry.plan).explain(format, context)?,
                     }),
@@ -192,7 +194,8 @@ impl OptimizerTrace {
                 .into_iter()
                 .map(|entry| TraceEntry {
                     instant: entry.instant,
-                    duration: entry.duration,
+                    span_duration: entry.span_duration,
+                    full_duration: entry.full_duration,
                     path: entry.path,
                     plan: entry.plan.to_string(),
                 })

--- a/src/adapter/src/explain/optimizer_trace.rs
+++ b/src/adapter/src/explain/optimizer_trace.rs
@@ -10,6 +10,7 @@
 //! Tracing utilities for explainable plans.
 
 use std::fmt::{Debug, Display};
+use std::time::Duration;
 
 use mz_compute_client::{plan::Plan, types::dataflows::DataflowDescription};
 use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
@@ -89,25 +90,27 @@ impl OptimizerTrace {
     ) -> Result<Vec<TraceEntry<String>>, ExplainError> {
         let mut results = vec![];
 
-        let context = ExplainContext {
+        let mut context = ExplainContext {
             config: &config,
             humanizer: &catalog,
             used_indexes: UsedIndexes::new(vec![]),
             finishing: row_set_finishing.clone(),
+            duration: Duration::default(),
         };
 
         // Drain trace entries of types produced by local optimizer stages.
         results.extend(itertools::chain!(
-            self.drain_explainable_entries::<HirRelationExpr>(&format, &context, &None)?,
-            self.drain_explainable_entries::<MirRelationExpr>(&format, &context, &None)?,
+            self.drain_explainable_entries::<HirRelationExpr>(&format, &mut context, &None)?,
+            self.drain_explainable_entries::<MirRelationExpr>(&format, &mut context, &None)?,
         ));
 
         // Drain trace entries of types produced by global optimizer stages.
-        let context = ExplainContext {
+        let mut context = ExplainContext {
             config: &config,
             humanizer: &catalog,
             used_indexes: UsedIndexes::new(used_indexes),
             finishing: row_set_finishing,
+            duration: Duration::default(),
         };
         let fast_path_plan = match fast_path_plan {
             Some(mut plan) if !context.config.no_fast_path => {
@@ -118,12 +121,12 @@ impl OptimizerTrace {
         results.extend(itertools::chain!(
             self.drain_explainable_entries::<DataflowDescription<OptimizedMirRelationExpr>>(
                 &format,
-                &context,
+                &mut context,
                 &fast_path_plan
             )?,
             self.drain_explainable_entries::<DataflowDescription<Plan>>(
                 &format,
-                &context,
+                &mut context,
                 &fast_path_plan
             )?,
         ));
@@ -149,7 +152,7 @@ impl OptimizerTrace {
     fn drain_explainable_entries<T>(
         &self,
         format: &ExplainFormat,
-        context: &ExplainContext,
+        context: &mut ExplainContext,
         fast_path_plan: &Option<String>,
     ) -> Result<Vec<TraceEntry<String>>, ExplainError>
     where
@@ -160,21 +163,25 @@ impl OptimizerTrace {
             trace
                 .drain_as_vec()
                 .into_iter()
-                .map(|mut entry| match fast_path_plan {
-                    Some(fast_path_plan) if !context.config.no_fast_path => Ok(TraceEntry {
-                        instant: entry.instant,
-                        span_duration: entry.span_duration,
-                        full_duration: entry.full_duration,
-                        path: entry.path,
-                        plan: fast_path_plan.clone(),
-                    }),
-                    _ => Ok(TraceEntry {
-                        instant: entry.instant,
-                        span_duration: entry.span_duration,
-                        full_duration: entry.full_duration,
-                        path: entry.path,
-                        plan: Explainable::new(&mut entry.plan).explain(format, context)?,
-                    }),
+                .map(|mut entry| {
+                    // update the context with the current time
+                    context.duration = entry.full_duration;
+                    match fast_path_plan {
+                        Some(fast_path_plan) if !context.config.no_fast_path => Ok(TraceEntry {
+                            instant: entry.instant,
+                            span_duration: entry.span_duration,
+                            full_duration: entry.full_duration,
+                            path: entry.path,
+                            plan: fast_path_plan.clone(),
+                        }),
+                        _ => Ok(TraceEntry {
+                            instant: entry.instant,
+                            span_duration: entry.span_duration,
+                            full_duration: entry.full_duration,
+                            path: entry.path,
+                            plan: Explainable::new(&mut entry.plan).explain(format, context)?,
+                        }),
+                    }
                 })
                 .collect()
         } else {

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -10,6 +10,7 @@
 //! `EXPLAIN` support for structures defined in this crate.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use mz_ore::stack::RecursionLimitError;
 use mz_repr::explain::{
@@ -32,6 +33,7 @@ pub struct ExplainContext<'a> {
     pub humanizer: &'a dyn ExprHumanizer,
     pub used_indexes: UsedIndexes,
     pub finishing: Option<RowSetFinishing>,
+    pub duration: Duration,
 }
 
 /// A structure produced by the `explain_$format` methods in

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -49,6 +49,11 @@ where
             self.context.used_indexes.fmt_text(f, &mut ctx)?;
         }
 
+        if self.context.config.timing {
+            writeln!(f, "")?;
+            writeln!(f, "Optimization time: {:?}", self.context.duration)?;
+        }
+
         Ok(())
     }
 }
@@ -102,6 +107,11 @@ where
         if !self.context.used_indexes.is_empty() {
             writeln!(f, "")?;
             self.context.used_indexes.fmt_text(f, &mut ctx)?;
+        }
+
+        if self.context.config.timing {
+            writeln!(f, "")?;
+            writeln!(f, "Optimization time: {:?}", self.context.duration)?;
         }
 
         Ok(())

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -69,6 +69,10 @@ where
                 self.context.config,
             );
 
+            if no > 0 {
+                writeln!(f, "")?;
+            }
+
             writeln!(f, "{}{}:", ctx.indent, id)?;
             ctx.indented(|ctx| {
                 match &self.context.finishing {

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -149,6 +149,7 @@ pub struct ExplainConfig {
     /// Show the `non_negative` in the explanation if it is supported by the backing IR.
     pub non_negative: bool,
     /// Show the slow path plan even if a fast path plan was created. Useful for debugging.
+    /// Enforced if `timing` is set.
     pub no_fast_path: bool,
     /// Don't normalize plans before explaining them.
     pub raw_plans: bool,
@@ -156,7 +157,7 @@ pub struct ExplainConfig {
     pub raw_syntax: bool,
     /// Show the `subtree_size` attribute in the explanation if it is supported by the backing IR.
     pub subtree_size: bool,
-    /// Print optimization timings (currently unsupported).
+    /// Print optimization timings.
     pub timing: bool,
     /// Show the `type` attribute in the explanation.
     pub types: bool,
@@ -201,7 +202,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
             keys: flags.remove("keys"),
             linear_chains: flags.remove("linear_chains") && !flags.contains("raw_plans"),
             non_negative: flags.remove("non_negative"),
-            no_fast_path: flags.remove("no_fast_path"),
+            no_fast_path: flags.remove("no_fast_path") || flags.contains("timing"),
             raw_plans: flags.remove("raw_plans"),
             raw_syntax: flags.remove("raw_syntax"),
             subtree_size: flags.remove("subtree_size"),

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -162,6 +162,24 @@ pub struct ExplainConfig {
     pub types: bool,
 }
 
+impl Default for ExplainConfig {
+    fn default() -> Self {
+        Self {
+            arity: false,
+            join_impls: true,
+            keys: false,
+            linear_chains: false,
+            non_negative: false,
+            no_fast_path: true,
+            raw_plans: true,
+            raw_syntax: true,
+            subtree_size: false,
+            timing: false,
+            types: false,
+        }
+    }
+}
+
 impl ExplainConfig {
     pub fn requires_attributes(&self) -> bool {
         self.subtree_size || self.non_negative || self.arity || self.types || self.keys

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -86,6 +86,7 @@
 mod tests {
     use std::collections::BTreeMap;
     use std::fmt::Write;
+    use std::time::Duration;
 
     use anyhow::{anyhow, Error};
     use mz_expr::explain::ExplainContext;
@@ -209,6 +210,7 @@ mod tests {
                     humanizer: cat,
                     used_indexes: UsedIndexes::new(vec![]),
                     finishing: None,
+                    duration: Duration::default(),
                 };
 
                 Explainable(&mut rel.clone())


### PR DESCRIPTION
Implements the `WITH(timing)` option and fixes the `optbench` scripts so we can keep track of end-to-end optimization performance as we tweak the optimizer pipeline.

Once this lands, we can:

1. Start collecting benchmark results for each new release deployed on `staging`.
2. Use `optbench` to catch performance regressions in Buildkite (#17641).

### Motivation

  * This PR adds a feature that has not yet been specified.

This was part of the original `EXPLAIN` epic but for some reason was left unimplemented.

### Tips for reviewer

- The first commits does some minor cosmetic touches to the explain output.
- The second commit:
    - refines `TraceEntry::duration` to `TraceEntry::span_duration` to indicate that this field denotes the duration of the entry since the start of the enclosing span, and
    - adds `TraceEntry::full_duration` in order to measure the time since the start of the top-level span in the enclosing `PlanTrace`.
- The third commit adds `duration` field to `ExplainContext`.
- The fourth commit interprets the timing option by rendering the `ExplainContext::duration` at the bottom of the `ExplainSinglePlan` and `ExplainMultiPlan` structs.
- The final commit fixes the `optimization_time` extraction logic in `bin/optbench`.

Note that with this fix, the reported time is from the beginning of the optimization pipeline (including decorrelation), whereas previous numbers that we have excluded decorrelation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The `EXPLAIN WITH(timing)` option will now print the optimization time until the selected stage.
