### PR TITLE
sql: support current_setting func

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -712,6 +712,11 @@
       The `include_implicit` parameter controls whether implicit schemas like
       `mz_catalog` and `pg_catalog` are included in the output.
     unmaterializable: true
+  - signature: 'current_setting(setting_name: text[, missing_ok: bool]) -> text'
+    description: >-
+      Returns the value of the named setting or error if it does not exist.
+      If `missing_ok` is true, return NULL if it does not exist.
+    unmaterializable: true
   - signature: 'obj_description(oid: oid, catalog: text) -> text'
     description: PostgreSQL compatibility shim. Currently always returns `NULL`.
   - signature: 'pg_backend_pid() -> int'

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -181,6 +181,8 @@ pub enum AdapterError {
         cluster_name: String,
         replica_name: String,
     },
+    /// The named setting does not exist.
+    UnrecognizedConfigurationParam(String),
     /// A generic error occurred.
     //
     // TODO(benesch): convert all those errors to structured errors.
@@ -515,6 +517,11 @@ impl fmt::Display for AdapterError {
             } => write!(
                 f,
                 "cluster replica '{cluster_name}.{replica_name}' does not exist"
+            ),
+            AdapterError::UnrecognizedConfigurationParam(setting_name) => write!(
+                f,
+                "unrecognized configuration parameter {}",
+                setting_name.quoted()
             ),
             AdapterError::UnstableDependency { object_type, .. } => {
                 write!(f, "cannot create {object_type} with unstable dependencies")

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -92,6 +92,7 @@ message ProtoUnmaterializableFunc {
         google.protobuf.Empty pg_postmaster_start_time = 12;
         google.protobuf.Empty version = 13;
         google.protobuf.Empty mz_version_num = 14;
+        google.protobuf.Empty current_setting = 15;
     }
 }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -83,6 +83,7 @@ pub enum UnmaterializableFunc {
     PgBackendPid,
     PgPostmasterStartTime,
     Version,
+    ViewableVariables,
 }
 
 impl UnmaterializableFunc {
@@ -107,6 +108,11 @@ impl UnmaterializableFunc {
             UnmaterializableFunc::PgBackendPid => ScalarType::Int32.nullable(false),
             UnmaterializableFunc::PgPostmasterStartTime => ScalarType::TimestampTz.nullable(false),
             UnmaterializableFunc::Version => ScalarType::String.nullable(false),
+            UnmaterializableFunc::ViewableVariables => ScalarType::Map {
+                value_type: Box::new(ScalarType::String),
+                custom_id: None,
+            }
+            .nullable(false),
         }
     }
 }
@@ -130,6 +136,7 @@ impl fmt::Display for UnmaterializableFunc {
             UnmaterializableFunc::PgBackendPid => f.write_str("pg_backend_pid"),
             UnmaterializableFunc::PgPostmasterStartTime => f.write_str("pg_postmaster_start_time"),
             UnmaterializableFunc::Version => f.write_str("version"),
+            UnmaterializableFunc::ViewableVariables => f.write_str("viewable_variables"),
         }
     }
 }
@@ -141,6 +148,7 @@ impl RustType<ProtoUnmaterializableFunc> for UnmaterializableFunc {
             UnmaterializableFunc::CurrentDatabase => CurrentDatabase(()),
             UnmaterializableFunc::CurrentSchemasWithSystem => CurrentSchemasWithSystem(()),
             UnmaterializableFunc::CurrentSchemasWithoutSystem => CurrentSchemasWithoutSystem(()),
+            UnmaterializableFunc::ViewableVariables => CurrentSetting(()),
             UnmaterializableFunc::CurrentTimestamp => CurrentTimestamp(()),
             UnmaterializableFunc::CurrentUser => CurrentUser(()),
             UnmaterializableFunc::MzEnvironmentId => MzEnvironmentId(()),
@@ -166,6 +174,7 @@ impl RustType<ProtoUnmaterializableFunc> for UnmaterializableFunc {
                     Ok(UnmaterializableFunc::CurrentSchemasWithoutSystem)
                 }
                 CurrentTimestamp(()) => Ok(UnmaterializableFunc::CurrentTimestamp),
+                CurrentSetting(()) => Ok(UnmaterializableFunc::ViewableVariables),
                 CurrentUser(()) => Ok(UnmaterializableFunc::CurrentUser),
                 MzEnvironmentId(()) => Ok(UnmaterializableFunc::MzEnvironmentId),
                 MzNow(()) => Ok(UnmaterializableFunc::MzNow),

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -376,6 +376,7 @@ impl ErrorResponse {
             AdapterError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
             AdapterError::UnknownClusterReplica { .. } => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::UnrecognizedConfigurationParam(_) => SqlState::UNDEFINED_OBJECT,
             AdapterError::UnstableDependency { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::Unstructured(_) => SqlState::INTERNAL_ERROR,

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -206,3 +206,43 @@ COMPLETE 0
 
 statement error parameter "idle_in_transaction_session_timeout" requires a "duration" value
 SET idle_in_transaction_session_timeout TO '-10ms'
+
+statement error unrecognized configuration parameter
+SELECT current_setting('unknown')
+
+statement error does not exist
+SELECT current_setting(true)
+
+query T
+SELECT current_setting('unknown', true)
+----
+NULL
+
+query T
+SELECT current_setting('unknown', 'true')
+----
+NULL
+
+statement error does not exist
+SELECT current_setting('datestyle', 3)
+
+statement error unrecognized configuration parameter
+SELECT current_setting('unknown', false)
+
+query T
+SELECT current_setting('dateSTYLE')
+----
+ISO, MDY
+
+statement ok
+SET cluster_replica = 'r1'
+
+query T
+SELECT current_setting('cluster') || '.' || current_setting('cluster_replica')
+----
+default.r1
+
+query T
+SELECT current_setting('max_tables')
+----
+100


### PR DESCRIPTION
Have to do some shennanigans to avoid eval'ing the func arguments. Good enough for our needs at the moment.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support the `pg_catalog.current_setting` function.