### PR TITLE
cluster-unification/storage: make it more explicit that storage connects to the last replica

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -87,7 +87,9 @@ use uuid::Uuid;
 use mz_build_info::BuildInfo;
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig};
 use mz_compute_client::types::dataflows::DataflowDescription;
-use mz_controller::clusters::{ClusterConfig, ClusterEvent, ClusterId, ReplicaId};
+use mz_controller::clusters::{
+    ClusterConfig, ClusterEvent, ClusterId, CreateReplicaConfig, ReplicaId,
+};
 use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::cast::CastFrom;
@@ -642,7 +644,12 @@ impl Coordinator {
             )?;
             for (replica_id, replica) in instance.replicas_by_id.clone() {
                 let role = instance.role();
-                replicas_to_start.push((instance.id, replica_id, role, replica.config));
+                replicas_to_start.push(CreateReplicaConfig {
+                    cluster_id: instance.id,
+                    replica_id,
+                    role,
+                    config: replica.config,
+                });
             }
         }
         self.controller.create_replicas(replicas_to_start).await?;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -28,8 +28,8 @@ use mz_compute_client::types::sinks::{
     ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection,
 };
 use mz_controller::clusters::{
-    ClusterConfig, ClusterId, ReplicaAllocation, ReplicaConfig, ReplicaId, ReplicaLogging,
-    DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS,
+    ClusterConfig, ClusterId, CreateReplicaConfig, ReplicaAllocation, ReplicaConfig, ReplicaId,
+    ReplicaLogging, DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS,
 };
 use mz_expr::{
     permutation_for_arrangement, CollectionPlan, MirRelationExpr, MirScalarExpr,
@@ -749,7 +749,12 @@ impl Coordinator {
             let role = cluster.role();
             let replica_config = cluster.replicas_by_id[&replica_id].config.clone();
 
-            replicas_to_start.push((cluster_id, replica_id, role, replica_config));
+            replicas_to_start.push(CreateReplicaConfig {
+                cluster_id,
+                replica_id,
+                role,
+                config: replica_config,
+            });
         }
 
         self.controller

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use differential_dataflow::lattice::Lattice;
-use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use futures::stream::{BoxStream, StreamExt};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -198,6 +198,15 @@ pub struct ClusterEvent {
     pub time: DateTime<Utc>,
 }
 
+/// A struct describing a replica that needs to be created,
+/// using `Controller::create_replicas`.
+pub struct CreateReplicaConfig {
+    pub cluster_id: ClusterId,
+    pub replica_id: ReplicaId,
+    pub role: ClusterRole,
+    pub config: ReplicaConfig,
+}
+
 impl<T> Controller<T>
 where
     T: Timestamp + Lattice,
@@ -236,13 +245,30 @@ where
     /// always wrong to do anything but abort the process on `Err`.
     pub async fn create_replicas(
         &mut self,
-        replicas: Vec<(ClusterId, ReplicaId, ClusterRole, ReplicaConfig)>,
+        replicas: Vec<CreateReplicaConfig>,
     ) -> Result<(), anyhow::Error> {
+        /// A intermediate struct to hold info about a replica, to avoid
+        /// a large tuple.
+        struct ReplicaInfo {
+            replica_id: ReplicaId,
+            compute_config: ComputeReplicaConfig,
+            storage_location: ClusterReplicaLocation,
+            compute_location: ClusterReplicaLocation,
+            metrics_task_join_handle: Option<AbortOnDropHandle<()>>,
+        }
+
         // Reborrow the `&mut self` as immutable, as all the concurrent work to be processed in
         // this stream cannot all have exclusive access.
         let this = &*self;
-        let replicas: Vec<_> = futures::stream::iter(replicas)
-            .map(|(cluster_id, replica_id, role, config)| async move {
+        let mut replica_stream = futures::stream::iter(replicas)
+            .map(|config| async move {
+                let CreateReplicaConfig {
+                    cluster_id,
+                    replica_id,
+                    role,
+                    config,
+                } = config;
+
                 match config.location {
                     // This branch doesn't do any async work, so there is a slight performance
                     // opportunity to serially process it, but it makes the code worse to read.
@@ -267,11 +293,13 @@ where
 
                         Ok::<_, anyhow::Error>((
                             cluster_id,
-                            replica_id,
-                            config.compute,
-                            storage_location,
-                            compute_location,
-                            None,
+                            ReplicaInfo {
+                                replica_id,
+                                compute_config: config.compute,
+                                storage_location,
+                                compute_location,
+                                metrics_task_join_handle: None,
+                            },
                         ))
                     }
                     ReplicaLocation::Managed(m) => {
@@ -291,42 +319,61 @@ where
                         };
                         Ok((
                             cluster_id,
-                            replica_id,
-                            config.compute,
-                            storage_location,
-                            compute_location,
-                            Some(metrics_task_join_handle),
+                            ReplicaInfo {
+                                replica_id,
+                                compute_config: config.compute,
+                                storage_location,
+                                compute_location,
+                                metrics_task_join_handle: Some(metrics_task_join_handle),
+                            },
                         ))
                     }
                 }
             })
             // TODO(guswynn): make this configurable.
-            .buffer_unordered(50)
-            // `try_collect` and `collect` are the only safe ways to process a
-            // `buffer_unordered`. See the docs in `mz_storage_client::controller` for more
-            // details.
-            .try_collect()
-            .await?;
+            .buffer_unordered(50);
 
-        for (
-            cluster_id,
-            replica_id,
-            compute_config,
-            storage_location,
-            compute_location,
-            metrics_task_join_handle,
-        ) in replicas
-        {
-            if let Some(jh) = metrics_task_join_handle {
-                self.metrics_tasks.insert(replica_id, jh);
-            }
-            self.storage.connect_replica(cluster_id, storage_location);
-            self.active_compute().add_replica_to_instance(
+        // _Usually_ `try_collect` and `collect` are the only safe ways to process a
+        // `buffer_unordered`, but if we ensure we don't do
+        // any async work in this loop, we are fine.
+        //
+        // If we do do async work in the loop, we could starve the stream itself of
+        // polls, which can cause errors.
+        // See the docs in `mz_storage_client::controller` for more info.
+        let mut replicas: BTreeMap<_, Vec<_>> = BTreeMap::new();
+        while let Some(res) = replica_stream.next().await {
+            let (cluster_id, replica_info) = res?;
+
+            replicas.entry(cluster_id).or_default().push(replica_info);
+        }
+        drop(replica_stream);
+
+        for (cluster_id, replicas) in replicas {
+            // We only connect to the last replica (chosen arbitrarily)
+            // for storage, until we support multi-replica storage objects
+            self.storage.connect_replica(
                 cluster_id,
+                replicas.last().unwrap().storage_location.clone(),
+            );
+
+            for ReplicaInfo {
                 replica_id,
-                compute_location,
                 compute_config,
-            )?;
+                storage_location: _,
+                compute_location,
+                metrics_task_join_handle,
+            } in replicas
+            {
+                if let Some(jh) = metrics_task_join_handle {
+                    self.metrics_tasks.insert(replica_id, jh);
+                }
+                self.active_compute().add_replica_to_instance(
+                    cluster_id,
+                    replica_id,
+                    compute_location,
+                    compute_config,
+                )?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
The code as written _ultimately_ connects to _last_ replica for the cluster (`connect_replica` overrides previous ones). For storage clusters with actual storage objects, there is only ever 1 replica, but we do end up connecting and creating a storage timely cluster for compute clusters. It was bugging me that there was this _implicit_ behavior, that also caused churned as we re-connected to many replicas, settling on the last, so I decided to just clean it up!

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

