### PR TITLE
compute: avoid FrontierUppers regressions

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1076,14 +1076,34 @@ where
         list: Vec<(GlobalId, Antichain<T>)>,
         replica_id: ReplicaId,
     ) {
-        // We should not receive updates for collections we don't track. It is possible that we
-        // currently do due to a bug where replicas send `FrontierUppers` for collections they drop
-        // during reconciliation.
-        // TODO(teskje): Revisit this after #16247 is resolved.
-        let updates: Vec<_> = list
-            .into_iter()
-            .filter(|(id, _)| self.compute.collections.contains_key(id))
-            .collect();
+        // According to the compute protocol, replicas are not allowed to send `FrontierUppers`
+        // that regress frontiers they have reported previously. We still perform a check here,
+        // rather than risking the controller becoming confused trying to handle regressions.
+        let mut updates = Vec::with_capacity(list.len());
+        for (id, new_frontier) in list {
+            let Ok(coll) = self.compute.collection(id) else {
+                // We should not receive updates for collections we don't track. It is possible
+                // that we currently do due to a bug where replicas send `FrontierUppers` for
+                // collections they drop during reconciliation.
+                // TODO(teskje): Revisit this after #16247 is resolved.
+                continue;
+            };
+
+            if let Some(old_frontier) = coll.replica_write_frontiers.get(&replica_id) {
+                if !PartialOrder::less_equal(old_frontier, &new_frontier) {
+                    tracing::warn!(
+                        ?replica_id,
+                        "Frontier of collection {id} regressed: {:?} -> {:?}",
+                        old_frontier.elements(),
+                        new_frontier.elements(),
+                    );
+                    tracing::error!("Replica reported a regressed collection frontier");
+                    continue;
+                }
+            }
+
+            updates.push((id, new_frontier));
+        }
 
         self.update_write_frontiers(replica_id, &updates);
     }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -105,7 +105,8 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// subscribe dataflow's `as_of` until the subscribe advances to the empty frontier or is
     /// dropped. The time intervals of consecutive [`Batch`]es must be increasing, contiguous,
     /// non-overlapping, and non-empty. All updates transmitted in a batch must have times within
-    /// that batch’s time interval.
+    /// that batch’s time interval. The `upper` of the first [`Batch`] of a subscribe must not be
+    /// less than that subscribe's initial `as_of` frontier.
     ///
     /// The replica must send [`DroppedAt`] responses if the subscribe was dropped in response to
     /// an [`AllowCompaction` command] that advanced its read frontier to the empty frontier. The

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -47,6 +47,13 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// Replicas must send `FrontierUppers` responses for compute collections that are indexes or
     /// storage sinks. Replicas must not send `FrontierUppers` responses for subscribes.
     ///
+    /// Replicas must never report regressing frontiers. Specifically:
+    ///
+    ///   * The first frontier reported for a collection must not be less than that collection's
+    ///     initial `as_of` frontier.
+    ///   * Subsequent reported frontiers for a collection must not be less than any frontier
+    ///     reported previously for the same collection.
+    ///
     /// Replicas must send a `FrontierUppers` response reporting advancement to the empty frontier
     /// for a collection in two cases:
     ///
@@ -61,11 +68,13 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * The replica must not send further `FrontierUppers` responses for that collection.
     ///
     /// The replica must not send `FrontierUppers` responses for collections that have not
-    /// been created previously by a [`CreateDataflows` command]. An exception are `FrontierUppers`
-    /// responses that report the empty frontier. ([#16247])
+    /// been created previously by a [`CreateDataflows` command] or by a [`CreateInstance`
+    /// command]. An exception are `FrontierUppers` responses that report the empty frontier.
+    /// ([#16247])
     ///
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
     /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
+    /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
     /// [#16247]: https://github.com/MaterializeInc/materialize/issues/16247
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -76,7 +76,7 @@ pub struct ComputeState {
     /// Peek commands that are awaiting fulfillment.
     pub pending_peeks: BTreeMap<Uuid, PendingPeek>,
     /// Tracks the frontier information that has been sent over `response_tx`.
-    pub reported_frontiers: BTreeMap<GlobalId, Antichain<Timestamp>>,
+    pub reported_frontiers: BTreeMap<GlobalId, ReportedFrontier>,
     /// Collections that were recently dropped and whose removal needs to be reported.
     pub dropped_collections: Vec<GlobalId>,
     /// The logger, from Timely's logging framework, if logs are enabled.
@@ -194,10 +194,14 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
             // Initialize frontiers for each object, and optionally log their construction.
             for (object_id, collection_id) in exported_ids {
-                if let Some(frontier) = self.compute_state.reported_frontiers.insert(
-                    object_id,
-                    Antichain::from_elem(timely::progress::Timestamp::minimum()),
-                ) {
+                let reported_frontier = ReportedFrontier::NotReported {
+                    lower: dataflow.as_of.clone().unwrap(),
+                };
+                if let Some(frontier) = self
+                    .compute_state
+                    .reported_frontiers
+                    .insert(object_id, reported_frontier)
+                {
                     error!(
                         "existing frontier {frontier:?} for newly created dataflow id {object_id}"
                     );
@@ -247,7 +251,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     .expect("Dropped compute collection with no frontier");
                 if let Some(logger) = self.compute_state.compute_logger.as_mut() {
                     logger.log(ComputeEvent::Dataflow(id, false));
-                    if let Some(&time) = prev_frontier.get(0) {
+                    if let Some(time) = prev_frontier.logging_time() {
                         logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
                     }
                 }
@@ -568,10 +572,11 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let index_ids = logging.index_logs.values().copied();
         let sink_ids = logging.sink_logs.values().map(|(id, _)| *id);
         for id in index_ids.chain(sink_ids) {
-            if let Some(frontier) = self.compute_state.reported_frontiers.insert(
-                id,
-                Antichain::from_elem(timely::progress::Timestamp::minimum()),
-            ) {
+            if let Some(frontier) = self
+                .compute_state
+                .reported_frontiers
+                .insert(id, ReportedFrontier::new())
+            {
                 error!(
                     "existing frontier {frontier:?} for newly initialized logging export id {id}"
                 );
@@ -608,26 +613,39 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let mut new_uppers = Vec::new();
 
         let mut update_frontier = |id, new_frontier: &Antichain<Timestamp>| {
-            let prev_frontier = self.compute_state.reported_frontiers.get_mut(&id);
-            let prev_frontier = prev_frontier
+            let reported_frontier = self
+                .compute_state
+                .reported_frontiers
+                .get_mut(&id)
                 .unwrap_or_else(|| panic!("Frontier update for untracked identifier: {id}"));
 
-            assert!(PartialOrder::less_equal(prev_frontier, new_frontier));
-            if prev_frontier == new_frontier {
-                return; // nothing new to report
+            match reported_frontier {
+                ReportedFrontier::Reported(old_frontier) => {
+                    assert!(PartialOrder::less_equal(old_frontier, new_frontier));
+                    if old_frontier == new_frontier {
+                        return; // nothing new to report
+                    }
+                }
+                ReportedFrontier::NotReported { lower } => {
+                    if !PartialOrder::less_equal(lower, new_frontier) {
+                        return; // lower bound for reporting not yet reached
+                    }
+                }
             }
 
+            let new_reported_frontier = ReportedFrontier::Reported(new_frontier.clone());
+
             if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                if let Some(&time) = prev_frontier.get(0) {
+                if let Some(time) = reported_frontier.logging_time() {
                     logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
                 }
-                if let Some(&time) = new_frontier.get(0) {
+                if let Some(time) = new_reported_frontier.logging_time() {
                     logger.log(ComputeEvent::Frontier { id, time, diff: 1 });
                 }
             }
 
             new_uppers.push((id, new_frontier.clone()));
-            prev_frontier.clone_from(new_frontier);
+            *reported_frontier = new_reported_frontier;
         };
 
         let mut new_frontier = Antichain::new();
@@ -709,22 +727,33 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         let mut subscribe_responses = self.compute_state.subscribe_response_buffer.borrow_mut();
         for (sink_id, mut response) in subscribe_responses.drain(..) {
             // Update frontier logging for this subscribe.
-            if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&sink_id) {
+            if let Some(reported_frontier) = self.compute_state.reported_frontiers.get_mut(&sink_id)
+            {
                 let new_frontier = match &response {
                     SubscribeResponse::Batch(b) => b.upper.clone(),
                     SubscribeResponse::DroppedAt(_) => Antichain::new(),
                 };
-                assert!(PartialOrder::less_equal(prev_frontier, &new_frontier));
+
+                match reported_frontier {
+                    ReportedFrontier::Reported(old_frontier) => {
+                        assert!(PartialOrder::less_equal(old_frontier, &new_frontier))
+                    }
+                    ReportedFrontier::NotReported { .. } => {
+                        // TODO: ensure subscribe frontiers don't regress
+                    }
+                }
+
+                let new_reported_frontier = ReportedFrontier::Reported(new_frontier);
 
                 if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                    if let Some(&time) = prev_frontier.get(0) {
+                    if let Some(time) = reported_frontier.logging_time() {
                         logger.log(ComputeEvent::Frontier {
                             id: sink_id,
                             time,
                             diff: -1,
                         });
                     }
-                    if let Some(&time) = new_frontier.get(0) {
+                    if let Some(time) = new_reported_frontier.logging_time() {
                         logger.log(ComputeEvent::Frontier {
                             id: sink_id,
                             time,
@@ -733,7 +762,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     }
                 }
 
-                prev_frontier.clone_from(&new_frontier);
+                *reported_frontier = new_reported_frontier;
             } else {
                 // Presumably tracking state for this frontier was already dropped by
                 // `handle_allow_compaction`. There is nothing left to do for logging.
@@ -1014,5 +1043,41 @@ impl PendingPeek {
         }
 
         Ok(results)
+    }
+}
+
+/// A frontier we have reported to the controller, or the least frontier we are allowed to report.
+#[derive(Debug)]
+pub enum ReportedFrontier {
+    /// A frontier has been previously reported.
+    Reported(Antichain<Timestamp>),
+    /// No frontier has been reported yet.
+    NotReported {
+        /// A lower bound for frontiers that may be reported in the future.
+        lower: Antichain<Timestamp>,
+    },
+}
+
+impl ReportedFrontier {
+    /// Create a new `ReportedFrontier` enforcing the minimum lower bound.
+    pub fn new() -> Self {
+        let lower = Antichain::from_elem(timely::progress::Timestamp::minimum());
+        Self::NotReported { lower }
+    }
+
+    /// Whether the reported frontier is the empty frontier.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Reported(frontier) => frontier.is_empty(),
+            Self::NotReported { .. } => false,
+        }
+    }
+
+    /// Return a timestamp suitable for logging the reported frontier.
+    pub fn logging_time(&self) -> Option<Timestamp> {
+        match self {
+            Self::Reported(frontier) => frontier.get(0).copied(),
+            Self::NotReported { .. } => Some(timely::progress::Timestamp::minimum()),
+        }
     }
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -736,10 +736,10 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
                 match reported_frontier {
                     ReportedFrontier::Reported(old_frontier) => {
-                        assert!(PartialOrder::less_equal(old_frontier, &new_frontier))
+                        assert!(PartialOrder::less_than(old_frontier, &new_frontier))
                     }
-                    ReportedFrontier::NotReported { .. } => {
-                        // TODO: ensure subscribe frontiers don't regress
+                    ReportedFrontier::NotReported { lower } => {
+                        assert!(PartialOrder::less_equal(lower, &new_frontier))
                     }
                 }
 


### PR DESCRIPTION
Prior to this PR, it was possible for replicas hydrating a dataflow to report new upper frontiers that were below the dataflow `as_of`. To the compute controller this would look like a frontier regression, and it would potentially become confused.

The first commit prevents regressions in `FrontierUppers` responses by implementing three measures:

1. Making replicas suppress upper updates for frontiers that are less than the respective dataflow `as_of`.
2. Changing the compute protocol spec to disallow regressions in `FrontierUppers` responses.
3. Adding a check to the compute controller to detect and gracefully handle frontier regressions (by ignoring them).

Measure (3) is not strictly required and only acts as a safeguard against unintentional violations of the compute protocol.

The second commit does the same for `SubscribeResponse`s, with the notable difference that it the compute controller panics on receiving a frontier regression in a `SubscribeResponse`, rather than ignoring the response. We cannot simply ignore `SubscribeResponse`s, as that would cause us to change the subscribe's output by dropping updates on the floor.

### Motivation

  * This PR fixes a recognized bug.

Fixes an invalid storage read capability update reported in https://github.com/MaterializeInc/materialize/pull/17669#issuecomment-1430183774.

[Discussion in Slack](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1676399595322229).

I verified that `bin/mzcompose --find platform-checks run default --scenario=RestartEnvironmentdClusterdStorage` passes on this branch with the changes from #17669 applied.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
