### PR TITLE
[persist] Pull stats for all the recent rollups in an environment

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -10,9 +10,11 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
+use std::iter::Peekable;
 use std::marker::PhantomData;
 use std::ops::{ControlFlow, ControlFlow::Break, ControlFlow::Continue};
 use std::ops::{Deref, DerefMut};
+use std::slice;
 use std::time::Duration;
 
 use differential_dataflow::lattice::Lattice;
@@ -199,6 +201,49 @@ impl<T: Ord> Ord for HollowBatch<T> {
                 other_len,
                 other_runs,
             ))
+    }
+}
+
+impl<T> HollowBatch<T> {
+    pub(crate) fn runs(&self) -> HollowBatchRunIter<T> {
+        HollowBatchRunIter {
+            batch: self,
+            inner: self.runs.iter().peekable(),
+            emitted_implicit: false,
+        }
+    }
+}
+
+pub(crate) struct HollowBatchRunIter<'a, T> {
+    batch: &'a HollowBatch<T>,
+    inner: Peekable<slice::Iter<'a, usize>>,
+    emitted_implicit: bool,
+}
+
+impl<'a, T> Iterator for HollowBatchRunIter<'a, T> {
+    type Item = &'a [HollowBatchPart];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.batch.parts.is_empty() {
+            return None;
+        }
+
+        if !self.emitted_implicit {
+            self.emitted_implicit = true;
+            return Some(match self.inner.peek() {
+                None => &self.batch.parts,
+                Some(run_end) => &self.batch.parts[0..**run_end],
+            });
+        }
+
+        if let Some(run_start) = self.inner.next() {
+            return Some(match self.inner.peek() {
+                Some(run_end) => &self.batch.parts[*run_start..**run_end],
+                None => &self.batch.parts[*run_start..],
+            });
+        }
+
+        None
     }
 }
 


### PR DESCRIPTION
Scan an S3 prefix to find recent shard rollups, then iterate over the rollups and extract various stats about the number of parts/runs/batches, longest run length, etc.

### Motivation

Some of these are motivated by #16858 - eg. byte width, which will help us estimate whether we need to worry about memory during consolidation - but it also seems helpful to have a global picture of an environment.

### Tips for reviewer

Some choices I've made:
- I'm relying purely on Blob; seems good enough for stats and avoids the pressure of scanning all of CRDB. (Not sure how much to worry about that but easier not to worry about it at all.)
- I'm dumping the whole thing out as a CSV; atypical for this tool, I know, but it's very handy to copy/paste into a spreadsheet and start poking around and making charts. Fine to change this to JSON if that feels important; I can always write some jq.
- The big stats-collection method is large and a bit brittle. (Column labels having to match values, etc.) Trying to break it up into small little stats collectors seems like it would not be worth it, but holler if you disagree.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
