### PR TITLE
Print human-readable error messages when build fails due to Protobuf issues

### DIFF
--- a/src/compute-client/build.rs
+++ b/src/compute-client/build.rs
@@ -126,5 +126,5 @@ fn main() {
             ],
             &[".."],
         )
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"));
 }

--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -106,5 +106,5 @@ fn main() {
             ],
             &[".."],
         )
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/interchange/build.rs
+++ b/src/interchange/build.rs
@@ -88,5 +88,5 @@ fn main() {
         .file_descriptor_set_path(out_dir.join("file_descriptor_set.pb"))
         .btree_map(["."])
         .compile_protos(&["benchmark.proto"], &["testdata"])
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -91,5 +91,5 @@ fn main() {
             ],
             &[".."],
         )
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/persist/build.rs
+++ b/src/persist/build.rs
@@ -83,5 +83,5 @@ fn main() {
     prost_build::Config::new()
         .btree_map(["."])
         .compile_protos(&["persist/src/persist.proto"], &[".."])
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/postgres-util/build.rs
+++ b/src/postgres-util/build.rs
@@ -91,5 +91,5 @@ fn main() {
         // broad, but it's better.
         .emit_rerun_if_changed(false)
         .compile_with_config(config, &["postgres-util/src/desc.proto"], &[".."])
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -86,5 +86,5 @@ fn main() {
             &["proto/src/proto.proto", "proto/src/tokio_postgres.proto"],
             &[".."],
         )
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -103,5 +103,5 @@ fn main() {
             ],
             &[".."],
         )
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }

--- a/src/storage-client/build.rs
+++ b/src/storage-client/build.rs
@@ -123,5 +123,5 @@ fn main() {
             ],
             &[".."],
         )
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{e}"))
 }


### PR DESCRIPTION
Before:

```
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "protoc failed: persist/src/persist.proto:18:3: Expected top-level statement (e.g. \"message\").\npersist/src/persist.proto:67:1: warning: Enum constant should be in UPPER_CASE. Found: Unknown. See https://developers.google.com/protocol-buffers/docs/style\npersist/src/persist.proto:67:1: warning: Enum constant should be in UPPER_CASE. Found: ArrowKVTD. See https://developers.google.com/protocol-buffers/docs/style\npersist/src/persist.proto:67:1: warning: Enum constant should be in UPPER_CASE. Found: ParquetKvtd. See https://developers.google.com/protocol-buffers/docs/style\n" }', src/persist/build.rs:86:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

After:

```
  thread 'main' panicked at 'protoc failed: persist/src/persist.proto:18:3: Expected top-level statement (e.g. "message").
  persist/src/persist.proto:67:1: warning: Enum constant should be in UPPER_CASE. Found: Unknown. See https://developers.google.com/protocol-buffers/docs/style
  persist/src/persist.proto:67:1: warning: Enum constant should be in UPPER_CASE. Found: ArrowKVTD. See https://developers.google.com/protocol-buffers/docs/style
  persist/src/persist.proto:67:1: warning: Enum constant should be in UPPER_CASE. Found: ParquetKvtd. See https://developers.google.com/protocol-buffers/docs/style
  ', src/persist/build.rs:86:29
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```