### PR TITLE
environmentd: add `storage_usage_retention_threshold`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3399,6 +3399,7 @@ impl Catalog {
             aws_principal_context: None,
             aws_privatelink_availability_zones: None,
             system_parameter_frontend: None,
+            // when debugging, no reaping
             storage_usage_retention_period: None,
         })
         .await?;

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -10,6 +10,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::Deserialize;
 
@@ -64,6 +65,8 @@ pub struct Config<'a> {
     /// Catalog::open. A `None` value indicates that the initial sync should be
     /// skipped.
     pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
+    /// How long to retain storage usage records
+    pub storage_usage_retention_period: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -308,6 +308,7 @@ pub struct Config {
     pub connection_context: ConnectionContext,
     pub storage_usage_client: StorageUsageClient,
     pub storage_usage_collection_interval: Duration,
+    pub storage_usage_retention_period: Option<Duration>,
     pub segment_client: Option<mz_segment::Client>,
     pub egress_ips: Vec<Ipv4Addr>,
     pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
@@ -1211,6 +1212,7 @@ pub async fn serve(
         connection_context,
         storage_usage_client,
         storage_usage_collection_interval,
+        storage_usage_retention_period,
         segment_client,
         egress_ips,
         aws_account_id,
@@ -1275,6 +1277,7 @@ pub async fn serve(
             aws_principal_context,
             aws_privatelink_availability_zones,
             system_parameter_frontend,
+            storage_usage_retention_period,
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -450,6 +450,11 @@ pub struct Args {
         default_value = "3600s"
     )]
     storage_usage_collection_interval_sec: Duration,
+    /// The period for which to retain usage records. Note that the retention
+    /// period is only evaluated at server start time, so rebooting the server
+    /// is required to discard old records.
+    #[clap(long, env = "STORAGE_USAGE_RETENTION_PERIOD", parse(try_from_str = humantime::parse_duration))]
+    storage_usage_retention_period: Option<Duration>,
     /// An API key for Segment. Enables export of audit events to Segment.
     #[clap(long, env = "SEGMENT_API_KEY")]
     segment_api_key: Option<String>,
@@ -782,6 +787,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         ),
         tracing_handle,
         storage_usage_collection_interval: args.storage_usage_collection_interval_sec,
+        storage_usage_retention_period: args.storage_usage_retention_period,
         segment_api_key: args.segment_api_key,
         egress_ips: args.announce_egress_ip,
         aws_account_id: args.aws_account_id,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -189,6 +189,8 @@ pub struct Config {
     pub bootstrap_system_parameters: BTreeMap<String, String>,
     /// The interval at which to collect storage usage information.
     pub storage_usage_collection_interval: Duration,
+    /// How long to retain storage usage records for.
+    pub storage_usage_retention_period: Option<Duration>,
     /// An API key for Segment. Enables export of audit events to Segment.
     pub segment_api_key: Option<String>,
     /// IP Addresses which will be used for egress.
@@ -401,6 +403,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         connection_context: config.connection_context,
         storage_usage_client,
         storage_usage_collection_interval: config.storage_usage_collection_interval,
+        storage_usage_retention_period: config.storage_usage_retention_period,
         segment_client: segment_client.clone(),
         egress_ips: config.egress_ips,
         system_parameter_frontend: system_parameter_frontend.clone(),

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -131,6 +131,7 @@ pub struct Config {
     now: NowFn,
     seed: u32,
     storage_usage_collection_interval: Duration,
+    storage_usage_retention_period: Option<Duration>,
     default_cluster_replica_size: String,
     builtin_cluster_replica_size: String,
     propagate_crashes: bool,
@@ -148,6 +149,7 @@ impl Default for Config {
             now: SYSTEM_TIME.clone(),
             seed: rand::random(),
             storage_usage_collection_interval: Duration::from_secs(3600),
+            storage_usage_retention_period: None,
             default_cluster_replica_size: "1".to_string(),
             builtin_cluster_replica_size: "1".to_string(),
             propagate_crashes: false,
@@ -201,6 +203,14 @@ impl Config {
         storage_usage_collection_interval: Duration,
     ) -> Self {
         self.storage_usage_collection_interval = storage_usage_collection_interval;
+        self
+    }
+
+    pub fn with_storage_usage_retention_period(
+        mut self,
+        storage_usage_retention_period: Duration,
+    ) -> Self {
+        self.storage_usage_retention_period = Some(storage_usage_retention_period);
         self
     }
 
@@ -358,7 +368,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         connection_context,
         tracing_handle,
         storage_usage_collection_interval: config.storage_usage_collection_interval,
-        storage_usage_retention_period: None,
+        storage_usage_retention_period: config.storage_usage_retention_period,
         segment_api_key: None,
         egress_ips: vec![],
         aws_account_id: None,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -358,6 +358,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         connection_context,
         tracing_handle,
         storage_usage_collection_interval: config.storage_usage_collection_interval,
+        storage_usage_retention_period: None,
         segment_api_key: None,
         egress_ips: vec![],
         aws_account_id: None,

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -162,6 +162,12 @@ impl From<Timestamp> for u64 {
     }
 }
 
+impl From<Timestamp> for u128 {
+    fn from(ts: Timestamp) -> Self {
+        u128::from(ts.internal)
+    }
+}
+
 impl TryFrom<Timestamp> for i64 {
     type Error = TryFromIntError;
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -860,6 +860,7 @@ impl RunnerInner {
             connection_context,
             tracing_handle: TracingHandle::disabled(),
             storage_usage_collection_interval: Duration::from_secs(3600),
+            storage_usage_retention_period: None,
             segment_api_key: None,
             egress_ips: vec![],
             aws_account_id: None,

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -403,6 +403,7 @@ impl Usage {
             aws_principal_context: None,
             aws_privatelink_availability_zones: None,
             system_parameter_frontend: None,
+            storage_usage_retention_period: None,
         })
         .await?;
 


### PR DESCRIPTION
Add a `storage_usage_retention_threshold` configuration parameter which takes a Unix epoch timestamp. If this is set, records collected before the cutoff time are discarded when being read in from the Stash at boot.

Note that a sufficiently robust solution would ideally also handle #17548; this is not that solution (yet), although I would welcome feedback that evolves it that way.

### Motivation

  * This PR adds a known-desirable feature: Closes https://github.com/MaterializeInc/cloud/issues/3716

### Tips for reviewer



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->