### PR TITLE
adapter: prevent `ALTER .. SIZE` on unlinked sources and sinks

### DIFF
--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -29,6 +29,9 @@ contains:only one of IN CLUSTER or SIZE can be set
 # Creating a source in an empty, zero-replica cluster should work.
 > CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER
 
+! ALTER SOURCE loadgen SET (SIZE = '1')
+contains:cannot change the size of a source or sink created with IN CLUSTER
+
 # Create indexes and materialized views in a storage cluster is banned.
 ! CREATE INDEX bad IN CLUSTER storage ON t (a)
 contains:cannot create this kind of item in a cluster that contains sources or sinks
@@ -126,6 +129,9 @@ bb
   FROM view1
   INTO KAFKA CONNECTION kafka (TOPIC 'sink1-${testdrive.seed}')
   FORMAT JSON ENVELOPE DEBEZIUM
+
+! ALTER SINK sink1 SET (SIZE = '1')
+contains:cannot change the size of a source or sink created with IN CLUSTER
 
 > CREATE SINK sink2
   IN CLUSTER storage


### PR DESCRIPTION
Altering the size of a source or a sink that was not linked to a cluster previously succeeded but had no effect. This commit changes the behavior to return an error instead, which will be less surprising to users.

Fix #17638.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
