### PR TITLE
storage: followups from multi-process storage replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mz-compute"
-version = "0.38.0-dev"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "mz-storage"
-version = "0.38.0-dev"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -178,10 +178,13 @@ impl TimelyConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClusterReplicaLocation {
     /// The network addresses of the cluster control endpoints for each process in
-    /// the replica.
+    /// the replica. Connections from the controller to these addresses
+    /// are sent commands, and send responses back.
     pub ctl_addrs: Vec<String>,
     /// The network addresses of the dataflow (Timely) endpoints for
-    /// each process in the replica.
+    /// each process in the replica. These are used for _internal_
+    /// networking, that is, timely worker communicating messages
+    /// between themselves.
     pub dataflow_addrs: Vec<String>,
     /// The workers per process in the replica.
     pub workers: usize,

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-compute"
 description = "Materialize's compute layer."
-version = "0.38.0-dev"
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-storage"
 description = "Materialize's storage layer."
-version = "0.38.0-dev"
+version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Followups from https://github.com/MaterializeInc/materialize/pull/17483



### Motivation

   * This PR refactors existing code.

Light documentation changes, and fixing some old versions (the storage and compute crates used to be binaries, so are stuck on an old version!


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

