### PR TITLE
Minor fix in join optimization docs

### DIFF
--- a/doc/user/content/ops/optimization.md
+++ b/doc/user/content/ops/optimization.md
@@ -94,7 +94,7 @@ SELECT
     count(*)
 FROM teachers t
 INNER JOIN sections s ON t.id = s.teacher_id
-GROUP BY t.id;
+GROUP BY t.id, t.name;
 ```
 
 We can eliminate redundant memory usage for these two queries by creating an index on the common column being joined, `teachers.id`.
@@ -109,7 +109,7 @@ If your query filters one or more of the join inputs by a literal equality (e.g.
 
 #### Optimize Multi-Way Joins with Delta Joins
 
-Materialize has access to a join execution strategy we call `DeltaQuery`, a.k.a. **delta joins**, that aggressively re-uses indexes and maintains no intermediate results. Materialize considers this plan only if all the necessary indexes already exist, in which case the additional memory cost of the join is zero This is typically possible when you index all the join keys.
+Materialize has access to a join execution strategy we call `DeltaQuery`, a.k.a. **delta joins**, that aggressively re-uses indexes and maintains no intermediate results. Materialize considers this plan only if all the necessary indexes already exist, in which case the additional memory cost of the join is zero. This is typically possible when you index all the join keys.
 
 From the previous example, add the name of the course rather than just the course ID.
 


### PR DESCRIPTION
The second example query at https://materialize.com/docs/ops/optimization/#multiple-queries-join-on-the-same-collection is failing with `ERROR:  column "t.name" must appear in the GROUP BY clause or be used in an aggregate function`. This PR adds it to the GROUP BY.

It also corrects a minor typo.

(Btw. there is also the issue https://materializeinc.slack.com/archives/CPNFV9CVB/p1676319621670909 concerning the same page, but that can go into a separate PR, because I'd say the example is more urgent to fix.)

### Motivation

  * This PR fixes a previously unreported bug: Wrong example query on a doc page.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No (only a minor doc change)
