### PR TITLE
adapter: support multi-valued settings

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -879,7 +879,8 @@ impl CatalogState {
         name: &str,
         value: &str,
     ) -> Result<bool, AdapterError> {
-        self.system_configuration.set(name, value)
+        let values = plan::parse_set_variable_value(value)?;
+        self.system_configuration.set(name, &values)
     }
 
     /// Reset system configuration `name`.
@@ -5193,7 +5194,7 @@ impl Catalog {
                     )?;
                 }
                 Op::UpdateSystemConfiguration { name, value } => {
-                    tx.upsert_system_config(&name, &value)?;
+                    tx.upsert_system_config(&name, value.clone())?;
                     catalog_action(
                         state,
                         builtin_table_updates,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -90,7 +90,7 @@ use crate::catalog::storage::{BootstrapArgs, Transaction};
 use crate::client::ConnectionId;
 use crate::config::{SynchronizedParameters, SystemParameterFrontend};
 use crate::coord::DEFAULT_LOGICAL_COMPACTION_WINDOW;
-use crate::session::vars::{SystemVars, Var, CONFIG_HAS_SYNCED_ONCE};
+use crate::session::vars::{parse_set_variable_value, SystemVars, Var, CONFIG_HAS_SYNCED_ONCE};
 use crate::session::{PreparedStatement, Session, User, DEFAULT_DATABASE_NAME};
 use crate::util::{index_sql, ResultExt};
 use crate::{AdapterError, DUMMY_AVAILABILITY_ZONE};
@@ -879,7 +879,7 @@ impl CatalogState {
         name: &str,
         value: &str,
     ) -> Result<bool, AdapterError> {
-        let values = plan::parse_set_variable_value(value)?;
+        let values = parse_set_variable_value(value)?;
         self.system_configuration.set(name, &values)
     }
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -90,7 +90,7 @@ use crate::catalog::storage::{BootstrapArgs, Transaction};
 use crate::client::ConnectionId;
 use crate::config::{SynchronizedParameters, SystemParameterFrontend};
 use crate::coord::DEFAULT_LOGICAL_COMPACTION_WINDOW;
-use crate::session::vars::{parse_set_variable_value, SystemVars, Var, CONFIG_HAS_SYNCED_ONCE};
+use crate::session::vars::{OwnedVarInput, SystemVars, Var, VarInput, CONFIG_HAS_SYNCED_ONCE};
 use crate::session::{PreparedStatement, Session, User, DEFAULT_DATABASE_NAME};
 use crate::util::{index_sql, ResultExt};
 use crate::{AdapterError, DUMMY_AVAILABILITY_ZONE};
@@ -877,10 +877,9 @@ impl CatalogState {
     fn insert_system_configuration(
         &mut self,
         name: &str,
-        value: &str,
+        value: VarInput,
     ) -> Result<bool, AdapterError> {
-        let values = parse_set_variable_value(value)?;
-        self.system_configuration.set(name, &values)
+        self.system_configuration.set(name, value)
     }
 
     /// Reset system configuration `name`.
@@ -2769,7 +2768,10 @@ impl Catalog {
             (system_config, boot_ts)
         };
         for (name, value) in &bootstrap_system_parameters {
-            match self.state.insert_system_configuration(name, value) {
+            match self
+                .state
+                .insert_system_configuration(name, VarInput::Flat(value))
+            {
                 Ok(_) => (),
                 Err(AdapterError::UnknownParameter(name)) => {
                     warn!(%name, "cannot load unknown system parameter from stash");
@@ -2778,7 +2780,10 @@ impl Catalog {
             };
         }
         for (name, value) in system_config {
-            match self.state.insert_system_configuration(&name, &value) {
+            match self
+                .state
+                .insert_system_configuration(&name, VarInput::Flat(&value))
+            {
                 Ok(_) => (),
                 Err(AdapterError::UnknownParameter(name)) => {
                     warn!(%name, "cannot load unknown system parameter from stash");
@@ -2839,13 +2844,19 @@ impl Catalog {
                         let name = param.name;
                         let value = param.value;
                         tracing::debug!(name, value, "sync parameter");
-                        Op::UpdateSystemConfiguration { name, value }
+                        Op::UpdateSystemConfiguration {
+                            name,
+                            value: OwnedVarInput::Flat(value),
+                        }
                     })
                     .chain(std::iter::once({
                         let name = CONFIG_HAS_SYNCED_ONCE.name().to_string();
                         let value = true.to_string();
                         tracing::debug!(name, value, "sync parameter");
-                        Op::UpdateSystemConfiguration { name, value }
+                        Op::UpdateSystemConfiguration {
+                            name,
+                            value: OwnedVarInput::Flat(value),
+                        }
                     }))
                     .collect::<Vec<_>>();
                 self.transact(boot_ts, None, ops, |_| Ok(()))
@@ -3470,7 +3481,9 @@ impl Catalog {
             .vars()
             .search_path()
             .iter()
-            .map(|schema| state.resolve_schema(database.as_ref(), None, schema, session.conn_id()))
+            .map(|schema| {
+                state.resolve_schema(database.as_ref(), None, schema.as_str(), session.conn_id())
+            })
             .filter_map(|schema| schema.ok())
             .map(|schema| (schema.name().database.clone(), schema.id().clone()))
             .collect();
@@ -4260,14 +4273,6 @@ impl Catalog {
             UpdateClusterReplicaStatus {
                 event: ClusterEvent,
             },
-            UpdateSystemConfiguration {
-                name: String,
-                value: String,
-            },
-            ResetSystemConfiguration {
-                name: String,
-            },
-            ResetAllSystemConfiguration,
             UpdateRotatedKeys {
                 id: GlobalId,
                 new_item: CatalogItem,
@@ -5194,28 +5199,17 @@ impl Catalog {
                     )?;
                 }
                 Op::UpdateSystemConfiguration { name, value } => {
-                    tx.upsert_system_config(&name, value.clone())?;
-                    catalog_action(
-                        state,
-                        builtin_table_updates,
-                        Action::UpdateSystemConfiguration { name, value },
-                    )?;
+                    state.insert_system_configuration(&name, value.borrow())?;
+                    let var = state.get_system_configuration(&name)?;
+                    tx.upsert_system_config(&name, var.value())?;
                 }
                 Op::ResetSystemConfiguration { name } => {
+                    state.remove_system_configuration(&name)?;
                     tx.remove_system_config(&name);
-                    catalog_action(
-                        state,
-                        builtin_table_updates,
-                        Action::ResetSystemConfiguration { name },
-                    )?;
                 }
                 Op::ResetAllSystemConfiguration {} => {
+                    state.clear_system_configuration();
                     tx.clear_system_configs();
-                    catalog_action(
-                        state,
-                        builtin_table_updates,
-                        Action::ResetAllSystemConfiguration,
-                    )?;
                 }
                 Op::UpdateRotatedKeys {
                     id,
@@ -5524,15 +5518,6 @@ impl Catalog {
                         event.process_id,
                         1,
                     ));
-                }
-                Action::UpdateSystemConfiguration { name, value } => {
-                    state.insert_system_configuration(&name, &value)?;
-                }
-                Action::ResetSystemConfiguration { name } => {
-                    state.remove_system_configuration(&name)?;
-                }
-                Action::ResetAllSystemConfiguration {} => {
-                    state.clear_system_configuration();
                 }
 
                 Action::UpdateRotatedKeys { id, new_item } => {
@@ -6034,7 +6019,7 @@ pub enum Op {
     },
     UpdateSystemConfiguration {
         name: String,
-        value: String,
+        value: OwnedVarInput,
     },
     ResetSystemConfiguration {
         name: String,
@@ -6639,6 +6624,7 @@ mod tests {
     use crate::catalog::{
         Catalog, CatalogItem, Index, MaterializedView, Op, Table, SYSTEM_CONN_ID,
     };
+    use crate::session::vars::VarInput;
     use crate::session::{Session, DEFAULT_DATABASE_NAME};
 
     /// System sessions have an empty `search_path` so it's necessary to
@@ -6802,7 +6788,7 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", &["pg_catalog".into()], false)
+                .set("search_path", VarInput::Flat("pg_catalog"), false)
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(
@@ -6829,7 +6815,7 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", &["mz_catalog".into()], false)
+                .set("search_path", VarInput::Flat("mz_catalog"), false)
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(
@@ -6856,7 +6842,7 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", &["mz_temp".into()], false)
+                .set("search_path", VarInput::Flat("mz_temp"), false)
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6801,7 +6801,7 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", "pg_catalog", false)
+                .set("search_path", &["pg_catalog".into()], false)
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(
@@ -6828,7 +6828,7 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", "mz_catalog", false)
+                .set("search_path", &["mz_catalog".into()], false)
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(
@@ -6855,7 +6855,7 @@ mod tests {
             let mut session = Session::dummy();
             session
                 .vars_mut()
-                .set("search_path", "mz_temp", false)
+                .set("search_path", &["mz_temp".into()], false)
                 .expect("failed to set search_path");
             let conn_catalog = catalog.for_session(&session);
             assert_ne!(

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1558,13 +1558,11 @@ impl<'a> Transaction<'a> {
     }
 
     /// Upserts persisted system configuration `name` to `value`.
-    pub fn upsert_system_config(&mut self, name: &str, value: &str) -> Result<(), Error> {
+    pub fn upsert_system_config(&mut self, name: &str, value: String) -> Result<(), Error> {
         let key = ServerConfigurationKey {
             name: name.to_string(),
         };
-        let value = ServerConfigurationValue {
-            value: value.to_string(),
-        };
+        let value = ServerConfigurationValue { value };
         self.system_configurations.set(key, Some(value))?;
         Ok(())
     }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -417,6 +417,21 @@ impl SessionClient {
         .await
     }
 
+    /// Gets the current value of all system variables.
+    pub async fn get_system_vars(&mut self) -> Result<BTreeMap<String, String>, AdapterError> {
+        self.send(|tx, session| Command::GetSystemVars { session, tx })
+            .await
+    }
+
+    /// Updates the specified system variables to the specified values.
+    pub async fn set_system_vars(
+        &mut self,
+        vars: BTreeMap<String, String>,
+    ) -> Result<(), AdapterError> {
+        self.send(|tx, session| Command::SetSystemVars { vars, session, tx })
+            .await
+    }
+
     /// Terminates the client session.
     pub async fn terminate(&mut self) {
         let res = self
@@ -467,6 +482,8 @@ impl SessionClient {
                     | Command::CancelRequest { .. }
                     | Command::DumpCatalog { .. }
                     | Command::CopyRows { .. }
+                    | Command::GetSystemVars { .. }
+                    | Command::SetSystemVars { .. }
                     | Command::Terminate { .. } => {}
                 };
                 cmd

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -11,6 +11,7 @@
 // https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
 #![allow(clippy::extra_unused_lifetimes)]
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -100,6 +101,17 @@ pub enum Command {
         rows: Vec<Row>,
         session: Session,
         tx: oneshot::Sender<Response<ExecuteResponse>>,
+    },
+
+    GetSystemVars {
+        session: Session,
+        tx: oneshot::Sender<Response<BTreeMap<String, String>>>,
+    },
+
+    SetSystemVars {
+        vars: BTreeMap<String, String>,
+        session: Session,
+        tx: oneshot::Sender<Response<()>>,
     },
 
     Terminate {

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -52,6 +52,9 @@ impl SystemParameterBackend {
     /// Pull the current values for all [SynchronizedParameters] from the
     /// [SystemParameterBackend].
     pub async fn pull(&mut self, params: &mut SynchronizedParameters) {
+        // TODO: It'd be an improvement to not flatten multi-valued settings and
+        // instead return them in their original form so we don't have to call
+        // parse_set_variable_value to split them back.
         let show_all = Statement::Show(ShowStatement::ShowVariable(ShowVariableStatement {
             variable: Ident::from("ALL"),
         }));

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -52,9 +52,6 @@ impl SystemParameterBackend {
     /// Pull the current values for all [SynchronizedParameters] from the
     /// [SystemParameterBackend].
     pub async fn pull(&mut self, params: &mut SynchronizedParameters) {
-        // TODO: It'd be an improvement to not flatten multi-valued settings and
-        // instead return them in their original form so we don't have to call
-        // parse_set_variable_value to split them back.
         let show_all = Statement::Show(ShowStatement::ShowVariable(ShowVariableStatement {
             variable: Ident::from("ALL"),
         }));

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -7,14 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use mz_repr::Row;
-use mz_sql::ast::{Ident, Raw, ShowStatement, ShowVariableStatement, Statement};
+use std::collections::BTreeMap;
+
+use tracing::{debug, error};
 
 use crate::catalog::SYSTEM_USER;
-use crate::session::EndTransactionAction;
-use crate::{AdapterError, Client, ExecuteResponse, PeekResponseUnary, SessionClient};
-
-use super::SynchronizedParameters;
+use crate::config::SynchronizedParameters;
+use crate::{AdapterError, Client, SessionClient};
 
 /// A backend client for pushing and pulling [SynchronizedParameters].
 ///
@@ -37,13 +36,19 @@ impl SystemParameterBackend {
     /// modified status.
     pub async fn push(&mut self, params: &mut SynchronizedParameters) {
         for param in params.modified() {
-            let alter_system = param.as_stmt();
-            match self.execute_alter_system(alter_system).await {
+            let mut vars = BTreeMap::new();
+            vars.insert(param.name.clone(), param.value.clone());
+            match self.session_client.set_system_vars(vars).await {
                 Ok(()) => {
-                    tracing::debug!(name = param.name, value = param.value, "sync parameter");
+                    debug!(name = param.name, value = param.value, "sync parameter");
                 }
                 Err(error) => {
-                    tracing::error!("cannot execute `ALTER SYSTEM` query: {}", error);
+                    error!(
+                        name = param.name,
+                        value = param.value,
+                        "cannot update system variable: {}",
+                        error
+                    );
                 }
             }
         }
@@ -52,112 +57,17 @@ impl SystemParameterBackend {
     /// Pull the current values for all [SynchronizedParameters] from the
     /// [SystemParameterBackend].
     pub async fn pull(&mut self, params: &mut SynchronizedParameters) {
-        let show_all = Statement::Show(ShowStatement::ShowVariable(ShowVariableStatement {
-            variable: Ident::from("ALL"),
-        }));
-        match self.execute_query(show_all).await {
-            Ok(rows) => {
-                let mut datum_vec = mz_repr::DatumVec::new();
-                for row in rows {
-                    let datums = datum_vec.borrow_with(&row);
-                    let name = datums[NAME_COLUMN].unwrap_str();
-                    let value = datums[VALUE_COLUMN].unwrap_str();
-                    if params.is_synchronized(name) {
-                        params.modify(name, value);
+        match self.session_client.get_system_vars().await {
+            Ok(vars) => {
+                for (name, value) in vars {
+                    if params.is_synchronized(&name) {
+                        params.modify(&name, &value);
                     }
                 }
             }
             Err(error) => {
-                tracing::error!("cannot execute `SHOW ALL` query: {}", error)
+                error!("cannot execute `SHOW ALL` query: {}", error)
             }
         }
     }
-
-    /// Execute a single `ALTER SYSTEM` statement.
-    async fn execute_alter_system(&mut self, stmt: Statement<Raw>) -> Result<(), AdapterError> {
-        self.session_client.start_transaction(Some(1)).await?;
-
-        self.prepare(stmt).await?;
-        let result = match self.session_client.execute(EMPTY_PORTAL.into()).await? {
-            ExecuteResponse::AlteredSystemConfiguration => Ok(()),
-            _ => Err(AdapterError::Internal(UNEXPECTED_RESPONSE.to_string())),
-        };
-
-        if result.is_ok() {
-            self.session_client
-                .end_transaction(EndTransactionAction::Commit)
-                .await?;
-        } else {
-            self.session_client.fail_transaction();
-        }
-
-        result
-    }
-
-    /// Execute a single query and returns the results.
-    async fn execute_query(&mut self, stmt: Statement<Raw>) -> Result<Vec<Row>, AdapterError> {
-        self.session_client.start_transaction(Some(1)).await?;
-
-        self.prepare(stmt).await?;
-        let result = match self.session_client.execute(EMPTY_PORTAL.into()).await? {
-            ExecuteResponse::SendingRows { future: rows, .. } => match rows.await {
-                PeekResponseUnary::Rows(rows) => Ok(rows),
-                PeekResponseUnary::Error(e) => Err(AdapterError::Internal(e)),
-                PeekResponseUnary::Canceled => {
-                    Err(AdapterError::Internal(UNEXPECTED_RESPONSE.to_string()))
-                }
-            },
-            _ => Err(AdapterError::Internal(UNEXPECTED_RESPONSE.to_string())),
-        };
-
-        if result.is_ok() {
-            self.session_client
-                .end_transaction(EndTransactionAction::Commit)
-                .await?;
-        } else {
-            self.session_client.fail_transaction();
-        }
-
-        result
-    }
-
-    /// Prepare a statement for execution. After calling this, you can call
-    /// [SessionClient::execute] in order to execute the passed [Statement].
-    async fn prepare(&mut self, stmt: Statement<Raw>) -> Result<(), AdapterError> {
-        self.session_client
-            .describe(EMPTY_PORTAL.into(), Some(stmt.clone()), vec![])
-            .await?;
-
-        let prep_stmt = self
-            .session_client
-            .get_prepared_statement(EMPTY_PORTAL)
-            .await?;
-        let params = vec![];
-        let result_formats = vec![
-            mz_pgrepr::Format::Text;
-            prep_stmt
-                .desc()
-                .relation_desc
-                .clone()
-                .map(|desc| desc.typ().column_types.len())
-                .unwrap_or(0)
-        ];
-        let desc = prep_stmt.desc().clone();
-        let revision = prep_stmt.catalog_revision;
-        let stmt = prep_stmt.sql().cloned();
-
-        self.session_client.session().set_portal(
-            EMPTY_PORTAL.into(),
-            desc,
-            stmt,
-            params,
-            result_formats,
-            revision,
-        )
-    }
 }
-
-const NAME_COLUMN: usize = 0;
-const VALUE_COLUMN: usize = 1;
-const EMPTY_PORTAL: &str = "";
-const UNEXPECTED_RESPONSE: &str = "unexpected response to SessionClient::execute request";

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -10,8 +10,8 @@
 use std::collections::BTreeSet;
 
 use mz_sql::ast::{
-    AlterSystemResetStatement, AlterSystemSetStatement, Ident, Raw, SetVariableValue, Statement,
-    Value,
+    AlterSystemResetStatement, AlterSystemSetStatement, Ident, Raw, SetVariableTo,
+    SetVariableValue, Statement, Value,
 };
 
 use crate::session::vars::SystemVars;
@@ -158,7 +158,9 @@ impl ModifiedParameter {
             }),
             false => Statement::AlterSystemSet(AlterSystemSetStatement {
                 name: Ident::from(self.name.clone()),
-                value: SetVariableValue::Literal(Value::String(self.value.clone())),
+                to: SetVariableTo::Values(vec![SetVariableValue::Literal(Value::String(
+                    self.value.clone(),
+                ))]),
             }),
         }
     }

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -9,11 +9,6 @@
 
 use std::collections::BTreeSet;
 
-use mz_sql::ast::{
-    AlterSystemResetStatement, AlterSystemSetStatement, Ident, Raw, SetVariableTo,
-    SetVariableValue, Statement, Value,
-};
-
 use crate::session::vars::{SystemVars, VarInput};
 
 /// A struct that defines the system parameters that should be synchronized
@@ -142,27 +137,4 @@ pub struct ModifiedParameter {
     pub name: String,
     pub value: String,
     pub is_default: bool,
-}
-
-impl ModifiedParameter {
-    pub fn as_alter_system(&self) -> String {
-        match self.is_default {
-            true => format!("ALTER SYSTEM RESET {}", self.name),
-            false => format!("ALTER SYSTEM SET {} = {}", self.name, self.value),
-        }
-    }
-
-    pub fn as_stmt(&self) -> Statement<Raw> {
-        match self.is_default {
-            true => Statement::AlterSystemReset(AlterSystemResetStatement {
-                name: Ident::from(self.name.clone()),
-            }),
-            false => Statement::AlterSystemSet(AlterSystemSetStatement {
-                name: Ident::from(self.name.clone()),
-                to: SetVariableTo::Values(vec![SetVariableValue::Literal(Value::String(
-                    self.value.clone(),
-                ))]),
-            }),
-        }
-    }
 }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -96,7 +96,7 @@ use crate::session::{
 };
 use crate::subscribe::ActiveSubscribe;
 use crate::util::{send_immediate_rows, ClientTransmitter, ComputeSinkId, ResultExt};
-use crate::{guard_write_critical_section, session, PeekResponseUnary};
+use crate::{guard_write_critical_section, PeekResponseUnary};
 
 use super::timestamp_selection::{TimestampExplanation, TimestampSource};
 use super::ReplicaMetadata;
@@ -906,7 +906,7 @@ impl Coordinator {
             let config = ReplicaConfig {
                 location: self.catalog.concretize_replica_location(
                     location,
-                    self.catalog.system_config().allowed_cluster_replica_sizes(),
+                    &self.catalog.system_config().allowed_cluster_replica_sizes(),
                 )?,
                 compute: ComputeReplicaConfig {
                     logging,
@@ -1056,7 +1056,7 @@ impl Coordinator {
         let config = ReplicaConfig {
             location: self.catalog.concretize_replica_location(
                 location,
-                self.catalog.system_config().allowed_cluster_replica_sizes(),
+                &self.catalog.system_config().allowed_cluster_replica_sizes(),
             )?,
             compute: ComputeReplicaConfig {
                 logging,
@@ -3813,13 +3813,6 @@ impl Coordinator {
         AlterSystemSetPlan { name, value }: AlterSystemSetPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session)?;
-        let var = self.catalog.state().get_system_configuration(&name)?;
-        if !var.safe() {
-            self.catalog.require_unsafe_mode(var.name())?;
-        }
-        let update_compute_config = session::vars::is_compute_config_var(&name);
-        let update_storage_config = session::vars::is_storage_config_var(&name);
-        let update_metrics_retention = name == session::vars::METRICS_RETENTION.name();
         let op = match value {
             VariableValue::Values(values) => catalog::Op::UpdateSystemConfiguration {
                 name,
@@ -3828,15 +3821,6 @@ impl Coordinator {
             VariableValue::Default => catalog::Op::ResetSystemConfiguration { name },
         };
         self.catalog_transact(Some(session), vec![op]).await?;
-        if update_compute_config {
-            self.update_compute_config();
-        }
-        if update_storage_config {
-            self.update_storage_config();
-        }
-        if update_metrics_retention {
-            self.update_metrics_retention();
-        }
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
@@ -3846,24 +3830,8 @@ impl Coordinator {
         AlterSystemResetPlan { name }: AlterSystemResetPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session)?;
-        let var = self.catalog.state().get_system_configuration(&name)?;
-        if !var.safe() {
-            self.catalog.require_unsafe_mode(var.name())?;
-        }
-        let update_compute_config = session::vars::is_compute_config_var(&name);
-        let update_storage_config = session::vars::is_storage_config_var(&name);
-        let update_metrics_retention = name == session::vars::METRICS_RETENTION.name();
         let op = catalog::Op::ResetSystemConfiguration { name };
         self.catalog_transact(Some(session), vec![op]).await?;
-        if update_compute_config {
-            self.update_compute_config();
-        }
-        if update_storage_config {
-            self.update_storage_config();
-        }
-        if update_metrics_retention {
-            self.update_metrics_retention();
-        }
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
@@ -3873,11 +3841,8 @@ impl Coordinator {
         _: AlterSystemResetAllPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session)?;
-        let op = catalog::Op::ResetAllSystemConfiguration {};
+        let op = catalog::Op::ResetAllSystemConfiguration;
         self.catalog_transact(Some(session), vec![op]).await?;
-        self.update_compute_config();
-        self.update_storage_config();
-        self.update_metrics_retention();
         Ok(ExecuteResponse::AlteredSystemConfiguration)
     }
 
@@ -3890,33 +3855,6 @@ impl Coordinator {
                 SYSTEM_USER.name,
             )))
         }
-    }
-
-    fn update_compute_config(&mut self) {
-        let config_params = self.catalog.compute_config();
-        self.controller.compute.update_configuration(config_params);
-    }
-
-    fn update_storage_config(&mut self) {
-        let config_params = self.catalog.storage_config();
-        self.controller.storage.update_configuration(config_params);
-    }
-
-    fn update_metrics_retention(&mut self) {
-        let duration = self.catalog.system_config().metrics_retention();
-        let policy = ReadPolicy::lag_writes_by(Timestamp::new(
-            u64::try_from(duration.as_millis()).unwrap_or_else(|_e| {
-                tracing::error!("Absurd metrics retention duration: {duration:?}.");
-                u64::MAX
-            }),
-        ));
-        let policies = self
-            .catalog
-            .entries()
-            .filter(|entry| entry.item().is_retained_metrics_relation())
-            .map(|entry| (entry.id(), policy.clone()))
-            .collect::<Vec<_>>();
-        self.update_storage_base_read_policies(policies)
     }
 
     // Returns the name of the portal to execute.
@@ -4099,7 +4037,7 @@ impl Coordinator {
         };
         let location = self.catalog.concretize_replica_location(
             location,
-            self.catalog.system_config().allowed_cluster_replica_sizes(),
+            &self.catalog.system_config().allowed_cluster_replica_sizes(),
         )?;
         let logging = {
             ReplicaLogging {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -47,7 +47,7 @@ pub enum AdapterError {
     /// The specified session parameter is constrained to a finite set of values.
     ConstrainedParameter {
         parameter: &'static (dyn Var + Send + Sync),
-        value: String,
+        values: Vec<String>,
         valid_values: Option<Vec<&'static str>>,
     },
     /// The cursor already exists.
@@ -57,6 +57,9 @@ pub enum AdapterError {
     /// An error occurred while planning the statement.
     Explain(ExplainError),
     /// The specified parameter is fixed to a single specific value.
+    ///
+    /// We allow setting the parameter to its fixed value for compatibility
+    /// with PostgreSQL-based tools.
     FixedValueParameter(&'static (dyn Var + Send + Sync)),
     /// The ID allocator exhausted all valid IDs.
     IdExhaustionError,
@@ -77,7 +80,7 @@ pub enum AdapterError {
     /// The value of the specified parameter is incorrect
     InvalidParameterValue {
         parameter: &'static (dyn Var + Send + Sync),
-        value: String,
+        values: Vec<String>,
         reason: String,
     },
     /// No such cluster replica size has been configured.
@@ -358,12 +361,16 @@ impl fmt::Display for AdapterError {
             AdapterError::ChangedPlan => f.write_str("cached plan must not change result type"),
             AdapterError::Catalog(e) => e.fmt(f),
             AdapterError::ConstrainedParameter {
-                parameter, value, ..
+                parameter, values, ..
             } => write!(
                 f,
                 "invalid value for parameter {}: {}",
                 parameter.name().quoted(),
-                value.quoted()
+                values
+                    .iter()
+                    .map(|v| v.quoted().to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
             ),
             AdapterError::DuplicateCursor(name) => {
                 write!(f, "cursor {} already exists", name.quoted())
@@ -396,13 +403,17 @@ impl fmt::Display for AdapterError {
             ),
             AdapterError::InvalidParameterValue {
                 parameter,
-                value,
+                values,
                 reason,
             } => write!(
                 f,
                 "parameter {} cannot have value {}: {}",
                 parameter.name().quoted(),
-                value.quoted(),
+                values
+                    .iter()
+                    .map(|v| v.quoted().to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
                 reason,
             ),
             AdapterError::InvalidClusterReplicaAz { az, expected: _ } => {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -39,7 +39,7 @@ use crate::session::vars::IsolationLevel;
 use crate::AdapterNotice;
 
 pub use self::vars::{
-    ClientSeverity, SessionVars, Var, DEFAULT_DATABASE_NAME, SERVER_MAJOR_VERSION,
+    ClientSeverity, SessionVars, Var, VarInput, DEFAULT_DATABASE_NAME, SERVER_MAJOR_VERSION,
     SERVER_MINOR_VERSION, SERVER_PATCH_VERSION,
 };
 
@@ -214,7 +214,7 @@ impl<T: TimestampManipulation> Session<T> {
 
         if let Some(isolation_level) = isolation_level {
             self.vars
-                .set("transaction_isolation", &[IsolationLevel::from(isolation_level).as_str().into()], true)
+                .set("transaction_isolation", VarInput::Flat(IsolationLevel::from(isolation_level).as_str()), true)
                 .expect("transaction_isolation should be a valid var and isolation level is a valid value");
         }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -214,7 +214,7 @@ impl<T: TimestampManipulation> Session<T> {
 
         if let Some(isolation_level) = isolation_level {
             self.vars
-                .set("transaction_isolation", IsolationLevel::from(isolation_level).as_str(), true)
+                .set("transaction_isolation", &[IsolationLevel::from(isolation_level).as_str().into()], true)
                 .expect("transaction_isolation should be a valid var and isolation level is a valid value");
         }
 

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -351,8 +351,8 @@ pub const METRICS_RETENTION: ServerVar<Duration> = ServerVar {
     safe: true,
 };
 
-static DEFAULT_ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<Vec<String>> = Lazy::new(Vec::new);
-static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<String>>> = Lazy::new(|| ServerVar {
+static DEFAULT_ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<Vec<Ident>> = Lazy::new(Vec::new);
+static ALLOWED_CLUSTER_REPLICA_SIZES: Lazy<ServerVar<Vec<Ident>>> = Lazy::new(|| ServerVar {
     name: UncasedStr::new("allowed_cluster_replica_sizes"),
     value: &DEFAULT_ALLOWED_CLUSTER_REPLICA_SIZES,
     description: "The allowed sizes when creating a new cluster replica (Materialize).",
@@ -1082,7 +1082,7 @@ pub struct SystemVars {
     max_secrets: SystemVar<u32>,
     max_roles: SystemVar<u32>,
     max_result_size: SystemVar<u32>,
-    allowed_cluster_replica_sizes: SystemVar<Vec<String>>,
+    allowed_cluster_replica_sizes: SystemVar<Vec<Ident>>,
 
     // features
     // (empty)
@@ -1475,8 +1475,12 @@ impl SystemVars {
     }
 
     /// Returns the value of the `allowed_cluster_replica_sizes` configuration parameter.
-    pub fn allowed_cluster_replica_sizes(&self) -> &Vec<String> {
-        self.allowed_cluster_replica_sizes.value()
+    pub fn allowed_cluster_replica_sizes(&self) -> Vec<String> {
+        self.allowed_cluster_replica_sizes
+            .value()
+            .into_iter()
+            .map(|s| s.as_str().into())
+            .collect()
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -1182,57 +1182,56 @@ impl SystemVars {
         }
     }
 
-    /// Check if the given `value` is the default value for the [`Var`]
+    /// Check if the given `values` is the default value for the [`Var`]
     /// identified by `name`.
     ///
     /// # Errors
     ///
     /// The call will return an error:
     /// 1. If `name` does not refer to a valid [`SystemVars`] field.
-    /// 2. If `value` does not represent a valid [`SystemVars`] value for
+    /// 2. If `values` does not represent a valid [`SystemVars`] value for
     ///    `name`.
-    pub fn is_default(&self, name: &str, value: &str) -> Result<bool, AdapterError> {
-        let values = parse_set_variable_value(value)?;
+    pub fn is_default(&self, name: &str, values: &[String]) -> Result<bool, AdapterError> {
         if name == CONFIG_HAS_SYNCED_ONCE.name {
-            self.config_has_synced_once.is_default(&values)
+            self.config_has_synced_once.is_default(values)
         } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
-            self.max_aws_privatelink_connections.is_default(&values)
+            self.max_aws_privatelink_connections.is_default(values)
         } else if name == MAX_TABLES.name {
-            self.max_tables.is_default(&values)
+            self.max_tables.is_default(values)
         } else if name == MAX_SOURCES.name {
-            self.max_sources.is_default(&values)
+            self.max_sources.is_default(values)
         } else if name == MAX_SINKS.name {
-            self.max_sinks.is_default(&values)
+            self.max_sinks.is_default(values)
         } else if name == MAX_MATERIALIZED_VIEWS.name {
-            self.max_materialized_views.is_default(&values)
+            self.max_materialized_views.is_default(values)
         } else if name == MAX_CLUSTERS.name {
-            self.max_clusters.is_default(&values)
+            self.max_clusters.is_default(values)
         } else if name == MAX_REPLICAS_PER_CLUSTER.name {
-            self.max_replicas_per_cluster.is_default(&values)
+            self.max_replicas_per_cluster.is_default(values)
         } else if name == MAX_DATABASES.name {
-            self.max_databases.is_default(&values)
+            self.max_databases.is_default(values)
         } else if name == MAX_SCHEMAS_PER_DATABASE.name {
-            self.max_schemas_per_database.is_default(&values)
+            self.max_schemas_per_database.is_default(values)
         } else if name == MAX_OBJECTS_PER_SCHEMA.name {
-            self.max_objects_per_schema.is_default(&values)
+            self.max_objects_per_schema.is_default(values)
         } else if name == MAX_SECRETS.name {
-            self.max_secrets.is_default(&values)
+            self.max_secrets.is_default(values)
         } else if name == MAX_ROLES.name {
-            self.max_roles.is_default(&values)
+            self.max_roles.is_default(values)
         } else if name == MAX_RESULT_SIZE.name {
-            self.max_result_size.is_default(&values)
+            self.max_result_size.is_default(values)
         } else if name == ALLOWED_CLUSTER_REPLICA_SIZES.name {
-            self.allowed_cluster_replica_sizes.is_default(&values)
+            self.allowed_cluster_replica_sizes.is_default(values)
         } else if name == PERSIST_BLOB_TARGET_SIZE.name {
-            self.persist_blob_target_size.is_default(&values)
+            self.persist_blob_target_size.is_default(values)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
-            self.persist_compaction_minimum_timeout.is_default(&values)
+            self.persist_compaction_minimum_timeout.is_default(values)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
-            self.dataflow_max_inflight_bytes.is_default(&values)
+            self.dataflow_max_inflight_bytes.is_default(values)
         } else if name == METRICS_RETENTION.name {
-            self.metrics_retention.is_default(&values)
+            self.metrics_retention.is_default(values)
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
-            self.mock_audit_event_timestamp.is_default(&values)
+            self.mock_audit_event_timestamp.is_default(values)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -1191,46 +1191,47 @@ impl SystemVars {
     /// 2. If `value` does not represent a valid [`SystemVars`] value for
     ///    `name`.
     pub fn is_default(&self, name: &str, value: &str) -> Result<bool, AdapterError> {
+        let values = mz_sql::plan::parse_set_variable_value(value)?;
         if name == CONFIG_HAS_SYNCED_ONCE.name {
-            self.config_has_synced_once.is_default(value)
+            self.config_has_synced_once.is_default(&values)
         } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
-            self.max_aws_privatelink_connections.is_default(value)
+            self.max_aws_privatelink_connections.is_default(&values)
         } else if name == MAX_TABLES.name {
-            self.max_tables.is_default(value)
+            self.max_tables.is_default(&values)
         } else if name == MAX_SOURCES.name {
-            self.max_sources.is_default(value)
+            self.max_sources.is_default(&values)
         } else if name == MAX_SINKS.name {
-            self.max_sinks.is_default(value)
+            self.max_sinks.is_default(&values)
         } else if name == MAX_MATERIALIZED_VIEWS.name {
-            self.max_materialized_views.is_default(value)
+            self.max_materialized_views.is_default(&values)
         } else if name == MAX_CLUSTERS.name {
-            self.max_clusters.is_default(value)
+            self.max_clusters.is_default(&values)
         } else if name == MAX_REPLICAS_PER_CLUSTER.name {
-            self.max_replicas_per_cluster.is_default(value)
+            self.max_replicas_per_cluster.is_default(&values)
         } else if name == MAX_DATABASES.name {
-            self.max_databases.is_default(value)
+            self.max_databases.is_default(&values)
         } else if name == MAX_SCHEMAS_PER_DATABASE.name {
-            self.max_schemas_per_database.is_default(value)
+            self.max_schemas_per_database.is_default(&values)
         } else if name == MAX_OBJECTS_PER_SCHEMA.name {
-            self.max_objects_per_schema.is_default(value)
+            self.max_objects_per_schema.is_default(&values)
         } else if name == MAX_SECRETS.name {
-            self.max_secrets.is_default(value)
+            self.max_secrets.is_default(&values)
         } else if name == MAX_ROLES.name {
-            self.max_roles.is_default(value)
+            self.max_roles.is_default(&values)
         } else if name == MAX_RESULT_SIZE.name {
-            self.max_result_size.is_default(value)
+            self.max_result_size.is_default(&values)
         } else if name == ALLOWED_CLUSTER_REPLICA_SIZES.name {
-            self.allowed_cluster_replica_sizes.is_default(value)
+            self.allowed_cluster_replica_sizes.is_default(&values)
         } else if name == PERSIST_BLOB_TARGET_SIZE.name {
-            self.persist_blob_target_size.is_default(value)
+            self.persist_blob_target_size.is_default(&values)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
-            self.persist_compaction_minimum_timeout.is_default(value)
+            self.persist_compaction_minimum_timeout.is_default(&values)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
-            self.dataflow_max_inflight_bytes.is_default(value)
+            self.dataflow_max_inflight_bytes.is_default(&values)
         } else if name == METRICS_RETENTION.name {
-            self.metrics_retention.is_default(value)
+            self.metrics_retention.is_default(&values)
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
-            self.mock_audit_event_timestamp.is_default(value)
+            self.mock_audit_event_timestamp.is_default(&values)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1254,47 +1255,47 @@ impl SystemVars {
     /// 1. If `name` does not refer to a valid [`SystemVars`] field.
     /// 2. If `value` does not represent a valid [`SystemVars`] value for
     ///    `name`.
-    pub fn set(&mut self, name: &str, value: &str) -> Result<bool, AdapterError> {
+    pub fn set(&mut self, name: &str, values: &[String]) -> Result<bool, AdapterError> {
         if name == CONFIG_HAS_SYNCED_ONCE.name {
-            self.config_has_synced_once.set(value)
+            self.config_has_synced_once.set(values)
         } else if name == MAX_AWS_PRIVATELINK_CONNECTIONS.name {
-            self.max_aws_privatelink_connections.set(value)
+            self.max_aws_privatelink_connections.set(values)
         } else if name == MAX_TABLES.name {
-            self.max_tables.set(value)
+            self.max_tables.set(values)
         } else if name == MAX_SOURCES.name {
-            self.max_sources.set(value)
+            self.max_sources.set(values)
         } else if name == MAX_SINKS.name {
-            self.max_sinks.set(value)
+            self.max_sinks.set(values)
         } else if name == MAX_MATERIALIZED_VIEWS.name {
-            self.max_materialized_views.set(value)
+            self.max_materialized_views.set(values)
         } else if name == MAX_CLUSTERS.name {
-            self.max_clusters.set(value)
+            self.max_clusters.set(values)
         } else if name == MAX_REPLICAS_PER_CLUSTER.name {
-            self.max_replicas_per_cluster.set(value)
+            self.max_replicas_per_cluster.set(values)
         } else if name == MAX_DATABASES.name {
-            self.max_databases.set(value)
+            self.max_databases.set(values)
         } else if name == MAX_SCHEMAS_PER_DATABASE.name {
-            self.max_schemas_per_database.set(value)
+            self.max_schemas_per_database.set(values)
         } else if name == MAX_OBJECTS_PER_SCHEMA.name {
-            self.max_objects_per_schema.set(value)
+            self.max_objects_per_schema.set(values)
         } else if name == MAX_SECRETS.name {
-            self.max_secrets.set(value)
+            self.max_secrets.set(values)
         } else if name == MAX_ROLES.name {
-            self.max_roles.set(value)
+            self.max_roles.set(values)
         } else if name == MAX_RESULT_SIZE.name {
-            self.max_result_size.set(value)
+            self.max_result_size.set(values)
         } else if name == ALLOWED_CLUSTER_REPLICA_SIZES.name {
-            self.allowed_cluster_replica_sizes.set(value)
+            self.allowed_cluster_replica_sizes.set(values)
         } else if name == PERSIST_BLOB_TARGET_SIZE.name {
-            self.persist_blob_target_size.set(value)
+            self.persist_blob_target_size.set(values)
         } else if name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name {
-            self.persist_compaction_minimum_timeout.set(value)
+            self.persist_compaction_minimum_timeout.set(values)
         } else if name == DATAFLOW_MAX_INFLIGHT_BYTES.name {
-            self.dataflow_max_inflight_bytes.set(value)
+            self.dataflow_max_inflight_bytes.set(values)
         } else if name == METRICS_RETENTION.name {
-            self.metrics_retention.set(value)
+            self.metrics_retention.set(values)
         } else if name == MOCK_AUDIT_EVENT_TIMESTAMP.name {
-            self.mock_audit_event_timestamp.set(value)
+            self.mock_audit_event_timestamp.set(values)
         } else {
             Err(AdapterError::UnknownParameter(name.into()))
         }
@@ -1562,8 +1563,8 @@ where
         }
     }
 
-    fn set(&mut self, s: &str) -> Result<bool, AdapterError> {
-        match V::parse(&[s.into()]) {
+    fn set(&mut self, values: &[String]) -> Result<bool, AdapterError> {
+        match V::parse(values) {
             Ok(v) => {
                 if self.persisted_value.as_ref() != Some(&v) {
                     self.persisted_value = Some(v);
@@ -1592,8 +1593,8 @@ where
             .unwrap_or(self.parent.value)
     }
 
-    fn is_default(&self, s: &str) -> Result<bool, AdapterError> {
-        match V::parse(&[s.into()]) {
+    fn is_default(&self, values: &[String]) -> Result<bool, AdapterError> {
+        match V::parse(values) {
             Ok(v) => Ok(self.parent.value == v.borrow()),
             Err(()) => Err(AdapterError::InvalidParameterType(self.parent)),
         }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -27,7 +27,7 @@ use mz_adapter::catalog::INTERNAL_USER_NAMES;
 use mz_adapter::session::User;
 use mz_adapter::session::{
     EndTransactionAction, ExternalUserMetadata, InProgressRows, Portal, PortalState,
-    RowBatchStream, TransactionStatus,
+    RowBatchStream, TransactionStatus, VarInput,
 };
 use mz_adapter::{AdapterNotice, ExecuteResponse, PeekResponseUnary, RowsFuture};
 use mz_frontegg_auth::FronteggAuthentication;
@@ -206,7 +206,7 @@ where
     });
     for (name, value) in params {
         let local = false;
-        let _ = session.vars_mut().set(&name, &[value], local);
+        let _ = session.vars_mut().set(&name, VarInput::Flat(&value), local);
     }
 
     let mut buf = vec![BackendMessage::AuthenticationOk];

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -206,7 +206,7 @@ where
     });
     for (name, value) in params {
         let local = false;
-        let _ = session.vars_mut().set(&name, &value, local);
+        let _ = session.vars_mut().set(&name, &[value], local);
     }
 
     let mut buf = vec![BackendMessage::AuthenticationOk];

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1754,7 +1754,7 @@ impl_display!(DropClusterReplicasStatement);
 pub struct SetVariableStatement {
     pub local: bool,
     pub variable: Ident,
-    pub value: SetVariableValue,
+    pub to: SetVariableTo,
 }
 
 impl AstDisplay for SetVariableStatement {
@@ -1765,7 +1765,7 @@ impl AstDisplay for SetVariableStatement {
         }
         f.write_node(&self.variable);
         f.write_str(" = ");
-        f.write_node(&self.value);
+        f.write_node(&self.to);
     }
 }
 impl_display!(SetVariableStatement);
@@ -2407,12 +2407,26 @@ impl AstDisplay for TransactionIsolationLevel {
 impl_display!(TransactionIsolationLevel);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SetVariableTo {
+    Default,
+    Values(Vec<SetVariableValue>),
+}
+
+impl AstDisplay for SetVariableTo {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        use SetVariableTo::*;
+        match self {
+            Values(values) => f.write_node(&display::comma_separated(values)),
+            Default => f.write_str("DEFAULT"),
+        }
+    }
+}
+impl_display!(SetVariableTo);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SetVariableValue {
     Ident(Ident),
-    Idents(Vec<Ident>),
     Literal(Value),
-    Literals(Vec<Value>),
-    Default,
 }
 
 impl AstDisplay for SetVariableValue {
@@ -2420,10 +2434,7 @@ impl AstDisplay for SetVariableValue {
         use SetVariableValue::*;
         match self {
             Ident(ident) => f.write_node(ident),
-            Idents(idents) => f.write_node(&display::separated(idents, ", ")),
             Literal(literal) => f.write_node(literal),
-            Literals(literals) => f.write_node(&display::separated(literals, ", ")),
-            Default => f.write_str("DEFAULT"),
         }
     }
 }
@@ -2741,7 +2752,7 @@ impl_display!(NoticeSeverity);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterSystemSetStatement {
     pub name: Ident,
-    pub value: SetVariableValue,
+    pub to: SetVariableTo,
 }
 
 impl AstDisplay for AlterSystemSetStatement {
@@ -2749,7 +2760,7 @@ impl AstDisplay for AlterSystemSetStatement {
         f.write_str("ALTER SYSTEM SET ");
         f.write_node(&self.name);
         f.write_str(" = ");
-        f.write_node(&self.value);
+        f.write_node(&self.to);
     }
 }
 impl_display!(AlterSystemSetStatement);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2440,6 +2440,19 @@ impl AstDisplay for SetVariableValue {
 }
 impl_display!(SetVariableValue);
 
+impl SetVariableValue {
+    /// Returns the underlying value without quotes.
+    pub fn into_unquoted_value(self) -> String {
+        match self {
+            // `lit.to_string` will quote a `Value::String`, so get the unquoted
+            // version.
+            SetVariableValue::Literal(Value::String(s)) => s,
+            SetVariableValue::Literal(lit) => lit.to_string(),
+            SetVariableValue::Ident(ident) => ident.into_string(),
+        }
+    }
+}
+
 /// SQL assignment `foo = expr` as used in SQLUpdate
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Assignment<T: AstInfo> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -114,20 +114,18 @@ pub fn parse_data_type(sql: &str) -> Result<RawDataType, ParserError> {
     }
 }
 
-/// Parses a SQL string containing a `SET` variable value.
-pub fn parse_set_variable_to(sql: &str) -> Result<SetVariableTo, ParserError> {
-    let tokens = lexer::lex(sql)?;
-    let mut parser = Parser::new(sql, tokens);
-    let to = parser.parse_set_variable_to()?;
-    if parser.next_token().is_some() {
-        parser_err!(
-            parser,
-            parser.peek_prev_pos(),
-            "extra token after SET variable value"
-        )
-    } else {
-        Ok(to)
-    }
+/// Parses a string containing a comma-separated list of identifiers and
+/// returns their underlying string values.
+///
+/// This is analogous to the `SplitIdentifierString` function in PostgreSQL.
+pub fn split_identifier_string(s: &str) -> Result<Vec<String>, ParserError> {
+    let tokens = lexer::lex(s)?;
+    let mut parser = Parser::new(s, tokens);
+    let values = parser.parse_comma_separated(Parser::parse_set_variable_value)?;
+    Ok(values
+        .into_iter()
+        .map(|v| v.into_unquoted_value())
+        .collect())
 }
 
 macro_rules! maybe {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -114,6 +114,22 @@ pub fn parse_data_type(sql: &str) -> Result<RawDataType, ParserError> {
     }
 }
 
+/// Parses a SQL string containing a `SET` variable value.
+pub fn parse_set_variable_to(sql: &str) -> Result<SetVariableTo, ParserError> {
+    let tokens = lexer::lex(sql)?;
+    let mut parser = Parser::new(sql, tokens);
+    let to = parser.parse_set_variable_to()?;
+    if parser.next_token().is_some() {
+        parser_err!(
+            parser,
+            parser.peek_prev_pos(),
+            "extra token after SET variable value"
+        )
+    } else {
+        Ok(to)
+    }
+}
+
 macro_rules! maybe {
     ($e:expr) => {{
         if let Some(v) = $e {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1462,70 +1462,70 @@ ALTER SYSTEM SET wal_level TO logical
 ----
 ALTER SYSTEM SET wal_level = logical
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("wal_level"), value: Ident(Ident("logical")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("wal_level"), to: Values([Ident(Ident("logical"))]) })
 
 parse-statement
 ALTER SYSTEM SET wal_level = logical
 ----
 ALTER SYSTEM SET wal_level = logical
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("wal_level"), value: Ident(Ident("logical")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("wal_level"), to: Values([Ident(Ident("logical"))]) })
 
 parse-statement
 ALTER SYSTEM SET log_destination TO 'syslog'
 ----
 ALTER SYSTEM SET log_destination = 'syslog'
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("log_destination"), value: Literal(String("syslog")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("log_destination"), to: Values([Literal(String("syslog"))]) })
 
 parse-statement
 ALTER SYSTEM SET log_destination = 'syslog'
 ----
 ALTER SYSTEM SET log_destination = 'syslog'
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("log_destination"), value: Literal(String("syslog")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("log_destination"), to: Values([Literal(String("syslog"))]) })
 
 parse-statement
 ALTER SYSTEM SET shared_buffers TO 42
 ----
 ALTER SYSTEM SET shared_buffers = 42
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("shared_buffers"), value: Literal(Number("42")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("shared_buffers"), to: Values([Literal(Number("42"))]) })
 
 parse-statement
 ALTER SYSTEM SET shared_buffers = 42
 ----
 ALTER SYSTEM SET shared_buffers = 42
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("shared_buffers"), value: Literal(Number("42")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("shared_buffers"), to: Values([Literal(Number("42"))]) })
 
 parse-statement
 ALTER SYSTEM SET search_path TO default
 ----
 ALTER SYSTEM SET search_path = DEFAULT
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("search_path"), value: Default })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("search_path"), to: Default })
 
 parse-statement
 ALTER SYSTEM SET search_path = default
 ----
 ALTER SYSTEM SET search_path = DEFAULT
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("search_path"), value: Default })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("search_path"), to: Default })
 
 parse-statement
 ALTER SYSTEM SET log_connections TO 'default'
 ----
 ALTER SYSTEM SET log_connections = 'default'
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("log_connections"), value: Literal(String("default")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("log_connections"), to: Values([Literal(String("default"))]) })
 
 parse-statement
 ALTER SYSTEM SET log_connections = 'default'
 ----
 ALTER SYSTEM SET log_connections = 'default'
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("log_connections"), value: Literal(String("default")) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("log_connections"), to: Values([Literal(String("default"))]) })
 
 parse-statement
 ALTER SYSTEM SET some_array_key = [667, 668]
@@ -1539,14 +1539,14 @@ ALTER SYSTEM SET quantum_enabled = true
 ----
 ALTER SYSTEM SET quantum_enabled = true
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("quantum_enabled"), value: Literal(Boolean(true)) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("quantum_enabled"), to: Values([Literal(Boolean(true))]) })
 
 parse-statement
 ALTER SYSTEM SET use_optional = NULL
 ----
 ALTER SYSTEM SET use_optional = NULL
 =>
-AlterSystemSet(AlterSystemSetStatement { name: Ident("use_optional"), value: Literal(Null) })
+AlterSystemSet(AlterSystemSetStatement { name: Ident("use_optional"), to: Values([Literal(Null)]) })
 
 parse-statement
 ALTER SYSTEM SET key value

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -347,77 +347,98 @@ SET a = b
 ----
 SET a = b
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("b")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Ident(Ident("b"))]) })
 
 parse-statement
 SET a = 'b'
 ----
 SET a = 'b'
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Literal(String("b")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Literal(String("b"))]) })
 
 parse-statement
 SET a = 0
 ----
 SET a = 0
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Literal(Number("0")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Literal(Number("0"))]) })
 
 parse-statement
 SET a = default
 ----
 SET a = DEFAULT
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Default })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Default })
 
 parse-statement
 SET a = 'default'
 ----
 SET a = 'default'
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Literal(String("default")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Literal(String("default"))]) })
 
 parse-statement
 SET LOCAL a = b
 ----
 SET LOCAL a = b
 =>
-SetVariable(SetVariableStatement { local: true, variable: Ident("a"), value: Ident(Ident("b")) })
+SetVariable(SetVariableStatement { local: true, variable: Ident("a"), to: Values([Ident(Ident("b"))]) })
 
 parse-statement
 SET TIME ZONE utc
 ----
 SET timezone = utc
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("timezone"), value: Ident(Ident("utc")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("timezone"), to: Values([Ident(Ident("utc"))]) })
 
 parse-statement
 SET a TO b
 ----
 SET a = b
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("b")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Ident(Ident("b"))]) })
 
 parse-statement
 SET SESSION a = b
 ----
 SET a = b
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("b")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Ident(Ident("b"))]) })
 
 parse-statement
 SET tiMe ZoNE 7
 ----
 SET timezone = 7
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("timezone"), value: Literal(Number("7")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("timezone"), to: Values([Literal(Number("7"))]) })
 
 parse-statement
 SET LOCAL tiMe ZoNE 7
 ----
 SET LOCAL timezone = 7
 =>
-SetVariable(SetVariableStatement { local: true, variable: Ident("timezone"), value: Literal(Number("7")) })
+SetVariable(SetVariableStatement { local: true, variable: Ident("timezone"), to: Values([Literal(Number("7"))]) })
+
+parse-statement
+SET a = b, c, d
+----
+SET a = b, c, d
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Ident(Ident("b")), Ident(Ident("c")), Ident(Ident("d"))]) })
+
+parse-statement
+SET a TO b, c, d
+----
+SET a = b, c, d
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Ident(Ident("b")), Ident(Ident("c")), Ident(Ident("d"))]) })
+
+parse-statement
+SET a = 1, '2', 3.0, four
+----
+SET a = 1, '2', 3.0, four
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), to: Values([Literal(Number("1")), Literal(String("2")), Literal(Number("3.0")), Ident(Ident("four"))]) })
 
 parse-statement
 SET

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -80,7 +80,7 @@ use mz_sql_parser::ast::TransactionIsolationLevel;
 pub use optimize::OptimizerConfig;
 pub use query::{QueryContext, QueryLifetime};
 pub use statement::{
-    describe, plan, plan_copy_from, scl::parse_set_variable_value, StatementContext, StatementDesc,
+    describe, plan, plan_copy_from, scl::plan_set_variable_to, StatementContext, StatementDesc,
 };
 
 /// Instructions for executing a SQL query.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -79,7 +79,9 @@ pub use explain::normalize_subqueries;
 use mz_sql_parser::ast::TransactionIsolationLevel;
 pub use optimize::OptimizerConfig;
 pub use query::{QueryContext, QueryLifetime};
-pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
+pub use statement::{
+    describe, plan, plan_copy_from, scl::parse_set_variable_value, StatementContext, StatementDesc,
+};
 
 /// Instructions for executing a SQL query.
 #[derive(Debug, EnumKind)]
@@ -581,7 +583,8 @@ pub struct AlterSecretPlan {
 #[derive(Debug)]
 pub struct AlterSystemSetPlan {
     pub name: String,
-    pub value: VariableValue,
+    // If Some, the flattened SET values. If None, reset to default.
+    pub value: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -79,9 +79,7 @@ pub use explain::normalize_subqueries;
 use mz_sql_parser::ast::TransactionIsolationLevel;
 pub use optimize::OptimizerConfig;
 pub use query::{QueryContext, QueryLifetime};
-pub use statement::{
-    describe, plan, plan_copy_from, scl::plan_set_variable_to, StatementContext, StatementDesc,
-};
+pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
 
 /// Instructions for executing a SQL query.
 #[derive(Debug, EnumKind)]
@@ -583,8 +581,7 @@ pub struct AlterSecretPlan {
 #[derive(Debug)]
 pub struct AlterSystemSetPlan {
     pub name: String,
-    // If Some, the flattened SET values. If None, reset to default.
-    pub value: Option<String>,
+    pub value: VariableValue,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -50,7 +50,7 @@ use mz_storage_client::types::sources::{SourceDesc, Timeline};
 
 use crate::ast::{
     ExplainStage, Expr, FetchDirection, IndexOptionName, NoticeSeverity, ObjectType, Raw,
-    SetVariableValue, Statement, StatementKind, TransactionAccessMode,
+    Statement, StatementKind, TransactionAccessMode,
 };
 use crate::catalog::{CatalogType, IdReference};
 use crate::names::{
@@ -436,8 +436,14 @@ pub struct ShowVariablePlan {
 #[derive(Debug)]
 pub struct SetVariablePlan {
     pub name: String,
-    pub value: SetVariableValue,
+    pub value: VariableValue,
     pub local: bool,
+}
+
+#[derive(Debug)]
+pub enum VariableValue {
+    Default,
+    Values(Vec<String>),
 }
 
 #[derive(Debug)]
@@ -575,7 +581,7 @@ pub struct AlterSecretPlan {
 #[derive(Debug)]
 pub struct AlterSystemSetPlan {
     pub name: String,
-    pub value: SetVariableValue,
+    pub value: VariableValue,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -38,7 +38,7 @@ use crate::plan::{Params, Plan, PlanContext, PlanKind};
 pub(crate) mod ddl;
 mod dml;
 mod raise;
-pub mod scl;
+mod scl;
 pub(crate) mod show;
 mod tcl;
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -38,7 +38,7 @@ use crate::plan::{Params, Plan, PlanContext, PlanKind};
 pub(crate) mod ddl;
 mod dml;
 mod raise;
-mod scl;
+pub mod scl;
 pub(crate) mod show;
 mod tcl;
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -38,7 +38,7 @@ use mz_sql_parser::ast::{
     AlterSinkAction, AlterSinkStatement, AlterSourceAction, AlterSourceStatement,
     AlterSystemResetAllStatement, AlterSystemResetStatement, AlterSystemSetStatement,
     CreateTypeListOption, CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName,
-    DeferredObjectName, SshConnectionOption, UnresolvedObjectName, Value,
+    DeferredObjectName, SetVariableTo, SshConnectionOption, UnresolvedObjectName, Value,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
 use mz_storage_client::types::connections::{
@@ -115,8 +115,6 @@ use crate::plan::{
     Plan, QueryContext, ReplicaConfig, RotateKeysPlan, Secret, Sink, Source,
     SourceSinkClusterConfig, Table, Type, View,
 };
-
-use super::scl;
 
 pub fn describe_create_database(
     _: &StatementContext,
@@ -3908,8 +3906,13 @@ pub fn plan_alter_system_set(
     AlterSystemSetStatement { name, to }: AlterSystemSetStatement,
 ) -> Result<Plan, PlanError> {
     let name = name.to_string();
-    let value = scl::plan_set_variable_to(to)?;
-    Ok(Plan::AlterSystemSet(AlterSystemSetPlan { name, value }))
+    Ok(Plan::AlterSystemSet(AlterSystemSetPlan {
+        name,
+        value: match to {
+            SetVariableTo::Default => None,
+            SetVariableTo::Values(_) => Some(to.to_ast_string_stable()),
+        },
+    }))
 }
 
 pub fn describe_alter_system_reset(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -38,7 +38,7 @@ use mz_sql_parser::ast::{
     AlterSinkAction, AlterSinkStatement, AlterSourceAction, AlterSourceStatement,
     AlterSystemResetAllStatement, AlterSystemResetStatement, AlterSystemSetStatement,
     CreateTypeListOption, CreateTypeListOptionName, CreateTypeMapOption, CreateTypeMapOptionName,
-    DeferredObjectName, SetVariableTo, SshConnectionOption, UnresolvedObjectName, Value,
+    DeferredObjectName, SshConnectionOption, UnresolvedObjectName, Value,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
 use mz_storage_client::types::connections::{
@@ -99,7 +99,7 @@ use crate::plan::error::PlanError;
 use crate::plan::expr::ColumnRef;
 use crate::plan::query::{ExprContext, QueryLifetime};
 use crate::plan::scope::Scope;
-use crate::plan::statement::{StatementContext, StatementDesc};
+use crate::plan::statement::{scl, StatementContext, StatementDesc};
 use crate::plan::typeconv::{plan_cast, CastContext};
 use crate::plan::with_options::{self, OptionalInterval, TryFromValue};
 use crate::plan::{
@@ -3908,10 +3908,7 @@ pub fn plan_alter_system_set(
     let name = name.to_string();
     Ok(Plan::AlterSystemSet(AlterSystemSetPlan {
         name,
-        value: match to {
-            SetVariableTo::Default => None,
-            SetVariableTo::Values(_) => Some(to.to_ast_string_stable()),
-        },
+        value: scl::plan_set_variable_to(to)?,
     }))
 }
 

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -13,6 +13,7 @@
 //! like `DISCARD` and `SET`.
 
 use mz_sql_parser::ast::{SetVariableTo, SetVariableValue, Value};
+use mz_sql_parser::parser::ParserError;
 use uncased::UncasedStr;
 
 use mz_repr::adt::interval::Interval;
@@ -54,6 +55,22 @@ pub fn plan_set_variable(
         value,
         local,
     }))
+}
+
+/// Split a single string into what would be parsed by `SET v TO <string>` into
+/// multpile values.
+pub fn parse_set_variable_value(value: &str) -> Result<Vec<String>, PlanError> {
+    let parsed = mz_sql_parser::parser::parse_set_variable_to(value)?;
+    match plan_set_variable_to(parsed)? {
+        // This is an awkward error, but makes the types work well for how this
+        // function is called (which is only by system var things).
+        VariableValue::Default => Err(ParserError {
+            message: "unexpected SET DEFAULT".into(),
+            pos: 0,
+        }
+        .into()),
+        VariableValue::Values(values) => Ok(values),
+    }
 }
 
 pub fn plan_set_variable_to(to: SetVariableTo) -> Result<VariableValue, PlanError> {

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -12,12 +12,11 @@
 //! This module houses the handlers for statements that manipulate the session,
 //! like `DISCARD` and `SET`.
 
-use mz_sql_parser::ast::{SetVariableTo, SetVariableValue, Value};
-use mz_sql_parser::parser::ParserError;
 use uncased::UncasedStr;
 
 use mz_repr::adt::interval::Interval;
 use mz_repr::{RelationDesc, ScalarType};
+use mz_sql_parser::ast::{SetVariableTo, SetVariableValue, Value};
 
 use crate::ast::display::AstDisplay;
 use crate::ast::{
@@ -55,22 +54,6 @@ pub fn plan_set_variable(
         value,
         local,
     }))
-}
-
-/// Split a single string into what would be parsed by `SET v TO <string>` into
-/// multpile values.
-pub fn parse_set_variable_value(value: &str) -> Result<Vec<String>, PlanError> {
-    let parsed = mz_sql_parser::parser::parse_set_variable_to(value)?;
-    match plan_set_variable_to(parsed)? {
-        // This is an awkward error, but makes the types work well for how this
-        // function is called (which is only by system var things).
-        VariableValue::Default => Err(ParserError {
-            message: "unexpected SET DEFAULT".into(),
-            pos: 0,
-        }
-        .into()),
-        VariableValue::Values(values) => Ok(values),
-    }
 }
 
 pub fn plan_set_variable_to(to: SetVariableTo) -> Result<VariableValue, PlanError> {

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -121,10 +121,22 @@ ALTER SYSTEM SET max_replicas_per_cluster = 100
 #> CREATE CLUSTER REPLICA c1.r2 SIZE '1'
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET allowed_cluster_replica_sizes = '2', '4'
+ALTER SYSTEM SET allowed_cluster_replica_sizes = '2', 4
 
 > SHOW allowed_cluster_replica_sizes
-"'2', '4'"
+"\"2\", \"4\""
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET allowed_cluster_replica_sizes = "2, 4"
+
+> SHOW allowed_cluster_replica_sizes
+"\"2, 4\""
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET allowed_cluster_replica_sizes = '2, 4'
+
+> SHOW allowed_cluster_replica_sizes
+"\"2, 4\""
 
 ! CREATE CLUSTER REPLICA c1.r3 SIZE '1'
 contains:unknown cluster replica size 1

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -268,6 +268,21 @@ def workflow_allowed_cluster_replica_sizes(c: Composition) -> None:
         ),
     )
 
+    # Assert that the persisted allowed_cluster_replica_sizes (a setting that
+    # supports multiple values) is correctly restored on restart.
+    c.kill("materialized")
+    c.up("materialized")
+
+    c.testdrive(
+        service="testdrive_no_reset",
+        input=dedent(
+            """
+            > SHOW allowed_cluster_replica_sizes
+            "\\"1\\", \\"2\\""
+            """
+        ),
+    )
+
 
 def workflow_default(c: Composition) -> None:
     c.workflow("github-17578")

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -31,12 +31,12 @@ show search_path
 foo
 
 statement ok
-SET search_path = 'bar', foo, "blah"
+SET search_path = 'ba r', foo, 'x, y', "a, b"
 
 query T
 show search_path
 ----
-bar, foo, blah
+"ba r", foo, "x, y", "a, b"
 
 query T
 SELECT current_schema()

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -14,9 +14,13 @@ show search_path
 ----
 public
 
-# TODO: Check `search_path = 'bar', 'foo'` later once we correctly support multi
-# variable settings. That is, where the first schema of search_path doesn't exist
-# but the second does.
+statement ok
+SET search_path = foo
+
+query T
+show search_path
+----
+foo
 
 statement ok
 SET search_path = 'foo'
@@ -25,6 +29,14 @@ query T
 show search_path
 ----
 foo
+
+statement ok
+SET search_path = 'bar', foo, "blah"
+
+query T
+show search_path
+----
+bar, foo, blah
 
 query T
 SELECT current_schema()

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -246,3 +246,41 @@ query T
 SELECT current_setting('max_tables')
 ----
 100
+
+# Test multi-valued variable planning.
+
+simple
+set datestyle = iso,mdy;
+show datestyle;
+set datestyle = iso, mdy;
+show datestyle;
+set datestyle = "iso,mdy";
+show datestyle;
+set datestyle = "iso, mdy";
+show datestyle;
+set datestyle = 'iso,mdy';
+show datestyle;
+set datestyle = 'iso, mdy';
+show datestyle;
+----
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
+
+statement error parameter "database" requires a "string" value
+set database = one, two

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -262,7 +262,12 @@ set datestyle = 'iso,mdy';
 show datestyle;
 set datestyle = 'iso, mdy';
 show datestyle;
+set datestyle = '"iso", "mdy", "iso", "mdy"', "mdy", "iso", "ISO", "IsO", "mDy";
+show datestyle;
 ----
+COMPLETE 0
+ISO, MDY
+COMPLETE 1
 COMPLETE 0
 ISO, MDY
 COMPLETE 1


### PR DESCRIPTION
Postgres flattens SET vars into a string based on some of the var's flags, then each var is incharge of splitting it if desired. We can instead pass a `Vec<String>` and ignore flattening rules like whether to quote identifiers.

Fixes #6754

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve the Postgres-compatibilty of the `search_path` session setting.