### PR TITLE
mz: accept `psql` args in `shell` command

### DIFF
--- a/src/mz/Readme.md
+++ b/src/mz/Readme.md
@@ -117,11 +117,24 @@ mz region status aws/us-east-1
 
 ### Shell
 
-Connect to a Materialize region and run your SQL:
+Connect and interact with your Materialize database:
 
 ```bash
-mz shell aws/us-east-1
+mz shell
 ```
+
+Connect to a particular region:
+
+```bash
+mz shell --cloud-provider-region aws/us-east-1
+```
+
+Pass extra arguments to `psql`:
+
+```bash
+mz shell -l --csv
+```
+
 
 ### Help
 

--- a/src/mz/src/bin/mz/shell.rs
+++ b/src/mz/src/bin/mz/shell.rs
@@ -21,11 +21,16 @@ use mz::configuration::ValidProfile;
 /// ----------------------------
 
 /// Runs psql as a subprocess command
-fn run_psql_shell(valid_profile: ValidProfile<'_>, environment: &Environment) -> Result<()> {
+fn run_psql_shell(
+    valid_profile: ValidProfile<'_>,
+    environment: &Environment,
+    psql_extra_args: Vec<String>,
+) -> Result<()> {
     let error = Command::new("psql")
         .arg(environment.sql_url(&valid_profile).to_string())
         // Enable query timing output by default.
         .args(["-c", "\\timing", "-f", "-"])
+        .args(psql_extra_args)
         .env("PGPASSWORD", valid_profile.app_password)
         .exec();
 
@@ -54,11 +59,12 @@ pub(crate) async fn shell(
     client: Client,
     valid_profile: ValidProfile<'_>,
     cloud_provider_region: CloudProviderRegion,
+    psql_args: Vec<String>,
 ) -> Result<()> {
     let environment =
         get_provider_region_environment(&client, &valid_profile, &cloud_provider_region)
             .await
             .context("Retrieving cloud provider region.")?;
 
-    run_psql_shell(valid_profile, &environment)
+    run_psql_shell(valid_profile, &environment, psql_args)
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Accept passing `psql` args in the `shell` command.
https://github.com/MaterializeInc/materialize/issues/16987

**Usage**

Connect and interact with your Materialize database:

```bash
mz shell
```

Connect to a particular region:

```bash
mz shell --cloud-provider-region aws/us-east-1
```

Pass extra arguments to `psql`:

```bash
mz shell -l --csv
```


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I had to turn `cloud_provider_region` as an `Option` command rather than an `<Optional> Arg`. 

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
