### PR TITLE
compute-client: retry connecting to replicas more eagerly

### DIFF
--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -204,7 +204,7 @@ where
     ComputeGrpcClient: ComputeClient<T>,
 {
     let mut client = Retry::default()
-        .clamp_backoff(Duration::from_secs(32))
+        .clamp_backoff(Duration::from_secs(1))
         .retry_async(|state| {
             let dests = addrs
                 .clone()


### PR DESCRIPTION
This PR changes the replica connection retry behavior from exponential backoff to retrying every second. The rationale is:

 1. Retrying more eagerly reduces the delay until the replica is functional. This is particularly relevant for tests.
 2. Retrying more eagerly should not cause any harm since one request per second is still low traffic.
 3. This is the same behavior as the storage client uses to connect to replicas.

### Motivation

  * This PR fixes a recognized bug.

Fixes #13604.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
