### PR TITLE
platform-checks: Try shuffling checks in sequential runs

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -458,7 +458,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=DropCreateDefaultReplica]
+          args: [--scenario=DropCreateDefaultReplica, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-restart-clusterd-compute
     label: "Checks + restart clusterd compute"
@@ -470,7 +470,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartClusterdCompute]
+          args: [--scenario=RestartClusterdCompute, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-restart-entire-mz
     label: "Checks + restart of the entire Mz"
@@ -482,7 +482,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartEntireMz]
+          args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-restart-environmentd-clusterd-storage
     label: "Checks + restart of environmentd & storage clusterd"
@@ -494,7 +494,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartEnvironmentdClusterdStorage]
+          args: [--scenario=RestartEnvironmentdClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-kill-clusterd-storage
     label: "Checks + kill storage clusterd"
@@ -506,7 +506,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=KillClusterdStorage]
+          args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-restart-cockroach
     label: "Checks + restart Cockroach"
@@ -518,7 +518,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartCockroach]
+          args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: checks-restart-source-postgres
     label: "Checks + restart source Postgres"
@@ -553,7 +553,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartRedpandaDebezium]
+          args: [--scenario=RestartRedpandaDebezium, "--seed=$BUILDKITE_JOB_ID"]
 
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -47,16 +47,16 @@ class UpgradeEntireMz(Scenario):
         print(f"Upgrading from tag {self.tag()}")
         return [
             StartMz(tag=self.tag()),
-            Initialize(self.checks),
-            Manipulate(self.checks, phase=1),
+            Initialize(self.checks()),
+            Manipulate(self.checks(), phase=1),
             KillMz(),
             StartMz(tag=None),
-            Manipulate(self.checks, phase=2),
-            Validate(self.checks),
+            Manipulate(self.checks(), phase=2),
+            Validate(self.checks()),
             # A second restart while already on the new version
             KillMz(),
             StartMz(tag=None),
-            Validate(self.checks),
+            Validate(self.checks()),
         ]
 
 
@@ -84,8 +84,8 @@ class UpgradeClusterdComputeLast(Scenario):
             StartMz(tag=last_version),
             StartClusterdCompute(tag=last_version),
             UseClusterdCompute(),
-            Initialize(self.checks),
-            Manipulate(self.checks, phase=1),
+            Initialize(self.checks()),
+            Manipulate(self.checks(), phase=1),
             KillMz(),
             StartMz(tag=None),
             # No useful work can be done while clusterd is old-version
@@ -96,12 +96,12 @@ class UpgradeClusterdComputeLast(Scenario):
             Sleep(10),
             KillClusterdCompute(),
             StartClusterdCompute(tag=None),
-            Manipulate(self.checks, phase=2),
-            Validate(self.checks),
+            Manipulate(self.checks(), phase=2),
+            Validate(self.checks()),
             # A second restart while already on the new version
             KillMz(),
             StartMz(tag=None),
-            Validate(self.checks),
+            Validate(self.checks()),
         ]
 
 
@@ -113,8 +113,8 @@ class UpgradeClusterdComputeFirst(Scenario):
             StartMz(tag=last_version),
             StartClusterdCompute(tag=last_version),
             UseClusterdCompute(),
-            Initialize(self.checks),
-            Manipulate(self.checks, phase=1),
+            Initialize(self.checks()),
+            Manipulate(self.checks(), phase=1),
             KillClusterdCompute(),
             StartClusterdCompute(tag=None),
             # No useful work can be done while clusterd is new-version
@@ -125,9 +125,9 @@ class UpgradeClusterdComputeFirst(Scenario):
             Sleep(10),
             KillMz(),
             StartMz(tag=None),
-            Manipulate(self.checks, phase=2),
-            Validate(self.checks),
+            Manipulate(self.checks(), phase=2),
+            Validate(self.checks()),
             KillMz(),
             StartMz(tag=None),
-            Validate(self.checks),
+            Validate(self.checks()),
         ]

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -68,11 +68,11 @@ class CloudtestUpgrade(Scenario):
     def actions(self) -> List[Action]:
         return [
             LiftClusterLimits(),
-            Initialize(self.checks),
-            Manipulate(self.checks, phase=1),
+            Initialize(self.checks()),
+            Manipulate(self.checks(), phase=1),
             ReplaceEnvironmentdStatefulSet(new_tag=None),
-            Manipulate(self.checks, phase=2),
-            Validate(self.checks),
+            Manipulate(self.checks(), phase=2),
+            Validate(self.checks()),
         ]
 
 

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -77,6 +77,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         default=ExecutionMode.SEQUENTIAL,
     )
 
+    parser.add_argument(
+        "--seed",
+        metavar="SEED",
+        type=str,
+        help="Seed for shuffling checks in sequential run.",
+    )
+
     args = parser.parse_args()
 
     scenarios = (
@@ -102,7 +109,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         if args.execution_mode in [ExecutionMode.SEQUENTIAL, ExecutionMode.PARALLEL]:
             setup(c)
-            scenario = scenario_class(checks=checks, executor=executor)
+            scenario = scenario_class(checks=checks, executor=executor, seed=args.seed)
             scenario.run()
             teardown(c)
         elif args.execution_mode is ExecutionMode.ONEATATIME:


### PR DESCRIPTION
I saw some failures because of changes in one test affecting the queries of another, so shuffling them might find something of interest.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
