### PR TITLE
adapter,compute*: dynamic config of persist_source flow control

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5862,6 +5862,7 @@ impl Catalog {
         let config = self.system_config();
         ComputeParameters {
             max_result_size: Some(config.max_result_size()),
+            dataflow_max_inflight_bytes: Some(config.dataflow_max_inflight_bytes()),
             persist: self.persist_config(),
         }
     }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -378,6 +378,16 @@ const PERSIST_COMPACTION_MINIMUM_TIMEOUT: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
+/// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
+const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("dataflow_max_inflight_bytes"),
+    value: &usize::MAX,
+    description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
+                  dataflows (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Boolean flag indicating that the remote configuration was synchronized at
 /// least once with the persistent [SessionVars].
 pub static CONFIG_HAS_SYNCED_ONCE: ServerVar<bool> = ServerVar {
@@ -1042,6 +1052,9 @@ pub struct SystemVars {
     persist_blob_target_size: SystemVar<usize>,
     persist_compaction_minimum_timeout: SystemVar<Duration>,
 
+    // dataflow configuration
+    dataflow_max_inflight_bytes: SystemVar<usize>,
+
     // misc
     metrics_retention: SystemVar<Duration>,
 
@@ -1069,6 +1082,7 @@ impl Default for SystemVars {
             allowed_cluster_replica_sizes: SystemVar::new(&ALLOWED_CLUSTER_REPLICA_SIZES),
             persist_blob_target_size: SystemVar::new(&PERSIST_BLOB_TARGET_SIZE),
             persist_compaction_minimum_timeout: SystemVar::new(&PERSIST_COMPACTION_MINIMUM_TIMEOUT),
+            dataflow_max_inflight_bytes: SystemVar::new(&DATAFLOW_MAX_INFLIGHT_BYTES),
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
             mock_audit_event_timestamp: SystemVar::new(&MOCK_AUDIT_EVENT_TIMESTAMP),
         }
@@ -1079,7 +1093,7 @@ impl SystemVars {
     /// Returns an iterator over the configuration parameters and their current
     /// values on disk.
     pub fn iter(&self) -> impl Iterator<Item = &dyn Var> {
-        let vars: [&dyn Var; 19] = [
+        let vars: [&dyn Var; 20] = [
             &self.config_has_synced_once,
             &self.max_aws_privatelink_connections,
             &self.max_tables,
@@ -1097,6 +1111,7 @@ impl SystemVars {
             &self.allowed_cluster_replica_sizes,
             &self.persist_blob_target_size,
             &self.persist_compaction_minimum_timeout,
+            &self.dataflow_max_inflight_bytes,
             &self.metrics_retention,
             &self.mock_audit_event_timestamp,
         ];
@@ -1161,6 +1176,8 @@ impl SystemVars {
             Ok(&self.persist_blob_target_size)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(&self.persist_compaction_minimum_timeout)
+        } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
+            Ok(&self.dataflow_max_inflight_bytes)
         } else if name == METRICS_RETENTION.name {
             Ok(&self.metrics_retention)
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
@@ -1214,6 +1231,8 @@ impl SystemVars {
             self.persist_blob_target_size.is_default(value)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.is_default(value)
+        } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
+            self.dataflow_max_inflight_bytes.is_default(value)
         } else if name == METRICS_RETENTION.name {
             self.metrics_retention.is_default(value)
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
@@ -1276,6 +1295,8 @@ impl SystemVars {
             self.persist_blob_target_size.set(value)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             self.persist_compaction_minimum_timeout.set(value)
+        } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
+            self.dataflow_max_inflight_bytes.set(value)
         } else if name == METRICS_RETENTION.name {
             self.metrics_retention.set(value)
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
@@ -1333,6 +1354,8 @@ impl SystemVars {
             Ok(self.persist_blob_target_size.reset())
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
             Ok(self.persist_compaction_minimum_timeout.reset())
+        } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
+            Ok(self.dataflow_max_inflight_bytes.reset())
         } else if name == METRICS_RETENTION.name {
             Ok(self.metrics_retention.reset())
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
@@ -1425,6 +1448,11 @@ impl SystemVars {
     /// Returns the `persist_compaction_minimum_timeout` configuration parameter.
     pub fn persist_compaction_minimum_timeout(&self) -> Duration {
         *self.persist_compaction_minimum_timeout.value()
+    }
+
+    /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
+    pub fn dataflow_max_inflight_bytes(&self) -> usize {
+        *self.dataflow_max_inflight_bytes.value()
     }
 
     /// Returns the `metrics_retention` configuration parameter.
@@ -2272,7 +2300,9 @@ impl From<TransactionIsolationLevel> for IsolationLevel {
 
 /// Returns whether the named variable is a compute configuration parameter.
 pub(crate) fn is_compute_config_var(name: &str) -> bool {
-    name == MAX_RESULT_SIZE.name() || is_persist_config_var(name)
+    name == MAX_RESULT_SIZE.name()
+        || name == DATAFLOW_MAX_INFLIGHT_BYTES.name()
+        || is_persist_config_var(name)
 }
 
 /// Returns whether the named variable is a storage configuration parameter.

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -75,4 +75,5 @@ message ProtoPeek {
 message ProtoComputeParameters {
     optional uint32 max_result_size = 1;
     mz_persist_client.cfg.ProtoPersistParameters persist = 2;
+    optional uint64 dataflow_max_inflight_bytes = 3;
 }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -207,9 +207,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     );
                     let flow_control = FlowControl {
                         progress_stream: flow_control_input,
-                        // TODO: Enable flow control with a sensible limit value. This is currently
-                        // blocked by a bug in `persist_source` (#16995).
-                        max_inflight_bytes: usize::MAX,
+                        max_inflight_bytes: compute_state.dataflow_max_inflight_bytes,
                     };
 
                     // Note: For correctness, we require that sources only emit times advanced by

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -612,6 +612,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     persist_clients: Arc::clone(&self.persist_clients),
                     command_history: ComputeCommandHistory::default(),
                     max_result_size: u32::MAX,
+                    dataflow_max_inflight_bytes: usize::MAX,
                     metrics: self.compute_metrics.clone(),
                 });
             }

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -380,7 +380,7 @@ where
             while inflight_bytes >= max_inflight_bytes {
                 // We can never get here when flow control is disabled, as we are not tracking
                 // in-flight bytes in this case.
-                assert_eq!(flow_control_bytes, None);
+                assert!(flow_control_bytes.is_some());
 
                 // Get an upper bound until which we should produce data
                 let flow_control_upper = match flow_control_input.next().await {


### PR DESCRIPTION
This PR adds a new (internal) configuration parameter called `dataflow_max_inflight_bytes` to dynamically configure the `max_inflight_bytes` value of the persist_source flow control configuration in compute dataflows.

I mostly added the parameter to simplify benchmarking with different values for myself, but it might be a useful tool to have in production too.

Note that when you change this value, the new value is only applied to newly rendered dataflows, not existing ones. To change this, we'd have to make persist_source expose a way of dynamically changing the in-flight bytes value. I don't think this is necessary though. It's fine for different dataflows on different replicas to have different in-flight bytes limits, as this setting only influences ingestion speed.

### Motivation

  * This PR adds a known-desirable feature.

Advances #15974.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
