### PR TITLE
repr: safeguard `tracing::error` call from #17577

### DIFF
--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -357,6 +357,7 @@ impl RowPacker<'_> {
                     // We plan to remove the `Dummy` variant soon (#17099). To prepare for that, we
                     // emit a log to Sentry here, to notify us of any instances that might have
                     // been made durable.
+                    #[cfg(feature = "tracing_")]
                     tracing::error!("protobuf decoding found Dummy datum");
                     self.push(Datum::Dummy);
                 }


### PR DESCRIPTION
It's a one-liner to fix compiler errors in things like

```bash
REWRITE=1 cargo test -p mz-expr-test-util --test test_runner
```

### Motivation

  * This PR fixes a previously unreported bug.

The above statement fails with a compiler error at the moment because the `tracing` dependency in `repr` is optional.


### Tips for reviewer

It's a one-liner.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
