### PR TITLE
Cloud canary kafka sources

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -152,6 +152,8 @@ case "$cmd" in
             --env LAUNCHDARKLY_API_TOKEN
             --env LAUNCHDARKLY_SDK_KEY
             --env NIGHTLY_CANARY_APP_PASSWORD
+            --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_KEY
+            --env NIGHTLY_CANARY_CONFLUENT_CLOUD_API_SECRET
             --env PYPI_TOKEN
         )
         for env in $(printenv | grep '^BUILDKITE' | sed 's/=.*//'); do

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -904,7 +904,7 @@ def _wait_for_pg(
     args = f"dbname={dbname} host={host} port={port} user={user} password='{obfuscated_password}...'"
     ui.progress(f"waiting for {args} to handle {query!r}", "C")
     error = None
-    for remaining in ui.timeout_loop(timeout_secs, tick=0.1):
+    for remaining in ui.timeout_loop(timeout_secs, tick=0.5):
         try:
             conn = pg8000.connect(
                 database=dbname,

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -695,6 +695,8 @@ class Testdrive(Service):
         materialize_params: Dict[str, str] = {},
         kafka_url: str = "kafka:9092",
         kafka_default_partitions: Optional[int] = None,
+        kafka_args: Optional[str] = None,
+        schema_registry_url: str = "http://schema-registry:8081",
         no_reset: bool = False,
         default_timeout: str = "120s",
         seed: Optional[int] = None,
@@ -737,7 +739,7 @@ class Testdrive(Service):
             entrypoint = [
                 "testdrive",
                 f"--kafka-addr={kafka_url}",
-                "--schema-registry-url=http://schema-registry:8081",
+                f"--schema-registry-url={schema_registry_url}",
                 f"--materialize-url={materialize_url}",
                 f"--materialize-internal-url={materialize_url_internal}",
             ]

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -321,7 +321,7 @@ impl State {
         {
             let db_name: String = row.get(0);
             let query = format!("DROP DATABASE {}", db_name);
-            sql::print_query(&query);
+            sql::print_query(&query, None);
             self.pgclient.batch_execute(&query).await.context(format!(
                 "resetting materialize state: DROP DATABASE {}",
                 db_name,
@@ -342,7 +342,7 @@ impl State {
                     continue;
                 }
                 let query = format!("DROP ROLE {}", role_name);
-                sql::print_query(&query);
+                sql::print_query(&query, None);
                 self.pgclient.batch_execute(&query).await.context(format!(
                     "resetting materialize state: DROP ROLE {}",
                     role_name,

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -329,12 +329,7 @@ pub async fn run_fail_sql(
     let expected_hint = cmd.expected_hint.map(ErrorMatcher::Contains);
 
     let query = &cmd.query;
-
-    if let Some(stmt) = &stmt {
-        print_query(query, Some(stmt));
-    } else {
-        print_query(query, None);
-    }
+    print_query(query, stmt.as_ref());
 
     let should_retry = match &stmt {
         // Do not retry statements that could not be parsed
@@ -470,16 +465,11 @@ async fn try_run_fail_sql(
 
 pub fn print_query(query: &str, stmt: Option<&Statement<Raw>>) {
     use Statement::*;
-    if let Some(stmt) = stmt {
-        match &stmt {
-            CreateSecret(_) => {
-                println!("> CREATE SECRET [query truncated on purpose as to not reveal the secret in the log]");
-                return;
-            }
-            _ => {}
-        }
+    if let Some(CreateSecret(_)) = stmt {
+        println!("> CREATE SECRET [query truncated on purpose so as to not reveal the secret in the log]");
+    } else {
+        println!("> {}", query)
     }
-    println!("> {}", query)
 }
 
 pub fn decode_row(state: &State, row: Row) -> Result<Vec<String>, anyhow::Error> {

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -116,7 +116,7 @@ struct Args {
     ///
     /// Passing `--var foo=bar` will create a variable named `arg.foo` with the
     /// value `bar`. Can be specified multiple times to set multiple variables.
-    #[clap(long, value_name = "NAME=VALUE")]
+    #[clap(long, env = "VAR", use_delimiter = true, value_name = "NAME=VALUE")]
     var: Vec<String>,
     /// A random number to distinguish each testdrive run.
     #[clap(long, value_name = "N")]
@@ -223,7 +223,7 @@ struct Args {
     kafka_default_partitions: usize,
     /// Arbitrary rdkafka options for testdrive to use when connecting to the
     /// Kafka broker.
-    #[clap(long, value_name = "KEY=VAL", parse(from_str = parse_kafka_opt))]
+    #[clap(long, env = "KAFKA_OPTION", use_delimiter=true, value_name = "KEY=VAL", parse(from_str = parse_kafka_opt))]
     kafka_option: Vec<(String, String)>,
     /// URL of the schema registry that testdrive will connect to.
     #[clap(long, value_name = "URL", default_value = "http://localhost:8081")]

--- a/test/cloud-canary/canary-load-generator.td
+++ b/test/cloud-canary/canary-load-generator.td
@@ -1,0 +1,19 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> DROP SOURCE IF EXISTS generator1 CASCADE;
+
+> CREATE SOURCE generator1 FROM LOAD GENERATOR COUNTER WITH (SIZE '3xsmall');
+
+> CREATE MATERIALIZED VIEW generator_view1 AS SELECT COUNT(*) AS cnt FROM generator1;
+
+> SELECT cnt > 0 FROM generator_view1;
+true
+
+> DROP SOURCE generator1 CASCADE;

--- a/test/cloud-canary/canary-sources.td
+++ b/test/cloud-canary/canary-sources.td
@@ -7,13 +7,34 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> DROP SOURCE IF EXISTS source1 CASCADE;
+# The free tier of Confluent Cloud does not alow for programatic
+# topic creation
+# $ kafka-create-topic topic=bytes
 
-> CREATE SOURCE source1 FROM LOAD GENERATOR COUNTER WITH (SIZE '3xsmall');
+$ kafka-ingest format=bytes key-terminator=: key-format=bytes topic=bytes repeat=1000
+abc:abc
 
-> CREATE MATERIALIZED VIEW source_view1 AS SELECT COUNT(*) AS cnt FROM source1;
+> DROP SOURCE IF EXISTS bytes CASCADE;
+> DROP CONNECTION IF EXISTS kafka_conn;
+> DROP SECRET IF EXISTS confluent_username
+> DROP SECRET IF EXISTS confluent_password
 
-> SELECT cnt > 0 FROM source_view1;
+> CREATE SECRET confluent_username AS '${arg.confluent-api-key}';
+
+> CREATE SECRET confluent_password AS '${arg.confluent-api-secret}';
+
+> CREATE CONNECTION kafka_conn TO KAFKA (
+  BROKER '${testdrive.kafka-addr}',
+  SASL MECHANISMS = 'PLAIN',
+  SASL USERNAME = SECRET confluent_username,
+  SASL PASSWORD = SECRET confluent_password
+  );
+
+> CREATE SOURCE bytes
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bytes-${testdrive.seed}')
+  FORMAT BYTES
+  ENVELOPE NONE
+  WITH (SIZE '3xsmall');
+
+> SELECT COUNT(*) > 0 from bytes
 true
-
-> DROP SOURCE source1 CASCADE;

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -20,9 +20,16 @@ from materialize.ui import UIError
 
 REGION = "aws/us-east-1"
 ENVIRONMENT = "staging"
-USERNAME = "infra+nightly-canary@materialize.com"
+USERNAME = os.getenv("NIGHTLY_CANARY_USERNAME", "infra+nightly-canary@materialize.com")
 APP_PASSWORD = os.environ["NIGHTLY_CANARY_APP_PASSWORD"]
 VERSION = "devel-" + os.environ["BUILDKITE_COMMIT"]
+
+# The DevEx account in the Confluent Cloud is used to provide Kafka services
+KAFKA_BOOTSTRAP_SERVER = "pkc-n00kk.us-east-1.aws.confluent.cloud:9092"
+SCHEMA_REGISTRY_ENDPOINT = "https://psrc-8kz20.us-east-2.aws.confluent.cloud"
+# The actual values are stored as Pulumi secrets in the i2 repository
+CONFLUENT_API_KEY = os.environ["NIGHTLY_CANARY_CONFLUENT_CLOUD_API_KEY"]
+CONFLUENT_API_SECRET = os.environ["NIGHTLY_CANARY_CONFLUENT_CLOUD_API_SECRET"]
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -35,7 +42,7 @@ SERVICES = [
         persist_blob_url="file:///mzdata/persist/blob",
         options=["--orchestrator-process-secrets-directory=/mzdata/secrets"],
     ),
-    Testdrive(),
+    Testdrive(),  # Overriden below
     Mz(
         region=REGION,
         environment=ENVIRONMENT,
@@ -46,11 +53,7 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    """Deploy the current source to the cloud and run a smoke test."""
-
-    print("Obtaining mz_version() string from local instance ...")
-    c.up("materialized")
-    local_version = c.sql_query("SELECT mz_version();")[0][0]
+    """Deploy the current source to the cloud and run tests."""
 
     print(f"Shutting down region {REGION} ...")
     c.run("mz", "region", "disable", REGION)
@@ -66,55 +69,105 @@ def workflow_default(c: Composition) -> None:
 
         time.sleep(10)
 
-        print("Obtaining hostname of cloud instance ...")
-        region_status = c.run("mz", "region", "status", REGION, capture=True)
-        sql_line = region_status.stdout.split("\n")[1]
-        cloud_hostname = sql_line.split(":")[1].strip()
-        assert "materialize.cloud" in cloud_hostname
+        assert "materialize.cloud" in cloud_hostname(c)
+        wait_for_cloud(c)
 
-        materialize_url = f"postgres://{urllib.parse.quote(USERNAME)}:{urllib.parse.quote(APP_PASSWORD)}@{cloud_hostname}:6875"
+        version_check(c)
 
-        print("Waiting for cloud cluster to come up ...")
-        _wait_for_pg(
-            host=cloud_hostname,
-            user=USERNAME,
-            password=APP_PASSWORD,
-            port=6875,
-            query="SELECT 1",
-            expected=[[1]],
-            timeout_secs=600,
-            dbname="materialize",
-            ssl_context=ssl.SSLContext(),
-        )
-
-        print("Obtaining mz_version() string from the cloud ...")
-        cloud_cursor = pg8000.connect(
-            host=cloud_hostname,
-            user=USERNAME,
-            password=APP_PASSWORD,
-            port=6875,
-            ssl_context=ssl.SSLContext(),
-        ).cursor()
-        cloud_cursor.execute("SELECT mz_version()")
-        cloud_version = cloud_cursor.fetchone()[0]
-        assert (
-            local_version == cloud_version
-        ), f"local version: {local_version} is not identical to cloud version: {cloud_version}"
-
-        print("Running smoke tests ...")
-        with c.override(
-            Testdrive(
-                default_timeout="600s",
-                materialize_url=materialize_url,
-                no_reset=True,  # Required so that admin port 6877 is not used
-            )
-        ):
-            c.run("testdrive", "*.td", rm=True)
-
+        print("Running tests ...")
+        td(c, "*.td")
         test_failed = False
     finally:
         # Clean up
-        print(f"Shutting down region {REGION} ...")
-        c.run("mz", "region", "disable", REGION)
+        workflow_disable_region(c)
 
     assert not test_failed
+
+
+def cloud_hostname(c: Composition) -> str:
+    print("Obtaining hostname of cloud instance ...")
+    region_status = c.run("mz", "region", "status", REGION, capture=True)
+    sql_line = region_status.stdout.split("\n")[2]
+    cloud_url = sql_line.split("\t")[1].strip()
+    cloud_hostname = urllib.parse.urlparse(cloud_url).hostname
+    return str(cloud_hostname)
+
+
+def wait_for_cloud(c: Composition) -> None:
+    print(f"Waiting for cloud cluster to come up with username {USERNAME} ...")
+    _wait_for_pg(
+        host=cloud_hostname(c),
+        user=USERNAME,
+        password=APP_PASSWORD,
+        port=6875,
+        query="SELECT 1",
+        expected=[[1]],
+        timeout_secs=600,
+        dbname="materialize",
+        ssl_context=ssl.SSLContext(),
+        # print_result=True
+    )
+
+
+def version_check(c: Composition) -> None:
+    print("Obtaining mz_version() string from local instance ...")
+    c.up("materialized")
+    local_version = c.sql_query("SELECT mz_version();")[0][0]
+
+    print("Obtaining mz_version() string from the cloud ...")
+    cloud_cursor = pg8000.connect(
+        host=cloud_hostname(c),
+        user=USERNAME,
+        password=APP_PASSWORD,
+        port=6875,
+        ssl_context=ssl.SSLContext(),
+    ).cursor()
+    cloud_cursor.execute("SELECT mz_version()")
+    cloud_version = cloud_cursor.fetchone()[0]
+    assert (
+        local_version == cloud_version
+    ), f"local version: {local_version} is not identical to cloud version: {cloud_version}"
+
+
+def td(c: Composition, *args: str) -> None:
+    materialize_url = f"postgres://{urllib.parse.quote(USERNAME)}:{urllib.parse.quote(APP_PASSWORD)}@{urllib.parse.quote(cloud_hostname(c))}:6875"
+
+    with c.override(
+        Testdrive(
+            default_timeout="1200s",
+            materialize_url=materialize_url,
+            no_reset=True,  # Required so that admin port 6877 is not used
+            seed=1,  # Required for predictable Kafka topic names
+            kafka_url=KAFKA_BOOTSTRAP_SERVER,
+            schema_registry_url=SCHEMA_REGISTRY_ENDPOINT,
+            environment=[
+                "KAFKA_OPTION="
+                + ",".join(
+                    [
+                        "security.protocol=SASL_SSL",
+                        "sasl.mechanisms=PLAIN",
+                        f"sasl.username={CONFLUENT_API_KEY}",
+                        f"sasl.password={CONFLUENT_API_SECRET}",
+                    ]
+                ),
+                "VAR="
+                + ",".join(
+                    [
+                        f"confluent-api-key={CONFLUENT_API_KEY}",
+                        f"confluent-api-secret={CONFLUENT_API_SECRET}",
+                    ]
+                ),
+            ],
+        )
+    ):
+        c.run(
+            "testdrive",
+            *args,
+            rm=True,
+        )
+
+
+def workflow_disable_region(c: Composition) -> None:
+    print(f"Shutting down region {REGION} ...")
+
+    c.run("mz", "region", "disable", REGION)


### PR DESCRIPTION
Add Kafka sources to the cloud-canary test
### Motivation

  * This PR adds a known-desirable feature.
The cloud canary test was not using any Kafka sources, which significantly reduced its realism.


### Tips for reviewer

@benesch If you can review the small rust bits that would be much appreciated.

@def- test/cloud-canary/mzcompose.py file has been refactored a lot , so the diff may not be informative -- look at the raw file instead.

Basically what this test does is:
1. fetches some secrets that Pulumi has made sure are exposed to the buildkite agents
2. calls the bin/mz tool (containerized) to "enable a region", the same button you see in the cloud UI
3. Calls testdrive (containerized) with the right options so that all the SQL commands are sent to the Mz cloud and all the Kafka-related commands are sent to the Confluent Cloud
4. A set of .td files provide a smoke test for various functionalities

 