### PR TITLE
storage: restore pg-snapshot-partial-failure test

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -65,6 +65,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-resource-limits",
         "test-invalid-compute-reuse",
         "pg-snapshot-resumption",
+        "pg-snapshot-partial-failure",
         "test-system-table-indexes",
         "test-replica-targeted-subscribe-abort",
         "test-compute-reconciliation-reuse",

--- a/test/cluster/pg-snapshot-partial-failure/02-create-sources.td
+++ b/test/cluster/pg-snapshot-partial-failure/02-create-sources.td
@@ -11,6 +11,15 @@
 > DROP SECRET IF EXISTS pgpass CASCADE;
 > DROP CONNECTION IF EXISTS pg CASCADE;
 
+> CREATE CLUSTER storage REPLICAS (
+    r1 (
+      STORAGECTL ADDRESSES ['storage:2100'],
+      STORAGE ADDRESSES ['storage:2103'],
+      COMPUTECTL ADDRESSES ['storage:2101'],
+      COMPUTE ADDRESSES ['storage:2102']
+    )
+  )
+
 > CREATE SECRET pgpass AS 'postgres'
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
@@ -20,10 +29,8 @@
   )
 
 > CREATE SOURCE mz_source
+  IN CLUSTER storage
   FROM POSTGRES
   CONNECTION pg
   (PUBLICATION 'mz_source')
-  FOR ALL TABLES
-  WITH (
-    REMOTE = 'storage:2100'
-  );
+  FOR ALL TABLES;


### PR DESCRIPTION
When working on #17589, I noticed that this test wasn't actually running, after the original cluster unification work!

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

